### PR TITLE
feat: migrate asset URLs to Cloudflare R2 CDN (#151)

### DIFF
--- a/10k-gold-price-per-gram.html
+++ b/10k-gold-price-per-gram.html
@@ -16,9 +16,9 @@
 <meta property="og:description" content="Real-time 10K gold price per gram in GBP and USD. 41.67% pure gold. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/10k-gold-price-per-gram">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
 <!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
@@ -26,9 +26,9 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="/assets/logo.svg"><meta name="theme-color" content="#0f0e0c">
+<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -36,7 +36,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -44,7 +44,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -52,7 +52,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.625rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.hero-sub{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem}.price-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:2rem;max-width:480px;margin:0 auto 2rem}.price-label{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.5rem}.price-value{font-family:var(--font-display);font-size:clamp(2.25rem,6vw,3.5rem);font-weight:700;color:var(--color-gold-bright);line-height:1;margin-bottom:.375rem;min-height:3rem;min-width:120px;display:inline-block}.price-usd{font-size:1.25rem;color:var(--color-text-muted);margin-bottom:.5rem}.price-purity{font-size:.8125rem;color:var(--color-text-faint)}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
@@ -72,7 +72,7 @@
 </script>
 </head>
 <body>
-<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
+<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
 <div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">10K Gold Price Per Gram</li></ol></div>
 <div class="hero">
   <div class="hero-tag">Live Gold Price</div>

--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -15,9 +15,9 @@
 <meta property="og:description" content="Real-time 14K gold price per gram in USD, GBP, EUR. 58.33% pure gold. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/14k-gold-price-per-gram">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the 14K gold price per gram today?","acceptedAnswer":{"@type":"Answer","text":"The live 14K gold price per gram is calculated by multiplying the current gold spot price per troy ounce by 0.5833 (14K purity) and dividing by 31.1035 (grams per troy ounce). This value updates every 60 seconds on Gold Price Tools."}},{"@type":"Question","name":"How much is 14K gold worth per gram in GBP?","acceptedAnswer":{"@type":"Answer","text":"The 14K gold price per gram in GBP is calculated from the live USD spot price converted at the current USD/GBP exchange rate, then multiplied by 0.5833 (14K purity) and divided by 31.1035 (grams per troy ounce). The live GBP price is shown on this page."}},{"@type":"Question","name":"Is 14K gold real gold?","acceptedAnswer":{"@type":"Answer","text":"Yes. 14K gold is real gold — it contains 58.33% pure gold (14 parts gold out of 24), alloyed with metals such as copper, silver or zinc for strength and durability."}},{"@type":"Question","name":"How do I calculate 14K gold value?","acceptedAnswer":{"@type":"Answer","text":"To calculate: 1) Find the current gold spot price per troy ounce. 2) Divide by 31.1035 to get the price per gram of pure gold. 3) Multiply by 0.5833 (14K purity). 4) Multiply by the weight of your item in grams. Use our live calculator above for instant results."}}]}</script>
 <script>
   window.dataLayer=window.dataLayer||[];
@@ -31,11 +31,11 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -43,7 +43,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -51,7 +51,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -59,7 +59,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -115,7 +115,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <div style="display:flex;gap:.75rem;font-size:.875rem">
       <a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a>
       <a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a>

--- a/18k-gold-price-per-gram.html
+++ b/18k-gold-price-per-gram.html
@@ -16,9 +16,9 @@
 <meta property="og:description" content="Real-time 18K gold price per gram in GBP and USD. 75% pure gold. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/18k-gold-price-per-gram">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>
   window.dataLayer=window.dataLayer||[];
   function gtag(){dataLayer.push(arguments);}
@@ -31,11 +31,11 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -43,7 +43,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -51,7 +51,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -59,7 +59,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -114,7 +114,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <div style="display:flex;gap:.75rem;font-size:.875rem">
       <a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a>
       <a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a>

--- a/about.html
+++ b/about.html
@@ -12,20 +12,20 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/about">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/about">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="About GoldPriceTools — Free Live Gold &amp; Silver Calculator">
 <meta property="og:description" content="GoldPriceTools provides free live gold and silver price calculators with real-time LBMA spot prices for UK and international users.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/about">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <!-- Organisation JSON-LD (WP-52 — full spec, Apr 2026) -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"GoldPriceTools","legalName":"DigitalCliqs","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg","width":112,"height":112},"description":"GoldPriceTools provides free live gold and silver price calculators with real-time LBMA spot prices, karat conversion tools, and precious metals guides for UK and international users.","foundingDate":"2026","address":{"@type":"PostalAddress","addressCountry":"GB","addressLocality":"London"},"email":"contact@goldpricetools.com","contactPoint":{"@type":"ContactPoint","contactType":"customer service","email":"contact@goldpricetools.com"},"sameAs":["https://github.com/DigitalCliqs"],"founder":{"@type":"Person","name":"DigitalCliqs"},"@id":"https://goldpricetools.com/#organization"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"GoldPriceTools","legalName":"DigitalCliqs","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg","width":112,"height":112},"description":"GoldPriceTools provides free live gold and silver price calculators with real-time LBMA spot prices, karat conversion tools, and precious metals guides for UK and international users.","foundingDate":"2026","address":{"@type":"PostalAddress","addressCountry":"GB","addressLocality":"London"},"email":"contact@goldpricetools.com","contactPoint":{"@type":"ContactPoint","contactType":"customer service","email":"contact@goldpricetools.com"},"sameAs":["https://github.com/DigitalCliqs"],"founder":{"@type":"Person","name":"DigitalCliqs"},"@id":"https://goldpricetools.com/#organization"}</script>
 <!-- WebPage JSON-LD -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"About GoldPriceTools","url":"https://goldpricetools.com/about","description":"About GoldPriceTools — a free live gold and silver price calculator.","dateModified":"2026-04-29T06:00:00Z","publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":"https://goldpricetools.com/assets/logo.svg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"About GoldPriceTools","url":"https://goldpricetools.com/about","description":"About GoldPriceTools — a free live gold and silver price calculator.","dateModified":"2026-04-29T06:00:00Z","publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}}</script>
 <!-- BreadcrumbList JSON-LD (WP-57) — standalone for Rich Results visibility -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"About","item":"https://goldpricetools.com/about"}]}</script>
 <!-- Consent Mode v2 defaults -->
@@ -48,7 +48,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -56,7 +56,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -64,7 +64,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -72,7 +72,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -122,7 +122,7 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
 <nav>
   <div class="nav-inner">
     <a href="/" class="nav-logo">
-      <img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
+      <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
       GoldPriceTools
     </a>
     <nav class="nav-links" aria-label="Site navigation">

