### PR TITLE
tooling: auto-generate sitemap.xml on push to main

### DIFF
--- a/.github/workflows/sitemap.yml
+++ b/.github/workflows/sitemap.yml
@@ -1,0 +1,33 @@
+name: Generate Sitemap
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.html'
+      - 'scripts/generate-sitemap.js'
+      - '.github/workflows/sitemap.yml'
+
+jobs:
+  generate-sitemap:
+    name: Auto-generate sitemap.xml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate sitemap
+        run: node scripts/generate-sitemap.js
+
+      - name: Commit updated sitemap
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: regenerate sitemap.xml [skip ci]"
+          file_pattern: sitemap.xml

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Sitemap generator — scans all HTML pages, extracts canonical URLs + hreflang
+ * alternates, derives lastmod from git history, and writes sitemap.xml.
+ *
+ * Priority / changefreq table mirrors the hand-maintained sitemap:
+ *   /                                   → 1.0  hourly
+ *   /10k|14k|18k-gold-price-per-gram    → 0.95 hourly
+ *   /scrap-gold-calculator              → 0.9  hourly
+ *   /silver-price-per-kilo              → 0.9  hourly
+ *   /gold-and-silver-price-today/       → 0.9  always
+ *   /guides/what-is-14k-gold            → 0.8  monthly
+ *   /guides/how-to-calculate-scrap-gold → 0.8  monthly
+ *   /guides/*                           → 0.75 monthly
+ *   /how-many-grams-in-troy-ounce       → 0.75 monthly
+ *   /about | /contact                   → 0.4  yearly
+ *   /privacy-policy | /terms            → 0.3  yearly
+ *
+ * Run via: node scripts/generate-sitemap.js
+ */
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ROOT = process.cwd();
+const SITEMAP_PATH = path.join(ROOT, 'sitemap.xml');
+const DEFAULT_IMAGE = 'https://goldpricetools.com/assets/og-image.jpg';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function findHtmlFiles(dir, files = []) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return files; }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) findHtmlFiles(full, files);
+    else if (entry.name.endsWith('.html')) files.push(full);
+  }
+  return files;
+}
+
+function extractAttr(html, tagPattern, attrName) {
+  const re = new RegExp(`<${tagPattern}([^>]+)>`, 'i');
+  const tagMatch = html.match(re);
+  if (!tagMatch) return null;
+  const attrMatch = tagMatch[1].match(new RegExp(`${attrName}=["']([^"']+)["']`, 'i'));
+  return attrMatch ? attrMatch[1] : null;
+}
+
+function extractCanonical(content) {
+  const m = content.match(/<link([^>]+)>/gi);
+  if (!m) return null;
+  for (const tag of m) {
+    if (/rel=["']canonical["']/i.test(tag)) {
+      const h = tag.match(/href=["']([^"']+)["']/i);
+      if (h) return h[1];
+    }
+  }
+  return null;
+}
+
+function extractHreflang(content) {
+  const links = [];
+  const re = /<link([^>]+)>/gi;
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    const attrs = m[1];
+    if (!/rel=["']alternate["']/i.test(attrs)) continue;
+    const hreflangM = attrs.match(/hreflang=["']([^"']+)["']/i);
+    const hrefM = attrs.match(/href=["']([^"']+)["']/i);
+    if (hreflangM && hrefM) links.push({ hreflang: hreflangM[1], href: hrefM[1] });
+  }
+  return links;
+}
+
+function extractOg(content, property) {
+  // Try double-quoted then single-quoted content attribute, in both attribute orders.
+  // Kept separate so apostrophes in content values aren't mis-treated as delimiters.
+  const patterns = [
+    new RegExp(`<meta[^>]+property=["']${property}["'][^>]+content="([^"]+)"`, 'i'),
+    new RegExp(`<meta[^>]+content="([^"]+)"[^>]+property=["']${property}["']`, 'i'),
+    new RegExp(`<meta[^>]+property=["']${property}["'][^>]+content='([^']+)'`, 'i'),
+    new RegExp(`<meta[^>]+content='([^']+)'[^>]+property=["']${property}["']`, 'i'),
+  ];
+  for (const re of patterns) {
+    const m = content.match(re);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+function getLastmod(filePath) {
+  try {
+    const rel = path.relative(ROOT, filePath);
+    const date = execSync(`git log -1 --format=%cs -- "${rel}"`, { cwd: ROOT }).toString().trim();
+    return date || todayIso();
+  } catch {
+    return todayIso();
+  }
+}
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getSchedule(url) {
+  const p = url.replace('https://goldpricetools.com', '') || '/';
+  if (p === '/') return { priority: '1.0', changefreq: 'hourly' };
+  if (/^\/(10|14|18)k-gold-price-per-gram$/.test(p)) return { priority: '0.95', changefreq: 'hourly' };
+  if (/^\/(scrap-gold-calculator|silver-price-per-kilo)$/.test(p)) return { priority: '0.9', changefreq: 'hourly' };
+  if (p === '/gold-and-silver-price-today/') return { priority: '0.9', changefreq: 'always' };
+  if (/^\/guides\/(what-is-14k-gold|how-to-calculate-scrap-gold)$/.test(p)) return { priority: '0.8', changefreq: 'monthly' };
+  if (p.startsWith('/guides/')) return { priority: '0.75', changefreq: 'monthly' };
+  if (/^\/(about|contact)$/.test(p)) return { priority: '0.4', changefreq: 'yearly' };
+  if (/^\/(privacy-policy|terms)$/.test(p)) return { priority: '0.3', changefreq: 'yearly' };
+  return { priority: '0.75', changefreq: 'monthly' };
+}
+
+function wantsImage(url) {
+  const p = url.replace('https://goldpricetools.com', '') || '/';
+  return !/^\/(about|contact|privacy-policy|terms)$/.test(p);
+}
+
+function xmlEsc(str) {
+  // HTML already uses &amp; for &, which is valid XML — only escape bare & and < >
+  return str
+    .replace(/&(?!amp;|lt;|gt;|quot;|apos;)/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// ── scan ──────────────────────────────────────────────────────────────────────
+
+const htmlFiles = findHtmlFiles(ROOT);
+const seen = new Set();
+const pages = [];
+
+for (const file of htmlFiles) {
+  let content;
+  try { content = fs.readFileSync(file, 'utf8'); } catch { continue; }
+
+  // Skip redirect stubs (meta refresh)
+  if (/<meta[^>]+http-equiv=["']refresh["']/i.test(content)) continue;
+
+  const canonical = extractCanonical(content);
+  if (!canonical) continue;
+  if (seen.has(canonical)) continue;
+  seen.add(canonical);
+
+  const lastmod = getLastmod(file);
+  const schedule = getSchedule(canonical);
+  const hreflang = extractHreflang(content);
+  const imgUrl = extractOg(content, 'og:image') || DEFAULT_IMAGE;
+  const imgTitle = extractOg(content, 'og:title') || '';
+  const imgDesc = extractOg(content, 'og:description') || '';
+  const isHomepage = canonical === 'https://goldpricetools.com/';
+
+  pages.push({ canonical, lastmod, schedule, hreflang, imgUrl, imgTitle, imgDesc, isHomepage });
+}
+
+// Sort: priority descending, URL ascending within same priority
+pages.sort((a, b) => {
+  const pd = parseFloat(b.schedule.priority) - parseFloat(a.schedule.priority);
+  return pd !== 0 ? pd : a.canonical.localeCompare(b.canonical);
+});
+
+// ── render ────────────────────────────────────────────────────────────────────
+
+const lines = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
+  '        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"',
+  '        xmlns:xhtml="http://www.w3.org/1999/xhtml">',
+  '',
+];
+
+for (const { canonical, lastmod, schedule, hreflang, imgUrl, imgTitle, imgDesc, isHomepage } of pages) {
+  lines.push('  <url>');
+  lines.push(`    <loc>${canonical}</loc>`);
+  lines.push(`    <lastmod>${lastmod}</lastmod>`);
+  lines.push(`    <changefreq>${schedule.changefreq}</changefreq>`);
+  lines.push(`    <priority>${schedule.priority}</priority>`);
+  for (const { hreflang: lang, href } of hreflang) {
+    lines.push(`    <xhtml:link rel="alternate" hreflang="${lang}" href="${href}"/>`);
+  }
+  if (wantsImage(canonical)) {
+    lines.push('    <image:image>');
+    lines.push(`      <image:loc>${imgUrl}</image:loc>`);
+    if (imgTitle) lines.push(`      <image:title>${xmlEsc(imgTitle)}</image:title>`);
+    if (imgDesc)  lines.push(`      <image:caption>${xmlEsc(imgDesc)}</image:caption>`);
+    if (isHomepage) lines.push('      <image:geo_location>United Kingdom</image:geo_location>');
+    lines.push('    </image:image>');
+  }
+  lines.push('  </url>');
+  lines.push('');
+}
+
+lines.push('</urlset>');
+lines.push('');
+
+fs.writeFileSync(SITEMAP_PATH, lines.join('\n'), 'utf8');
+console.log(`✅ sitemap.xml written — ${pages.length} URL(s)`);

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,10 +3,9 @@
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
 
-  <!-- ===== HOMEPAGE ===== -->
   <url>
     <loc>https://goldpricetools.com/</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>hourly</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/"/>
@@ -14,44 +13,15 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/"/>
     <image:image>
       <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>GoldPriceTools – Live Gold and Silver Price Calculator</image:title>
-      <image:caption>Free real-time gold and silver calculator showing live 10K, 14K, 18K and 24K gold price per gram, scrap gold value, and silver spot price.</image:caption>
+      <image:title>Gold &amp; Silver Price Calculator — Live Prices Per Gram</image:title>
+      <image:caption>Real-time 10K, 14K, 18K, 24K gold price per gram. Scrap gold &amp; silver calculators updated every 60 seconds.</image:caption>
       <image:geo_location>United Kingdom</image:geo_location>
     </image:image>
   </url>
 
-  <!-- ===== GOLD LANDING PAGES ===== -->
-  <url>
-    <loc>https://goldpricetools.com/14k-gold-price-per-gram</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>0.95</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/14k-gold-price-per-gram"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/14k-gold-price-per-gram"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/14k-gold-price-per-gram"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>14K Gold Price Per Gram Today — Live GoldPriceTools</image:title>
-      <image:caption>Live 14K gold price per gram in USD, GBP and EUR. 14 karat gold is 58.33% pure. Updated every 60 seconds.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/18k-gold-price-per-gram</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>hourly</changefreq>
-    <priority>0.95</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/18k-gold-price-per-gram"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/18k-gold-price-per-gram"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/18k-gold-price-per-gram"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>18K Gold Price Per Gram Today — Live GoldPriceTools</image:title>
-      <image:caption>Live 18K gold price per gram in USD, GBP and EUR. 18 karat gold is 75% pure — the most popular karat for fine jewellery. Updated every 60 seconds.</image:caption>
-    </image:image>
-  </url>
   <url>
     <loc>https://goldpricetools.com/10k-gold-price-per-gram</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.95</priority>
     <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/10k-gold-price-per-gram"/>
@@ -59,229 +29,41 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/10k-gold-price-per-gram"/>
     <image:image>
       <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>10K Gold Price Per Gram Today — Live GoldPriceTools</image:title>
-      <image:caption>Live 10K gold price per gram in USD, GBP and EUR. 10 karat gold is 41.67% pure. Updated every 60 seconds.</image:caption>
+      <image:title>10K Gold Price Per Gram Today (Live)</image:title>
+      <image:caption>Real-time 10K gold price per gram in GBP and USD. 41.67% pure gold. Updated every 60 seconds.</image:caption>
     </image:image>
   </url>
+
   <url>
-    <loc>https://goldpricetools.com/scrap-gold-calculator</loc>
-    <lastmod>2026-04-26</lastmod>
+    <loc>https://goldpricetools.com/14k-gold-price-per-gram</loc>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>hourly</changefreq>
-    <priority>0.9</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/scrap-gold-calculator"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/scrap-gold-calculator"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/scrap-gold-calculator"/>
+    <priority>0.95</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/14k-gold-price-per-gram"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/14k-gold-price-per-gram"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/14k-gold-price-per-gram"/>
     <image:image>
       <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>Scrap Gold Calculator — Live Melt Value by Karat</image:title>
-      <image:caption>Free scrap gold calculator showing live melt value for 9K, 10K, 14K, 18K and 24K gold by weight in grams.</image:caption>
+      <image:title>14K Gold Price Per Gram Today (Live)</image:title>
+      <image:caption>Real-time 14K gold price per gram in USD, GBP, EUR. 58.33% pure gold. Updated every 60 seconds.</image:caption>
     </image:image>
   </url>
 
-  <!-- ===== SILVER LANDING PAGES ===== -->
   <url>
-    <loc>https://goldpricetools.com/silver-price-per-kilo</loc>
-    <lastmod>2026-04-26</lastmod>
+    <loc>https://goldpricetools.com/18k-gold-price-per-gram</loc>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>hourly</changefreq>
-    <priority>0.9</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/silver-price-per-kilo"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/silver-price-per-kilo"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/silver-price-per-kilo"/>
+    <priority>0.95</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/18k-gold-price-per-gram"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/18k-gold-price-per-gram"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/18k-gold-price-per-gram"/>
     <image:image>
       <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>Silver Price Per Kilo Today — Live GoldPriceTools</image:title>
-      <image:caption>Live silver price per kilogram in USD and GBP. Also shows .999 fine and 925 sterling silver. Updated every 60 seconds.</image:caption>
+      <image:title>18K Gold Price Per Gram Today (Live)</image:title>
+      <image:caption>Real-time 18K gold price per gram in GBP and USD. 75% pure gold. Updated every 60 seconds.</image:caption>
     </image:image>
   </url>
 
-  <!-- ===== UTILITY / CONVERTER PAGES ===== -->
-  <url>
-    <loc>https://goldpricetools.com/how-many-grams-in-troy-ounce</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/how-many-grams-in-troy-ounce"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/how-many-grams-in-troy-ounce"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/how-many-grams-in-troy-ounce"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>How Many Grams in a Troy Ounce — Weight Converter</image:title>
-      <image:caption>1 troy ounce = 31.1035 grams. Gold and silver weight converter: grams, troy ounces, pennyweight and kilograms.</image:caption>
-    </image:image>
-  </url>
-
-  <!-- ===== GUIDES ===== -->
-  <url>
-    <loc>https://goldpricetools.com/guides/what-is-14k-gold</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/what-is-14k-gold"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-14k-gold"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-14k-gold"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>What Is 14K Gold? Purity, Value and How to Identify It</image:title>
-      <image:caption>Guide to 14K gold: what 58.33% purity means, hallmarks to look for, and how to calculate value at today's spot price.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/how-to-calculate-scrap-gold</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>How to Calculate Scrap Gold Value — Step by Step Guide</image:title>
-      <image:caption>Step-by-step guide to calculating scrap gold value using live spot price, weight and karat purity.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/troy-ounce-vs-gram-explained</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>Troy Ounce vs Gram — The Complete Precious Metals Guide</image:title>
-      <image:caption>Why precious metals are weighed in troy ounces (31.1035g) and how to convert between gold weight units.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/gold-purity-guide</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/gold-purity-guide"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-purity-guide"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-purity-guide"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>Gold Purity Guide — 9K to 24K Karats Explained</image:title>
-      <image:caption>Complete gold karat purity guide from 9K to 24K: what each karat means, hallmarks, uses and current melt value.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/what-is-925-sterling-silver</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/what-is-925-sterling-silver"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-925-sterling-silver"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-925-sterling-silver"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>What Is 925 Sterling Silver and How Much Is It Worth?</image:title>
-      <image:caption>Guide to 925 sterling silver: 92.5% purity, hallmarks, jewellery uses and live melt value calculator.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>When Is the Best Time to Sell Scrap Gold?</image:title>
-      <image:caption>Guide to timing scrap gold sales: price drivers, seasonal patterns and how to find the best dealer rates.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/gold-vs-silver-investment</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/gold-vs-silver-investment"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-vs-silver-investment"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-vs-silver-investment"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>Gold vs Silver Investment — Which Precious Metal Is Better?</image:title>
-      <image:caption>Comparing gold and silver as investments: returns, volatility, the gold-silver ratio, and which metal suits different investor goals.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/how-to-invest-in-gold</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-to-invest-in-gold"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-invest-in-gold"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-invest-in-gold"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>How to Invest in Gold — Bullion, ETFs and More</image:title>
-      <image:caption>Guide to investing in gold: physical bullion, gold ETFs, mining stocks and gold ISAs — pros, cons and current price context.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/gold-price-history</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/gold-price-history"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-price-history"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-price-history"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>Gold Price History — Key Milestones From 1970 to 2026</image:title>
-      <image:caption>Historical gold price chart and milestones: Nixon Shock 1971, 1980 peak, 2008 crisis, 2020 ATH and 2026 prices.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/how-to-read-gold-spot-price</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>How to Read a Gold Spot Price — Beginner's Guide</image:title>
-      <image:caption>Beginner's guide to gold spot prices: what it means, where it comes from, and how to use it to value jewellery and bars.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/how-to-sell-gold-jewellery</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>How to Sell Gold Jewellery — Get the Best Price Guide</image:title>
-      <image:caption>Step-by-step guide to selling gold jewellery: calculate melt value, find the best buyer and avoid common pitfalls.</image:caption>
-    </image:image>
-  </url>
-  <url>
-    <loc>https://goldpricetools.com/guides/silver-price-per-gram-explained</loc>
-    <lastmod>2026-04-26</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.75</priority>
-    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/silver-price-per-gram-explained"/>
-    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/silver-price-per-gram-explained"/>
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/silver-price-per-gram-explained"/>
-    <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
-      <image:title>Silver Price Per Gram Explained — Live Calculation Guide</image:title>
-      <image:caption>How the silver price per gram is calculated from the troy ounce spot price, with live examples for .999 fine and 925 sterling silver.</image:caption>
-    </image:image>
-  </url>
-
-
-  <!-- ===== NEW GUIDE ===== -->
   <url>
     <loc>https://goldpricetools.com/gold-and-silver-price-today/</loc>
     <lastmod>2026-04-28</lastmod>
@@ -290,39 +72,271 @@
     <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/gold-and-silver-price-today/"/>
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/gold-and-silver-price-today/"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/gold-and-silver-price-today/"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>Gold and Silver Price Today (Live)</image:title>
+      <image:caption>Live gold and silver price today per ounce, gram, and kilo in GBP and USD. Updated every 60 seconds.</image:caption>
+    </image:image>
   </url>
 
-  <!-- ===== UTILITY / LEGAL PAGES ===== -->
+  <url>
+    <loc>https://goldpricetools.com/scrap-gold-calculator</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/scrap-gold-calculator"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/scrap-gold-calculator"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/scrap-gold-calculator"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>Scrap Gold Calculator — Live Melt Value</image:title>
+      <image:caption>Free scrap gold calculator. Enter weight and karat to find the live melt value of your gold jewellery in GBP and USD.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/silver-price-per-kilo</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/silver-price-per-kilo"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/silver-price-per-kilo"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/silver-price-per-kilo"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>Silver Price Per Kilo Today (Live)</image:title>
+      <image:caption>Real-time silver price per kilogram, gram and troy ounce in GBP and USD. Updated every 60 seconds.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/how-to-calculate-scrap-gold</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>How to Calculate Scrap Gold Value — Step by Step</image:title>
+      <image:caption>Step-by-step guide to calculating the value of scrap gold jewellery using the live gold spot price. Includes worked examples.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/what-is-14k-gold</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/what-is-14k-gold"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-14k-gold"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-14k-gold"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>What Is 14K Gold? Purity, Price &amp; Uses Explained</image:title>
+      <image:caption>14 karat gold purity (58.33%), hallmarks, price per gram, durability, and how it compares to 18K and 24K gold.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/gold-price-history</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/gold-price-history"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-price-history"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-price-history"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>Gold Price History — All-Time Highs and Key Milestones</image:title>
+      <image:caption>A complete gold price history covering all-time highs, major market events, and long-term price trends from 1970 to 2026.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/gold-purity-guide</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/gold-purity-guide"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-purity-guide"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-purity-guide"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>Gold Purity Guide — Karats, Hallmarks &amp; What They Mean</image:title>
+      <image:caption>Complete guide to gold purity: what karats mean, how to read hallmarks, and the difference between 9K, 14K, 18K, 22K and 24K gold.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/gold-vs-silver-investment</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/gold-vs-silver-investment"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-vs-silver-investment"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-vs-silver-investment"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>Gold vs Silver Investment — Which Is Better in 2026?</image:title>
+      <image:caption>Gold vs silver investment compared: historical returns, volatility, liquidity, storage costs, and which suits your portfolio in 2026.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/how-to-invest-in-gold</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-to-invest-in-gold"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-invest-in-gold"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-invest-in-gold"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>How to Invest in Gold — Beginner's Guide 2026</image:title>
+      <image:caption>How to invest in gold in 2026: physical gold, ETFs, mining stocks, and digital gold compared.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/how-to-read-gold-spot-price</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>How to Read the Gold Spot Price</image:title>
+      <image:caption>What the gold spot price means, how it's quoted, and how to convert troy oz to per gram for any karat.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/how-to-sell-gold-jewellery</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>How to Sell Gold Jewellery — Get the Best Price</image:title>
+      <image:caption>Where to sell gold jewellery, how dealers calculate offers, and how to avoid getting underpaid.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/silver-price-per-gram-explained</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/silver-price-per-gram-explained"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/silver-price-per-gram-explained"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/silver-price-per-gram-explained"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>Silver Price Per Gram Explained</image:title>
+      <image:caption>How the silver price per gram is calculated, what affects it, and how to convert troy oz to grams.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/troy-ounce-vs-gram-explained</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>Troy Ounce vs Gram — What's the Difference?</image:title>
+      <image:caption>Why gold is quoted in troy ounces, how many grams in a troy ounce, and how to convert.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/what-is-925-sterling-silver</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/what-is-925-sterling-silver"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-925-sterling-silver"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-925-sterling-silver"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>What Is 925 Sterling Silver?</image:title>
+      <image:caption>What does 925 mean on silver? Complete guide to sterling silver: purity, hallmarks, value, and how to spot fakes.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>When Is the Best Time to Sell Scrap Gold?</image:title>
+      <image:caption>Key signals — spot price levels, USD/GBP rate, seasonal demand — that tell you when to sell scrap gold for the best price.</image:caption>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://goldpricetools.com/how-many-grams-in-troy-ounce</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.75</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/how-many-grams-in-troy-ounce"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/how-many-grams-in-troy-ounce"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/how-many-grams-in-troy-ounce"/>
+    <image:image>
+      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:title>How Many Grams in a Troy Ounce? (31.1035g Explained)</image:title>
+      <image:caption>A troy ounce equals 31.1035 grams. Learn the difference from regular ounces and how to convert for gold pricing.</image:caption>
+    </image:image>
+  </url>
+
   <url>
     <loc>https://goldpricetools.com/about</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
     <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/about"/>
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/about"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/about"/>
   </url>
+
   <url>
     <loc>https://goldpricetools.com/contact</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
     <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/contact"/>
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/contact"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/contact"/>
   </url>
+
   <url>
     <loc>https://goldpricetools.com/privacy-policy</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
     <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/privacy-policy"/>
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/privacy-policy"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/privacy-policy"/>
   </url>
+
   <url>
     <loc>https://goldpricetools.com/terms</loc>
-    <lastmod>2026-04-26</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
     <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/terms"/>


### PR DESCRIPTION
Adds scripts/generate-sitemap.js which scans all HTML files, extracts canonical URLs + hreflang alternates from each page, derives lastmod from git history, and writes a fresh sitemap.xml.

.github/workflows/sitemap.yml triggers on pushes to main that touch any HTML file, runs the generator, and auto-commits the updated sitemap.xml back to the branch via stefanzweifel/git-auto-commit-action.

URL set confirmed identical to the hand-maintained sitemap (24 URLs). Image title/caption now sourced from og:title/og:description, keeping metadata in sync with the HTML itself going forward.

https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq