### PR TITLE
feat: Add .800 and .900 Silver Purity Sub-Pages

### DIFF
--- a/800-silver-price-per-gram.html
+++ b/800-silver-price-per-gram.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>.800 European Silver Price Per Gram Today (Live) — GoldPriceTools</title>
+<meta name="description" content="Live .800 European Silver price per gram in GBP and USD today. Also shows price per gram, per troy ounce and per 100g. Updated every 60 seconds from LBMA spot market.">
+<meta name="robots" content="index, follow">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/800-silver-price-per-gram">
+<link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/800-silver-price-per-gram">
+<link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/800-silver-price-per-gram">
+<link rel="canonical" href="https://goldpricetools.com/800-silver-price-per-gram">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":".800 European Silver Price Per Gram","item":"https://goldpricetools.com/800-silver-price-per-gram"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is .800 silver worth per gram today?","acceptedAnswer":{"@type":"Answer","text":"The value of .800 silver per gram is calculated by multiplying the live silver spot price per gram by 0.800 (80% purity). The live price is shown on this page."}},{"@type":"Question","name":"Is .800 silver worth anything?","acceptedAnswer":{"@type":"Answer","text":"Yes, .800 silver contains 80% pure silver, giving it significant intrinsic melt value based on the current silver spot price."}},{"@type":"Question","name":"How do I identify .800 European silver?","acceptedAnswer":{"@type":"Answer","text":".800 silver is typically identified by an '800' hallmark stamp. German pieces often feature a crescent moon and crown mark alongside the 800 stamp."}},{"@type":"Question","name":"What is the difference between .800 silver and sterling silver?","acceptedAnswer":{"@type":"Answer","text":".800 silver is 80% pure silver, commonly used in continental Europe for cutlery and holloware. Sterling silver (.925) is purer, containing 92.5% silver, and is the standard in the UK and US."}}]}</script>
+<!-- Dataset JSON-LD (WP-53) -->
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Dataset","name":"Live .800 European Silver Price Per Gram \u2014 Daily Historical Data","description":"Daily silver spot price data per gram and troy ounce in GBP and USD. Updated daily from LBMA spot market via gold-api.com. Covers 1 month, 3 months, 1 year, 5 years, and 10 years of historical silver price data.","url":"https://goldpricetools.com/800-silver-price-per-gram","keywords":["silver price","silver price per kilo","silver price per gram","LBMA spot price","precious metals data","XAG/GBP","XAG/USD"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"temporalCoverage":"2016-06-01/..","variableMeasured":"Silver spot price per troy ounce in USD (XAG/USD) and GBP (XAG/GBP)"}</script>
+<meta property="og:title" content=".800 European Silver Price Per Gram Today (Live)">
+<meta property="og:description" content="Real-time .800 European Silver price per gram, gram and troy ounce in GBP and USD. Updated every 60 seconds.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://goldpricetools.com/800-silver-price-per-gram">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
+<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
+<script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
+<script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
+<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<style>
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+}
+</style>
+<style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.price-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1rem;max-width:700px;margin:0 auto 2rem}.price-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:.875rem;padding:1.25rem;text-align:center}.price-tile-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-faint);margin-bottom:.375rem}.price-tile-value{font-family:var(--font-display);font-size:1.5rem;color:var(--color-gold-bright);font-weight:700;min-height:2rem}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+.share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+</style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org/",
+  "@type": "WebPage",
+  "name": ".800 European Silver Price Per Gram",
+  "url": "https://goldpricetools.com/800-silver-price-per-gram",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": [".snippet-answer", ".faq-answer"]
+  }
+}
+</script>
+</head>
+<body>
+<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
+<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">.800 European Silver Price Per Gram</li></ol></div>
+<div class="hero">
+  <div class="hero-tag">Live .800 European Silver Price</div>
+  <h1 class="hero-title">.800 European Silver Price Per Gram Today</h1>
+  <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Live silver spot price in multiple weights. Updated every 60 seconds.</p>
+  </div>
+<div class="content">
+  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about.html">About our data</a></div>
+
+      <div class="calc-panel" id="panel-silver" role="tabpanel" style="display:block; max-width: 600px; margin: 2rem auto; border: 1px solid var(--color-border); border-radius: 12px; padding: 1.5rem;">
+        <div class="calc-row" style="display:grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem;">
+          <div class="form-group">
+            <label class="form-label" for="silverPurity" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Silver Purity</label>
+            <div class="form-select-wrap">
+              <select class="form-select" id="silverPurity" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);" disabled>
+                <option value="0.800" selected>.800 European Silver</option>
+              </select>
+            </div>
+            <p style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: 0.25rem;">Locked to .800 European Silver</p>
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="silverWeight" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Weight</label>
+            <input class="form-input" type="number" id="silverWeight" value="1" min="0" step="0.01" placeholder="Enter weight" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
+          </div>
+        </div>
+        <div class="calc-row" style="display:grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem;">
+          <div class="form-group">
+            <label class="form-label" for="silverUnit" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Weight Unit</label>
+            <div class="form-select-wrap">
+              <select class="form-select" id="silverUnit" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
+                <option value="1" selected>Grams (g)</option>
+                <option value="31.1035">Troy Ounces (oz t)</option>
+                <option value="1000">Kilograms (kg)</option>
+                <option value="1.55517">Pennyweight (dwt)</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="silverCurrency" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Currency</label>
+            <div class="form-select-wrap">
+              <select class="form-select" id="silverCurrency" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
+                <option value="USD" selected>USD ($)</option>
+                <option value="GBP">GBP (£)</option>
+                <option value="EUR">EUR (€)</option>
+                <option value="INR">INR (₹)</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="calc-result" style="text-align:center; padding: 1.5rem; background: var(--color-surface); border-radius: 8px;">
+          <div class="calc-result-label" style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--color-text-muted); margin-bottom: 0.5rem;">Estimated Value</div>
+          <div class="calc-result-value" id="silverResult" style="font-family: var(--font-display); font-size: 2.5rem; font-weight: 700; color: var(--color-gold-bright);">—</div>
+          <div class="calc-result-meta" id="silverResultMeta" style="font-size: 0.875rem; color: var(--color-text-muted); margin-top: 0.5rem;"></div>
+        </div>
+      </div>
+
+  <div class="prose">
+    <h2>Silver Price by Weight</h2>
+    <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
+    <table class="data-table" aria-label="Live silver price by weight">
+      <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
+      <tbody>
+        <tr><td>1 gram</td><td id="t-1g-gbp" data-nosnippet>&mdash;</td><td id="t-1g-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>10 grams</td><td id="t-10g-gbp" data-nosnippet>&mdash;</td><td id="t-10g-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>100 grams</td><td id="t-100g-gbp" data-nosnippet>&mdash;</td><td id="t-100g-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>1 troy ounce (31.1g)</td><td id="t-oz-gbp" data-nosnippet>&mdash;</td><td id="t-oz-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>500 grams</td><td id="t-500g-gbp" data-nosnippet>&mdash;</td><td id="t-500g-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>1 kilogram</td><td id="t-1k-gbp" data-nosnippet>&mdash;</td><td id="t-1k-usd" data-nosnippet>&mdash;</td></tr>
+      </tbody>
+    </table>
+    <h2>Silver Purity Grades</h2>
+<table class="data-table" aria-label="Silver purity grades and indicative prices">
+  <thead><tr><th>Purity</th><th>Grade</th><th>Price per Gram</th><th>Price per Kg</th><th>Price per Troy Oz</th></tr></thead>
+  <tbody>
+    <tr><td>.999</td><td>Fine</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+    <tr><td>.925</td><td>Sterling</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+    <tr><td>.900</td><td>Coin</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+    <tr><td>.800</td><td>European</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+  </tbody>
+</table>
+
+
+    <h2>What is .800 European Silver?</h2>
+    <p>.800 silver is an alloy composed of 80% pure silver and 20% other metals, usually copper. This purity grade is most strongly associated with continental Europe, particularly Germany, Italy, France, and the Netherlands, where it was historically the standard for silverware, flatware, and holloware.</p>
+
+    <h2>Where is .800 Silver Found?</h2>
+    <p>You will frequently find .800 silver in antique European cutlery sets, tea services, decorative trays, and some older pocket watches. Because it contains more copper than sterling silver, it is harder and more durable, which made it ideal for functional household items that saw daily use.</p>
+
+    <h2>How to Identify .800 Silver</h2>
+    <p>.800 silver is identified by its hallmark. Look for a stamp that simply reads "800". In Germany, following the unification hallmark laws of 1888, the "800" stamp is often accompanied by a crescent moon (Halbmond) and a crown (Krone). Italian pieces may also have regional assay marks next to the 800 stamp.</p>
+
+    <h2>.800 Silver vs Sterling Silver</h2>
+    <p>Sterling silver (.925) contains 92.5% pure silver, making it significantly purer than .800 European silver. For an extensive breakdown of silver purities, read our <a href="/guides/gold-purity-guide.html">Purity Guide</a>. Because .800 silver has a lower silver content, its melt value per gram is lower than that of sterling.</p>
+
+    <h2>Selling .800 Silver in the UK</h2>
+    <p>While the UK standard is sterling, antique dealers and scrap buyers in the UK readily purchase .800 silver. Since it is below the UK standard, it cannot legally be described simply as "silver" in trade without specifying the fineness, and it is usually valued purely on its 80% silver melt content rather than antique value, unless it is a particularly rare or desirable piece.</p>
+
+<h2>Frequently Asked Questions</h2>
+
+<div class="faq-container">
+<details>
+  <summary class="faq-answer-summary">What is .800 silver worth per gram today?</summary>
+  <p class="faq-answer">The value of .800 silver per gram is calculated by multiplying the live silver spot price per gram by 0.800 (80% purity). The live price is shown on this page.</p>
+</details>
+<details>
+  <summary class="faq-answer-summary">Is .800 silver worth anything?</summary>
+  <p class="faq-answer">Yes, .800 silver contains 80% pure silver, giving it significant intrinsic melt value based on the current silver spot price.</p>
+</details>
+<details>
+  <summary class="faq-answer-summary">How do I identify .800 European silver?</summary>
+  <p class="faq-answer">.800 silver is typically identified by an '800' hallmark stamp. German pieces often feature a crescent moon and crown mark alongside the 800 stamp.</p>
+</details>
+<details>
+  <summary class="faq-answer-summary">What is the difference between .800 silver and sterling silver?</summary>
+  <p class="faq-answer">.800 silver is 80% pure silver, commonly used in continental Europe for cutlery and holloware. Sterling silver (.925) is purer, containing 92.5% silver, and is the standard in the UK and US.</p>
+</details>
+</div>
+
+<div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative spot values and do not include dealer premiums. Physical silver coins and bars typically sell at 5&ndash;20% above spot. Not financial advice.</div>
+  </div>
+</div>
+<div class="content" style="padding-bottom:1.5rem">
+<!-- Social share buttons (WP-34) -->
+<div class="share-buttons">
+  <span>Share:</span>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/800-silver-price-per-gram&text=.800+European+Silver+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/800-silver-price-per-gram&title=Silver+Price+Per+Kilo+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=.800+European+Silver+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fsilver-price-per-kilo" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+</div>
+</div>
+<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
+<script>
+async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
+
+
+function fmtCurr(val, cur) {
+  if (cur==='USD') return '$'+val.toFixed(2);
+  if (cur==='GBP') return '£'+(val*window._gbpusd).toFixed(2);
+  if (cur==='EUR') return '€'+(val*1.16).toFixed(2);
+  if (cur==='INR') return '₹'+(val*83.0).toFixed(2);
+  return val.toFixed(2);
+}
+function calcSilver(spotOz) {
+  if (!spotOz) return;
+  const purity=0.800, weight=parseFloat(document.getElementById('silverWeight').value)||0, unit=parseFloat(document.getElementById('silverUnit').value), currency=document.getElementById('silverCurrency').value;
+  const grams = weight * unit;
+  const usdVal = (spotOz / 31.1035) * purity * grams;
+  document.getElementById('silverResult').textContent = fmtCurr(usdVal, currency);
+  document.getElementById('silverResultMeta').textContent = `${grams.toFixed(4)}g × $80.0% purity × $${(spotOz/31.1035).toFixed(2)}/g spot`;
+}
+
+async function fetchSpot(){try{const r=await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();const ozUSD=d.price;const gbpusd=window._gbpusd||0.79;const perG_USD=(ozUSD/31.1035)*0.800;const perG_GBP=perG_USD*gbpusd;
+    [[1,'1g'],[10,'10g'],[100,'100g'],[31.1035,'oz'],[500,'500g'],[1000,'1k']].forEach(([w,id])=>{const g=document.getElementById('t-'+id+'-gbp');const u=document.getElementById('t-'+id+'-usd');if(g)g.textContent='£'+(perG_GBP*w).toFixed(2);if(u)u.textContent='$'+(perG_USD*w).toFixed(2);});
+
+    // Purity Table logic
+    const purities = [0.999, 0.925, 0.900, 0.800];
+    const pure_oz = ozUSD;
+    const pure_g = pure_oz / 31.1035;
+    const tbody = document.querySelector('.data-table:nth-of-type(2) tbody');
+    if (tbody) {
+      const rows = tbody.querySelectorAll('tr');
+      purities.forEach((p, i) => {
+        if (rows[i]) {
+          const p_g = pure_g * p;
+          rows[i].cells[2].textContent = '£' + (p_g * gbpusd).toFixed(2);
+          rows[i].cells[3].textContent = '£' + (p_g * 1000 * gbpusd).toFixed(2);
+          rows[i].cells[4].textContent = '£' + (pure_oz * p * gbpusd).toFixed(2);
+        }
+      });
+    }
+
+    calcSilver(ozUSD);
+
+    ['silverWeight','silverUnit','silverCurrency'].forEach(id=>document.getElementById(id)?.addEventListener('input',() => calcSilver(ozUSD)));
+
+    gtag('event','price_view',{metal:'silver',unit:'0.800'});}catch(e){console.warn('Silver price fetch failed',e);}}
+
+Promise.all([fetchFx(),fetchSpot()]);setInterval(fetchSpot,60000);
+</script>
+<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+<script>
+let _deepReadFired = false;
+window.addEventListener('scroll', () => {
+  if (_deepReadFired) return;
+  const scrollTop = window.scrollY || document.documentElement.scrollTop;
+  const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+  if (scrollHeight > 0 && (scrollTop / scrollHeight) > 0.75) {
+    gtag('event', 'guide_deep_read');
+    _deepReadFired = true;
+  }
+}, { passive: true });
+</script>
+</body>
+</html>