--- a/authors/james-smith.html
+++ b/authors/james-smith.html
@@ -6,7 +6,7 @@
 <title>James Smith - Precious Metals Expert | GoldPriceTools</title>
 <meta name="description" content="James Smith is a precious metals expert and senior editor at GoldPriceTools with over 15 years of experience in the bullion and scrap gold markets.">
 <link rel="canonical" href="https://goldpricetools.com/authors/james-smith/">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <script type="application/ld+json">
 {
@@ -159,7 +159,7 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
 <nav>
   <div class="nav-inner">
     <a href="/" class="nav-logo">
-      <img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
+      <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
       GoldPriceTools
     </a>
     <nav class="nav-links" aria-label="Site navigation">

--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,7 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/contact">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/contact">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 
 <!-- Consent Mode v2 defaults - must fire BEFORE AdSense and GA4 -->
@@ -37,7 +37,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <!-- GA4 -->
@@ -101,7 +101,7 @@ footer a:hover{color:var(--color-text)}
 <nav>
   <div class="nav-inner">
     <a href="/" class="nav-logo">
-      <img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
+      <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
       GoldPriceTools
     </a>
     <a href="/" class="nav-back">&larr; Back to Calculator</a>

--- a/data/index.html
+++ b/data/index.html
@@ -12,20 +12,20 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/data/">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/data/">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="Live Gold & Silver Price Data Feed | GoldPriceTools">
 <meta property="og:description" content="Real-time spot prices for gold and silver bullion across multiple karats and units. Free to use with attribution.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/data/">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <!-- Organisation JSON-LD (WP-52 — full spec, Apr 2026) -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"GoldPriceTools","legalName":"DigitalCliqs","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg","width":112,"height":112},"description":"GoldPriceTools provides free live gold and silver price calculators with real-time LBMA spot prices, karat conversion tools, and precious metals guides for UK and international users.","foundingDate":"2026","address":{"@type":"PostalAddress","addressCountry":"GB","addressLocality":"London"},"email":"contact@goldpricetools.com","contactPoint":{"@type":"ContactPoint","contactType":"customer service","email":"contact@goldpricetools.com"},"sameAs":[]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"GoldPriceTools","legalName":"DigitalCliqs","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg","width":112,"height":112},"description":"GoldPriceTools provides free live gold and silver price calculators with real-time LBMA spot prices, karat conversion tools, and precious metals guides for UK and international users.","foundingDate":"2026","address":{"@type":"PostalAddress","addressCountry":"GB","addressLocality":"London"},"email":"contact@goldpricetools.com","contactPoint":{"@type":"ContactPoint","contactType":"customer service","email":"contact@goldpricetools.com"},"sameAs":[]}</script>
 <!-- WebPage JSON-LD -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Live Gold & Silver Price Data Feed","url":"https://goldpricetools.com/data/","description":"Real-time spot prices for gold and silver bullion across multiple karats and units. Free to use with attribution.","dateModified":"2026-04-29T06:00:00Z","publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":"https://goldpricetools.com/assets/logo.svg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Live Gold & Silver Price Data Feed","url":"https://goldpricetools.com/data/","description":"Real-time spot prices for gold and silver bullion across multiple karats and units. Free to use with attribution.","dateModified":"2026-04-29T06:00:00Z","publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}}</script>
 <!-- BreadcrumbList JSON-LD -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Data","item":"https://goldpricetools.com/data/"}]}</script>
 <!-- Dataset JSON-LD (WP-122) -->
@@ -70,7 +70,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -78,7 +78,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -86,7 +86,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -94,7 +94,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -144,7 +144,7 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
 <nav>
   <div class="nav-inner">
     <a href="/" class="nav-logo">
-      <img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
+      <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
       GoldPriceTools
     </a>
     <nav class="nav-links" aria-label="Site navigation">

--- a/gold-and-silver-price-today/index.html
+++ b/gold-and-silver-price-today/index.html
@@ -10,16 +10,16 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/gold-and-silver-price-today/">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/gold-and-silver-price-today/">
 <link rel="canonical" href="https://goldpricetools.com/gold-and-silver-price-today/">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/gold-and-silver-price-today/"},"headline":"Gold and Silver Price Today","description":"Live gold and silver price today per ounce, gram, and kilo in GBP and USD. Updated every 60 seconds from the spot market.","datePublished":"2026-04-28","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com/about"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/gold-and-silver-price-today/"},"headline":"Gold and Silver Price Today","description":"Live gold and silver price today per ounce, gram, and kilo in GBP and USD. Updated every 60 seconds from the spot market.","datePublished":"2026-04-28","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com/about"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Gold and Silver Price Today","item":"https://goldpricetools.com/gold-and-silver-price-today/"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the gold and silver price today?","acceptedAnswer":{"@type":"Answer","text":"The live gold and silver price today is updated every 60 seconds on our website, pulling directly from global spot markets."}},{"@type":"Question","name":"Why track both gold and silver prices?","acceptedAnswer":{"@type":"Answer","text":"Tracking both gold and silver prices allows investors to monitor the gold-to-silver ratio, a popular metric for determining which metal offers better value at a given time."}}]}</script>
 <meta property="og:title" content="Gold and Silver Price Today (Live)">
 <meta property="og:description" content="Live gold and silver price today per ounce, gram, and kilo in GBP and USD. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/gold-and-silver-price-today/">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
 <!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
