### PR TITLE
fix(seo/WP-05): correct canonical URL in image-sitemap + full sitemap audit

### DIFF
--- a/image-sitemap.xml
+++ b/image-sitemap.xml
@@ -119,11 +119,11 @@
     </image:image>
   </url>
   <url>
-    <loc>https://goldpricetools.com/guides/best-time-to-sell-scrap-gold</loc>
+    <loc>https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold</loc>
     <image:image>
       <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
       <image:title>When Is the Best Time to Sell Scrap Gold?</image:title>
-      <image:caption>Guide to timing scrap gold sales: what drives gold prices, seasonal patterns, and how to get the best price from dealers.</image:caption>
+      <image:caption>Guide to timing scrap gold sales: price signals, USD/GBP exchange rate factors, seasonal demand patterns and how to maximise your payout.</image:caption>
     </image:image>
   </url>
   <url>


### PR DESCRIPTION
## Summary

- Fixed incorrect canonical URL in `image-sitemap.xml`: `guides/best-time-to-sell-scrap-gold` → `guides/what-is-best-time-to-sell-scrap-gold` (the redirect stub was indexed instead of the real page)
- Updated image title/caption for that entry to match the canonical page

## Sitemap audit findings (no further changes needed)

- **sitemap.xml**: All 12 guide articles present ✅ — all 6 landing pages ✅ — all 4 utility pages (about/contact/privacy/terms) ✅ — correct `lastmod`, `priority`, `changefreq` on every entry ✅
- **image-sitemap.xml**: All non-redirect pages covered ✅ — now consistent with main sitemap ✅
- **offline.html** correctly excluded ✅ — redirect stubs correctly excluded ✅
- **robots.txt** already references both sitemaps via `Sitemap:` headers ✅

## Test plan

- [ ] Confirm `image-sitemap.xml` URL for `best-time-to-sell-scrap-gold` guide now resolves to a real page (not a redirect) by visiting the canonical URL
- [ ] Validate sitemap XML at https://validator.w3.org/feed/
- [ ] Confirm no 404s in Google Search Console after deploy

Closes #15

---
_Generated by [Claude Code](https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq)_