### PR TITLE
Add new Tier-1 SEO guide for gold and silver price today

### DIFF
--- a/gold-and-silver-price-today/index.html
+++ b/gold-and-silver-price-today/index.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Gold and Silver Price Today (Live) — GoldPriceTools</title>
+<meta name="description" content="Live gold and silver price today per ounce, gram, and kilo in GBP and USD. Updated every 60 seconds from the spot market.">
+<meta name="robots" content="index, follow">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/gold-and-silver-price-today/">
+<link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/gold-and-silver-price-today/">
+<link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/gold-and-silver-price-today/">
+<link rel="canonical" href="https://goldpricetools.com/gold-and-silver-price-today/">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/gold-and-silver-price-today/"},"headline":"Gold and Silver Price Today","description":"Live gold and silver price today per ounce, gram, and kilo in GBP and USD. Updated every 60 seconds from the spot market.","author":{"@type":"Organization","name":"GoldPriceTools"},"publisher":{"@type":"Organization","name":"GoldPriceTools","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.png"}}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Gold and Silver Price Today","item":"https://goldpricetools.com/gold-and-silver-price-today/"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the gold and silver price today?","acceptedAnswer":{"@type":"Answer","text":"The live gold and silver price today is updated every 60 seconds on our website, pulling directly from global spot markets."}},{"@type":"Question","name":"Why track both gold and silver prices?","acceptedAnswer":{"@type":"Answer","text":"Tracking both gold and silver prices allows investors to monitor the gold-to-silver ratio, a popular metric for determining which metal offers better value at a given time."}}]}</script>
+<meta property="og:title" content="Gold and Silver Price Today (Live)">
+<meta property="og:description" content="Live gold and silver price today per ounce, gram, and kilo in GBP and USD. Updated every 60 seconds.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://goldpricetools.com/gold-and-silver-price-today/">
+<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
+<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
+<script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
+<script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
+<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="/assets/logo.svg"><meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<style>
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+:root{--color-bg:#0f0e0c;--color-surface:#1c1a17;--color-border:#2a2824;--color-text:#f0e6d2;--color-text-muted:#a39b8a;--color-accent:#d4af37}
+body{background:var(--color-bg);color:var(--color-text);font-family:Inter,system-ui,sans-serif;margin:0;padding:0;line-height:1.6}
+nav{border-bottom:1px solid var(--color-border);padding:1rem}
+.nav-inner{max-width:800px;margin:0 auto;display:flex;justify-content:space-between;align-items:center}
+.nav-logo{font-family:'Instrument Serif',serif;font-size:1.5rem;color:var(--color-accent);text-decoration:none;display:flex;align-items:center;gap:.5rem}
+.breadcrumb-wrap{max-width:800px;margin:0 auto;padding:1.5rem 1rem 0}
+.breadcrumb{display:flex;list-style:none;padding:0;margin:0;font-size:.875rem;color:var(--color-text-muted)}
+.breadcrumb li::after{content:'›';margin:0 .5rem}
+.breadcrumb li:last-child::after{content:''}
+.breadcrumb a{color:inherit;text-decoration:none}
+.breadcrumb a:hover{text-decoration:underline}
+.hero{max-width:800px;margin:2rem auto;padding:0 1rem;text-align:center}
+.hero-tag{display:inline-block;padding:.25rem .75rem;background:var(--color-surface);border:1px solid var(--color-border);border-radius:100px;font-size:.875rem;color:var(--color-accent);margin-bottom:1rem}
+.hero-title{font-family:'Instrument Serif',serif;font-size:clamp(2.5rem,8vw,4rem);line-height:1.1;margin:0 0 1rem;font-weight:400}
+.price-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:1rem;margin:2rem 0}
+.price-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:12px;padding:1.5rem;text-align:center}
+.price-tile-label{font-size:.875rem;color:var(--color-text-muted);margin-bottom:.5rem}
+.price-tile-value{font-size:1.5rem;font-weight:600;font-variant-numeric:tabular-nums}
+.content{max-width:800px;margin:0 auto;padding:0 1rem 4rem}
+.trust-bar{display:flex;flex-wrap:wrap;justify-content:center;gap:1rem;padding:1rem;background:var(--color-surface);border-radius:8px;font-size:.875rem;color:var(--color-text-muted);margin-bottom:3rem}
+.trust-bar a{color:var(--color-text-muted);text-decoration:underline}
+.prose h2{font-family:'Instrument Serif',serif;font-size:2rem;font-weight:400;margin:2.5rem 0 1rem}
+.prose p{margin-bottom:1.5rem;color:var(--color-text)}
+.data-table{width:100%;border-collapse:collapse;margin:2rem 0;font-variant-numeric:tabular-nums}
+.data-table th,.data-table td{padding:1rem;border-bottom:1px solid var(--color-border);text-align:left}
+.data-table th{color:var(--color-text-muted);font-weight:500;font-size:.875rem}
+.data-table td{font-size:.9375rem}
+.data-table tr:hover{background:var(--color-surface)}
+.disclaimer{font-size:.875rem;color:var(--color-text-muted);padding:1rem;background:var(--color-surface);border-radius:8px;margin-top:3rem}
+.ad-slot{margin:2rem auto;text-align:center;min-height:280px;background:var(--color-surface);display:flex;align-items:center;justify-content:center;border-radius:8px;border:1px solid var(--color-border);position:relative;overflow:hidden;}
+.ad-slot::before{content:'Advertisement';position:absolute;top:0;left:0;right:0;font-size:0.65rem;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:1px;padding:4px 0;background:var(--color-bg);border-bottom:1px solid var(--color-border);z-index:1}
+footer{border-top:1px solid var(--color-border);padding:3rem 1rem;text-align:center;font-size:.875rem;color:var(--color-text-muted)}
+footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+.share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+</style>
+</head>
+<body>
+<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
+<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">Gold and Silver Price Today</li></ol></div>
+<div class="hero">
+  <div class="hero-tag">Live Market Prices</div>
+  <h1 class="hero-title">Gold and Silver Price Today</h1>
+  <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Check the live gold and silver price today per ounce, gram, and kilo. Updated every 60 seconds from the global spot market.</p>
+
+  <h2 style="font-family:'Instrument Serif',serif;font-size:2rem;font-weight:400;margin:2rem 0 1rem;text-align:left;">Gold Spot Price</h2>
+  <div class="price-grid">
+    <div class="price-tile"><div class="price-tile-label">Per Troy Oz (USD)</div><div class="price-tile-value" id="g-oz-usd" data-nosnippet>&mdash;</div></div>
+    <div class="price-tile"><div class="price-tile-label">Per Gram (USD)</div><div class="price-tile-value" id="g-g-usd" data-nosnippet>&mdash;</div></div>
+    <div class="price-tile"><div class="price-tile-label">Per Troy Oz (GBP)</div><div class="price-tile-value" id="g-oz-gbp" data-nosnippet>&mdash;</div></div>
+    <div class="price-tile"><div class="price-tile-label">Per Gram (GBP)</div><div class="price-tile-value" id="g-g-gbp" data-nosnippet>&mdash;</div></div>
+  </div>
+
+  <h2 style="font-family:'Instrument Serif',serif;font-size:2rem;font-weight:400;margin:2rem 0 1rem;text-align:left;">Silver Spot Price</h2>
+  <div class="price-grid">
+    <div class="price-tile"><div class="price-tile-label">Per Troy Oz (USD)</div><div class="price-tile-value" id="s-oz-usd" data-nosnippet>&mdash;</div></div>
+    <div class="price-tile"><div class="price-tile-label">Per Kilo (USD)</div><div class="price-tile-value" id="s-kg-usd" data-nosnippet>&mdash;</div></div>
+    <div class="price-tile"><div class="price-tile-label">Per Troy Oz (GBP)</div><div class="price-tile-value" id="s-oz-gbp" data-nosnippet>&mdash;</div></div>
+    <div class="price-tile"><div class="price-tile-label">Per Kilo (GBP)</div><div class="price-tile-value" id="s-kg-gbp" data-nosnippet>&mdash;</div></div>
+  </div>
+</div>
+
+<div class="content">
+  <div class="trust-bar">Live prices sourced from spot market &middot; Updated every 60 seconds &middot; <a href="/about.html">About our data</a></div>
+
+  <div class="ad-slot">
+    <!-- Ad space -->
+  </div>
+
+  <div class="prose">
+    <h2>Why the Gold and Silver Price Today Matters</h2>
+    <p>Monitoring the gold and silver price today provides essential insight into the precious metals market. Investors often use these spot prices to determine value, spot trends, and calculate the gold-to-silver ratio. The live spot prices shown above represent the global market rate for 24k gold and .999 fine silver.</p>
+
+    <h2>Live Gold & Silver Prices by Weight</h2>
+    <table class="data-table" aria-label="Live gold and silver price by weight">
+      <thead><tr><th>Metal & Weight</th><th>USD (live)</th><th>GBP (live)</th></tr></thead>
+      <tbody>
+        <tr><td>Gold - 1 Gram</td><td id="t-gold-1g-usd" data-nosnippet>&mdash;</td><td id="t-gold-1g-gbp" data-nosnippet>&mdash;</td></tr>
+        <tr><td>Gold - 1 Troy Ounce</td><td id="t-gold-oz-usd" data-nosnippet>&mdash;</td><td id="t-gold-oz-gbp" data-nosnippet>&mdash;</td></tr>
+        <tr><td>Gold - 1 Kilogram</td><td id="t-gold-1k-usd" data-nosnippet>&mdash;</td><td id="t-gold-1k-gbp" data-nosnippet>&mdash;</td></tr>
+        <tr><td>Silver - 1 Gram</td><td id="t-silver-1g-usd" data-nosnippet>&mdash;</td><td id="t-silver-1g-gbp" data-nosnippet>&mdash;</td></tr>
+        <tr><td>Silver - 1 Troy Ounce</td><td id="t-silver-oz-usd" data-nosnippet>&mdash;</td><td id="t-silver-oz-gbp" data-nosnippet>&mdash;</td></tr>
+        <tr><td>Silver - 1 Kilogram</td><td id="t-silver-1k-usd" data-nosnippet>&mdash;</td><td id="t-silver-1k-gbp" data-nosnippet>&mdash;</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Tools & Calculators</h2>
+    <p>Use our detailed tools to calculate specific karat values or value your items based on weight:</p>
+    <ul>
+      <li><a href="/scrap-gold-calculator.html">Scrap Gold Calculator</a></li>
+      <li><a href="/10k-gold-price-per-gram.html">10K Gold Price Per Gram</a></li>
+      <li><a href="/silver-price-per-kilo.html">Silver Price Per Kilo</a></li>
+    </ul>
+
+    <div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative spot values and do not include dealer premiums. Physical gold and silver typically sell at a premium above spot. Not financial advice.</div>
+  </div>
+</div>
+<div class="content" style="padding-bottom:1.5rem">
+<!-- Social share buttons (WP-34) -->
+<div class="share-buttons">
+  <span>Share:</span>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/gold-and-silver-price-today/&text=Gold+and+Silver+Price+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/gold-and-silver-price-today/&title=Gold+and+Silver+Price+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=Gold+and+Silver+Price+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fgold-and-silver-price-today%2F" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+</div>
+</div>
+<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
+<script>
+async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
+async function fetchPrices(){
+  try{
+    const [goldRes, silverRes] = await Promise.all([
+      fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'}),
+      fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'})
+    ]);
+    if(!goldRes.ok || !silverRes.ok)throw new Error();
+    const goldData = await goldRes.json();
+    const silverData = await silverRes.json();
+
+    const gbpusd=window._gbpusd||0.79;
+
+    // Gold math
+    const goldOzUSD = goldData.price;
+    const goldOzGBP = goldOzUSD * gbpusd;
+    const goldPerG_USD = goldOzUSD / 31.1035;
+    const goldPerG_GBP = goldOzGBP / 31.1035;
+
+    document.getElementById('g-oz-usd').textContent = '$' + goldOzUSD.toFixed(2);
+    document.getElementById('g-oz-gbp').textContent = '£' + goldOzGBP.toFixed(2);
+    document.getElementById('g-g-usd').textContent = '$' + goldPerG_USD.toFixed(2);
+    document.getElementById('g-g-gbp').textContent = '£' + goldPerG_GBP.toFixed(2);
+
+    document.getElementById('t-gold-1g-usd').textContent = '$' + goldPerG_USD.toFixed(2);
+    document.getElementById('t-gold-1g-gbp').textContent = '£' + goldPerG_GBP.toFixed(2);
+    document.getElementById('t-gold-oz-usd').textContent = '$' + goldOzUSD.toFixed(2);
+    document.getElementById('t-gold-oz-gbp').textContent = '£' + goldOzGBP.toFixed(2);
+    document.getElementById('t-gold-1k-usd').textContent = '$' + (goldPerG_USD * 1000).toFixed(2);
+    document.getElementById('t-gold-1k-gbp').textContent = '£' + (goldPerG_GBP * 1000).toFixed(2);
+
+    // Silver math
+    const silverOzUSD = silverData.price;
+    const silverOzGBP = silverOzUSD * gbpusd;
+    const silverPerG_USD = silverOzUSD / 31.1035;
+    const silverPerG_GBP = silverOzGBP / 31.1035;
+    const silverPerKg_USD = silverPerG_USD * 1000;
+    const silverPerKg_GBP = silverPerG_GBP * 1000;
+
+    document.getElementById('s-oz-usd').textContent = '$' + silverOzUSD.toFixed(2);
+    document.getElementById('s-oz-gbp').textContent = '£' + silverOzGBP.toFixed(2);
+    document.getElementById('s-kg-usd').textContent = '$' + silverPerKg_USD.toFixed(2);
+    document.getElementById('s-kg-gbp').textContent = '£' + silverPerKg_GBP.toFixed(2);
+
+    document.getElementById('t-silver-1g-usd').textContent = '$' + silverPerG_USD.toFixed(2);
+    document.getElementById('t-silver-1g-gbp').textContent = '£' + silverPerG_GBP.toFixed(2);
+    document.getElementById('t-silver-oz-usd').textContent = '$' + silverOzUSD.toFixed(2);
+    document.getElementById('t-silver-oz-gbp').textContent = '£' + silverOzGBP.toFixed(2);
+    document.getElementById('t-silver-1k-usd').textContent = '$' + silverPerKg_USD.toFixed(2);
+    document.getElementById('t-silver-1k-gbp').textContent = '£' + silverPerKg_GBP.toFixed(2);
+
+    gtag('event','price_view',{page:'gold_and_silver'});
+  }catch(e){
+    console.warn('Price fetch failed',e);
+  }
+}
+Promise.all([fetchFx()]).then(fetchPrices);
+setInterval(fetchPrices,60000);
+</script>
+<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+<script>
+let _deepReadFired = false;
+window.addEventListener('scroll', () => {
+  if (_deepReadFired) return;
+  const scrollTop = window.scrollY || document.documentElement.scrollTop;
+  const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+  if (scrollHeight > 0 && (scrollTop / scrollHeight) > 0.75) {
+    gtag('event', 'guide_deep_read');
+    _deepReadFired = true;
+  }
+}, { passive: true });
+</script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -280,6 +280,18 @@
     </image:image>
   </url>
 
+
+  <!-- ===== NEW GUIDE ===== -->
+  <url>
+    <loc>https://goldpricetools.com/gold-and-silver-price-today/</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>always</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/gold-and-silver-price-today/"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/gold-and-silver-price-today/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/gold-and-silver-price-today/"/>
+  </url>
+
   <!-- ===== UTILITY / LEGAL PAGES ===== -->
   <url>
     <loc>https://goldpricetools.com/about</loc>


### PR DESCRIPTION
This PR adds a new Tier-1 SEO guide page targeting the keyword "gold and silver price today" at `/gold-and-silver-price-today/`. It follows the layout of `/silver-price-per-kilo/index.html`, includes GA4 events with passive listeners, adds the URL to `sitemap.xml`, and provides Article + BreadcrumbList JSON-LD schema. Prices for both gold and silver are pulled via the existing JS fetchers.

Closes #56

---
*PR created automatically by Jules for task [17194763821412735142](https://jules.google.com/task/17194763821412735142) started by @DigitalCliqs*