### PR TITLE
docs(adsense): invalid-traffic prevention policy + IVT reporting + CTR monitoring runbook (closes #49)

### DIFF
--- a/docs/adsense/README.md
+++ b/docs/adsense/README.md
@@ -1,0 +1,16 @@
+# AdSense Documentation
+
+This directory contains policies and runbooks related to Google AdSense integration, with a focus on compliance and preventing invalid traffic.
+
+## Documents
+
+* [Invalid Traffic Prevention Policy](./invalid-traffic-policy.md) - Outlines the prohibition on publisher own-clicks and the required browser setup for developers.
+* [Invalid Activity Reporting Runbook](./invalid-activity-reporting.md) - Step-by-step procedure for reporting accidental clicks or suspected invalid traffic to Google.
+* [CTR Monitoring Runbook](./ctr-monitoring-runbook.md) - Process for weekly CTR monitoring to detect anomalies post-launch.
+
+## WP-37 Acceptance Criteria Checklist
+
+- [x] Create `invalid-traffic-policy.md` covering own-click prohibition, risk profile, sign-offs, dev browser setup with ad blocker, and Cloudflare bot fight mode.
+- [x] Create `invalid-activity-reporting.md` with step-by-step AdSense contact form instructions, email template, SLAs, and a log table.
+- [x] Create `ctr-monitoring-runbook.md` defining baseline thresholds (>10% site, >15% page), GA4 navigation, and a weekly checklist.
+- [x] Create an index `README.md` linking the docs and containing this checklist.

--- a/docs/adsense/ctr-monitoring-runbook.md
+++ b/docs/adsense/ctr-monitoring-runbook.md
@@ -1,0 +1,44 @@
+# CTR Monitoring Runbook
+
+This runbook defines the process for weekly Click-Through Rate (CTR) monitoring for the first 3 months post-launch to detect and mitigate invalid traffic.
+
+## Baseline Thresholds
+
+Unusually high CTR can be an indicator of invalid traffic or bot activity. We monitor against the following thresholds:
+
+* **Site-wide CTR Flag:** `> 10%`
+* **Per-page CTR Flag:** `> 15%`
+
+If these thresholds are breached, an investigation must be initiated.
+
+## GA4 × AdSense Linked-Report Navigation
+
+*Prerequisite Note: This assumes the GA4 and AdSense link (WP-14) is already in place.*
+
+1. Log in to **Google Analytics 4 (GA4)**.
+2. Navigate to **Reports** in the left sidebar.
+3. Go to **Monetization** > **Publisher ads**.
+4. In the main table, look for the **Ad clicks** and **Ad impressions** columns to calculate CTR (Clicks / Impressions * 100).
+5. To view per-page CTR, change the primary dimension of the table to **Page path and screen class**.
+
+## Weekly Review Checklist
+
+**Schedule:** Every Monday morning.
+**Duration:** First 3 months post-launch.
+
+- [ ] Check overall site CTR in AdSense dashboard for the past 7 days.
+- [ ] Check per-page CTR in GA4 (Publisher ads report) for the past 7 days.
+- [ ] Review Cloudflare Web Analytics for any unusual spikes in traffic from specific countries or ASNs.
+- [ ] Verify Cloudflare Bot Fight Mode remains enabled.
+- [ ] Check the Invalid Activity Log for any reported accidental clicks in the past week.
+
+## Escalation Triggers
+
+If any of the following triggers are met during the weekly review, take immediate action:
+
+* **Trigger:** Overall site CTR exceeds 10% for 2 consecutive days.
+    * **Action:** Investigate traffic sources in GA4. If specific referrers or regions are suspicious, consider implementing Cloudflare firewall rules to challenge or block that traffic. Report suspicious activity to AdSense via the Invalid Clicks Contact Form.
+* **Trigger:** Per-page CTR exceeds 15%.
+    * **Action:** Review the specific page layout. Ensure ad placement complies with AdSense policies and isn't encouraging accidental clicks (e.g., too close to interactive elements). Report if necessary.
+* **Trigger:** Significant spike in direct traffic with 0s engagement time combined with ad clicks.
+    * **Action:** Likely bot traffic. Review Cloudflare security settings. Report to AdSense.

--- a/docs/adsense/invalid-activity-reporting.md
+++ b/docs/adsense/invalid-activity-reporting.md
@@ -1,0 +1,44 @@
+# Invalid Activity Reporting Runbook
+
+This runbook details the procedure for reporting accidental own-clicks or suspected invalid traffic to Google AdSense.
+
+## Step-by-Step Reporting Procedure
+
+1. **Identify the Incident:** Note the date, time, approximate URL, and ad unit where the accidental click or invalid activity occurred.
+2. **Access the Form:** Go to the [AdSense Invalid Clicks Contact Form](https://support.google.com/adsense/contact/invalid_clicks_contact).
+3. **Fill Out the Form:**
+   - **Name:** Your name
+   - **Contact email address:** The email address associated with the AdSense account
+   - **Publisher ID:** `ca-pub-8849494330640880`
+   - **URL where invalid activity occurred:** e.g., `https://goldpricetools.com/scrap-gold-calculator.html`
+   - **Topic:** Select the most appropriate option (e.g., "Reporting unusual activity on my account")
+   - **Date(s) and time(s) of the invalid activity:** Be as precise as possible.
+   - **A paragraph describing what led you to believe the click activity is invalid:** Use the template below.
+   - **Please include any data from your site traffic logs or reports that indicate suspicious IP addresses, referrers, or requests which could explain invalid activity:** Include your IP address if reporting an accidental own-click.
+4. **Submit the Form.**
+5. **Log the Incident:** Record the submission in the Invalid Activity Log below.
+
+## Template Email/Description Body
+
+Use this template when filling out the description field in the contact form:
+
+> We are proactively reporting an incident of accidental own-clicks on our website, GoldPriceTools.com.
+>
+> **Date/Time:** [Insert Date/Time]
+> **URL:** [Insert URL, e.g., https://goldpricetools.com/scrap-gold-calculator.html]
+> **Ad Unit:** [Insert Ad Unit, e.g., Bottom Anchor]
+> **IP Address:** [Insert Your IP Address]
+>
+> **Remediation:** This was an accidental click by a developer during testing/use. We have reinforced our internal policy requiring the use of a dedicated browser profile with an ad blocker (uBlock Origin) to prevent future occurrences.
+
+## Escalation Path and SLA
+
+- **Reporting SLA:** All suspected invalid activity or accidental own-clicks MUST be reported to Google via the form within **7 days** of the incident.
+- **Internal Escalation:** Notify the site owner/lead developer immediately upon submitting the report so it can be logged and monitored.
+
+## Invalid Activity Log
+
+| Date | URL | Ad Unit | Reporter | Reference Number / Notes |
+|---|---|---|---|---|
+| | | | | |
+| | | | | |

--- a/docs/adsense/invalid-traffic-policy.md
+++ b/docs/adsense/invalid-traffic-policy.md
@@ -1,0 +1,39 @@
+# Invalid Traffic Prevention Policy
+
+This policy outlines the steps GoldPriceTools takes to prevent invalid traffic, specifically focusing on publisher own-clicks.
+
+## Publisher Own-Click Prohibition Policy
+
+> "Publishers may not click their own ads or use any means to inflate impressions and/or clicks artificially, including manual methods. Testing your own ads by clicking on them is not permitted."
+> — Google AdSense Program Policies
+
+## Risk Profile for GoldPriceTools
+
+As the owner of GoldPriceTools is also a frequent user of the application to check real-time spot prices and perform conversions, there is an elevated risk of accidental own-clicks. It is critical that strict measures are followed to ensure compliance with AdSense policies.
+
+## Mandatory Acknowledgement
+
+All developers, testers, and content editors must acknowledge and adhere to this policy.
+
+| Name | Role | Date | Signature |
+|---|---|---|---|
+| | | | |
+| | | | |
+
+## Required "Development" Browser Profile Setup Steps
+
+To mitigate the risk of accidental clicks, a dedicated "Development" browser profile MUST be used when accessing GoldPriceTools.
+
+1. **Create Profile:** Open your web browser (Chrome, Firefox, Edge, etc.) and create a new user profile named "GPT Dev".
+2. **Install Ad Blocker:** Immediately install an ad blocker extension in this profile. **uBlock Origin** is strongly recommended.
+3. **Verify Blocking:** Navigate to the live GoldPriceTools site and ensure no AdSense ads are visible.
+4. **Exclusive Use:** Always use this "GPT Dev" profile when developing, testing, or casually using the site. Never use your primary, unblocked browsing profile for GoldPriceTools access.
+
+## Cloudflare Bot Fight Mode Verification Steps
+
+*(Screenshots section placeholder)*
+
+1. Log in to the Cloudflare dashboard.
+2. Select the `goldpricetools.com` domain.
+3. Navigate to **Security** > **Bots**.
+4. Verify that **Bot Fight Mode** is toggled to the **ON** position.


### PR DESCRIPTION
Creates the required AdSense invalid traffic and reporting documentation:

- `docs/adsense/invalid-traffic-policy.md`: publisher own-click prohibition policy, risk profile, sign-offs, dev browser setup with ad blocker, and Cloudflare bot fight mode steps.
- `docs/adsense/invalid-activity-reporting.md`: step-by-step AdSense contact form instructions, email template, SLAs, and log table.
- `docs/adsense/ctr-monitoring-runbook.md`: baseline thresholds (>10% site, >15% page), GA4 navigation, and a weekly checklist.
- `docs/adsense/README.md`: index linking to the three docs and a checklist mirroring the issue acceptance criteria.

Closes #49

---
*PR created automatically by Jules for task [1239306748054146413](https://jules.google.com/task/1239306748054146413) started by @DigitalCliqs*