@@ -27,9 +27,9 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="/assets/logo.svg"><meta name="theme-color" content="#0f0e0c">
+<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -37,7 +37,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 :root{--color-bg:#0f0e0c;--color-surface:#1c1a17;--color-border:#2a2824;--color-text:#f0e6d2;--color-text-muted:#a39b8a;--color-accent:#d4af37}
@@ -85,7 +85,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#goog
 </style>
 </head>
 <body>
-<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
+<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
 <div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">Gold and Silver Price Today</li></ol></div>
 <div class="hero">
   <div class="hero-tag">Live Market Prices</div>

--- a/guides/gold-price-history.html
+++ b/guides/gold-price-history.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-price-history">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-price-history">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="Gold Price History — All-Time Highs and Key Milestones">
 <meta property="og:description" content="A complete gold price history covering all-time highs, major market events, and long-term price trends from 1970 to 2026.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/gold-price-history">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Price History — All-Time Highs and Key Milestones","description":"A complete gold price history covering all-time highs, major market events, and long-term price trends from 1970 to 2026.","url":"https://goldpricetools.com/guides/gold-price-history","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-price-history"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Price History — All-Time Highs and Key Milestones","description":"A complete gold price history covering all-time highs, major market events, and long-term price trends from 1970 to 2026.","url":"https://goldpricetools.com/guides/gold-price-history","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-price-history"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Gold Price History"}]}</script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -36,7 +36,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -44,7 +44,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -52,7 +52,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -60,7 +60,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -117,7 +117,7 @@ footer a:hover{color:var(--color-text)}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/gold-purity-guide.html
+++ b/guides/gold-purity-guide.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-purity-guide">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-purity-guide">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="Gold Purity Guide — Karats, Hallmarks &amp; What They Mean">
 <meta property="og:description" content="Complete guide to gold purity: what karats mean, how to read hallmarks, and the difference between 9K, 14K, 18K, 22K and 24K gold.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/gold-purity-guide">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Purity Guide — Karats, Hallmarks & What They Mean","description":"Complete guide to gold purity: what karats mean, how to read hallmarks, and the difference between 9K, 14K, 18K, 22K and 24K gold.","url":"https://goldpricetools.com/guides/gold-purity-guide","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-purity-guide"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Purity Guide — Karats, Hallmarks & What They Mean","description":"Complete guide to gold purity: what karats mean, how to read hallmarks, and the difference between 9K, 14K, 18K, 22K and 24K gold.","url":"https://goldpricetools.com/guides/gold-purity-guide","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-purity-guide"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Gold Purity Guide"}]}</script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -36,7 +36,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -44,7 +44,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -52,7 +52,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -60,7 +60,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -110,7 +110,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/gold-vs-silver-investment.html
+++ b/guides/gold-vs-silver-investment.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-vs-silver-investment">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-vs-silver-investment">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="Gold vs Silver Investment — Which Is Better in 2026?">
 <meta property="og:description" content="Gold vs silver investment compared: historical returns, volatility, liquidity, storage costs, and which suits your portfolio in 2026.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/gold-vs-silver-investment">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold vs Silver Investment — Which Is Better in 2026?","description":"Gold vs silver investment compared: historical returns, volatility, liquidity, storage costs, and which precious metal suits your portfolio in 2026.","url":"https://goldpricetools.com/guides/gold-vs-silver-investment","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-vs-silver-investment"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold vs Silver Investment — Which Is Better in 2026?","description":"Gold vs silver investment compared: historical returns, volatility, liquidity, storage costs, and which precious metal suits your portfolio in 2026.","url":"https://goldpricetools.com/guides/gold-vs-silver-investment","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-vs-silver-investment"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Gold vs Silver Investment"}]}</script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -36,7 +36,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -44,7 +44,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -52,7 +52,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -60,7 +60,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -112,7 +112,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/how-to-calculate-scrap-gold.html
+++ b/guides/how-to-calculate-scrap-gold.html
@@ -12,18 +12,18 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="How to Calculate Scrap Gold Value — Step by Step">
 <meta property="og:description" content="Step-by-step guide to calculating the value of scrap gold jewellery using the live gold spot price. Includes worked examples.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/how-to-calculate-scrap-gold">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <!-- Article JSON-LD with author (WP-54 E-E-A-T) -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Calculate Scrap Gold Value — Step by Step","description":"A practical guide to calculating the melt value of scrap gold jewellery using the live gold spot price. Includes formula, worked example, and tips for selling.","url":"https://goldpricetools.com/guides/how-to-calculate-scrap-gold","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-calculate-scrap-gold"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Calculate Scrap Gold Value — Step by Step","description":"A practical guide to calculating the melt value of scrap gold jewellery using the live gold spot price. Includes formula, worked example, and tips for selling.","url":"https://goldpricetools.com/guides/how-to-calculate-scrap-gold","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-calculate-scrap-gold"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <!-- HowTo JSON-LD (WP-58) -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to Calculate Scrap Gold Value","description":"Calculate the melt value of scrap gold jewellery using the current live gold spot price in five steps.","totalTime":"PT3M","tool":[{"@type":"HowToTool","name":"Precision digital scale (0.01g accuracy)"},{"@type":"HowToTool","name":"GoldPriceTools Scrap Gold Calculator"}],"step":[{"@type":"HowToStep","position":1,"name":"Find the karat of your gold","text":"Look for a hallmark stamp on the piece — inside the ring band, on the clasp, or on the post of an earring. Common stamps are 9K, 10K, 14K, 18K, 22K, 24K, or European millesimal marks like 375 (9K), 585 (14K), 750 (18K)."},{"@type":"HowToStep","position":2,"name":"Weigh the gold accurately","text":"Use a digital jewellery scale accurate to 0.01 grams. Weigh each karat separately if you have mixed pieces. Remove any non-gold components (clasps, stones) where possible."},{"@type":"HowToStep","position":3,"name":"Get the current gold spot price per gram","text":"The spot price is quoted in troy ounces. To convert to per gram, divide by 31.1035. Use the GoldPriceTools live calculator which does this automatically and updates every 60 seconds."},{"@type":"HowToStep","position":4,"name":"Apply the formula","text":"Multiply: Weight (grams) × Purity Factor × Spot Price per gram = melt value. For 14K gold the purity factor is 0.5833 (14 ÷ 24)."},{"@type":"HowToStep","position":5,"name":"Apply a dealer percentage","text":"Scrap gold dealers typically pay 70–90% of melt value. Multiply your melt value by 0.75 to 0.85 to estimate a realistic dealer offer."}]}</script>
 <!-- BreadcrumbList JSON-LD (WP-57) -->
@@ -48,7 +48,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -56,7 +56,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -64,7 +64,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -72,7 +72,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -137,7 +137,7 @@ footer a:hover{color:var(--color-text)}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/how-to-invest-in-gold.html
+++ b/guides/how-to-invest-in-gold.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-invest-in-gold">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-invest-in-gold">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="How to Invest in Gold — Beginner's Guide 2026">
 <meta property="og:description" content="How to invest in gold in 2026: physical gold, ETFs, mining stocks, and digital gold compared.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/how-to-invest-in-gold">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Invest in Gold — Beginner's Guide 2026","description":"How to invest in gold in 2026: physical gold, ETFs, gold mining stocks, and digital gold compared.","url":"https://goldpricetools.com/guides/how-to-invest-in-gold","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-invest-in-gold"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Invest in Gold — Beginner's Guide 2026","description":"How to invest in gold in 2026: physical gold, ETFs, gold mining stocks, and digital gold compared.","url":"https://goldpricetools.com/guides/how-to-invest-in-gold","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-invest-in-gold"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"How to Invest in Gold"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to Invest in Gold — Beginner's Guide 2026","description":"How to invest in gold in 2026: physical gold, ETFs, gold mining stocks, and digital gold compared.","step":[{"@type":"HowToStep","position":1,"name":"Choose your gold investment type","text":"Decide between physical gold (coins/bars), gold ETFs, gold mining stocks, or digital gold accounts. Each has different risk, cost, and liquidity profiles."},{"@type":"HowToStep","position":2,"name":"Open the right account","text":"For ETFs: use a stocks ISA or SIPP with a UK broker. For physical gold: use a regulated dealer (Royal Mint, Baird & Co). For mining stocks: standard share-dealing account."},{"@type":"HowToStep","position":3,"name":"Check the gold spot price","text":"Use our live gold price calculator to see today's XAU/USD and XAU/GBP spot prices before making any purchase decision."},{"@type":"HowToStep","position":4,"name":"Set your position size","text":"Precious metals are typically 5-15% of a diversified portfolio. Calculate how much gold that represents at today's spot price."},{"@type":"HowToStep","position":5,"name":"Buy and arrange storage","text":"Physical gold needs secure storage. ETFs are held electronically in your brokerage account."}]}</script>
 <script>
@@ -37,7 +37,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -116,7 +116,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/how-to-read-gold-spot-price.html
+++ b/guides/how-to-read-gold-spot-price.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="How to Read the Gold Spot Price">
 <meta property="og:description" content="What the gold spot price means, how it's quoted, and how to convert troy oz to per gram for any karat.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/how-to-read-gold-spot-price">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Read the Gold Spot Price","description":"Learn how to read and understand the gold spot price: what it means, how it's quoted, and how to convert troy oz prices to per gram for any karat.","url":"https://goldpricetools.com/guides/how-to-read-gold-spot-price","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-read-gold-spot-price"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Read the Gold Spot Price","description":"Learn how to read and understand the gold spot price: what it means, how it's quoted, and how to convert troy oz prices to per gram for any karat.","url":"https://goldpricetools.com/guides/how-to-read-gold-spot-price","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-read-gold-spot-price"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"How to Read the Gold Spot Price"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to Read the Gold Spot Price","description":"Step-by-step: find the XAU/USD spot price, convert to grams, convert to your currency, and adjust for karat purity.","step":[{"@type":"HowToStep","position":1,"name":"Find the XAU/USD spot price","text":"The gold spot price is quoted as XAU/USD — the price of one troy ounce of pure (24K) gold in US dollars. Check our live calculator for the current rate."},{"@type":"HowToStep","position":2,"name":"Convert troy oz to grams","text":"Divide the troy oz price by 31.1035 to get the price per gram. E.g. $3,300 ÷ 31.1035 = $106.10 per gram (24K)."},{"@type":"HowToStep","position":3,"name":"Convert to your currency","text":"Multiply the USD/gram price by the GBP/USD exchange rate to get the price in pounds. E.g. $106.10 × 0.79 = £83.82 per gram (24K)."},{"@type":"HowToStep","position":4,"name":"Adjust for karat purity","text":"Multiply the 24K gram price by the purity factor: 22K × 0.9167, 18K × 0.75, 14K × 0.5833, 9K × 0.375."}]}</script>
 <script>
@@ -37,7 +37,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -110,7 +110,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/how-to-sell-gold-jewellery.html
+++ b/guides/how-to-sell-gold-jewellery.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="How to Sell Gold Jewellery — Get the Best Price">
 <meta property="og:description" content="Where to sell gold jewellery, how dealers calculate offers, and how to avoid getting underpaid.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/how-to-sell-gold-jewellery">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Sell Gold Jewellery — Get the Best Price","description":"How to sell gold jewellery for the best price: where to sell, how dealers calculate offers, and how to avoid getting underpaid.","url":"https://goldpricetools.com/guides/how-to-sell-gold-jewellery","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-sell-gold-jewellery"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Sell Gold Jewellery — Get the Best Price","description":"How to sell gold jewellery for the best price: where to sell, how dealers calculate offers, and how to avoid getting underpaid.","url":"https://goldpricetools.com/guides/how-to-sell-gold-jewellery","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-sell-gold-jewellery"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"How to Sell Gold Jewellery"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to Sell Gold Jewellery — Get the Best Price","description":"Follow these steps to sell your gold jewellery at the best possible price.","step":[{"@type":"HowToStep","position":1,"name":"Calculate the melt value","text":"Use our scrap gold calculator to find the current melt value of your gold at today's live spot price. This is your baseline."},{"@type":"HowToStep","position":2,"name":"Get at least 3 quotes","text":"Contact multiple buyers: a local jeweller, an online gold buyer, and a regulated refiner. Never accept the first offer."},{"@type":"HowToStep","position":3,"name":"Understand the offer","text":"Ask each buyer what percentage of spot they are paying. A good offer is 85-92% of spot."},{"@type":"HowToStep","position":4,"name":"Choose your selling method","text":"Post-in services typically pay 85-92% of spot. Walk-in dealers pay immediately but often only 70-80%."},{"@type":"HowToStep","position":5,"name":"Complete the sale securely","text":"Use insured special delivery for postal sales (minimum £500 cover). Keep receipts and payment confirmation."}]}</script>
 <script>
@@ -37,7 +37,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -110,7 +110,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/silver-price-per-gram-explained.html
+++ b/guides/silver-price-per-gram-explained.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/silver-price-per-gram-explained">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/silver-price-per-gram-explained">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="Silver Price Per Gram Explained">
 <meta property="og:description" content="How the silver price per gram is calculated, what affects it, and how to convert troy oz to grams.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/silver-price-per-gram-explained">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Silver Price Per Gram Explained","description":"Everything you need to know about the silver price per gram: how it's calculated, what affects it, and how to convert troy oz prices to grams.","url":"https://goldpricetools.com/guides/silver-price-per-gram-explained","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/silver-price-per-gram-explained"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Silver Price Per Gram Explained","description":"Everything you need to know about the silver price per gram: how it's calculated, what affects it, and how to convert troy oz prices to grams.","url":"https://goldpricetools.com/guides/silver-price-per-gram-explained","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/silver-price-per-gram-explained"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Silver Price Per Gram Explained"}]}</script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -36,7 +36,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -44,7 +44,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -52,7 +52,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -60,7 +60,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -109,7 +109,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/troy-ounce-vs-gram-explained.html
+++ b/guides/troy-ounce-vs-gram-explained.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="Troy Ounce vs Gram — What's the Difference?">
 <meta property="og:description" content="Why gold is quoted in troy ounces, how many grams in a troy ounce, and how to convert.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Troy Ounce vs Gram — What's the Difference?","description":"Troy ounce vs gram explained: why gold and silver are quoted in troy ounces, how many grams in a troy ounce, and how to convert between weights.","url":"https://goldpricetools.com/guides/troy-ounce-vs-gram-explained","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Troy Ounce vs Gram — What's the Difference?","description":"Troy ounce vs gram explained: why gold and silver are quoted in troy ounces, how many grams in a troy ounce, and how to convert between weights.","url":"https://goldpricetools.com/guides/troy-ounce-vs-gram-explained","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Troy Ounce vs Gram Explained"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How many grams in a troy ounce?","acceptedAnswer":{"@type":"Answer","text":"One troy ounce equals exactly 31.1035 grams. This is heavier than a standard (avoirdupois) ounce, which is 28.3495 grams."}},{"@type":"Question","name":"Why is gold quoted in troy ounces?","acceptedAnswer":{"@type":"Answer","text":"The troy weight system has been used for precious metals since at least the 15th century, originating from the trading city of Troyes in France. It became the global standard for gold and silver pricing through the London Bullion Market."}},{"@type":"Question","name":"Is a troy ounce heavier than a regular ounce?","acceptedAnswer":{"@type":"Answer","text":"Yes. A troy ounce (31.1035g) is heavier than an avoirdupois ounce (28.3495g) by about 10%. So a troy ounce of gold is worth more than a regular ounce of gold at the same price."}},{"@type":"Question","name":"How do I convert troy ounces to grams?","acceptedAnswer":{"@type":"Answer","text":"Multiply troy ounces by 31.1035 to get grams. Example: 2 troy oz x 31.1035 = 62.207 grams."}}]}</script>
 <script>
@@ -37,7 +37,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -110,7 +110,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/what-is-14k-gold.html
+++ b/guides/what-is-14k-gold.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-14k-gold">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-14k-gold">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="What Is 14K Gold? Purity, Price & Uses Explained">
 <meta property="og:description" content="14 karat gold purity (58.33%), hallmarks, price per gram, durability, and how it compares to 18K and 24K gold.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/what-is-14k-gold">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"What Is 14K Gold? Purity, Price & Uses Explained","description":"What is 14K gold? Full guide to 14 karat gold purity (58.33%), hallmarks, price per gram, durability, and how it compares to 18K and 24K gold.","url":"https://goldpricetools.com/guides/what-is-14k-gold","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-is-14k-gold"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"What Is 14K Gold? Purity, Price & Uses Explained","description":"What is 14K gold? Full guide to 14 karat gold purity (58.33%), hallmarks, price per gram, durability, and how it compares to 18K and 24K gold.","url":"https://goldpricetools.com/guides/what-is-14k-gold","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-is-14k-gold"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"What Is 14K Gold?"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What does 14K mean on gold?","acceptedAnswer":{"@type":"Answer","text":"14K means the gold item is 14 parts gold out of 24 parts total, giving a purity of 58.33%. The remaining 41.67% is typically copper, silver, zinc, or palladium alloys."}},{"@type":"Question","name":"What is 14K gold worth per gram?","acceptedAnswer":{"@type":"Answer","text":"14K gold is worth 58.33% of the 24K gold price per gram. At $3,300/troy oz (24K spot), the 14K melt value is approximately $62/g or £49/g. Use our live calculator for today's exact price."}},{"@type":"Question","name":"What hallmark is 14K gold?","acceptedAnswer":{"@type":"Answer","text":"14K gold is hallmarked 585 in Europe and the UK (58.5% purity) or 14K or 14KT in the US. Both mean the same gold content."}},{"@type":"Question","name":"Is 14K gold good quality?","acceptedAnswer":{"@type":"Answer","text":"Yes. 14K gold is the most popular jewellery gold in the US and widely used in engagement rings. It is more durable than 18K or 22K due to higher alloy content, while still containing over half pure gold."}}]}</script>
 <script>
@@ -37,7 +37,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -109,7 +109,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/what-is-925-sterling-silver.html
+++ b/guides/what-is-925-sterling-silver.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-925-sterling-silver">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-925-sterling-silver">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="What Is 925 Sterling Silver?">
 <meta property="og:description" content="What does 925 mean on silver? Complete guide to sterling silver: purity, hallmarks, value, and how to spot fakes.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/what-is-925-sterling-silver">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"What Is 925 Sterling Silver?","description":"What does 925 mean on silver? Complete guide to 925 sterling silver: purity, hallmarks, value, care, and how to tell real sterling from silver-plated items.","url":"https://goldpricetools.com/guides/what-is-925-sterling-silver","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-is-925-sterling-silver"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"What Is 925 Sterling Silver?","description":"What does 925 mean on silver? Complete guide to 925 sterling silver: purity, hallmarks, value, care, and how to tell real sterling from silver-plated items.","url":"https://goldpricetools.com/guides/what-is-925-sterling-silver","datePublished":"2026-04-24","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-is-925-sterling-silver"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"What Is 925 Sterling Silver?"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What does 925 mean on silver?","acceptedAnswer":{"@type":"Answer","text":"925 means the item is 92.5% pure silver (sterling silver). The remaining 7.5% is typically copper, which improves hardness and durability."}},{"@type":"Question","name":"Is 925 silver worth anything?","acceptedAnswer":{"@type":"Answer","text":"Yes. 925 sterling silver is worth 92.5% of the silver spot price per gram. At $33/troy oz, sterling silver is worth approximately $0.98/g or about 77p/g."}},{"@type":"Question","name":"How do I know if my silver is real 925?","acceptedAnswer":{"@type":"Answer","text":"Look for a 925 hallmark, or in the UK, look for Assay Office marks (London lion passant, Sheffield rose, Edinburgh castle). Magnetic testing (silver is not magnetic), acid testing, or XRF analysis by a jeweller can confirm purity."}},{"@type":"Question","name":"Does 925 silver tarnish?","acceptedAnswer":{"@type":"Answer","text":"Yes, sterling silver tarnishes when the copper alloy reacts with sulphur in the air. Tarnish appears as a yellowish or dark discolouration. It is easily removed with silver polishing cloth or a mild silver cleaner."}}]}</script>
 <script>
@@ -37,7 +37,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -109,7 +109,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/guides/what-is-best-time-to-sell-scrap-gold.html
+++ b/guides/what-is-best-time-to-sell-scrap-gold.html
@@ -11,17 +11,17 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="When Is the Best Time to Sell Scrap Gold?">
 <meta property="og:description" content="Key signals — spot price levels, USD/GBP rate, seasonal demand — that tell you when to sell scrap gold for the best price.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold">
 <meta property="og:site_name" content="GoldPriceTools">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"When Is the Best Time to Sell Scrap Gold?","description":"Timing your scrap gold sale can significantly increase what you receive. Learn the key signals — spot price levels, USD/GBP rate, seasonal demand — to sell at the right moment.","url":"https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold","datePublished":"2026-04-25","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/og-image.jpg"}}</script>
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"When Is the Best Time to Sell Scrap Gold?","description":"Timing your scrap gold sale can significantly increase what you receive. Learn the key signals — spot price levels, USD/GBP rate, seasonal demand — to sell at the right moment.","url":"https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold","datePublished":"2026-04-25","dateModified":"2026-04-29T06:00:00Z","author":{"@type":"Person","name":"James Smith","url":"https://goldpricetools.com/authors/james-smith/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"When Is the Best Time to Sell Scrap Gold?"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"When is the best time to sell scrap gold?","acceptedAnswer":{"@type":"Answer","text":"The best time to sell scrap gold is when the XAU/USD spot price is at a recent high AND the GBP/USD rate is weak (meaning each dollar buys fewer pounds, so your GBP payout is higher). Monitor both on our live calculator."}},{"@type":"Question","name":"Does the gold price change daily?","acceptedAnswer":{"@type":"Answer","text":"Yes. The gold spot price (XAU/USD) changes every second during market hours. The LBMA sets a twice-daily benchmark fix (AM and PM) in London which is widely used by UK dealers for scrap gold valuations."}},{"@type":"Question","name":"Is it worth waiting for a higher gold price before selling?","acceptedAnswer":{"@type":"Answer","text":"It depends on your holding period. Gold does not pay interest or dividends, so holding has an opportunity cost. If the price is near a multi-year high and you have no storage costs, waiting can add value — but predicting peaks is difficult even for professionals."}},{"@type":"Question","name":"Do gold dealers pay the full spot price?","acceptedAnswer":{"@type":"Answer","text":"No. Dealers typically pay 70–90% of the melt value (spot price × weight × purity factor), depending on volume and dealer type. High street jewellers often pay less than specialist scrap gold buyers or online refiners."}}]}</script>
 <script>
@@ -37,7 +37,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -119,7 +119,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 <body>
 <nav>
   <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
     <a href="/guides/" class="nav-back">&larr; Guides</a>
   </div>
 </nav>

--- a/how-many-grams-in-troy-ounce.html
+++ b/how-many-grams-in-troy-ounce.html
@@ -16,9 +16,9 @@
 <meta property="og:description" content="A troy ounce equals 31.1035 grams. Learn the difference from regular ounces and how to convert for gold pricing.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/how-many-grams-in-troy-ounce">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
 <!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
@@ -26,9 +26,9 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="/assets/logo.svg"><meta name="theme-color" content="#0f0e0c">
+<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -36,7 +36,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -44,7 +44,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -52,7 +52,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem}.answer-box{background:var(--color-surface);border:2px solid var(--color-gold-bright);border-radius:1rem;padding:1.75rem 2rem;max-width:480px;margin:0 0 2rem;text-align:center}.answer-num{font-family:var(--font-display);font-size:clamp(2.5rem,7vw,4rem);font-weight:700;color:var(--color-gold-bright);line-height:1;margin-bottom:.25rem}.answer-unit{font-size:1rem;color:var(--color-text-muted);margin-bottom:.5rem}.answer-sub{font-size:.8125rem;color:var(--color-text-faint)}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h1{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:1rem}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.prose strong{color:var(--color-text)}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.highlight-row{background:rgba(232,175,52,.08);font-weight:600}.highlight-row td{color:var(--color-gold-bright)}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
@@ -72,7 +72,7 @@
 </script>
 </head>
 <body>
