### PR TITLE
fix(ui): add sticky positioning to sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 .karat-table tr:last-child td{border-bottom:none}
 
 /* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4)}
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start;max-height:calc(100vh - 88px);overflow-y:auto}
 .sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
 .sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}


### PR DESCRIPTION
This PR adds sticky positioning to the sidebar in `index.html` to keep the sidebar (quick-ref prices, nav links, and Slot 3 ad) visible while the user scrolls through the main content.

Tested that sticky layout works visually and no mobile behavior or sticky header overlap regressions were introduced.

Closes #14

---
*PR created automatically by Jules for task [13313765009961833694](https://jules.google.com/task/13313765009961833694) started by @DigitalCliqs*