### PR TITLE
feat(nav/WP-06): add Guides section to mobile menu, sidebar, and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,9 +322,15 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <a href="/14k-gold-price-per-gram">14K Gold Price Per Gram</a>
   <a href="/18k-gold-price-per-gram">18K Gold Price Per Gram</a>
   <a href="/10k-gold-price-per-gram">10K Gold Price Per Gram</a>
-  <span class="menu-section">Silver &amp; Guides</span>
+  <span class="menu-section">Silver</span>
   <a href="/silver-price-per-kilo">Silver Price Per Kilo</a>
   <a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a>
+  <span class="menu-section">Guides</span>
+  <a href="/guides/what-is-14k-gold">What Is 14K Gold?</a>
+  <a href="/guides/how-to-calculate-scrap-gold">How to Calculate Scrap Gold</a>
+  <a href="/guides/gold-purity-guide">Gold Purity Guide</a>
+  <a href="/guides/gold-vs-silver-investment">Gold vs Silver Investment</a>
+  <a href="/guides/gold-price-history">Gold Price History</a>
   <span class="menu-section">Info</span>
   <a href="/about">About</a>
   <a href="/contact">Contact</a>
@@ -778,6 +784,18 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce <span>→</span></a>
       </div>
     </div>
+    <!-- SIDEBAR GUIDES -->
+    <div class="sidebar-widget">
+      <h3>Popular Guides</h3>
+      <div class="sidebar-nav">
+        <a href="/guides/what-is-14k-gold">What Is 14K Gold? <span>→</span></a>
+        <a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold Value <span>→</span></a>
+        <a href="/guides/gold-purity-guide">Gold Purity Guide <span>→</span></a>
+        <a href="/guides/gold-vs-silver-investment">Gold vs Silver Investment <span>→</span></a>
+        <a href="/guides/how-to-sell-gold-jewellery">Selling Gold Jewellery <span>→</span></a>
+        <a href="/guides/gold-price-history">Gold Price History <span>→</span></a>
+      </div>
+    </div>
     <!-- AD SLOT 3 — Sidebar, responsive -->
     <div class="ad-slot-sidebar" aria-label="Advertisement">
       <ins class="adsbygoogle"
@@ -820,12 +838,14 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Silver &amp; Guides</h4>
+      <h4>Guides</h4>
       <ul>
+        <li><a href="/guides/what-is-14k-gold">What Is 14K Gold?</a></li>
+        <li><a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a></li>
         <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
         <li><a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a></li>
-        <li><a href="/guides/what-is-14k-gold">What Is 14K Gold?</a></li>
-        <li><a href="/guides/how-to-calculate-scrap-gold">Scrap Gold Guide</a></li>
       </ul>
     </div>
     <div class="footer-col">


### PR DESCRIPTION
## Summary

Guides were accessible from the desktop top nav only. This PR surfaces them in all three secondary navigation surfaces on `index.html`:

**Mobile menu** — Split the misnamed "Silver & Guides" section (which had no guide links) into:
- `Silver` section: Silver Price Per Kilo, Grams in a Troy Ounce (unchanged)
- New `Guides` section: What Is 14K Gold, Calculate Scrap Gold, Gold Purity Guide, Gold vs Silver Investment, Gold Price History

**Sidebar** — New "Popular Guides" widget added above the ad slot, using the existing `sidebar-nav` style, with 6 guide links.

**Footer** — Renamed "Silver & Guides" column to "Guides" and replaced with 4 guide article links (14K gold, scrap gold calc, purity guide, gold vs silver). Silver tool links (Silver Per Kilo, Grams in Troy Oz) kept at the bottom of the column.

## Test plan

- [ ] Open the site on a mobile viewport (≤768px) and confirm the hamburger menu now shows a "Guides" section with guide links
- [ ] Verify the sidebar "Popular Guides" widget renders correctly in the desktop two-column layout
- [ ] Verify footer "Guides" column shows article links, not the old "Silver & Guides" mix
- [ ] Test all new links for correct destination pages (no 404s)

Closes #16

---
_Generated by [Claude Code](https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq)_