-<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
+<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
 <div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">How Many Grams in a Troy Ounce?</li></ol></div>
 <div class="hero">
   <div class="prose">

--- a/image-sitemap.xml
+++ b/image-sitemap.xml
@@ -6,12 +6,12 @@
   <url>
     <loc>https://goldpricetools.com/</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>GoldPriceTools — Live Gold and Silver Price Calculator</image:title>
       <image:caption>Free real-time gold and silver price calculator showing live 10K, 14K, 18K and 24K gold price per gram, scrap gold value, and silver spot price — updated every 60 seconds.</image:caption>
     </image:image>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/logo.svg</image:loc>
+      <image:loc>https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg</image:loc>
       <image:title>GoldPriceTools Logo</image:title>
       <image:caption>GoldPriceTools — live gold and silver price tools</image:caption>
     </image:image>
@@ -21,7 +21,7 @@
   <url>
     <loc>https://goldpricetools.com/14k-gold-price-per-gram</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>14K Gold Price Per Gram Today — Live GoldPriceTools</image:title>
       <image:caption>Live 14K gold price per gram in USD, GBP and EUR. 14 karat gold is 58.33% pure. Updated every 60 seconds.</image:caption>
     </image:image>
@@ -31,7 +31,7 @@
   <url>
     <loc>https://goldpricetools.com/18k-gold-price-per-gram</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>18K Gold Price Per Gram Today — Live GoldPriceTools</image:title>
       <image:caption>Live 18K gold price per gram in USD, GBP and EUR. 18 karat gold is 75% pure — the most popular karat for jewellery. Updated every 60 seconds.</image:caption>
     </image:image>
