### PR TITLE
feat(ads/WP-62): replace placeholder ad slot IDs with real AdSense slot IDs

### DIFF
--- a/guides/how-to-calculate-scrap-gold.html
+++ b/guides/how-to-calculate-scrap-gold.html
@@ -214,7 +214,7 @@ footer a:hover{color:var(--color-text)}
 
     <!-- Mid-article ad slot with reserved height to prevent CLS (WP-51) -->
     <div class="ad-slot" aria-label="Advertisement" style="min-height:100px">
-      <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8849494330640880" data-ad-slot="YOUR_SLOT_1" data-ad-format="auto" data-full-width-responsive="true"></ins>
+      <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8849494330640880" data-ad-slot="4865607694" data-ad-format="auto" data-full-width-responsive="true"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -357,12 +357,12 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </div>
 </section>
 
-<!-- AD SLOT 1 — below hero, responsive auto format -->
+<!-- AD SLOT 1 — below hero, display responsive -->
 <div class="ad-slot" aria-label="Advertisement">
   <ins class="adsbygoogle"
        style="display:block"
        data-ad-client="ca-pub-8849494330640880"
-       data-ad-slot="YOUR_SLOT_1"
+       data-ad-slot="4865607694"
        data-ad-format="auto"
        data-full-width-responsive="true"></ins>
   <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
@@ -542,11 +542,11 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <!-- AD SLOT 2 — Mid-content, responsive -->
     <div class="ad-slot" aria-label="Advertisement" style="margin:var(--space-6) 0;padding:0">
       <ins class="adsbygoogle"
-           style="display:block"
+           style="display:block; text-align:center;"
+           data-ad-layout="in-article"
+           data-ad-format="fluid"
            data-ad-client="ca-pub-8849494330640880"
-           data-ad-slot="YOUR_SLOT_2"
-           data-ad-format="auto"
-           data-full-width-responsive="true"></ins>
+           data-ad-slot="7108627652"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
 
@@ -773,23 +773,21 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <div class="ad-slot-sidebar" aria-label="Advertisement">
       <ins class="adsbygoogle"
            style="display:block"
+           data-ad-format="fluid"
            data-ad-client="ca-pub-8849494330640880"
-           data-ad-slot="YOUR_SLOT_3"
-           data-ad-format="auto"
-           data-full-width-responsive="true"></ins>
+           data-ad-slot="4729876325"></ins>
       <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
     </div>
   </aside>
 </section>
 
-<!-- AD SLOT 4 — Above footer, responsive -->
+<!-- AD SLOT 4 — Above footer, multiplex -->
 <div class="ad-slot" aria-label="Advertisement">
   <ins class="adsbygoogle"
        style="display:block"
+       data-ad-format="autorelaxed"
        data-ad-client="ca-pub-8849494330640880"
-       data-ad-slot="YOUR_SLOT_4"
-       data-ad-format="auto"
-       data-full-width-responsive="true"></ins>
+       data-ad-slot="9961009949"></ins>
   <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
 </div>
 


### PR DESCRIPTION
## Summary

Replaces all `YOUR_SLOT_X` placeholder strings with the real AdSense slot IDs provided. Zero revenue was being generated because the ad code was non-functional with placeholder IDs.

- **Slot 1** (index.html, below hero): Display responsive → `4865607694`
- **Slot 2** (index.html, mid-content): In-article fluid → `7108627652` (format updated to `fluid` + `data-ad-layout="in-article"`)
- **Slot 3** (index.html, sidebar): In-feed fluid → `4729876325` (format updated to `fluid`)
- **Slot 4** (index.html, above footer): Multiplex → `9961009949` (format updated to `autorelaxed`)
- **Guide slot** (guides/how-to-calculate-scrap-gold.html): Display → `4865607694`

## Test plan
- [ ] Deploy and open in incognito — no AdSense console errors
- [ ] Check AdSense dashboard → Reports → Ad units shows impressions within ~1 hour
- [ ] Verify no instances of `YOUR_SLOT` remain: `grep -rn YOUR_SLOT *.html guides/*.html`

Closes #72

https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq

---
_Generated by [Claude Code](https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq)_