### PR TITLE
Fix: Troy Ounce page live spot price widgets stuck on Loading

### DIFF
--- a/how-many-grams-in-troy-ounce.html
+++ b/how-many-grams-in-troy-ounce.html
@@ -210,8 +210,8 @@ async function fetchFxRates() {
 async function fetchPrices() {
   try {
     const [gRes, sRes] = await Promise.all([
-      fetch('https://gold-api.com/api/XAU/USD'),
-      fetch('https://gold-api.com/api/XAG/USD')
+      fetch('https://api.gold-api.com/price/XAU'),
+      fetch('https://api.gold-api.com/price/XAG')
     ]);
     const gData = await gRes.json();
     const sData = await sRes.json();


### PR DESCRIPTION
This pull request fixes the live spot price widgets on the `how-many-grams-in-troy-ounce.html` page which were stuck on "Loading...". The issue was caused by the page attempting to fetch data from deprecated endpoints (`https://gold-api.com/api/XAU/USD` and `XAG/USD`), which now return a 404 HTML response instead of JSON. 

The fix updates the fetch logic to use the correct API endpoints (`https://api.gold-api.com/price/XAU` and `https://api.gold-api.com/price/XAG`). The changes have been tested locally via Playwright verifying that the live prices populate successfully. JSON-LD validation also passes successfully. Closes #170.

---
*PR created automatically by Jules for task [6789854002117934477](https://jules.google.com/task/6789854002117934477) started by @DigitalCliqs*