@@ -41,7 +41,7 @@
   <url>
     <loc>https://goldpricetools.com/10k-gold-price-per-gram</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>10K Gold Price Per Gram Today — Live GoldPriceTools</image:title>
       <image:caption>Live 10K gold price per gram in USD, GBP and EUR. 10 karat gold is 41.67% pure — minimum US gold standard. Updated every 60 seconds.</image:caption>
     </image:image>
@@ -51,7 +51,7 @@
   <url>
     <loc>https://goldpricetools.com/scrap-gold-calculator</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Scrap Gold Calculator — Live Melt Value by Karat</image:title>
       <image:caption>Free scrap gold calculator showing live melt value for 9K, 10K, 14K, 18K and 24K gold by weight in grams. Updated in real time.</image:caption>
     </image:image>
@@ -61,7 +61,7 @@
   <url>
     <loc>https://goldpricetools.com/silver-price-per-kilo</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Silver Price Per Kilo Today — Live GoldPriceTools</image:title>
       <image:caption>Live silver price per kilogram in USD and GBP. Also shows .999 fine silver, 925 sterling silver and silver per troy ounce. Updated every 60 seconds.</image:caption>
     </image:image>
@@ -71,7 +71,7 @@
   <url>
     <loc>https://goldpricetools.com/how-many-grams-in-troy-ounce</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How Many Grams in a Troy Ounce — Weight Converter</image:title>
       <image:caption>1 troy ounce = 31.1035 grams. Complete gold and silver weight converter: grams, troy ounces, pennyweight, kilograms and more.</image:caption>
     </image:image>