--- a/900-silver-price-per-gram.html
+++ b/900-silver-price-per-gram.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>.900 Coin Silver Price Per Gram Today (Live) — GoldPriceTools</title>
+<meta name="description" content="Live .900 Coin Silver price per gram in GBP and USD today. Also shows price per gram, per troy ounce and per 100g. Updated every 60 seconds from LBMA spot market.">
+<meta name="robots" content="index, follow">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/900-silver-price-per-gram">
+<link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/900-silver-price-per-gram">
+<link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/900-silver-price-per-gram">
+<link rel="canonical" href="https://goldpricetools.com/900-silver-price-per-gram">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":".900 Coin Silver Price Per Gram","item":"https://goldpricetools.com/900-silver-price-per-gram"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is .900 coin silver worth today?","acceptedAnswer":{"@type":"Answer","text":"The value of .900 coin silver is calculated by multiplying the live silver spot price per troy ounce by 0.900 (90% purity). The live price in GBP and USD is shown above, updated every 60 seconds."}},{"@type":"Question","name":"How do I calculate the melt value of .900 silver coins?","acceptedAnswer":{"@type":"Answer","text":"You can calculate the melt value by weighing your coins in grams, multiplying by 0.900 to find the pure silver weight, and then multiplying by the live silver spot price per gram."}},{"@type":"Question","name":"Is .900 silver the same as sterling silver?","acceptedAnswer":{"@type":"Answer","text":"No, .900 silver is 90% pure silver and 10% copper (often called coin silver). Sterling silver is .925, meaning it is slightly purer at 92.5% silver."}},{"@type":"Question","name":"What US coins are made of .900 silver?","acceptedAnswer":{"@type":"Answer","text":"Most US silver coins minted before 1965, including Morgan and Peace Dollars, Washington Quarters, and Roosevelt Dimes, are made of .900 coin silver."}}]}</script>
+<!-- Dataset JSON-LD (WP-53) -->
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Dataset","name":"Live .900 Coin Silver Price Per Gram \u2014 Daily Historical Data","description":"Daily silver spot price data per gram and troy ounce in GBP and USD. Updated daily from LBMA spot market via gold-api.com. Covers 1 month, 3 months, 1 year, 5 years, and 10 years of historical silver price data.","url":"https://goldpricetools.com/900-silver-price-per-gram","keywords":["silver price","silver price per kilo","silver price per gram","LBMA spot price","precious metals data","XAG/GBP","XAG/USD"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"temporalCoverage":"2016-06-01/..","variableMeasured":"Silver spot price per troy ounce in USD (XAG/USD) and GBP (XAG/GBP)"}</script>
+<meta property="og:title" content=".900 Coin Silver Price Per Gram Today (Live)">
+<meta property="og:description" content="Real-time .900 Coin Silver price per gram, gram and troy ounce in GBP and USD. Updated every 60 seconds.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://goldpricetools.com/900-silver-price-per-gram">
+<meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
+<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
+<script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
+<script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
+<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<style>
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+}
+</style>
+<style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7977;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-text);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.price-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1rem;max-width:700px;margin:0 auto 2rem}.price-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:.875rem;padding:1.25rem;text-align:center}.price-tile-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-faint);margin-bottom:.375rem}.price-tile-value{font-family:var(--font-display);font-size:1.5rem;color:var(--color-gold-bright);font-weight:700;min-height:2rem}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+.share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+</style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org/",
+  "@type": "WebPage",
+  "name": ".900 Coin Silver Price Per Gram",
+  "url": "https://goldpricetools.com/900-silver-price-per-gram",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": [".snippet-answer", ".faq-answer"]
+  }
+}
+</script>
+</head>
+<body>
+<nav><div class="nav-inner"><a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a><div style="display:flex;gap:.75rem;font-size:.875rem"><a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a><a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a><a href="/about.html" style="color:var(--color-text-muted);text-decoration:none">About</a></div></div></nav>
+<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">.900 Coin Silver Price Per Gram</li></ol></div>
+<div class="hero">
+  <div class="hero-tag">Live .900 Coin Silver Price</div>
+  <h1 class="hero-title">.900 Coin Silver Price Per Gram Today</h1>
+  <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Live silver spot price in multiple weights. Updated every 60 seconds.</p>
+  </div>
+<div class="content">
+  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about.html">About our data</a></div>
+
+      <div class="calc-panel" id="panel-silver" role="tabpanel" style="display:block; max-width: 600px; margin: 2rem auto; border: 1px solid var(--color-border); border-radius: 12px; padding: 1.5rem;">
+        <div class="calc-row" style="display:grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem;">
+          <div class="form-group">
+            <label class="form-label" for="silverPurity" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Silver Purity</label>
+            <div class="form-select-wrap">
+              <select class="form-select" id="silverPurity" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);" disabled>
+                <option value="0.900" selected>.900 Coin Silver</option>
+              </select>
+            </div>
+            <p style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: 0.25rem;">Locked to .900 Coin Silver</p>
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="silverWeight" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Weight</label>
+            <input class="form-input" type="number" id="silverWeight" value="1" min="0" step="0.01" placeholder="Enter weight" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
+          </div>
+        </div>
+        <div class="calc-row" style="display:grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem;">
+          <div class="form-group">
+            <label class="form-label" for="silverUnit" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Weight Unit</label>
+            <div class="form-select-wrap">
+              <select class="form-select" id="silverUnit" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
+                <option value="1" selected>Grams (g)</option>
+                <option value="31.1035">Troy Ounces (oz t)</option>
+                <option value="1000">Kilograms (kg)</option>
+                <option value="1.55517">Pennyweight (dwt)</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="silverCurrency" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Currency</label>
+            <div class="form-select-wrap">
+              <select class="form-select" id="silverCurrency" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
+                <option value="USD" selected>USD ($)</option>
+                <option value="GBP">GBP (£)</option>
+                <option value="EUR">EUR (€)</option>
+                <option value="INR">INR (₹)</option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="calc-result" style="text-align:center; padding: 1.5rem; background: var(--color-surface); border-radius: 8px;">
+          <div class="calc-result-label" style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--color-text-muted); margin-bottom: 0.5rem;">Estimated Value</div>
+          <div class="calc-result-value" id="silverResult" style="font-family: var(--font-display); font-size: 2.5rem; font-weight: 700; color: var(--color-gold-bright);">—</div>
+          <div class="calc-result-meta" id="silverResultMeta" style="font-size: 0.875rem; color: var(--color-text-muted); margin-top: 0.5rem;"></div>
+        </div>
+      </div>
+
+  <div class="prose">
+    <h2>Silver Price by Weight</h2>
+    <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
+    <table class="data-table" aria-label="Live silver price by weight">
+      <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
+      <tbody>
+        <tr><td>1 gram</td><td id="t-1g-gbp" data-nosnippet>&mdash;</td><td id="t-1g-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>10 grams</td><td id="t-10g-gbp" data-nosnippet>&mdash;</td><td id="t-10g-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>100 grams</td><td id="t-100g-gbp" data-nosnippet>&mdash;</td><td id="t-100g-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>1 troy ounce (31.1g)</td><td id="t-oz-gbp" data-nosnippet>&mdash;</td><td id="t-oz-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>500 grams</td><td id="t-500g-gbp" data-nosnippet>&mdash;</td><td id="t-500g-usd" data-nosnippet>&mdash;</td></tr>
+        <tr><td>1 kilogram</td><td id="t-1k-gbp" data-nosnippet>&mdash;</td><td id="t-1k-usd" data-nosnippet>&mdash;</td></tr>
+      </tbody>
+    </table>
+    <h2>Silver Purity Grades</h2>
+<table class="data-table" aria-label="Silver purity grades and indicative prices">
+  <thead><tr><th>Purity</th><th>Grade</th><th>Price per Gram</th><th>Price per Kg</th><th>Price per Troy Oz</th></tr></thead>
+  <tbody>
+    <tr><td>.999</td><td>Fine</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+    <tr><td>.925</td><td>Sterling</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+    <tr><td>.900</td><td>Coin</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+    <tr><td>.800</td><td>European</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+  </tbody>
+</table>
+
+
+    <h2>What is .900 Coin Silver?</h2>
+    <p>.900 silver, commonly known as <strong>coin silver</strong>, is an alloy consisting of 90% pure silver and 10% other metals, typically copper. The copper is added to provide durability and strength, making the silver hard enough to withstand the wear and tear of daily circulation.</p>
+    <p>This purity was the standard for United States circulating silver coins minted before 1965, including Morgan Dollars, Peace Dollars, Washington Quarters, Roosevelt Dimes, and Franklin Half Dollars. Because of its historical use in currency, the melt value of these coins is heavily traded by investors and collectors today. You can calculate the exact value of specific US coins using our <a href="/silver-coins-calculator.html">US Silver Coins Calculator</a>.</p>
+
+    <h2>Identifying .900 Silver</h2>
+    <p>Unlike sterling silver which is usually marked "925" or "Sterling", coin silver may not have a numerical hallmark if it is an actual circulated coin. Instead, the coin's date and denomination indicate its composition. For non-coin items made of .900 silver (which is rare but exists in some antique flatware), look for a hallmark stamp of "900".</p>
+
+    <h2>.900 vs .925 Sterling Silver</h2>
+    <p>The primary difference is purity. .900 silver contains 90% pure silver, while sterling silver contains 92.5%. This means a sterling silver item has slightly more intrinsic melt value per gram than a coin silver item of the same weight. However, coin silver is often more durable due to the higher copper content.</p>
+
+    <h2>UK Context and Value</h2>
+    <p>In the UK, .900 silver is less common than sterling (.925), which has been the standard for centuries. Most .900 silver encountered in the UK is imported American coinage. When selling these coins, scrap dealers will pay a percentage of the live melt value calculated at 90% purity.</p>
+
+<h2>Frequently Asked Questions</h2>
+
+<div class="faq-container">
+<details>
+  <summary class="faq-answer-summary">What is .900 coin silver worth today?</summary>
+  <p class="faq-answer">The value of .900 coin silver is calculated by multiplying the live silver spot price per troy ounce by 0.900 (90% purity). The live price in GBP and USD is shown above, updated every 60 seconds.</p>
+</details>
+<details>
+  <summary class="faq-answer-summary">How do I calculate the melt value of .900 silver coins?</summary>
+  <p class="faq-answer">You can calculate the melt value by weighing your coins in grams, multiplying by 0.900 to find the pure silver weight, and then multiplying by the live silver spot price per gram.</p>
+</details>
+<details>
+  <summary class="faq-answer-summary">Is .900 silver the same as sterling silver?</summary>
+  <p class="faq-answer">No, .900 silver is 90% pure silver and 10% copper (often called coin silver). Sterling silver is .925, meaning it is slightly purer at 92.5% silver.</p>
+</details>
+<details>
+  <summary class="faq-answer-summary">What US coins are made of .900 silver?</summary>
+  <p class="faq-answer">Most US silver coins minted before 1965, including Morgan and Peace Dollars, Washington Quarters, and Roosevelt Dimes, are made of .900 coin silver.</p>
+</details>
+</div>
+
+<div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative spot values and do not include dealer premiums. Physical silver coins and bars typically sell at 5&ndash;20% above spot. Not financial advice.</div>
+  </div>
+</div>
+<div class="content" style="padding-bottom:1.5rem">
+<!-- Social share buttons (WP-34) -->
+<div class="share-buttons">
+  <span>Share:</span>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/900-silver-price-per-gram&text=.900+Coin+Silver+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/900-silver-price-per-gram&title=Silver+Price+Per+Kilo+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=.900+Coin+Silver+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fsilver-price-per-kilo" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+</div>
+</div>
+<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
+<script>
+async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
+
+
+function fmtCurr(val, cur) {
+  if (cur==='USD') return '$'+val.toFixed(2);
+  if (cur==='GBP') return '£'+(val*window._gbpusd).toFixed(2);
+  if (cur==='EUR') return '€'+(val*1.16).toFixed(2);
+  if (cur==='INR') return '₹'+(val*83.0).toFixed(2);
+  return val.toFixed(2);
+}
+function calcSilver(spotOz) {
+  if (!spotOz) return;
+  const purity=0.900, weight=parseFloat(document.getElementById('silverWeight').value)||0, unit=parseFloat(document.getElementById('silverUnit').value), currency=document.getElementById('silverCurrency').value;
+  const grams = weight * unit;
+  const usdVal = (spotOz / 31.1035) * purity * grams;
+  document.getElementById('silverResult').textContent = fmtCurr(usdVal, currency);
+  document.getElementById('silverResultMeta').textContent = `${grams.toFixed(4)}g × $90.0% purity × $${(spotOz/31.1035).toFixed(2)}/g spot`;
+}
+
+async function fetchSpot(){try{const r=await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();const ozUSD=d.price;const gbpusd=window._gbpusd||0.79;const perG_USD=(ozUSD/31.1035)*0.900;const perG_GBP=perG_USD*gbpusd;
+    [[1,'1g'],[10,'10g'],[100,'100g'],[31.1035,'oz'],[500,'500g'],[1000,'1k']].forEach(([w,id])=>{const g=document.getElementById('t-'+id+'-gbp');const u=document.getElementById('t-'+id+'-usd');if(g)g.textContent='£'+(perG_GBP*w).toFixed(2);if(u)u.textContent='$'+(perG_USD*w).toFixed(2);});
+
+    // Purity Table logic
+    const purities = [0.999, 0.925, 0.900, 0.800];
+    const pure_oz = ozUSD;
+    const pure_g = pure_oz / 31.1035;
+    const tbody = document.querySelector('.data-table:nth-of-type(2) tbody');
+    if (tbody) {
+      const rows = tbody.querySelectorAll('tr');
+      purities.forEach((p, i) => {
+        if (rows[i]) {
+          const p_g = pure_g * p;
+          rows[i].cells[2].textContent = '£' + (p_g * gbpusd).toFixed(2);
+          rows[i].cells[3].textContent = '£' + (p_g * 1000 * gbpusd).toFixed(2);
+          rows[i].cells[4].textContent = '£' + (pure_oz * p * gbpusd).toFixed(2);
+        }
+      });
+    }
+
+    calcSilver(ozUSD);
+
+    ['silverWeight','silverUnit','silverCurrency'].forEach(id=>document.getElementById(id)?.addEventListener('input',() => calcSilver(ozUSD)));
+
+    gtag('event','price_view',{metal:'silver',unit:'0.900'});}catch(e){console.warn('Silver price fetch failed',e);}}
+
+Promise.all([fetchFx(),fetchSpot()]);setInterval(fetchSpot,60000);
+</script>
+<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+<script>
+let _deepReadFired = false;
+window.addEventListener('scroll', () => {
+  if (_deepReadFired) return;
+  const scrollTop = window.scrollY || document.documentElement.scrollTop;
+  const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+  if (scrollHeight > 0 && (scrollTop / scrollHeight) > 0.75) {
+    gtag('event', 'guide_deep_read');
+    _deepReadFired = true;
+  }
+}, { passive: true });
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -352,7 +352,9 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <a href="/18k-gold-price-per-gram">18K Gold Price Per Gram</a>
   <a href="/10k-gold-price-per-gram">10K Gold Price Per Gram</a>
   <span class="menu-section">Silver</span>
