### PR TITLE
Fix #159: Change cyan/turquoise heading colours to gold/amber

### DIFF
--- a/gold-silver-test-kit-reviews.html
+++ b/gold-silver-test-kit-reviews.html
@@ -484,7 +484,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </header>
 
     <section style="margin-bottom: var(--space-10);">
-      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-primary); margin-bottom: var(--space-4);">1. Types of Testing Methods</h2>
+      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-gold-bright); margin-bottom: var(--space-4);">1. Types of Testing Methods</h2>
       <p style="margin-bottom: var(--space-3);">Before diving into the best kits, it's important to understand the different ways you can test gold and silver at home. The most common methods include:</p>
       <ul style="margin-bottom: var(--space-4); padding-left: var(--space-6);">
         <li style="margin-bottom: var(--space-2);"><strong>Acid Testing:</strong> The industry standard for home testing. It involves scratching the metal on a stone and applying specific nitric acid solutions. It's highly reliable for determining karats.</li>
@@ -495,7 +495,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </section>
 
     <section style="margin-bottom: var(--space-10);">
-      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-primary); margin-bottom: var(--space-4);">2. Best Acid Test Kits</h2>
+      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-gold-bright); margin-bottom: var(--space-4);">2. Best Acid Test Kits</h2>
 
       <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-6); margin-bottom: var(--space-6);">
         <h3 style="font-size: var(--text-lg); margin-bottom: var(--space-2);">1. PuriTEST 6 Acid Gold & Silver Test Kit</h3>
@@ -518,7 +518,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
             </ul>
           </div>
         </div>
-        <a href="#affiliate" style="display: inline-block; background: var(--color-primary); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
+        <a href="#affiliate" style="display: inline-block; background: var(--color-gold-bright); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
       </div>
 
       <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-6); margin-bottom: var(--space-6);">
@@ -542,7 +542,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
             </ul>
           </div>
         </div>
-        <a href="#affiliate" style="display: inline-block; background: var(--color-primary); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
+        <a href="#affiliate" style="display: inline-block; background: var(--color-gold-bright); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
       </div>
 
       <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-6); margin-bottom: var(--space-6);">
@@ -566,30 +566,30 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
             </ul>
           </div>
         </div>
-        <a href="#affiliate" style="display: inline-block; background: var(--color-primary); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
+        <a href="#affiliate" style="display: inline-block; background: var(--color-gold-bright); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
       </div>
     </section>
 
     <section style="margin-bottom: var(--space-10);">
-      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-primary); margin-bottom: var(--space-4);">3. Best Electronic Testers</h2>
+      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-gold-bright); margin-bottom: var(--space-4);">3. Best Electronic Testers</h2>
 
       <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-6); margin-bottom: var(--space-6);">
         <h3 style="font-size: var(--text-lg); margin-bottom: var(--space-2);">1. Kee Gold Tester (Kee Tester M-509 PRO)</h3>
         <p style="color: var(--color-text-muted); margin-bottom: var(--space-3);"><strong>Price Range:</strong> $300 - $350 | <strong>Accuracy:</strong> High | <strong>Best For:</strong> Serious hobbyists & small dealers</p>
         <p style="margin-bottom: var(--space-4);">The Kee Gold Tester is widely regarded as the best affordable electronic tester. It uses electrical conductivity to determine karat purity quickly and without scratching the item.</p>
-        <a href="#affiliate" style="display: inline-block; background: var(--color-primary); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
+        <a href="#affiliate" style="display: inline-block; background: var(--color-gold-bright); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
       </div>
 
       <div style="background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-6); margin-bottom: var(--space-6);">
         <h3 style="font-size: var(--text-lg); margin-bottom: var(--space-2);">2. Sigma Metalytics Precious Metal Verifier</h3>
         <p style="color: var(--color-text-muted); margin-bottom: var(--space-3);"><strong>Price Range:</strong> $1,000+ | <strong>Accuracy:</strong> Very High | <strong>Best For:</strong> Bullion investors & professionals</p>
         <p style="margin-bottom: var(--space-4);">While expensive, the Sigma Metalytics PMV is the gold standard for bullion testing. It reads through the metal, detecting tungsten cores or heavy plating without any surface damage.</p>
-        <a href="#affiliate" style="display: inline-block; background: var(--color-primary); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
+        <a href="#affiliate" style="display: inline-block; background: var(--color-gold-bright); color: var(--color-text-inverse); padding: var(--space-2) var(--space-4); border-radius: var(--radius-sm); text-decoration: none; font-weight: 500;">Check Price on Amazon</a>
       </div>
     </section>
 
     <section style="margin-bottom: var(--space-10);">
