### PR TITLE
Enhance E-E-A-T signals across About page, guides, and landing pages (WP-28)

### DIFF
--- a/10k-gold-price-per-gram.html
+++ b/10k-gold-price-per-gram.html
@@ -57,6 +57,20 @@
 </style>
 <style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.625rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.hero-sub{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem}.price-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:2rem;max-width:480px;margin:0 auto 2rem}.price-label{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.5rem}.price-value{font-family:var(--font-display);font-size:clamp(2.25rem,6vw,3.5rem);font-weight:700;color:var(--color-gold-bright);line-height:1;margin-bottom:.375rem;min-height:3rem;min-width:120px;display:inline-block}.price-usd{font-size:1.25rem;color:var(--color-text-muted);margin-bottom:.5rem}.price-purity{font-size:.8125rem;color:var(--color-text-faint)}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+.data-source {
+  font-size: 0.8125rem;
+  color: var(--color-text-faint);
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 2rem;
+}
+.data-source a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
 </style>
 <script type="application/ld+json">
 {
@@ -81,7 +95,7 @@
   <div class="price-card"><div class="price-label">10K Gold &mdash; Price Per Gram</div><div class="price-value" id="price-gbp" data-nosnippet>&mdash;</div><div class="price-usd" id="price-usd" data-nosnippet></div><div class="price-purity">10K = 41.67% pure gold (417 hallmark)</div></div>
 </div>
 <div class="content">
-  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about.html">About our data</a></div>
+  <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
   <div class="prose">
     <details>
   <summary class="faq-answer-summary">What is 10K Gold?</summary>

--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -98,6 +98,20 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+.data-source {
+  font-size: 0.8125rem;
+  color: var(--color-text-faint);
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 2rem;
+}
+.data-source a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
 </style>
 <script type="application/ld+json">
 {
@@ -144,7 +158,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <div class="content">
-  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about.html">About our data</a></div>
+  <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
 
   <div class="prose">
     <details>

--- a/18k-gold-price-per-gram.html
+++ b/18k-gold-price-per-gram.html
@@ -97,6 +97,20 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+.data-source {
+  font-size: 0.8125rem;
+  color: var(--color-text-faint);
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 2rem;
+}
+.data-source a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
 </style>
 <script type="application/ld+json">
 {
@@ -140,7 +154,7 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   </div>
 </div>
 <div class="content">
-  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about.html">About our data</a></div>
+  <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
   <div class="prose">
     <details>
   <summary class="faq-answer-summary">What is 18K Gold?</summary>

--- a/about.html
+++ b/about.html
@@ -204,6 +204,8 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
     <p>GoldPriceTools is powered by a team of precious metals experts, software engineers, and market analysts. We bring decades of combined experience in the bullion market, scrap gold valuation, and financial technology.</p>
     <p>Our lead editorial content is written by <a href="/authors/james-smith/">James Smith</a>, a senior precious metals expert with over 15 years of industry experience working alongside independent jewellers, regional bullion dealers, and the wider European metals market. His expertise ensures that our guides remain factually robust, market-accurate, and aligned with hallmarking standards.</p>
     <p>We believe in full transparency and rigorous E-E-A-T (Experience, Expertise, Authoritativeness, and Trustworthiness) standards. That means every calculator update and guide publication undergoes strict review before reaching our users.</p>
+    <p>As part of our commitment to transparency, GoldPriceTools is an open-source project. You can view our source code on <a href="https://github.com/DigitalCliqs/Gold-Price-Tools" target="_blank" rel="noopener noreferrer">GitHub</a>. We fund our development and data costs through advertising, using <a href="https://adsense.google.com/" target="_blank" rel="noopener noreferrer">Google AdSense</a> to keep our calculators free for everyone.</p>
+
   </div>
 
   <h2>Who GoldPriceTools Is For</h2>

--- a/guides/gold-price-history.html
+++ b/guides/gold-price-history.html
@@ -112,6 +112,15 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 footer a:hover{color:var(--color-text)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -211,6 +220,11 @@ footer a:hover{color:var(--color-text)}
     <a href="/" class="cta-btn">Open Gold Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/gold-purity-guide.html
+++ b/guides/gold-purity-guide.html
@@ -105,6 +105,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -210,6 +219,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/" class="cta-btn">Open Gold Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/gold-vs-silver-investment.html
+++ b/guides/gold-vs-silver-investment.html
@@ -107,6 +107,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -199,6 +208,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/" class="cta-btn">Open Price Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/how-to-calculate-scrap-gold.html
+++ b/guides/how-to-calculate-scrap-gold.html
@@ -132,6 +132,15 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 footer a:hover{color:var(--color-text)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -292,6 +301,11 @@ footer a:hover{color:var(--color-text)}
     <a href="/scrap-gold-calculator" class="cta-btn">Open Scrap Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; Operated by DigitalCliqs, UK &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/how-to-invest-in-gold.html
+++ b/guides/how-to-invest-in-gold.html
@@ -111,6 +111,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -220,6 +229,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/" class="cta-btn">Open Gold Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/how-to-read-gold-spot-price.html
+++ b/guides/how-to-read-gold-spot-price.html
@@ -105,6 +105,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -190,6 +199,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/" class="cta-btn">Open Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/how-to-sell-gold-jewellery.html
+++ b/guides/how-to-sell-gold-jewellery.html
@@ -105,6 +105,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -197,6 +206,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/guides/how-to-calculate-scrap-gold.html" class="cta-btn">Open Scrap Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/silver-price-per-gram-explained.html
+++ b/guides/silver-price-per-gram-explained.html
@@ -104,6 +104,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -190,6 +199,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/" class="cta-btn">Open Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/troy-ounce-vs-gram-explained.html
+++ b/guides/troy-ounce-vs-gram-explained.html
@@ -105,6 +105,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -190,6 +199,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/" class="cta-btn">Open Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/what-is-14k-gold.html
+++ b/guides/what-is-14k-gold.html
@@ -104,6 +104,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -197,6 +206,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/" class="cta-btn">Open Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/what-is-925-sterling-silver.html
+++ b/guides/what-is-925-sterling-silver.html
@@ -104,6 +104,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -192,6 +201,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/" class="cta-btn">Open Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/guides/what-is-best-time-to-sell-scrap-gold.html
+++ b/guides/what-is-best-time-to-sell-scrap-gold.html
@@ -114,6 +114,15 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.disclaimer-box {
+  border-left: 3px solid var(--color-gold-bright);
+  padding: 12px 16px;
+  margin: 24px 0;
+  background: rgba(232,175,52,0.05);
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
 </style>
 </head>
 <body>
@@ -243,6 +252,11 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <a href="/" class="cta-btn">Open Calculator &rarr;</a>
   </div>
 </article>
+
+
+<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
+  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+</div>
 
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>

--- a/how-many-grams-in-troy-ounce.html
+++ b/how-many-grams-in-troy-ounce.html
@@ -107,6 +107,7 @@
   </div>
 </div>
 
+<p class="data-source" style="text-align:center; font-size:0.8125rem; color:var(--color-text-muted); margin-bottom: 2rem;">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about.html">About our data</a></p>
 <h2>Live Weight Converter</h2>
 <div style="background:var(--color-surface);border:1px solid var(--color-border);border-radius:12px;padding:1.5rem;margin-bottom:2rem;">
   <div style="display:flex;gap:1rem;margin-bottom:1.5rem;flex-wrap:wrap;">

--- a/scrap-gold-calculator.html
+++ b/scrap-gold-calculator.html
@@ -229,6 +229,20 @@ function fireCalcEngaged() {
 }
 </style>
 <style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.calc-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:1.5rem;max-width:560px;margin:0 auto 2rem}.calc-row{display:grid;grid-template-columns:1fr 1fr auto;gap:.75rem;margin-bottom:.75rem;align-items:end}.calc-label{font-size:.75rem;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-bottom:.25rem}.calc-input{width:100%;padding:.625rem .875rem;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:.5rem;color:var(--color-text);font-size:.9375rem;font-family:var(--font-body)}.calc-select{width:100%;padding:.625rem .875rem;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:.5rem;color:var(--color-text);font-size:.9375rem;font-family:var(--font-body)}.calc-del{padding:.625rem .875rem;background:transparent;border:1px solid var(--color-border);border-radius:.5rem;color:var(--color-text-muted);cursor:pointer;font-size:1rem}.calc-add{width:100%;padding:.75rem;background:transparent;border:1px dashed var(--color-border);border-radius:.5rem;color:var(--color-text-muted);cursor:pointer;font-size:.875rem;margin-bottom:1rem}.result-box{background:var(--color-surface-offset);border-radius:.75rem;padding:1.25rem;text-align:center}.result-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.375rem}.result-gbp{font-family:var(--font-display);font-size:2.25rem;color:var(--color-gold-bright);font-weight:700;line-height:1;min-height:2.5rem}.result-usd{font-size:1rem;color:var(--color-text-muted)}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.prose ol{padding-left:1.5rem;margin-bottom:1.25rem}.prose li{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:.5rem}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.data-source {
+  font-size: 0.8125rem;
+  color: var(--color-text-faint);
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 2rem;
+}
+.data-source a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
 </style>
 <script type="application/ld+json">
 {
@@ -264,7 +278,7 @@ function fireCalcEngaged() {
   </div>
 </div>
 <div class="content">
-  <div class="trust-bar">Live gold price sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about.html">About our data</a></div>
+  <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
   <div class="prose">
     <h2 id="scrap-gold-calculator-formula">Scrap gold calculator formula</h2>
 <ol class="snippet-answer">

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -59,6 +59,20 @@
 </style>
 <style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.price-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1rem;max-width:700px;margin:0 auto 2rem}.price-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:.875rem;padding:1.25rem;text-align:center}.price-tile-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-faint);margin-bottom:.375rem}.price-tile-value{font-family:var(--font-display);font-size:1.5rem;color:var(--color-gold-bright);font-weight:700;min-height:2rem}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+.data-source {
+  font-size: 0.8125rem;
+  color: var(--color-text-faint);
+  text-align: center;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 2rem;
+}
+.data-source a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
 </style>
 <script type="application/ld+json">
 {
@@ -88,7 +102,7 @@
   </div>
 </div>
 <div class="content">
-  <div class="trust-bar">Live prices sourced from spot market &middot; Updated every 60 seconds &middot; <a href="/about.html">About our data</a></div>
+  <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
   <div class="prose">
     <h2>Silver Price by Weight</h2>
     <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->


### PR DESCRIPTION
Fixes #40 by adding:
1. GitHub and Google AdSense transparency links to the About page.
2. A financial disclaimer to all 12 guide articles.
3. Trust signals / data source attribution on the 6 landing pages (`14K`, `18K`, `10K`, `scrap`, `silver-kilo`, `troy-ounce`).

---
*PR created automatically by Jules for task [3368796949873301823](https://jules.google.com/task/3368796949873301823) started by @DigitalCliqs*