### PR TITLE
perf: mobile PageSpeed improvements — lazy Chart.js + DNS prefetch + price cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,9 @@
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="dns-prefetch" href="https://assets.goldpricetools.com">
+  <link rel="dns-prefetch" href="https://api.metals.live">
+  <link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
@@ -285,7 +288,54 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 </style>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
+<script>
+// Lazy-load Chart.js only when chart container is visible
+(function() {
+  var chartLoaded = false;
+  function loadChartJS(cb) {
+    if (chartLoaded) { if(cb) cb(); return; }
+    var s = document.createElement('script');
+    s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js';
+    s.onload = function() { chartLoaded = true; if(cb) cb(); };
+    document.head.appendChild(s);
+  }
+  window.__loadChartJS = loadChartJS;
+  if ('IntersectionObserver' in window) {
+    document.addEventListener('DOMContentLoaded', function() {
+      var chartEl = document.querySelector('canvas, #priceChart, .chart-container');
+      if (chartEl) {
+        var obs = new IntersectionObserver(function(entries) {
+          if (entries[0].isIntersecting) { loadChartJS(); obs.disconnect(); }
+        }, { rootMargin: '200px' });
+        obs.observe(chartEl);
+      } else {
+        // fallback: load after idle
+        if ('requestIdleCallback' in window) { requestIdleCallback(function(){ loadChartJS(); }); }
+        else { setTimeout(loadChartJS, 2000); }
+      }
+    });
+  } else { loadChartJS(); }
+})();
+</script>
+
+  <!-- Performance: show cached prices instantly before API load -->
+  <script>
+  (function(){
+    try {
+      var cached = localStorage.getItem('gpt_prices');
+      if (cached) {
+        var d = JSON.parse(cached);
+        var age = Date.now() - (d.ts||0);
+        if (age < 300000) { // 5 min cache
+          var goldEl = document.getElementById('gold-spot');
+          var silverEl = document.getElementById('silver-spot');
+          if (goldEl && d.gold) goldEl.textContent = '$' + d.gold.toFixed(2);
+          if (silverEl && d.silver) silverEl.textContent = '$' + d.silver.toFixed(2);
+        }
+      }
+    } catch(e) {}
+  })();
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
## Performance Improvements (Mobile PageSpeed: 59 → ~70-75 target)

Based on PageSpeed audit 3 May 2026 (mobile score: 59).

### Root Causes Identified
- **Chart.js (200KB)** loaded eagerly on every page — biggest single offender
- No DNS prefetch for metals API, assets CDN
- No cached price display — users see blank values while API loads (hurts LCP/CLS)

### Changes

| Fix | Impact |
|-----|--------|
| Chart.js now lazy-loaded via IntersectionObserver (only loads when chart scrolls into view) | ~8-12 points |
| Added `dns-prefetch` for `api.metals.live`, `assets.goldpricetools.com`, `cdn.jsdelivr.net` | ~2-3 points |
| Cache-first localStorage pattern: shows last known prices instantly before API responds | ~5-8 points LCP |

### Expected Result
Mobile Performance: **59 → ~72-78**