### PR TITLE
fix(cwv/WP-51): reserve ad slot height to reduce CLS + full CWV audit

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 .mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
 
 /* AD SLOTS */
-.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4)}
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px;contain:layout}
 .ad-slot ins{display:block;width:100%}
 .ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
 .ad-slot-sidebar ins{display:block;width:100%}


### PR DESCRIPTION
## Summary

Core Web Vitals code-review audit. PageSpeed Insights API was not reachable from the CI environment — **please run these manually after deploy:**
- https://pagespeed.web.dev/report?url=https://goldpricetools.com
- https://pagespeed.web.dev/report?url=https://goldpricetools.com/scrap-gold-calculator
- https://pagespeed.web.dev/report?url=https://goldpricetools.com/guides/how-to-calculate-scrap-gold

### CWV findings

**CLS — HIGH RISK, fixed here:**
- `.ad-slot` (3 non-sidebar slots) had no `min-height` — collapsed to 0px then expanded when ads loaded. Added `min-height:100px` and `contain:layout` to pre-reserve space and confine layout effects.
- `.ad-slot-sidebar` already had `min-height:250px` ✅

**CLS — LOW RISK, no change:**
- Ticker bar has `height:36px` fixed — content fills a fixed container ✅
- Hero spot-cards sized by CSS grid — JS fills values without geometry change ✅

**LCP:**
- No above-fold images → LCP candidate is the `<h1>` text, which renders with initial HTML paint
- Fonts loaded via Google Fonts with `preconnect` hints ✅
- Recommendation: verify LCP < 2.5s in PageSpeed after deploy

**INP:**
- All heavy third-party scripts (AdSense, GA4) loaded `async` ✅
- 60s price update interval minimal main-thread impact ✅
- Monitor AdSense long tasks in Chrome DevTools Performance panel

### Follow-up recommendations (not in this PR)

1. Lazy-load the above-footer multiplex ad (#9961009949) via IntersectionObserver — it's well below the fold
2. Pre-render static karat card skeletons in HTML (see #60 for context)
3. Set up monthly PageSpeed monitoring in Google Search Console CrUX dashboard

## Test plan

- [ ] Run PageSpeed Insights on the 3 URLs listed above after deploy
- [ ] Confirm CLS score improves (target < 0.1)
- [ ] Confirm ad slots visually have a reserved height space before ads load

Closes #61

---
_Generated by [Claude Code](https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq)_