### PR TITLE
WP-24: Add Gold Bar Value Calculator

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -23,3 +23,4 @@
 /scrap-gold-calculator                    /scrap-gold-calculator.html                200
 /silver-price-per-kilo                    /silver-price-per-kilo.html                200
 /how-many-grams-in-troy-ounce             /how-many-grams-in-troy-ounce.html         200
+/gold-bar-value                  /gold-bar-value.html                 200

--- a/gold-bar-value.html
+++ b/gold-bar-value.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Gold Bar Value Calculator — How Much Is a Gold Bar Worth?</title>
+<meta name="description" content="Live gold bar value calculator. Find out how much your 1 oz, 10 oz, 1 kg, or Good Delivery gold bar is worth today. Prices updated every 60 seconds.">
+<meta name="robots" content="index, follow">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/gold-bar-value">
+<link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/gold-bar-value">
+<link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/gold-bar-value">
+<link rel="canonical" href="https://goldpricetools.com/gold-bar-value">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Gold Bar Value Calculator","item":"https://goldpricetools.com/gold-bar-value"}]}</script>
+<meta property="og:title" content="Gold Bar Value Calculator — How Much Is a Gold Bar Worth?">
+<meta property="og:description" content="Live gold bar value calculator. Find out how much your 1 oz, 10 oz, 1 kg, or Good Delivery gold bar is worth today. Prices updated every 60 seconds.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://goldpricetools.com/gold-bar-value">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Good Delivery?","acceptedAnswer":{"@type":"Answer","text":"Good Delivery is a set of rules issued by the London Bullion Market Association (LBMA) describing the physical characteristics of gold and silver bars used in settlement in the wholesale market. A Good Delivery gold bar must weigh approximately 400 troy ounces and have a minimum purity of 995.0."}},{"@type":"Question","name":"How are gold bars priced?","acceptedAnswer":{"@type":"Answer","text":"Gold bars are priced based on the live spot price of gold per troy ounce, plus a dealer premium. This premium covers the cost of fabrication, assaying, distribution, and the dealer's profit margin. Larger bars generally have smaller percentage premiums compared to fractional bars."}},{"@type":"Question","name":"What is the cheapest way to buy a 1g gold bar?","acceptedAnswer":{"@type":"Answer","text":"The cheapest way to buy a 1g gold bar is often through a reputable online bullion dealer rather than a physical coin shop, as online dealers have lower overheads. However, be aware that 1g bars carry the highest percentage premiums (often 10-20% above spot price) due to manufacturing costs."}},{"@type":"Question","name":"Where is the best place to buy gold bars?","acceptedAnswer":{"@type":"Answer","text":"The best place to buy gold bars is through authorised, well-established bullion dealers who are members of industry organisations. Always compare premiums over the spot price and verify the dealer's reputation through independent reviews before purchasing."}}]}</script>
+<script>
+  window.dataLayer=window.dataLayer||[];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
+</script>
+<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
+<script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
+<script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
+<link rel="manifest" href="/manifest.json">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
+<meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<style>
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+}
+</style>
+<style>
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}
+.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}
+.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}
+.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}
+.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
+.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}
+.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.625rem}
+.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}
+.hero-sub{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem}
+.price-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:2rem;max-width:480px;margin:0 auto 2rem}
+.price-label{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.5rem}
+.price-value{font-family:var(--font-display);font-size:clamp(2.25rem,6vw,3.5rem);font-weight:700;color:var(--color-gold-bright);line-height:1;margin-bottom:.375rem}
+.price-usd{font-size:1.25rem;color:var(--color-text-muted);margin-bottom:.5rem}
+.price-purity{font-size:.8125rem;color:var(--color-text-faint)}
+.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}
+.prose{max-width:68ch}
+.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}
+.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}
+.prose a{color:var(--color-primary);text-decoration:none}
+.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}
+.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}
+.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}
+.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}
+.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}
+.trust-bar a{color:var(--color-text-muted);text-decoration:none}
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
+footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+.share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+</style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org/",
+  "@type": "WebPage",
+  "name": "Gold Bar Value Calculator",
+  "url": "https://goldpricetools.com/gold-bar-value",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": [".snippet-answer", ".faq-answer"]
+  }
+}
+</script>
+</head>
+<body>
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
+    <div style="display:flex;gap:.75rem;font-size:.875rem">
+      <a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a>
+      <a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a>
+      <a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a>
+    </div>
+  </div>
+</nav>
+
+<div class="breadcrumb-wrap">
+  <ol class="breadcrumb" aria-label="Breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li aria-current="page">Gold Bar Value Calculator</li>
+  </ol>
+</div>
+
+<div class="hero">
+  <div class="hero-tag">Live Gold Bar Calculator</div>
+  <h1 class="hero-title">Gold Bar Value Calculator &mdash; How Much Is a Gold Bar Worth?</h1>
+  <p class="hero-sub">Calculate the real-time value of your gold bars based on live LBMA spot prices. Choose from 9 standard sizes from 1g up to 400 oz Good Delivery.</p>
+
+  <div class="calc-section" style="max-width: 480px; margin: 0 auto; text-align: left;">
+    <div class="calc-panel active" style="padding: 1.5rem;">
+      <div class="form-group" style="margin-bottom: 1rem;">
+        <label class="form-label" for="bar-size">Bar Size</label>
+        <div class="form-select-wrap">
+          <select class="form-select" id="bar-size">
+            <option value="12441.39">Good Delivery (400 oz)</option>
+            <option value="3110.35">100 oz</option>
+            <option value="1000">1 kg (32.15 oz)</option>
+            <option value="311.035">10 oz</option>
+            <option value="31.1035">1 oz</option>
+            <option value="10">10 g</option>
+            <option value="5">5 g</option>
+            <option value="2.5">2.5 g</option>
+            <option value="1" selected>1 g</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="form-label" for="bar-qty">Quantity</label>
+        <input type="number" class="form-input" id="bar-qty" value="1" min="1" step="1">
+      </div>
+      <div class="calc-result">
+        <div class="calc-result-label">Total Gold Value</div>
+        <div class="calc-result-value" id="price-gbp" data-nosnippet>&mdash;</div>
+        <div class="price-usd" id="price-usd" data-nosnippet></div>
+        <div class="calc-result-meta">Based on 24K pure gold spot price</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="content">
+  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about.html">About our data</a></div>
+
+  <div class="prose">
+    <h2 id="reference-table">Gold Bar Reference Table</h2>
+    <figure itemscope itemtype="https://schema.org/Table">
+      <figcaption>Standard gold bar sizes, weights, and typical premium ranges</figcaption>
+      <table class="data-table" aria-label="Gold Bar Reference Table">
+        <thead><tr><th>Bar Size</th><th>Weight (g)</th><th>Weight (oz)</th><th>Typical Premium</th><th>Common Mints</th></tr></thead>
+        <tbody>
+          <tr><td>Good Delivery</td><td>12,441.39g</td><td>400 oz</td><td>0.5% - 1%</td><td>Valcambi, Metalor, PAMP</td></tr>
+          <tr><td>100 oz</td><td>3,110.35g</td><td>100 oz</td><td>1% - 2%</td><td>Royal Canadian Mint, Asahi</td></tr>
+          <tr><td>1 kg</td><td>1,000g</td><td>32.15 oz</td><td>1.5% - 3%</td><td>Perth Mint, PAMP Suisse</td></tr>
+          <tr><td>10 oz</td><td>311.03g</td><td>10 oz</td><td>2% - 4%</td><td>Credit Suisse, Valcambi</td></tr>
+          <tr><td>1 oz</td><td>31.10g</td><td>1 oz</td><td>3% - 5%</td><td>Argor-Heraeus, Perth Mint</td></tr>
+          <tr><td>10 g</td><td>10g</td><td>0.32 oz</td><td>4% - 8%</td><td>PAMP Suisse, Valcambi</td></tr>
+          <tr><td>5 g</td><td>5g</td><td>0.16 oz</td><td>6% - 12%</td><td>Credit Suisse, Argor-Heraeus</td></tr>
+          <tr><td>2.5 g</td><td>2.5g</td><td>0.08 oz</td><td>8% - 15%</td><td>PAMP Suisse, Valcambi</td></tr>
+          <tr><td>1 g</td><td>1g</td><td>0.03 oz</td><td>10% - 20%</td><td>Perth Mint, Metalor</td></tr>
+        </tbody>
+      </table>
+    </figure>
+
+    <h2 id="good-delivery">What Is a Good Delivery Gold Bar?</h2>
+    <p>A "Good Delivery" gold bar is the standard format used by central banks, institutional investors, and the <a href="/gold-and-silver-price-today.html">LBMA spot market</a>. Cast into a trapezoidal shape, these bars must contain between 350 and 430 troy ounces of gold, with a minimum purity of 995.0 parts per thousand (though they are typically 99.99% pure).</p>
+    <p>Weighing roughly 400 troy ounces (12.4 kilograms or 27.4 pounds), a single Good Delivery bar represents a substantial investment, often valued at over $900,000 USD. To maintain their status, these bars must remain within the LBMA's chain of integrity, moving only between approved refiners and recognised vaults. If a Good Delivery bar is removed from this secure network, it must be completely reassayed and recast before it can be readmitted.</p>
+
+    <h2 id="pound-of-gold">How Much Is a Pound of Gold Worth?</h2>
+    <p class="snippet-answer">A standard avoirdupois pound of gold (16 ounces or 453.59 grams) is worth significantly less than what many expect, because precious metals are measured in troy ounces. One avoirdupois pound equals exactly 14.583 troy ounces. At a spot price of $2,300 per troy ounce, a standard pound of pure gold is worth approximately $33,540. However, when dealers talk about a "pound of gold," they are technically referring to 12 troy ounces (one troy pound), which would be worth around $27,600.</p>
+
+    <h2 id="eagle-sovereign">Gold Eagle vs Sovereign: Are They Bars?</h2>
+    <p>While this calculator focuses on bullion bars, many investors prefer gold coins like the American Gold Eagle or the British Gold Sovereign. These are not considered gold bars, but they serve a similar investment purpose.</p>
+    <p>Unlike 24K bullion bars, these coins are often minted in 22K gold (91.67% purity) for added durability, though they contain exactly their stated weight in pure gold. For example, a 1 oz Gold Eagle weighs 1.0909 troy ounces in total to ensure it holds exactly 1 troy ounce of pure gold. If you have gold coins or other mixed purity items, you should use our <a href="/scrap-gold-calculator.html">scrap gold calculator</a> to determine their exact melt value.</p>
+
+    <h2 id="faq">Frequently Asked Questions</h2>
+    <details>
+      <summary class="faq-answer-summary">What is Good Delivery?</summary>
+      <p class="faq-answer">Good Delivery is a set of rules issued by the London Bullion Market Association (LBMA) describing the physical characteristics of gold and silver bars used in settlement in the wholesale market. A Good Delivery gold bar must weigh approximately 400 troy ounces and have a minimum purity of 995.0.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">How are gold bars priced?</summary>
+      <p class="faq-answer">Gold bars are priced based on the live spot price of gold per troy ounce, plus a dealer premium. This premium covers the cost of fabrication, assaying, distribution, and the dealer's profit margin. Larger bars generally have smaller percentage premiums compared to fractional bars.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">What is the cheapest way to buy a 1g gold bar?</summary>
+      <p class="faq-answer">The cheapest way to buy a 1g gold bar is often through a reputable online bullion dealer rather than a physical coin shop, as online dealers have lower overheads. However, be aware that 1g bars carry the highest percentage premiums (often 10-20% above spot price) due to manufacturing costs.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Where is the best place to buy gold bars?</summary>
+      <p class="faq-answer">The best place to buy gold bars is through authorised, well-established bullion dealers who are members of industry organisations. Always compare premiums over the spot price and verify the dealer's reputation through independent reviews before purchasing.</p>
+    </details>
+
+    <div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative melt values only based on the live <a href="/">gold price</a>. Dealer premiums apply when buying or selling. Not financial advice.</div>
+</div>
+</div>
+
+<div class="content" style="padding-bottom:1.5rem">
+<!-- Social share buttons (WP-34) -->
+<div class="share-buttons">
+  <span>Share:</span>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/gold-bar-value&text=14K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/gold-bar-value&title=14K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=14K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fgold-bar-value" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+</div>
+</div>
+<footer>
+  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
+  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+</footer>
+
+<script>
+async function fetchFx(){
+  try{
+    const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});
+    if(!r.ok)throw new Error();
+    const d=await r.json();
+    window._gbpusd=d.GBPUSD||0.79;
+  }catch{window._gbpusd=0.79;}
+}
+async function fetchSpot(){
+  try {
+    const r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
+    if(!r.ok)throw new Error();
+    const d=await r.json();
+    window._spotUSD = d.price;
+    updateCalc();
+  }catch(e){
+    console.warn('Price fetch failed',e);
+  }
+}
+function updateCalc() {
+  if(!window._spotUSD) return;
+  const gbpusd = window._gbpusd || 0.79;
+  const spotPerGramUSD = window._spotUSD / 31.1035;
+  const spotPerGramGBP = spotPerGramUSD * gbpusd;
+
+  const sizeGrams = parseFloat(document.getElementById('bar-size').value) || 0;
+  const qty = parseFloat(document.getElementById('bar-qty').value) || 0;
+
+  const totalGrams = sizeGrams * qty;
+  const totalUSD = totalGrams * spotPerGramUSD;
+  const totalGBP = totalGrams * spotPerGramGBP;
+
+  document.getElementById('price-gbp').textContent = '£' + totalGBP.toLocaleString('en-GB', {minimumFractionDigits:2, maximumFractionDigits:2});
+  document.getElementById('price-usd').textContent = '$' + totalUSD.toLocaleString('en-US', {minimumFractionDigits:2, maximumFractionDigits:2});
+}
+
+document.getElementById('bar-size').addEventListener('change', updateCalc);
+document.getElementById('bar-qty').addEventListener('input', updateCalc);
+
+Promise.all([fetchFx(),fetchSpot()]);
+setInterval(fetchSpot,60000);
+</script>
+<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+<script>
+let _deepReadFired = false;
+window.addEventListener('scroll', () => {
+  if (_deepReadFired) return;
+  const scrollTop = window.scrollY || document.documentElement.scrollTop;
+  const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+  if (scrollHeight > 0 && (scrollTop / scrollHeight) > 0.75) {
+    gtag('event', 'guide_deep_read');
+    _deepReadFired = true;
+  }
+}, { passive: true });
+</script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -384,4 +384,19 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/terms"/>
   </url>
 
+  <url>
+    <loc>https://goldpricetools.com/gold-bar-value</loc>
+    <lastmod>2026-04-30</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/gold-bar-value"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/gold-bar-value"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/gold-bar-value"/>
+    <image:image>
+      <image:loc>https://assets.goldpricetools.com/og-image.jpg</image:loc>
+      <image:title>Gold Bar Value Calculator</image:title>
+      <image:caption>Calculate the live value of Good Delivery and other standard gold bars.</image:caption>
+    </image:image>
+  </url>
+
 </urlset>


### PR DESCRIPTION
Closes #36

This PR adds the Gold Bar Value Calculator requested in WP-24.

Changes included:
- New `/gold-bar-value.html` page using the existing UI layout.
- Real-time calculator fetching spot prices to calculate values for 9 standard bar sizes, including Good Delivery 400 oz and 1kg.
- Editorial content with a reference table and FAQs.
- `FAQPage`, `BreadcrumbList`, and `WebPage` JSON-LD schemas.
- Updates to `_redirects` and `sitemap.xml`.

---
*PR created automatically by Jules for task [14915316713460350882](https://jules.google.com/task/14915316713460350882) started by @DigitalCliqs*