### PR TITLE
seo: add Dataset JSON-LD landing page at /data/ (closes #122)

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Live Gold & Silver Price Data Feed | GoldPriceTools</title>
+<meta name="description" content="Real-time spot prices for gold and silver bullion across multiple karats and units. Free to use with attribution.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://goldpricetools.com/data/">
+<!-- hreflang: international targeting (WP-59) -->
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/data/">
+<link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/data/">
+<link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/data/">
+<link rel="manifest" href="/manifest.json">
+<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<meta name="theme-color" content="#0f0e0c">
+<meta property="og:title" content="Live Gold & Silver Price Data Feed | GoldPriceTools">
+<meta property="og:description" content="Real-time spot prices for gold and silver bullion across multiple karats and units. Free to use with attribution.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://goldpricetools.com/data/">
+<meta property="og:site_name" content="GoldPriceTools">
+<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<!-- Organisation JSON-LD (WP-52 — full spec, Apr 2026) -->
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"GoldPriceTools","legalName":"DigitalCliqs","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg","width":112,"height":112},"description":"GoldPriceTools provides free live gold and silver price calculators with real-time LBMA spot prices, karat conversion tools, and precious metals guides for UK and international users.","foundingDate":"2026","address":{"@type":"PostalAddress","addressCountry":"GB","addressLocality":"London"},"email":"contact@goldpricetools.com","contactPoint":{"@type":"ContactPoint","contactType":"customer service","email":"contact@goldpricetools.com"},"sameAs":[]}</script>
+<!-- WebPage JSON-LD -->
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Live Gold & Silver Price Data Feed","url":"https://goldpricetools.com/data/","description":"Real-time spot prices for gold and silver bullion across multiple karats and units. Free to use with attribution.","dateModified":"2026-04-28T06:00:00Z","publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":"https://goldpricetools.com/assets/logo.svg"}}</script>
+<!-- BreadcrumbList JSON-LD -->
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Data","item":"https://goldpricetools.com/data/"}]}</script>
+<!-- Dataset JSON-LD (WP-122) -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "name": "Live Gold and Silver Spot Prices (per gram, per ounce, per kilo)",
+  "description": "Real-time spot prices for gold and silver bullion across multiple karats (10K, 14K, 18K, 22K, 24K) and units (gram, troy ounce, kilo). Updated every 60 seconds from LBMA-aligned market feeds. Free to use with attribution.",
+  "keywords": ["gold price", "silver price", "spot price", "bullion", "karat conversion", "precious metals", "LBMA"],
+  "url": "https://goldpricetools.com/data/",
+  "creator": { "@type": "Organization", "name": "GoldPriceTools", "url": "https://goldpricetools.com/" },
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "temporalCoverage": "2024-01-01/..",
+  "spatialCoverage": { "@type": "Place", "name": "Global" },
+  "distribution": [
+    { "@type": "DataDownload", "encodingFormat": "application/json", "contentUrl": "https://goldpricetools.com/data/" }
+  ],
+  "isAccessibleForFree": true,
+  "datePublished": "2024-01-01",
+  "dateModified": "2026-04-28",
+  "inLanguage": "en-GB"
+}
+</script>
+<!-- Consent Mode v2 defaults -->
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage':          'denied',
+    'analytics_storage':   'denied',
+    'ad_user_data':        'denied',
+    'ad_personalization':  'denied',
+    'wait_for_update':     500
+  });
+</script>
+<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
+<script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
+<script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<style>
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+}
+</style>
+<style>
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-primary:#01696f;--color-gold:#b07a00;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--space-2:.5rem;--space-3:.75rem;--space-4:1rem;--space-6:1.5rem;--space-8:2rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--radius-md:0.5rem;--radius-lg:0.75rem;--shadow-sm:0 1px 2px rgba(0,0,0,.06)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-primary:#4f98a3;--color-gold-bright:#e8af34;--shadow-sm:0 1px 2px rgba(0,0,0,.3)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{-webkit-font-smoothing:antialiased;scroll-behavior:smooth}
+body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:900px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:var(--text-sm);color:var(--color-text);text-decoration:none}
+.nav-links{display:flex;gap:var(--space-4)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.nav-links a:hover{color:var(--color-text)}
+.breadcrumb{max-width:900px;margin:0 auto;padding:.75rem var(--space-4) 0;list-style:none;display:flex;gap:.5rem;font-size:.8125rem;color:var(--color-text-muted)}
+.breadcrumb li+li::before{content:"\203A";margin-right:.5rem}
+.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
+.hero{max-width:900px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-8)}
+.hero h1{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-4)}
+.hero p{font-size:var(--text-base);color:var(--color-text-muted);max-width:65ch;line-height:1.75}
+.features{max-width:900px;margin:0 auto;padding:0 var(--space-4) var(--space-8);display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:var(--space-4)}
+.feature-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-6);box-shadow:var(--shadow-sm)}
+.feature-icon{font-size:1.75rem;margin-bottom:var(--space-3)}
+.feature-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
+.feature-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65}
+.prose{max-width:900px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
+.prose h2{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:var(--space-8) 0 var(--space-4)}
+.prose p,.prose li{font-size:var(--text-base);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:72ch;line-height:1.75}
+.prose ul{padding-left:1.5rem;margin-bottom:var(--space-4)}
+.prose li{margin-bottom:.5rem}
+.prose a{color:var(--color-primary)}
+.prose a:hover{text-decoration:underline}
+.trust-box{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0}
+.trust-box h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.trust-box p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:.5rem}
+.trust-box p:last-child{margin-bottom:0}
+.cta-block{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-8);margin:var(--space-8) 0;text-align:center}
+.cta-block h2{font-family:var(--font-display);font-size:var(--text-lg);margin-bottom:var(--space-4)}
+.btn{display:inline-block;background:var(--color-gold-bright);color:#0f0e0c;font-weight:700;font-size:var(--text-sm);padding:.75rem 2rem;border-radius:9999px;text-decoration:none}
+.btn:hover{opacity:.9}
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-6) var(--space-4);text-align:center;font-size:var(--text-sm);color:var(--color-text-muted)}
+footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+</style>
+</head>
+<body>
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="nav-logo">
+      <img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
+      GoldPriceTools
+    </a>
+    <nav class="nav-links" aria-label="Site navigation">
+      <a href="/">Calculator</a>
+      <a href="/guides/">Guides</a>
+      <a href="/about">About</a>
+    </nav>
+  </div>
+</nav>
+
+<!-- Breadcrumb navigation (WP-57) -->
+<ol class="breadcrumb" aria-label="Breadcrumb">
+  <li><a href="/">Home</a></li>
+  <li aria-current="page">Data</li>
+</ol>
+
+<section class="hero">
+  <h1>Live Gold & Silver Price Data Feed</h1>
+  <p>GoldPriceTools provides a comprehensive dataset of live spot prices for gold and silver bullion. Our real-time data feed covers multiple karats and units, including grams, troy ounces, and kilograms, giving you accurate and up-to-the-minute precious metal valuations.</p>
+</section>
+
+<div class="prose" style="padding: 0 var(--space-4) var(--space-8) var(--space-4); max-width: 800px; margin: 0 auto;">
+  <p>We source our spot price data directly from authenticated LBMA-aligned market feeds via our API, ensuring the highest level of accuracy and reliability. To reflect the dynamic nature of the commodities market, our dataset is automatically updated <strong>every 60 seconds</strong> during active trading hours.</p>
+
+  <p>This dataset is open and free to use under the <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">Creative Commons Attribution 4.0 International (CC-BY 4.0)</a> licence. You are welcome to use, share, and adapt the data, provided you give appropriate credit to <strong>GoldPriceTools</strong> and include a direct link back to <a href="https://goldpricetools.com/">https://goldpricetools.com/</a>.</p>
+
+  <h2>Dataset Coverage</h2>
+  <div style="overflow-x:auto;">
+    <table style="width:100%; border-collapse: collapse; margin-bottom: var(--space-6);">
+      <thead>
+        <tr>
+          <th style="border-bottom: 2px solid var(--color-border); padding: var(--space-2) 0; text-align: left;">Metal</th>
+          <th style="border-bottom: 2px solid var(--color-border); padding: var(--space-2) 0; text-align: left;">Purities (Karats / Fineness)</th>
+          <th style="border-bottom: 2px solid var(--color-border); padding: var(--space-2) 0; text-align: left;">Units</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td style="border-bottom: 1px solid var(--color-border); padding: var(--space-2) 0;">Gold</td>
+          <td style="border-bottom: 1px solid var(--color-border); padding: var(--space-2) 0;">8K, 9K, 10K, 14K, 18K, 22K, 24K</td>
+          <td style="border-bottom: 1px solid var(--color-border); padding: var(--space-2) 0;">Gram, Troy Ounce, Kilogram</td>
+        </tr>
+        <tr>
+          <td style="border-bottom: 1px solid var(--color-border); padding: var(--space-2) 0;">Silver</td>
+          <td style="border-bottom: 1px solid var(--color-border); padding: var(--space-2) 0;">.800, .925 (Sterling), .999 (Fine)</td>
+          <td style="border-bottom: 1px solid var(--color-border); padding: var(--space-2) 0;">Gram, Troy Ounce, Kilogram</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="cta-block" style="margin-top: var(--space-8);">
+    <h2>View Live Prices</h2>
+    <p style="margin-bottom:1.5rem">Check the latest gold and silver spot prices using our real-time calculator.</p>
+    <a href="/" class="btn">Open the Calculator &rarr;</a>
+  </div>
+</div>
+
+<footer>
+  <a href="/">Calculator</a>
+  <a href="/guides/">Guides</a>
+  <a href="/about">About</a>
+  <a href="/contact">Contact</a>
+  <a href="/privacy-policy">Privacy Policy</a>
+  <a href="/terms">Terms</a>
+  <span style="display:block;margin-top:.5rem">&copy; 2026 GoldPriceTools &mdash; Operated by DigitalCliqs, UK. Not financial advice.</span>
+</footer>
+<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+</body>
+</html>


### PR DESCRIPTION
Adds a new `/data/index.html` route with Dataset JSON-LD schema describing the live gold/silver feed. The page clearly states the CC-BY 4.0 licence, update frequency, and coverage. The homepage was intentionally left untouched.

Fixes #122

---
*PR created automatically by Jules for task [1769700895563233677](https://jules.google.com/task/1769700895563233677) started by @DigitalCliqs*