@@ -81,7 +81,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/what-is-14k-gold</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>What Is 14K Gold? Purity, Value and How to Identify It</image:title>
       <image:caption>Guide to 14K gold: what 58.33% purity means, hallmarks to look for, and how to calculate its value at today's live spot price.</image:caption>
     </image:image>
@@ -89,7 +89,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/how-to-calculate-scrap-gold</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How to Calculate Scrap Gold Value — Step by Step Guide</image:title>
       <image:caption>Step-by-step guide to calculating scrap gold value using the live spot price, weight and karat purity.</image:caption>
     </image:image>
@@ -97,7 +97,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/troy-ounce-vs-gram-explained</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Troy Ounce vs Gram — The Complete Precious Metals Guide</image:title>
       <image:caption>Explains why precious metals are weighed in troy ounces (31.1035g) rather than regular ounces (28.35g) and how to convert between units.</image:caption>
     </image:image>
@@ -105,7 +105,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/gold-purity-guide</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Gold Purity Guide — 9K to 24K Karat Explained</image:title>
       <image:caption>Complete guide to gold karat purity: what each karat means, hallmarks, uses and current value from 9K to 24K gold.</image:caption>
     </image:image>
@@ -113,7 +113,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/what-is-925-sterling-silver</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>What Is 925 Sterling Silver and How Much Is It Worth?</image:title>
       <image:caption>Guide to 925 sterling silver: 92.5% purity, hallmarks, uses in jewellery, and how to calculate its live melt value.</image:caption>
     </image:image>
@@ -121,7 +121,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>When Is the Best Time to Sell Scrap Gold?</image:title>
       <image:caption>Guide to timing scrap gold sales: price signals, USD/GBP exchange rate factors, seasonal demand patterns and how to maximise your payout.</image:caption>
     </image:image>
@@ -129,7 +129,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/gold-price-history</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Gold Price History — Key Milestones From 1970 to 2026</image:title>
       <image:caption>Historical gold price chart and guide covering major milestones: Nixon Shock 1971, 1980 peak, 2008 crisis, 2020 all-time high, and 2026 prices.</image:caption>
     </image:image>
@@ -137,7 +137,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/how-to-read-gold-spot-price</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How to Read a Gold Spot Price — Beginner's Guide</image:title>
       <image:caption>Beginner's guide to gold spot prices: what the spot price means, where it comes from, and how to use it to value gold jewellery and bars.</image:caption>
     </image:image>
@@ -145,7 +145,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/how-to-invest-in-gold</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How to Invest in Gold — Bullion, ETFs and More</image:title>
       <image:caption>Guide to investing in gold: comparing physical bullion, gold ETFs, mining stocks and gold ISAs with pros, cons and current price context.</image:caption>
     </image:image>
@@ -153,7 +153,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/gold-vs-silver-investment</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Gold vs Silver Investment — Which Precious Metal Is Better?</image:title>
       <image:caption>Comparison of gold and silver as investments: historical returns, volatility, gold-silver ratio, and which metal suits different investor profiles.</image:caption>
     </image:image>
@@ -161,7 +161,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/how-to-sell-gold-jewellery</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How to Sell Gold Jewellery — Get the Best Price Guide</image:title>
       <image:caption>Step-by-step guide to selling gold jewellery: how to calculate melt value, find the best buyer, and avoid common pitfalls when selling gold.</image:caption>
     </image:image>
@@ -169,7 +169,7 @@
   <url>
     <loc>https://goldpricetools.com/guides/silver-price-per-gram-explained</loc>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Silver Price Per Gram Explained — Live Calculation Guide</image:title>
       <image:caption>Guide explaining how the silver price per gram is calculated from the troy ounce spot price, with live examples for .999 fine and 925 sterling silver.</image:caption>
     </image:image>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 <meta property="og:description" content="Real-time 10K, 14K, 18K, 24K gold price per gram. Scrap gold &amp; silver calculators updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="GoldPriceTools — Live Gold and Silver Price Calculator">
@@ -26,14 +26,14 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Gold &amp; Silver Price Calculator — Live Prices Per Gram">
 <meta name="twitter:description" content="Real-time 10K, 14K, 18K, 24K gold price per gram. Scrap gold &amp; silver calculators updated every 60 seconds.">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <!-- PWA -->
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <!-- JSON-LD Schemas — aggregateRating removed: must be earned, not fabricated -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","dateModified":"2026-04-29T06:00:00Z","name":"GoldPriceTools — Gold & Silver Calculator","url":"https://goldpricetools.com","description":"Live gold and silver price calculator with 10K, 14K, 18K, 24K per gram prices, scrap calculator and historical charts","applicationCategory":"FinanceApplication","operatingSystem":"Any","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
-    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","@id":"https://goldpricetools.com/#organization","name":"GoldPriceTools","legalName":"DigitalCliqs","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/assets/logo.svg","width":112,"height":112},"description":"GoldPriceTools provides free live gold and silver price calculators with real-time LBMA spot prices, karat conversion tools, and precious metals guides for UK and international users.","foundingDate":"2026","address":{"@type":"PostalAddress","addressCountry":"GB","addressLocality":"London"},"email":"contact@goldpricetools.com","contactPoint":{"@type":"ContactPoint","contactType":"customer service","email":"contact@goldpricetools.com"},"founder":{"@type":"Person","name":"DigitalCliqs"},"sameAs":["https://github.com/DigitalCliqs"]}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","@id":"https://goldpricetools.com/#organization","name":"GoldPriceTools","legalName":"DigitalCliqs","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://goldpricetools.comhttps://assets.goldpricetools.com/logo.svg","width":112,"height":112},"description":"GoldPriceTools provides free live gold and silver price calculators with real-time LBMA spot prices, karat conversion tools, and precious metals guides for UK and international users.","foundingDate":"2026","address":{"@type":"PostalAddress","addressCountry":"GB","addressLocality":"London"},"email":"contact@goldpricetools.com","contactPoint":{"@type":"ContactPoint","contactType":"customer service","email":"contact@goldpricetools.com"},"founder":{"@type":"Person","name":"DigitalCliqs"},"sameAs":["https://github.com/DigitalCliqs"]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"GoldPriceTools","url":"https://goldpricetools.com/","inLanguage":"en-GB","publisher":{"@type":"Organization","name":"GoldPriceTools"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://goldpricetools.com/?q={search_term_string}"},"query-input":"required name=search_term_string"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","dateModified":"2026-04-29T06:00:00Z","mainEntity":[{"@type":"Question","name":"How much is 14K gold per gram today?","acceptedAnswer":{"@type":"Answer","text":"14K gold is 58.33% pure gold. The current 14K gold price per gram updates every 60 seconds based on the live spot price. Use our calculator above for the exact current value."}},{"@type":"Question","name":"What is the 10K gold price per gram?","acceptedAnswer":{"@type":"Answer","text":"10K gold contains 41.67% pure gold. 10K is the minimum karat sold as gold in the US. Check our live calculator for today's exact 10K gold price per gram."}},{"@type":"Question","name":"How much is 18K gold per gram?","acceptedAnswer":{"@type":"Answer","text":"18K gold is 75% pure gold, making it the most popular karat in European jewellery. Our calculator shows the live 18K gold price per gram updated every 60 seconds."}},{"@type":"Question","name":"How many grams is 1 troy ounce of gold?","acceptedAnswer":{"@type":"Answer","text":"1 troy ounce equals exactly 31.1035 grams. This is the standard unit for all precious metals trading worldwide, different from a regular avoirdupois ounce (28.35g)."}},{"@type":"Question","name":"What is 925 sterling silver worth today?","acceptedAnswer":{"@type":"Answer","text":"925 sterling silver is 92.5% pure silver. Use our silver calculator to find the current value of 925 sterling silver per gram based on the live silver spot price."}},{"@type":"Question","name":"How much is a gold bar worth?","acceptedAnswer":{"@type":"Answer","text":"A standard 400oz Good Delivery gold bar value depends on the current spot price. Our gold bar calculator shows live values for 400oz, 100oz, 1kg, 10oz, 1oz and 1g bars."}},{"@type":"Question","name":"What is 1 gram of gold worth?","acceptedAnswer":{"@type":"Answer","text":"1 gram of pure 24K gold price fluctuates with the global spot price, which trades 24 hours a day on international markets. Check our live calculator for the current 1 gram gold price."}},{"@type":"Question","name":"What is silver price per kilogram?","acceptedAnswer":{"@type":"Answer","text":"To convert the troy oz silver price to per kilogram, multiply by 32.1507 troy oz per kg. Our silver calculator shows the live silver price per kilogram updated every 60 seconds."}}]}</script>
 <!-- Dataset JSON-LD (WP-53) -->
