### PR TITLE
fix(ci): scope-guard — ignore deletions in deny-list check

### DIFF
--- a/.github/workflows/scope-guard.yml
+++ b/.github/workflows/scope-guard.yml
@@ -73,7 +73,15 @@ jobs:
           # ── Compute changed files ──────────────────────────────────────────
           BASE_REF="origin/${{ github.base_ref }}"
           echo "Diffing HEAD against ${BASE_REF} …"
-          mapfile -t CHANGED_FILES < <(git diff --name-only "${BASE_REF}...HEAD")
+
+          # --diff-filter=ACMR: Added, Copied, Modified, Renamed only.
+          # Deletions (D) are intentional cleanup and must NOT trigger the
+          # deny-list — removing a forbidden file is the right action, not a
+          # violation. Untracked/unknown statuses are also excluded.
+          mapfile -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACMR "${BASE_REF}...HEAD")
+
+          # Separately collect deleted forbidden files for the informational summary.
+          mapfile -t DELETED_FILES < <(git diff --name-only --diff-filter=D "${BASE_REF}...HEAD")
 
           if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
             echo "No changed files found — nothing to check."
@@ -139,11 +147,26 @@ jobs:
               echo "| ✅ allowed | \`${f}\` | — |"
             done
 
+            # Informational rows for deleted files that match the deny-list.
+            # These are not failures — deleting a forbidden file is the correct fix.
+            for f in "${DELETED_FILES[@]}"; do
+              for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+                if echo "$f" | grep -qE "$pattern"; then
+                  echo "| 🗑️ deleted (ok) | \`${f}\` | Previously forbidden; deletion is intentional cleanup |"
+                  break
+                fi
+              done
+            done
+
             echo ""
             if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
               echo "> **${#VIOLATIONS[@]} forbidden file(s) detected.** Remove them before merging."
             else
-              echo "> All ${#CLEAN[@]} changed file(s) passed the scope check."
+              echo "> All ${#CLEAN[@]} added/modified file(s) passed the scope check."
+              if [[ ${#DELETED_FILES[@]} -gt 0 ]]; then
+                echo ">"
+                echo "> ℹ️ ${#DELETED_FILES[@]} file(s) deleted in this PR (deletions are never flagged)."
+              fi
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Problem

PR #194 **deletes** `pr.py` and `issue_body.txt` (the exact cleanup we want), but the scope-guard workflow was treating deletions the same as additions — `git diff --name-only` returns every changed path regardless of direction. This caused a false-positive failure on a legitimate cleanup PR.

## Fix

Add `--diff-filter=ACMR` to the diff command so only **A**dded, **C**opied, **M**odified, and **R**enamed files are checked against the deny-list. Deletions (`D`) are collected separately and shown as informational `🗑️ deleted (ok)` rows in the job summary.

```diff
- mapfile -t CHANGED_FILES < <(git diff --name-only "${BASE_REF}...HEAD")
+ mapfile -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACMR "${BASE_REF}...HEAD")
+ mapfile -t DELETED_FILES < <(git diff --name-only --diff-filter=D "${BASE_REF}...HEAD")
```

## Changed files

`.github/workflows/scope-guard.yml` — **only file touched**.

## Behaviour after this fix

| Scenario | Result |
| -------- | ------ |
| PR **adds** `pr.py` | ❌ FAILS (deny-list hit) |
| PR **modifies** `pr.py` | ❌ FAILS (deny-list hit) |
| PR **deletes** `pr.py` | ✅ PASSES — shown as 🗑️ in summary |
| PR adds/modifies normal files | ✅ PASSES |

## Validation

1. Re-run scope-guard on PR #194 after merge — must pass (deletes `pr.py` and `issue_body.txt`).
2. Open a test PR adding a dummy `pr.py` — must still fail with the expected annotation.

https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq

---
_Generated by [Claude Code](https://claude.ai/code/session_0129aCxGZ96Z3hrNH5RrcXdq)_