-      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-primary); margin-bottom: var(--space-4);">4. How to Use an Acid Test Kit</h2>
+      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-gold-bright); margin-bottom: var(--space-4);">4. How to Use an Acid Test Kit</h2>
       <p style="margin-bottom: var(--space-3);">Testing gold with an acid kit is straightforward but requires care. Here is a step-by-step guide:</p>
       <ol style="margin-bottom: var(--space-4); padding-left: var(--space-6);">
         <li style="margin-bottom: var(--space-2);"><strong>Preparation:</strong> Put on safety glasses and gloves. Nitric acid is corrosive. Ensure you are in a well-ventilated area.</li>
@@ -605,11 +605,11 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <li style="margin-bottom: var(--space-2);"><strong>Repeat:</strong> If the scratch survived the 10K acid, try again with a fresh scratch and the 14K acid. Continue stepping up the karat until the scratch dissolves. The true karat is the one just below the acid that dissolved the mark.</li>
         <li style="margin-bottom: var(--space-2);"><strong>Clean Up:</strong> Neutralize the acid on the stone using water and baking soda, then wipe it clean with a paper towel.</li>
       </ol>
-      <p>Once you've determined the purity, use our <a href="/scrap-gold-calculator.html" style="color: var(--color-primary); text-decoration: underline;">Scrap Gold Calculator</a> to find out its live melt value.</p>
+      <p>Once you've determined the purity, use our <a href="/scrap-gold-calculator.html" style="color: var(--color-gold-bright); text-decoration: underline;">Scrap Gold Calculator</a> to find out its live melt value.</p>
     </section>
 
     <section style="margin-bottom: var(--space-10);">
-      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-primary); margin-bottom: var(--space-4);">FAQ</h2>
+      <h2 style="font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-gold-bright); margin-bottom: var(--space-4);">FAQ</h2>
       <div style="margin-bottom: var(--space-4);">
         <h3 style="font-size: var(--text-lg); margin-bottom: var(--space-2);">Are acid test kits accurate?</h3>
         <p style="color: var(--color-text-muted);">Yes, acid test kits are very accurate for determining the surface karat of gold. However, they only test the part of the metal you scratch off. To ensure an item isn't thickly plated over a base metal, you may need to make a deeper file mark before scratching the stone.</p>
@@ -629,7 +629,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </section>
 
     <div style="margin-top: var(--space-8); padding-top: var(--space-6); border-top: 1px solid var(--color-border);">
-        <p>Related: Learn more about the historical relationship between these metals in our <a href="/gold-silver-ratio.html" style="color: var(--color-primary); text-decoration: underline;">Gold Silver Ratio</a> guide.</p>
+        <p>Related: Learn more about the historical relationship between these metals in our <a href="/gold-silver-ratio.html" style="color: var(--color-gold-bright); text-decoration: underline;">Gold Silver Ratio</a> guide.</p>
     </div>
 
   </article>

--- a/silver-coins-calculator.html
+++ b/silver-coins-calculator.html
@@ -61,8 +61,8 @@ input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-a{color:var(--color-primary);text-decoration-thickness:1px;text-underline-offset:2px}
-a:hover{color:var(--color-primary-hover)}
+a{color:var(--color-gold-bright);text-decoration-thickness:1px;text-underline-offset:2px}
+a:hover{color:color-mix(in oklch, var(--color-gold-bright) 80%, black)}
 
 nav{position:sticky;top:0;z-index:40;background:oklch(from var(--color-surface) l c h / 0.85);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);border-bottom:1px solid var(--color-border)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:1rem 1.5rem;display:flex;align-items:center;justify-content:space-between}
@@ -110,7 +110,7 @@ nav{position:sticky;top:0;z-index:40;background:oklch(from var(--color-surface) 
 details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);margin-bottom:1rem;overflow:hidden}
 summary{padding:1.25rem;font-weight:600;cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;color:var(--color-text)}
 summary::-webkit-details-marker{display:none}
-summary::after{content:'+';font-size:1.5rem;color:var(--color-primary);line-height:1}
+summary::after{content:'+';font-size:1.5rem;color:var(--color-gold-bright);line-height:1}
 details[open] summary::after{content:'−'}
 .faq-answer{padding:0 1.25rem 1.25rem;color:var(--color-text-muted);font-size:1rem}
 


### PR DESCRIPTION
This PR fixes Issue #159 by replacing the cyan/turquoise elements (h2 headings, CTA buttons, links, etc.) with gold/amber (`var(--color-gold-bright)`) in both `gold-silver-test-kit-reviews.html` and `silver-coins-calculator.html` to match the site's design language. 

Blockquote left-borders were already set to `var(--color-gold)`.

Closes #159

---
*PR created automatically by Jules for task [10280173826248839340](https://jules.google.com/task/10280173826248839340) started by @DigitalCliqs*