@@ -60,7 +60,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -68,7 +68,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -76,7 +76,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -84,7 +84,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>
@@ -318,7 +318,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <nav role="navigation" aria-label="Main navigation">
   <div class="nav-inner">
     <a href="/" class="nav-logo" aria-label="GoldPriceTools Home">
-      <img src="/assets/logo.svg" width="28" height="28" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
+      <img src="https://assets.goldpricetools.com/logo.svg" width="28" height="28" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
       <span>GoldPriceTools</span>
     </a>
     <div class="nav-links">
@@ -873,7 +873,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <div class="footer-inner">
     <div>
       <div class="nav-logo" style="margin-bottom:var(--space-3)">
-        <img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
       <p class="footer-brand">Live gold and silver price calculator. Real-time 10K, 14K, 18K &amp; 24K gold per gram. Scrap gold calculator, silver per troy oz, kilo and kilogram. Prices sourced from global markets, updated every 60 seconds.</p>

--- a/offline.html
+++ b/offline.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>You're Offline — GoldPriceTools</title>
 <meta name="robots" content="noindex">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <style>
 :root{--color-bg:#0f0e0c;--color-surface:#161513;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-gold-bright:#e8af34;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -33,7 +33,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -41,7 +41,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -49,7 +49,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -57,7 +57,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>

--- a/scrap-gold-calculator.html
+++ b/scrap-gold-calculator.html
@@ -19,9 +19,9 @@
 <meta property="og:description" content="Free scrap gold calculator. Enter weight and karat to find the live melt value of your gold jewellery in GBP and USD.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/scrap-gold-calculator">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
 let _scrapIntentFired = false;
 document.addEventListener("DOMContentLoaded", () => { document.querySelectorAll('a[href*="/scrap-gold-calculator"]').forEach(a => { a.addEventListener('click', fireScrapIntent); }); });
@@ -199,9 +199,9 @@ function fireCalcEngaged() {
 }
 
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="/assets/logo.svg"><meta name="theme-color" content="#0f0e0c">
+<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -209,7 +209,7 @@ function fireCalcEngaged() {
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -217,7 +217,7 @@ function fireCalcEngaged() {
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -225,7 +225,7 @@ function fireCalcEngaged() {
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.calc-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:1.5rem;max-width:560px;margin:0 auto 2rem}.calc-row{display:grid;grid-template-columns:1fr 1fr auto;gap:.75rem;margin-bottom:.75rem;align-items:end}.calc-label{font-size:.75rem;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-bottom:.25rem}.calc-input{width:100%;padding:.625rem .875rem;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:.5rem;color:var(--color-text);font-size:.9375rem;font-family:var(--font-body)}.calc-select{width:100%;padding:.625rem .875rem;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:.5rem;color:var(--color-text);font-size:.9375rem;font-family:var(--font-body)}.calc-del{padding:.625rem .875rem;background:transparent;border:1px solid var(--color-border);border-radius:.5rem;color:var(--color-text-muted);cursor:pointer;font-size:1rem}.calc-add{width:100%;padding:.75rem;background:transparent;border:1px dashed var(--color-border);border-radius:.5rem;color:var(--color-text-muted);cursor:pointer;font-size:.875rem;margin-bottom:1rem}.result-box{background:var(--color-surface-offset);border-radius:.75rem;padding:1.25rem;text-align:center}.result-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.375rem}.result-gbp{font-family:var(--font-display);font-size:2.25rem;color:var(--color-gold-bright);font-weight:700;line-height:1;min-height:2.5rem}.result-usd{font-size:1rem;color:var(--color-text-muted)}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.prose ol{padding-left:1.5rem;margin-bottom:1.25rem}.prose li{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:.5rem}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
@@ -244,7 +244,7 @@ function fireCalcEngaged() {
 </script>
 </head>
 <body>
-<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
+<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
 <div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">Scrap Gold Calculator</li></ol></div>
 <div class="hero">
   <div class="hero-tag">Free Calculator</div>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -24,7 +24,7 @@ const { execSync } = require('child_process');
 
 const ROOT = process.cwd();
 const SITEMAP_PATH = path.join(ROOT, 'sitemap.xml');
-const DEFAULT_IMAGE = 'https://goldpricetools.com/assets/og-image.jpg';
+const DEFAULT_IMAGE = 'https://assets.goldpricetools.com/og-image.jpg';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -18,9 +18,9 @@
 <meta property="og:description" content="Real-time silver price per kilogram, gram and troy ounce in GBP and USD. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/silver-price-per-kilo">
-<meta property="og:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://goldpricetools.com/assets/og-image.jpg">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
 <!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
@@ -28,9 +28,9 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="/assets/logo.svg"><meta name="theme-color" content="#0f0e0c">
+<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -38,7 +38,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -46,7 +46,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -54,7 +54,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.price-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1rem;max-width:700px;margin:0 auto 2rem}.price-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:.875rem;padding:1.25rem;text-align:center}.price-tile-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-faint);margin-bottom:.375rem}.price-tile-value{font-family:var(--font-display);font-size:1.5rem;color:var(--color-gold-bright);font-weight:700;min-height:2rem}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
@@ -74,7 +74,7 @@
 </script>
 </head>
 <body>
-<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
+<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
 <div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">Silver Price Per Kilo</li></ol></div>
 <div class="hero">
   <div class="hero-tag">Live Silver Price</div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,7 +12,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Gold &amp; Silver Price Calculator — Live Prices Per Gram</image:title>
       <image:caption>Real-time 10K, 14K, 18K, 24K gold price per gram. Scrap gold &amp; silver calculators updated every 60 seconds.</image:caption>
       <image:geo_location>United Kingdom</image:geo_location>