-  <a href="/silver-price-per-kilo">Silver Price Per Kilo</a>
+    <a href="/silver-price-per-kilo">Silver Price Per Kilo</a>
+  <a href="/900-silver-price-per-gram">.900 Coin Silver Price</a>
+  <a href="/800-silver-price-per-gram">.800 European Silver Price</a>
   <a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a>
   <span class="menu-section">Guides</span>
   <a href="/guides/what-is-14k-gold">What Is 14K Gold?</a>
@@ -732,6 +734,18 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </section>
 
     <!-- ARTICLES SECTION -->
+
+    <h2>Silver Purity Grades</h2>
+    <table class="data-table" aria-label="Silver purity grades and indicative prices">
+      <thead><tr><th>Purity</th><th>Grade</th><th>Price per Gram</th><th>Price per Kg</th><th>Price per Troy Oz</th></tr></thead>
+      <tbody id="silverPurityTable">
+        <tr><td>.999</td><td>Fine</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+        <tr><td>.925</td><td>Sterling</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+        <tr><td>.900</td><td>Coin</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+        <tr><td>.800</td><td>European</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
+      </tbody>
+    </table>
+
     <section class="articles-section" aria-label="Gold and silver guides">
       <h2>Gold &amp; Silver Guides</h2>
       <p class="section-desc">Learn how gold karats work, how to value scrap metal, and what drives precious metals prices — from our free educational guides.</p>
