### PR TITLE
feat(seo/WP-32): add Table microdata (schema.org/Table) to karat price tables

### DIFF
--- a/10k-gold-price-per-gram.html
+++ b/10k-gold-price-per-gram.html
@@ -43,13 +43,19 @@
     <h2>What is 10K Gold?</h2>
     <p>10K gold contains 10 parts gold out of 24, giving it a purity of <strong>41.67%</strong>. It is the minimum legal standard for gold jewellery in the United States. While it has a lower gold content than 14K or 18K, it is the most durable and scratch-resistant commonly available gold alloy. The European hallmark is <strong>417</strong>.</p>
     <h2>10K Gold Price Table</h2>
-    <table class="data-table" aria-label="10K gold price by weight"><thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead><tbody>
-      <tr><td>1g</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-usd" data-nosnippet>&mdash;</td></tr>
-      <tr><td>5g</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-usd" data-nosnippet>&mdash;</td></tr>
-      <tr><td>10g</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-usd" data-nosnippet>&mdash;</td></tr>
-      <tr><td>20g</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-usd" data-nosnippet>&mdash;</td></tr>
-      <tr><td>1 troy oz (31.1g)</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-usd" data-nosnippet>&mdash;</td></tr>
-    </tbody></table>
+    <figure itemscope itemtype="https://schema.org/Table">
+      <figcaption>10K gold price per gram in GBP and USD — live, updated every 60 seconds</figcaption>
+      <table class="data-table" aria-label="10K gold price by weight">
+        <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
+        <tbody>
+          <tr><td>1g</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>5g</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>10g</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>20g</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>1 troy oz (31.1g)</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-usd" data-nosnippet>&mdash;</td></tr>
+        </tbody>
+      </table>
+    </figure>
     <h2>Is 10K Gold Worth Buying?</h2>
     <p>10K gold is an economical choice for everyday jewellery. Its high alloy content (copper, silver, zinc) makes it more resistant to scratches and tarnish than 14K or 18K. However, some people with sensitive skin may experience reactions to the higher base metal content. For investment purposes, 24K bullion offers a much higher gold content per pound spent.</p>
     <div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative melt values only. Dealer buy prices are typically 70&ndash;90% of melt value. Not financial advice.</div>

--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -108,33 +108,39 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <p>14K gold contains 14 parts gold out of 24 &mdash; a purity of <strong>58.33%</strong>. It is the most popular gold alloy for jewellery in the United States and is widely used for engagement rings and wedding bands. The hallmark you will see on European and UK pieces is <strong>585</strong>. On American pieces you will see <strong>14K</strong> or <strong>14KT</strong>.</p>
 
     <h2>14K Gold Price Table</h2>
-    <table class="data-table" aria-label="14K gold price by weight">
-      <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
-      <tbody>
-        <tr><td>0.5g</td><td id="t-0-5-gbp" data-nosnippet>&mdash;</td><td id="t-0-5-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>1g</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>2g</td><td id="t-2-gbp" data-nosnippet>&mdash;</td><td id="t-2-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>5g</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>10g</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>20g</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>1 troy oz (31.1g)</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-usd" data-nosnippet>&mdash;</td></tr>
-      </tbody>
-    </table>
+    <figure itemscope itemtype="https://schema.org/Table">
+      <figcaption>14K gold price per gram in GBP and USD — live, updated every 60 seconds</figcaption>
+      <table class="data-table" aria-label="14K gold price by weight">
+        <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
+        <tbody>
+          <tr><td>0.5g</td><td id="t-0-5-gbp" data-nosnippet>&mdash;</td><td id="t-0-5-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>1g</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>2g</td><td id="t-2-gbp" data-nosnippet>&mdash;</td><td id="t-2-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>5g</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>10g</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>20g</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>1 troy oz (31.1g)</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-usd" data-nosnippet>&mdash;</td></tr>
+        </tbody>
+      </table>
+    </figure>
 
     <h2>How Is the 14K Gold Price Calculated?</h2>
     <p>The 14K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>14K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 0.5833</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
 
     <h2>14K vs Other Karats</h2>