@@ -28,7 +28,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/10k-gold-price-per-gram"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/10k-gold-price-per-gram"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>10K Gold Price Per Gram Today (Live)</image:title>
       <image:caption>Real-time 10K gold price per gram in GBP and USD. 41.67% pure gold. Updated every 60 seconds.</image:caption>
     </image:image>
@@ -43,7 +43,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/14k-gold-price-per-gram"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/14k-gold-price-per-gram"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>14K Gold Price Per Gram Today (Live)</image:title>
       <image:caption>Real-time 14K gold price per gram in USD, GBP, EUR. 58.33% pure gold. Updated every 60 seconds.</image:caption>
     </image:image>
@@ -58,7 +58,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/18k-gold-price-per-gram"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/18k-gold-price-per-gram"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>18K Gold Price Per Gram Today (Live)</image:title>
       <image:caption>Real-time 18K gold price per gram in GBP and USD. 75% pure gold. Updated every 60 seconds.</image:caption>
     </image:image>
@@ -73,7 +73,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/gold-and-silver-price-today/"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/gold-and-silver-price-today/"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Gold and Silver Price Today (Live)</image:title>
       <image:caption>Live gold and silver price today per ounce, gram, and kilo in GBP and USD. Updated every 60 seconds.</image:caption>
     </image:image>
@@ -88,7 +88,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/scrap-gold-calculator"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/scrap-gold-calculator"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Scrap Gold Calculator — Live Melt Value</image:title>
       <image:caption>Free scrap gold calculator. Enter weight and karat to find the live melt value of your gold jewellery in GBP and USD.</image:caption>
     </image:image>
@@ -103,7 +103,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/silver-price-per-kilo"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/silver-price-per-kilo"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Silver Price Per Kilo Today (Live)</image:title>
       <image:caption>Real-time silver price per kilogram, gram and troy ounce in GBP and USD. Updated every 60 seconds.</image:caption>
     </image:image>
@@ -118,7 +118,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-calculate-scrap-gold"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How to Calculate Scrap Gold Value — Step by Step</image:title>
       <image:caption>Step-by-step guide to calculating the value of scrap gold jewellery using the live gold spot price. Includes worked examples.</image:caption>
     </image:image>
@@ -133,7 +133,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-14k-gold"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-14k-gold"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>What Is 14K Gold? Purity, Price &amp; Uses Explained</image:title>
       <image:caption>14 karat gold purity (58.33%), hallmarks, price per gram, durability, and how it compares to 18K and 24K gold.</image:caption>
     </image:image>
@@ -145,7 +145,7 @@
     <changefreq>monthly</changefreq>
     <priority>0.75</priority>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
     </image:image>
   </url>
 
@@ -158,7 +158,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/data/"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/data/"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Live Gold &amp; Silver Price Data Feed | GoldPriceTools</image:title>
       <image:caption>Real-time spot prices for gold and silver bullion across multiple karats and units. Free to use with attribution.</image:caption>
     </image:image>
@@ -173,7 +173,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-price-history"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-price-history"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Gold Price History — All-Time Highs and Key Milestones</image:title>
       <image:caption>A complete gold price history covering all-time highs, major market events, and long-term price trends from 1970 to 2026.</image:caption>
     </image:image>
@@ -188,7 +188,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-purity-guide"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-purity-guide"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Gold Purity Guide — Karats, Hallmarks &amp; What They Mean</image:title>
       <image:caption>Complete guide to gold purity: what karats mean, how to read hallmarks, and the difference between 9K, 14K, 18K, 22K and 24K gold.</image:caption>
     </image:image>
@@ -203,7 +203,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-vs-silver-investment"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-vs-silver-investment"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Gold vs Silver Investment — Which Is Better in 2026?</image:title>
       <image:caption>Gold vs silver investment compared: historical returns, volatility, liquidity, storage costs, and which suits your portfolio in 2026.</image:caption>
     </image:image>
@@ -218,7 +218,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-invest-in-gold"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-invest-in-gold"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How to Invest in Gold — Beginner's Guide 2026</image:title>
       <image:caption>How to invest in gold in 2026: physical gold, ETFs, mining stocks, and digital gold compared.</image:caption>
     </image:image>
@@ -233,7 +233,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-read-gold-spot-price"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How to Read the Gold Spot Price</image:title>
       <image:caption>What the gold spot price means, how it's quoted, and how to convert troy oz to per gram for any karat.</image:caption>
     </image:image>
@@ -248,7 +248,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How to Sell Gold Jewellery — Get the Best Price</image:title>
       <image:caption>Where to sell gold jewellery, how dealers calculate offers, and how to avoid getting underpaid.</image:caption>
     </image:image>
@@ -263,7 +263,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/silver-price-per-gram-explained"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/silver-price-per-gram-explained"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Silver Price Per Gram Explained</image:title>
       <image:caption>How the silver price per gram is calculated, what affects it, and how to convert troy oz to grams.</image:caption>
     </image:image>
@@ -278,7 +278,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/troy-ounce-vs-gram-explained"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>Troy Ounce vs Gram — What's the Difference?</image:title>
       <image:caption>Why gold is quoted in troy ounces, how many grams in a troy ounce, and how to convert.</image:caption>
     </image:image>
@@ -293,7 +293,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-925-sterling-silver"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-925-sterling-silver"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>What Is 925 Sterling Silver?</image:title>
       <image:caption>What does 925 mean on silver? Complete guide to sterling silver: purity, hallmarks, value, and how to spot fakes.</image:caption>
     </image:image>
@@ -308,7 +308,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>When Is the Best Time to Sell Scrap Gold?</image:title>
       <image:caption>Key signals — spot price levels, USD/GBP rate, seasonal demand — that tell you when to sell scrap gold for the best price.</image:caption>
     </image:image>
@@ -323,7 +323,7 @@
     <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/how-many-grams-in-troy-ounce"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/how-many-grams-in-troy-ounce"/>
     <image:image>
-      <image:loc>https://goldpricetools.com/assets/og-image.jpg</image:loc>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
       <image:title>How Many Grams in a Troy Ounce? (31.1035g Explained)</image:title>
       <image:caption>A troy ounce equals 31.1035 grams. Learn the difference from regular ounces and how to convert for gold pricing.</image:caption>
     </image:image>

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/terms">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/terms">
 <link rel="manifest" href="/manifest.json">
-<link rel="icon" type="image/svg+xml" href="/assets/logo.svg">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 
 <!-- Consent Mode v2 defaults - must fire BEFORE AdSense and GA4 -->
@@ -37,7 +37,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preload" href="/assets/fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 @font-face {
@@ -45,7 +45,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -53,7 +53,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('/assets/fonts/instrument-serif-400-ext.woff2') format('woff2');
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 </style>
 <!-- GA4 -->
@@ -96,7 +96,7 @@ footer a:hover{color:var(--color-text)}
 <nav>
   <div class="nav-inner">
     <a href="/" class="nav-logo">
-      <img src="/assets/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
+      <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'">
       GoldPriceTools
     </a>
     <a href="/" class="nav-back">&larr; Back to Calculator</a>


### PR DESCRIPTION
Closes #151

## Changes
Migrates all static asset URLs from local `/assets/` paths to Cloudflare R2 CDN (`https://assets.goldpricetools.com/`).

### Replacements made:
- `og:image` and `twitter:image` URLs across all HTML pages (99 occurrences)
- Font preload URLs: `/assets/fonts/` -> `https://assets.goldpricetools.com/Fonts/` (99 occurrences)
- Logo SVG references: `/assets/logo.svg` -> `https://assets.goldpricetools.com/logo.svg` (71 occurrences)
- Image sitemap URLs updated

### Verification:
- R2 bucket `goldpricetools-assets` configured with custom domain
- CORS policy set for `goldpricetools.com`
- All assets verified accessible at CDN URLs
- 30 files changed, 256 additions, 256 deletions