### PR TITLE
fix: use GH_PAT for bot auto-commit workflows (sitemap, dateModified, chart-data)

### DIFF
--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -44,13 +45,13 @@ jobs:
           SUCCESS=0
 
           while [ $RETRY_COUNT -le $MAX_RETRIES ]; do
-            if git push; then
+            if git push https://x-access-token:${{ secrets.GH_PAT }}@github.com/DigitalCliqs/Gold-Price-Tools.git HEAD:main; then
               echo "Push successful"
               SUCCESS=1
               break
             else
               echo "Push failed, attempting rebase..."
-              git pull --rebase origin main
+              git pull --rebase https://x-access-token:${{ secrets.GH_PAT }}@github.com/DigitalCliqs/Gold-Price-Tools.git main
 
               RETRY_COUNT=$((RETRY_COUNT+1))
               if [ $RETRY_COUNT -eq 1 ]; then

--- a/.github/workflows/update-chart-data.yml
+++ b/.github/workflows/update-chart-data.yml
@@ -15,6 +15,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
       - name: Fetch and write chart JSON
         run: python3 scripts/fetch-chart-data.py
       - name: Commit and push
@@ -29,13 +31,13 @@ jobs:
           SUCCESS=0
 
           while [ $RETRY_COUNT -le $MAX_RETRIES ]; do
-            if git push; then
+            if git push https://x-access-token:${{ secrets.GH_PAT }}@github.com/DigitalCliqs/Gold-Price-Tools.git HEAD:main; then
               echo "Push successful"
               SUCCESS=1
               break
             else
               echo "Push failed, attempting rebase..."
-              git pull --rebase origin main
+              git pull --rebase https://x-access-token:${{ secrets.GH_PAT }}@github.com/DigitalCliqs/Gold-Price-Tools.git main
 
               RETRY_COUNT=$((RETRY_COUNT+1))
               if [ $RETRY_COUNT -eq 1 ]; then

--- a/.github/workflows/update-datemodified-in-jsonld.yml
+++ b/.github/workflows/update-datemodified-in-jsonld.yml
@@ -52,13 +52,13 @@ jobs:
           SUCCESS=0
 
           while [ $RETRY_COUNT -le $MAX_RETRIES ]; do
-            if git push; then
+            if git push https://x-access-token:${{ secrets.GH_PAT }}@github.com/DigitalCliqs/Gold-Price-Tools.git HEAD:main; then
               echo "Push successful"
               SUCCESS=1
               break
             else
               echo "Push failed, attempting rebase..."
-              git pull --rebase origin main
+              git pull --rebase https://x-access-token:${{ secrets.GH_PAT }}@github.com/DigitalCliqs/Gold-Price-Tools.git main
 
               RETRY_COUNT=$((RETRY_COUNT+1))
               if [ $RETRY_COUNT -eq 1 ]; then


### PR DESCRIPTION
Fixes the GH013 branch protection error that was causing generate-sitemap, update-datemodified, and update-chart-data workflows to fail on push.

Root cause: branch protection requires PRs for all pushes, including github-actions[bot].
Fix: use `${{ secrets.GH_PAT }}` (admin token stored as repo secret) in checkout and git push.

Secret `GH_PAT` has already been added to repo secrets.