### PR TITLE
feat(privacy): add Cloudflare Web Analytics disclosure to privacy policy (#10)

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -152,6 +152,7 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
     <li><strong>GoldAPI.io</strong> — provides live precious metals spot price data. No personal user data is sent to GoldAPI.io.</li>
     <li><strong>Google Fonts</strong> — serves web fonts (Inter, Instrument Serif). Google may collect usage data per their <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Privacy Policy</a>.</li>
     <li><strong>Cloudflare Pages</strong> — hosts and delivers this website globally. Cloudflare may collect anonymised access logs per their <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">Privacy Policy</a>.</li>
+    <li><strong>Cloudflare Web Analytics</strong> — this website uses Cloudflare Web Analytics to measure traffic and Core Web Vitals performance. Cloudflare Web Analytics is cookieless and does not collect personally identifiable information or use cookies. It collects anonymised, aggregated metrics including page views, referrers, and browser performance data. No consent popup is required. See <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">Cloudflare's Privacy Policy</a> for details.</li>
   </ul>
 
   <h2>7. Children's Privacy</h2>


### PR DESCRIPTION
## Issue #10 — Cloudflare Web Analytics (Partial: Privacy Policy)

This PR covers the privacy policy update portion of #10. The beacon snippet deployment requires a Cloudflare Web Analytics token which must be obtained from the Cloudflare dashboard.

### What This PR Does

Updates `privacy-policy.html` to add a specific disclosure for Cloudflare Web Analytics, separate from the existing Cloudflare Pages hosting disclosure.

**New bullet added under third-party services:**
> **Cloudflare Web Analytics** — this website uses Cloudflare Web Analytics to measure traffic and Core Web Vitals performance. Cloudflare Web Analytics is cookieless and does not collect personally identifiable information or use cookies. It collects anonymised, aggregated metrics including page views, referrers, and browser performance data. No consent popup is required.

### What Still Needs to Be Done (Manual Step Required)

To complete issue #10, the following manual step is required by the site owner:

1. Log in to [Cloudflare Dashboard](https://dash.cloudflare.com)
2. Select `goldpricetools.com`
3. Go to **Analytics & Logs → Web Analytics**
4. Click **Enable Web Analytics** and copy the beacon snippet (looks like):
   ```html
   <script defer src='https://static.cloudflareinsights.com/beacon.min.js'
     data-cf-beacon='{"token": "YOUR_TOKEN_HERE"}'></script>
   ```
5. Add the token as a GitHub Actions secret named `CF_ANALYTICS_TOKEN`
6. Or open a follow-up PR adding the snippet to all HTML pages

The privacy policy disclosure (this PR) should be merged first so it is live before the analytics beacon is activated.

Closes partial #10 (privacy policy step)