### PR TITLE
ci: API Health workflow — add de-duplication + curl retry + auto-close-on-recovery

### DIFF
--- a/.github/workflows/api-health.yml
+++ b/.github/workflows/api-health.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           set +e
           # 1. curl the primary gold-api.com endpoint
-          RESPONSE=$(curl -s -w "\n%{http_code}" "https://api.gold-api.com/price/XAU")
+          RESPONSE=$(curl -s --retry 3 --retry-delay 5 --retry-all-errors --max-time 15 -w "\n%{http_code}" "https://api.gold-api.com/price/XAU")
           CURL_EXIT=$?
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           BODY=$(echo "$RESPONSE" | sed '$d')
@@ -93,10 +93,25 @@ jobs:
             fi
           fi
 
-      - name: Create Issue
-        if: env.status == 'failed'
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: ${{ env.title }}
-          content-filepath: ./issue_body.md
-          labels: api-health
+      - name: Manage API Health Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check for an open issue with the api-health label
+          OPEN_ISSUE=$(gh issue list --label "api-health" --state open --json number --jq ".[0].number")
+
+          if [ "${{ env.status }}" = "failed" ]; then
+            if [ -n "$OPEN_ISSUE" ]; then
+              echo "Issue already exists (#$OPEN_ISSUE). Appending comment."
+              gh issue comment "$OPEN_ISSUE" --body-file ./issue_body.md
+            else
+              echo "Creating new issue."
+              gh issue create --title "${{ env.title }}" --body-file ./issue_body.md --label "api-health"
+            fi
+          elif [ "${{ env.status }}" = "ok" ]; then
+            if [ -n "$OPEN_ISSUE" ]; then
+              echo "API recovered. Closing issue #$OPEN_ISSUE."
+              gh issue comment "$OPEN_ISSUE" --body "API health check passed. Recovery confirmed. Closing issue."
+              gh issue close "$OPEN_ISSUE"
+            fi
+          fi


### PR DESCRIPTION
Fixes #149 by modifying `.github/workflows/api-health.yml`.

Changes:
1. Adds `curl` retry flags to handle intermittent network failures.
2. Deduplicates issues using `gh issue` commands: instead of creating a new issue every time the check fails, it now checks for an open issue with the `api-health` label and appends a comment if one already exists.
3. Automatically closes the issue with a recovery comment if the API health check succeeds and there is currently an open issue.

---
*PR created automatically by Jules for task [15596674772517173887](https://jules.google.com/task/15596674772517173887) started by @DigitalCliqs*