### PR TITLE
Add editorial standards page (E-E-A-T)

### DIFF
--- a/editorial-standards/index.html
+++ b/editorial-standards/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en-GB" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Editorial Standards & Methodology | GoldPriceTools</title>
+<meta name="description" content="How GoldPriceTools researches, drafts, fact-checks and corrects every page. Sources include LBMA, the World Gold Council, HMRC and the Royal Mint. Live spot prices are sourced from gold-api.com.">
+<link rel="canonical" href="https://goldpricetools.com/editorial-standards/">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
+<meta name="theme-color" content="#0f0e0c">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "AboutPage",
+  "name": "Editorial Standards & Methodology",
+  "url": "https://goldpricetools.com/editorial-standards/",
+  "description": "GoldPriceTools editorial standards: sourcing, AI-assistance disclosure, review process, corrections policy, and data methodology.",
+  "isPartOf": {"@type": "WebSite", "name": "GoldPriceTools", "url": "https://goldpricetools.com/"},
+  "about": {"@id": "https://goldpricetools.com/authors/goldpricetools-editorial-team/#org"},
+  "datePublished": "2026-05-03",
+  "dateModified": "2026-05-03"
+}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Editorial Standards","item":"https://goldpricetools.com/editorial-standards/"}]}
+</script>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<style>
+:root{--color-bg:#0f0e0c;--color-surface:#1a1917;--color-border:#33302a;--color-text:#f5f4f0;--color-text-muted:#a39f96;--color-gold-bright:#ffd700;--font-sans:'Inter',system-ui,sans-serif;--space-2:.5rem;--space-3:.75rem;--space-4:1rem;--space-6:1.5rem;--space-8:2rem;--space-12:3rem;--radius-md:8px}
+*,::after,::before{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--font-sans);background:var(--color-bg);color:var(--color-text);line-height:1.65}
+.container{max-width:780px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+h1{font-size:2.25rem;margin-bottom:var(--space-4);color:var(--color-gold-bright)}
+h2{font-size:1.375rem;margin:var(--space-8) 0 var(--space-3);color:var(--color-text)}
+h3{font-size:1.125rem;margin:var(--space-6) 0 var(--space-2);color:var(--color-text)}
+p,li{margin-bottom:var(--space-3);color:var(--color-text-muted)}
+ul,ol{padding-left:var(--space-6);margin-bottom:var(--space-4)}
+a{color:var(--color-gold-bright)}
+.breadcrumb{font-size:.875rem;color:var(--color-text-muted);margin-bottom:var(--space-6)}
+.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
+.last-reviewed{font-size:.875rem;color:var(--color-text-muted);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4);margin-bottom:var(--space-6)}
+</style>
+</head>
+<body>
+<main class="container">
+<nav class="breadcrumb" aria-label="Breadcrumb"><a href="/">Home</a> &rsaquo; <span>Editorial Standards</span></nav>
+<h1>Editorial Standards &amp; Methodology</h1>
+<p class="last-reviewed"><strong>Last reviewed:</strong> 3 May 2026 by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a>. This page is reviewed annually or whenever a primary source publishes a material change.</p>
+<p>This page sets out, in plain UK English, how GoldPriceTools produces the calculator tools, guides and articles you see on this site. It exists so that readers, search engines and advertising partners can verify our editorial process, sourcing and corrections route.</p>
+<h2>1. Who we are</h2>
+<p>GoldPriceTools is a precious-metals data and reference site published by DigitalCliqs and based in the United Kingdom. Editorial responsibility sits with the in-house <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a>. We publish under an organisational byline rather than personal names; this is a deliberate UK GDPR choice, not an attempt to obscure responsibility — the publishing entity is named clearly here, on every page footer, and in the site’s structured data.</p>
+<h2>2. Our sources</h2>
+<p>Every factual claim on the site is checked against a primary or recognised industry source before publication. The whitelist below covers the great majority of citations:</p>
+<ul>
+  <li><strong>Live spot prices</strong> &mdash; <a href="https://www.goldapi.io/" rel="nofollow noopener">gold-api.com</a> (LBMA-referenced bid/ask, polled on each page load).</li>
+  <li><strong>Bullion market reference data</strong> &mdash; the <a href="https://www.lbma.org.uk/" rel="nofollow noopener">London Bullion Market Association</a> (LBMA) for AM/PM fixes and Good Delivery standards.</li>
+  <li><strong>Demand &amp; supply context</strong> &mdash; the <a href="https://www.gold.org/" rel="nofollow noopener">World Gold Council</a> for jewellery, investment, central bank and recycling data.</li>
+  <li><strong>UK tax guidance</strong> &mdash; <a href="https://www.gov.uk/government/organisations/hm-revenue-customs" rel="nofollow noopener">HMRC</a> for capital gains, the VAT exemption on investment gold (VAT Notice 701/21), and the legal-tender CGT exemption that applies to UK Royal Mint coins such as the Sovereign and Britannia.</li>
+  <li><strong>Coin &amp; bar specifications</strong> &mdash; <a href="https://www.royalmint.com/" rel="nofollow noopener">The Royal Mint</a> for British coinage; manufacturer datasheets for non-UK products such as Krugerrands, Maple Leafs and Vienna Philharmonics.</li>
+  <li><strong>Hallmarking</strong> &mdash; the four UK Assay Offices (Birmingham, Edinburgh, London, Sheffield) and the British Hallmarking Council.</li>
+</ul>
+<p>Where a claim depends on a non-whitelisted source, that source is cited inline with a link. We do not invent statistics, projections or expert quotes. If a figure cannot be sourced to a recognised primary, it is removed from the page rather than rounded or estimated.</p>
+<h2>3. How a page is produced</h2>
+<p>Every published page passes through four explicit stages before going live:</p>
+<ol>
+  <li><strong>Outline against a primary source.</strong> An editor drafts an outline that maps each section of the planned page to one or more whitelisted sources. The outline determines the page structure, not the language model.</li>
+  <li><strong>Draft with AI assistance.</strong> Drafting is performed with the help of large language models (currently Anthropic’s Claude and Perplexity Sonar/Opus). The model is given the outline and the source whitelist and is restricted to UK English, the editorial tone and the schema requirements set out below.</li>
+  <li><strong>Human fact-check.</strong> A human editor checks every numerical figure, every named entity and every external claim against the cited primary source. Anything not verifiable is rewritten or removed before publication.</li>
+  <li><strong>On-page audit.</strong> The editor verifies the page’s schema (FAQPage on tool pages, Article on blog posts, BreadcrumbList sitewide), canonical, title and meta description, internal links, and — for tool pages — the calculator output against an independent calculation.</li>
+</ol>
+<h2>4. Use of AI assistance</h2>
+<p>We disclose openly that drafts are produced with AI assistance. We think this is the honest position, and it is consistent with Google’s helpful-content guidance, which evaluates pages on whether they are useful and trustworthy rather than on whether a human or a model typed the first draft.</p>
+<p>The constraints we place on AI-assisted drafting are:</p>
+<ul>
+  <li>The model never picks the page’s factual claims; those come from the source whitelist in the outline.</li>
+  <li>The model never publishes directly. Every page is held in a draft state until a human editor signs it off against the primary sources.</li>
+  <li>We do not publish AI-generated images of people, fabricated bylines, or stock photography presented as real staff. Author pages use an organisational byline and an initials mark.</li>
+  <li>Generated text is post-edited for UK English (spellings, currency, units, regulator names) and for the site’s editorial voice.</li>
+</ul>
+<h2>5. Live data &amp; <code>dateModified</code></h2>
+<p>Spot prices on tool pages are pulled live from <a href="https://www.goldapi.io/" rel="nofollow noopener">gold-api.com</a> on each page load and are subject to a small bid-ask spread relative to the LBMA fix. The <code>dateModified</code> value embedded in each page’s structured data reflects the date of its most recent <em>human editorial review</em>, not the most recent price tick. We do this so that <code>dateModified</code> remains a meaningful editorial signal rather than a constantly refreshed timestamp.</p>
+<h2>6. Corrections policy</h2>
+<p>If a reader, a primary source or our own internal review identifies a factual error, a stale figure or a calculator output that disagrees with an independent calculation, we treat it as a correction:</p>
+<ol>
+  <li>The error is logged in our internal corrections register with the date, the affected URL and the source of the report.</li>
+  <li>The page is corrected and its <code>dateModified</code> is updated.</li>
+  <li>For material corrections — changes to a headline figure, a tax rule, a regulator name or a calculator formula — we add a short footnote at the bottom of the affected page noting what changed and when.</li>
+  <li>We do not silently rewrite figures. Minor typographical or copy-edit fixes are made without a footnote.</li>
+</ol>
+<p>To report a correction, please use our <a href="/contact/">contact form</a>.</p>
+<h2>7. Independence &amp; conflicts of interest</h2>
+<p>GoldPriceTools earns revenue from display advertising and, where indicated, affiliate links to bullion dealers and brokers. Affiliate relationships never determine whether a product is mentioned, the order of any list, or the figures we publish; product specifications come from the manufacturer or the Royal Mint, and prices come from the live API. Where a link is an affiliate link, we mark it as such on the page. We do not accept paid editorial placements.</p>
+<h2>8. Privacy of contributors</h2>
+<p>We deliberately do not publish personal data (real names, photographs, qualifications, addresses, social profiles) of individual contributors. This is a UK GDPR choice and is independent of editorial responsibility, which sits with GoldPriceTools as a publisher and is set out clearly above and on the <a href="/authors/goldpricetools-editorial-team/">editorial team page</a>.</p>
+<h2>9. Contact</h2>
+<p>For corrections, source queries, takedown requests or general feedback: <a href="/contact/">contact form</a>. For privacy and data-handling enquiries: <a href="/privacy/">privacy policy</a>.</p>
+<p><a href="/">&laquo; Back to home</a></p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
Adds `/editorial-standards/index.html` documenting:

- Sourcing & primary sources whitelist
- Editorial workflow (outline → AI-assisted draft → human fact-check → on-page audit)
- Disclosure of AI assistance (Claude / Perplexity) and constraints
- Live data via gold-api.com and `dateModified` policy
- Corrections policy and contact route
- Independence / conflicts of interest
- Privacy of contributors

Supports E-E-A-T signals required for AdSense reconsideration. UK English. Do not auto-merge — pending review.