-    <table class="data-table" aria-label="Gold karat comparison">
-      <thead><tr><th>Karat</th><th>Purity</th><th>Hallmark</th><th>Typical Use</th></tr></thead>
-      <tbody>
-        <tr><td>9K</td><td>37.5%</td><td>375</td><td>UK everyday jewellery</td></tr>
-        <tr><td><strong>14K</strong></td><td><strong>58.33%</strong></td><td><strong>585</strong></td><td><strong>US engagement rings (most popular)</strong></td></tr>
-        <tr><td>18K</td><td>75.0%</td><td>750</td><td>Fine jewellery, luxury watches</td></tr>
-        <tr><td>22K</td><td>91.67%</td><td>916</td><td>South Asian bridal gold</td></tr>
-        <tr><td>24K</td><td>99.9%</td><td>999</td><td>Bullion coins and bars</td></tr>
-      </tbody>
-    </table>
+    <figure itemscope itemtype="https://schema.org/Table">
+      <figcaption>Gold karat comparison — purity, hallmark, and typical use</figcaption>
+      <table class="data-table" aria-label="Gold karat comparison">
+        <thead><tr><th>Karat</th><th>Purity</th><th>Hallmark</th><th>Typical Use</th></tr></thead>
+        <tbody>
+          <tr><td>9K</td><td>37.5%</td><td>375</td><td>UK everyday jewellery</td></tr>
+          <tr><td><strong>14K</strong></td><td><strong>58.33%</strong></td><td><strong>585</strong></td><td><strong>US engagement rings (most popular)</strong></td></tr>
+          <tr><td>18K</td><td>75.0%</td><td>750</td><td>Fine jewellery, luxury watches</td></tr>
+          <tr><td>22K</td><td>91.67%</td><td>916</td><td>South Asian bridal gold</td></tr>
+          <tr><td>24K</td><td>99.9%</td><td>999</td><td>Bullion coins and bars</td></tr>
+        </tbody>
+      </table>
+    </figure>
 
     <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Dealer buy prices are typically 70&ndash;90% of melt value. Always verify with your dealer before selling.</div>
   </div>

--- a/18k-gold-price-per-gram.html
+++ b/18k-gold-price-per-gram.html
@@ -102,17 +102,20 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <h2>What is 18K Gold?</h2>
     <p>18K gold contains 18 parts gold out of 24 &mdash; a purity of <strong>75%</strong>. It is the standard for fine jewellery, high-end Swiss watches, and luxury accessories worldwide. The hallmark for 18K gold in the UK and Europe is <strong>750</strong>. In the US you will see <strong>18K</strong> or <strong>18KT</strong> stamped on items.</p>
     <h2>18K Gold Price Table</h2>
-    <table class="data-table" aria-label="18K gold price by weight">
-      <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
-      <tbody>
-        <tr><td>1g</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>2g</td><td id="t-2-gbp" data-nosnippet>&mdash;</td><td id="t-2-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>5g</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>10g</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>20g</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>1 troy oz (31.1g)</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-usd" data-nosnippet>&mdash;</td></tr>
-      </tbody>
-    </table>
+    <figure itemscope itemtype="https://schema.org/Table">
+      <figcaption>18K gold price per gram in GBP and USD — live, updated every 60 seconds</figcaption>
+      <table class="data-table" aria-label="18K gold price by weight">
+        <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
+        <tbody>
+          <tr><td>1g</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>2g</td><td id="t-2-gbp" data-nosnippet>&mdash;</td><td id="t-2-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>5g</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>10g</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>20g</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-usd" data-nosnippet>&mdash;</td></tr>
+          <tr><td>1 troy oz (31.1g)</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-usd" data-nosnippet>&mdash;</td></tr>
+        </tbody>
+      </table>
+    </figure>
     <h2>How Is 18K Gold Price Calculated?</h2>
     <p>The 18K price per gram = 24K spot price per troy oz &divide; 31.1035 &times; 0.75. The LBMA spot price is the global benchmark, set twice daily in London. Our calculator fetches this live and converts to GBP using the real-time exchange rate.</p>
     <div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative melt values. Dealer buy prices are typically 70&ndash;90% of melt value. Not financial advice.</div>


### PR DESCRIPTION
## Summary

Wraps all karat price tables with `<figure itemscope itemtype="https://schema.org/Table">` and descriptive `<figcaption>` elements, enabling Google to recognise them as structured data tables for featured snippet extraction.

**Pages updated:**
- `14k-gold-price-per-gram.html` — price table + karat comparison table (2 tables)
- `18k-gold-price-per-gram.html` — price table (1 table)
- `10k-gold-price-per-gram.html` — price table (1 table)

**Already done (no changes needed):**
- `scrap-gold-calculator.html` — HowTo JSON-LD and numbered list steps were already implemented in a previous PR

## Test plan
- [ ] Validate with Rich Results Test — no schema errors
- [ ] Check that JS still populates table cells correctly (IDs unchanged)
- [ ] Verify tables render identically in browser

Closes #44

https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq

---
_Generated by [Claude Code](https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq)_