@@ -830,7 +844,9 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <a href="/18k-gold-price-per-gram">18K Gold Price Per Gram <span>→</span></a>
         <a href="/10k-gold-price-per-gram">10K Gold Price Per Gram <span>→</span></a>
         <a href="/scrap-gold-calculator">Scrap Gold Calculator <span>→</span></a>
-        <a href="/silver-price-per-kilo">Silver Price Per Kilo <span>→</span></a>
+                <a href="/silver-price-per-kilo">Silver Price Per Kilo <span>→</span></a>
+        <a href="/900-silver-price-per-gram">.900 Silver Price <span>→</span></a>
+        <a href="/800-silver-price-per-gram">.800 Silver Price <span>→</span></a>
         <a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce <span>→</span></a>
       </div>
     </div>
@@ -894,7 +910,9 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <li><a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold</a></li>
         <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
         <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a></li>
-        <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
+                <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver Price</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver Price</a></li>
         <li><a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a></li>
       </ul>
     </div>
@@ -1039,6 +1057,25 @@ function calcSilver() {
   if (!silverSpotOz) return;
   const purity=parseFloat(document.getElementById('silverPurity').value),weight=parseFloat(document.getElementById('silverWeight').value)||0,unit=parseFloat(document.getElementById('silverUnit').value),currency=document.getElementById('silverCurrency').value,grams=weight*unit,usdVal=(silverSpotOz/TROY_OZ_TO_GRAM)*purity*grams;
   setText('silverResult',fmtCurr(usdVal,currency));setText('silverResultMeta',`${grams.toFixed(4)}g × ${(purity*100).toFixed(2)}% purity × ${fmtUSD(silverSpotOz/TROY_OZ_TO_GRAM)}/g spot`);
+
+  // Purity Table logic
+  const tbody = document.getElementById('silverPurityTable');
+  if (tbody) {
+    const purities = [0.999, 0.925, 0.900, 0.800];
+    const pure_oz = silverSpotOz;
+    const pure_g = pure_oz / TROY_OZ_TO_GRAM;
+    const gbpusd = fxRates.GBP || 0.79;
+    const rows = tbody.querySelectorAll('tr');
+    purities.forEach((p, i) => {
+      if (rows[i]) {
+        const p_g = pure_g * p;
+        rows[i].cells[2].textContent = '£' + (p_g * gbpusd).toFixed(2);
+        rows[i].cells[3].textContent = '£' + (p_g * 1000 * gbpusd).toFixed(2);
+        rows[i].cells[4].textContent = '£' + (pure_oz * p * gbpusd).toFixed(2);
+      }
+    });
+  }
+
 }
 function calcScrap() {
   let inputsFilled = 0;

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -154,7 +154,25 @@
 async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
 async function fetchSpot(){try{const r=await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();const ozUSD=d.price;const gbpusd=window._gbpusd||0.79;const perG_USD=ozUSD/31.1035;const perG_GBP=perG_USD*gbpusd;const perKg_USD=perG_USD*1000;const perKg_GBP=perG_GBP*1000;document.getElementById('p-kg-gbp').textContent='£'+perKg_GBP.toFixed(2);document.getElementById('p-kg-usd').textContent='$'+perKg_USD.toFixed(2);document.getElementById('p-oz-gbp').textContent='£'+(ozUSD*gbpusd).toFixed(2);document.getElementById('p-g-gbp').textContent='£'+perG_GBP.toFixed(3);
     const snippetEl = document.getElementById('snippet-price');
-    if(snippetEl) snippetEl.textContent='£'+perKg_GBP.toFixed(2)+' ($'+perKg_USD.toFixed(2)+' USD)';[[1,'1g'],[10,'10g'],[100,'100g'],[31.1035,'oz'],[500,'500g'],[1000,'1k']].forEach(([w,id])=>{const g=document.getElementById('t-'+id+'-gbp');const u=document.getElementById('t-'+id+'-usd');if(g)g.textContent='£'+(perG_GBP*w).toFixed(2);if(u)u.textContent='$'+(perG_USD*w).toFixed(2);});gtag('event','price_view',{metal:'silver',unit:'kilo'});}catch(e){console.warn('Silver price fetch failed',e);}}
+    if(snippetEl) snippetEl.textContent='£'+perKg_GBP.toFixed(2)+' ($'+perKg_USD.toFixed(2)+' USD)';[[1,'1g'],[10,'10g'],[100,'100g'],[31.1035,'oz'],[500,'500g'],[1000,'1k']].forEach(([w,id])=>{const g=document.getElementById('t-'+id+'-gbp');const u=document.getElementById('t-'+id+'-usd');if(g)g.textContent='£'+(perG_GBP*w).toFixed(2);if(u)u.textContent='$'+(perG_USD*w).toFixed(2);});gtag('event','price_view',{metal:'silver',unit:'kilo'});
+
+    // Purity Table logic
+    const purities = [0.999, 0.925, 0.900, 0.800];
+    const pure_oz = ozUSD;
+    const pure_g = pure_oz / 31.1035;
+    const tbody = document.querySelector('.data-table:nth-of-type(2) tbody');
+    if (tbody) {
+      const rows = tbody.querySelectorAll('tr');
+      purities.forEach((p, i) => {
+        if (rows[i]) {
+          const p_g = pure_g * p;
+          rows[i].cells[2].textContent = '£' + (p_g * gbpusd).toFixed(2);
+          rows[i].cells[3].textContent = '£' + (p_g * 1000 * gbpusd).toFixed(2);
+          rows[i].cells[4].textContent = '£' + (pure_oz * p * gbpusd).toFixed(2);
+        }
+      });
+    }
+}catch(e){console.warn('Silver price fetch failed',e);}}
 Promise.all([fetchFx(),fetchSpot()]);setInterval(fetchSpot,60000);
 </script>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -519,4 +519,23 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/terms"/>
   </url>
 
+
+  <url>
+    <loc>https://goldpricetools.com/900-silver-price-per-gram</loc>
+    <lastmod>2026-04-30</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>0.90</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/900-silver-price-per-gram"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/900-silver-price-per-gram"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/900-silver-price-per-gram"/>
+  </url>
+  <url>
+    <loc>https://goldpricetools.com/800-silver-price-per-gram</loc>
+    <lastmod>2026-04-30</lastmod>
+    <changefreq>hourly</changefreq>
+    <priority>0.90</priority>
+    <xhtml:link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/800-silver-price-per-gram"/>
+    <xhtml:link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/800-silver-price-per-gram"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/800-silver-price-per-gram"/>
+  </url>
 </urlset>


### PR DESCRIPTION
Add .800 and .900 Silver Purity Sub-Pages as required by #131. Includes SEO schemas, Live Spot Price calculators, and a cross-purity comparison HTML table.

---
*PR created automatically by Jules for task [238821104587354908](https://jules.google.com/task/238821104587354908) started by @DigitalCliqs*