### PR TITLE
fix(seo/WP-60): allow /chart-data/ in robots.txt, add /api/ disallow

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -5,10 +5,11 @@
 User-agent: *
 Allow: /
 Allow: /?q=
+Allow: /chart-data/
 Disallow: /scripts/
 Disallow: /worker/
 Disallow: /workers/
-Disallow: /chart-data/
+Disallow: /api/
 Disallow: /*?
 
 Sitemap: https://goldpricetools.com/sitemap.xml
@@ -17,6 +18,7 @@ Sitemap: https://goldpricetools.com/image-sitemap.xml
 User-agent: Googlebot
 Allow: /
 Allow: /?q=
+Allow: /chart-data/
 Crawl-delay: 0
 
 User-agent: Googlebot-Image


### PR DESCRIPTION
## Summary

- Remove `Disallow: /chart-data/` — chart JSON files (price history data used by the interactive charts) should be crawlable so Google can discover the Dataset `distribution` URLs referenced in the Dataset JSON-LD schema added in #88
- Add explicit `Allow: /chart-data/` to both wildcard and Googlebot blocks (belt-and-suspenders against the `Disallow: /*?` catch-all)
- Add `Disallow: /api/` to block any future internal API/worker endpoints from crawling

## Audit findings (no other changes needed)

- All crawlable pages already allowed via `Allow: /` ✅
- Sensitive paths blocked: `/scripts/`, `/worker/`, `/workers/` ✅
- Both `Sitemap:` headers already present (`sitemap.xml`, `image-sitemap.xml`) ✅
- `AdsBot-Google` and `Googlebot-Image` already have correct rules ✅

## Test plan

- [ ] Fetch `https://goldpricetools.com/robots.txt` after deploy and confirm `/chart-data/` is not in any `Disallow:` line
- [ ] Test with Google's robots.txt tester: https://support.google.com/webmasters/answer/6062598
- [ ] Confirm `https://goldpricetools.com/chart-data/XAU-1Y.json` returns 200 and is not blocked

Closes #70

---
_Generated by [Claude Code](https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq)_