### PR TITLE
fix(seo/WP-50): add noscript fallback for JS-rendered karat price grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,6 +566,16 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <div class="karat-grid" id="karatGrid">
         <!-- populated by JS -->
       </div>
+      <noscript>
+        <p style="margin:1rem 0;color:var(--color-text-muted);font-size:.9375rem">JavaScript is required to display live prices. View individual karat price pages:</p>
+        <ul style="margin:.5rem 0 1rem 1.5rem;color:var(--color-text-muted);font-size:.9375rem;line-height:2">
+          <li><a href="/14k-gold-price-per-gram">14K Gold Price Per Gram (58.33% pure)</a></li>
+          <li><a href="/18k-gold-price-per-gram">18K Gold Price Per Gram (75% pure)</a></li>
+          <li><a href="/10k-gold-price-per-gram">10K Gold Price Per Gram (41.67% pure)</a></li>
+          <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+          <li><a href="/silver-price-per-kilo">Silver Price Per Kilogram</a></li>
+        </ul>
+      </noscript>
 
       <!-- CHARTS -->
       <section id="charts" class="chart-section" aria-label="Gold price chart">


### PR DESCRIPTION
## Summary

JS SEO audit: verifying Googlebot can see karat tables, price data, and lazy-loaded content.

**Googlebot CAN execute JavaScript** (Chrome headless, second-wave rendering ~5–10s after first crawl). Most content is fine. One structural gap fixed here.

### Audit findings

| Content | Static HTML? | Googlebot sees it? | Action |
|---------|-------------|-------------------|--------|
| Scrap gold table rows (karat labels, purity %) | ✅ Yes | ✅ Yes | None |
| Landing page price tables (14K/18K/10K structure) | ✅ Yes | ✅ Yes | None |
| FAQ section, guide text, hero copy | ✅ Yes | ✅ Yes | None |
| `data-nosnippet` on price cells | ✅ Correct usage | N/A | None |
| Karat price card grid (`#karatGrid`) | ❌ Empty div | ⚠️ Only after JS | Fixed |

### Fix applied

`#karatGrid` is an empty `<div>` in the static HTML — all card content (karat name, purity, price rows) is created via `card.innerHTML` in JS. Added `<noscript>` block with links to each karat landing page. This:
1. Gives crawlers that don't execute JS a crawlable link to each landing page
2. Transfers link equity to the dedicated karat pages
3. Gracefully degrades for users with JS disabled

### Not fixed here (separate architectural issue)

Pre-rendering static card skeletons in HTML that JS then updates in-place would be a better long-term solution. This removes the JS dependency for initial card discovery. Recommend filing a separate issue.

## Test plan

- [ ] Disable JS in browser devtools, load `index.html` — verify the noscript block with links appears in place of the karat grid
- [ ] Confirm the noscript block is invisible in a normal JS-enabled browser session
- [ ] Check Google's Mobile-Friendly Test on the live URL after deploy

Closes #60

---
_Generated by [Claude Code](https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq)_