### PR TITLE
ux: add Related Guides sections to all 16 Phase 1 content pages

### DIFF
--- a/10k-gold-price-per-gram.html
+++ b/10k-gold-price-per-gram.html
@@ -214,6 +214,46 @@
   <a href="https://api.whatsapp.com/send?text=10K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F10k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/14k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">14K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Live 14K gold price per gram — the most widely traded karat for jewellery in the US.</div>
+      </a>
+      <a href="/18k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">18K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's 18K gold price per gram updated every 60 seconds.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate the melt value of 10K scrap gold using today's live spot price.</div>
+      </a>
+      <a href="/guides/how-to-calculate-scrap-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Calculate Scrap Gold Value</div>
+        <div style="font-size:0.875rem;color:#666;">Learn how to work out what your 10K gold jewellery is worth to a dealer.</div>
+      </a>
+      <a href="/guides/how-to-sell-gold-jewellery" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Sell Gold Jewellery</div>
+        <div style="font-size:0.875rem;color:#666;">How to get the best price for your 10K gold pieces.</div>
+      </a>
+      <a href="/guides/gold-purity-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Purity Guide</div>
+        <div style="font-size:0.875rem;color:#666;">Understand gold hallmarks, karats and millesimal fineness — 375, 585, 750 and 999 explained.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,INR',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.rates.GBP||0.79;window._usdinr=d.rates.INR||83.5;}catch{window._gbpusd=0.79;}}

--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -298,6 +298,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <a href="https://api.whatsapp.com/send?text=14K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F14k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/10k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">10K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's 10K gold price per gram — ideal for US jewellery and scrap gold.</div>
+      </a>
+      <a href="/18k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">18K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Live 18K gold price per gram — commonly used in European and Middle Eastern jewellery.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate the melt value of your 14K gold jewellery using today's live spot price.</div>
+      </a>
+      <a href="/guides/what-is-14k-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">What is 14K Gold?</div>
+        <div style="font-size:0.875rem;color:#666;">Understand 14K gold alloy composition, hallmarks, and why it's the most popular karat in the US.</div>
+      </a>
+      <a href="/guides/how-to-calculate-scrap-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Calculate Scrap Gold</div>
+        <div style="font-size:0.875rem;color:#666;">Step-by-step guide to valuing your scrap gold using karat, weight and today's spot price.</div>
+      </a>
+      <a href="/guides/how-to-sell-gold-jewellery" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Sell Gold Jewellery</div>
+        <div style="font-size:0.875rem;color:#666;">Get the best price for your gold — what dealers look for and how to avoid being underpaid.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/18k-gold-price-per-gram.html
+++ b/18k-gold-price-per-gram.html
@@ -272,6 +272,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <a href="https://api.whatsapp.com/send?text=18K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F18k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/14k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">14K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Live 14K gold price — widely used for US and international jewellery.</div>
+      </a>
+      <a href="/22k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">22K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's 22K gold price per gram — popular for Middle Eastern and Asian jewellery.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Find out what your 18K gold is worth today using live spot prices.</div>
+      </a>
+      <a href="/guides/what-is-14k-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">What is 14K Gold?</div>
+        <div style="font-size:0.875rem;color:#666;">Compare 14K vs 18K gold — purity, durability and value differences explained.</div>
+      </a>
+      <a href="/guides/how-to-sell-gold-jewellery" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Sell Gold Jewellery</div>
+        <div style="font-size:0.875rem;color:#666;">Maximise the value you receive when selling 18K gold pieces.</div>
+      </a>
+      <a href="/guides/gold-purity-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Purity Guide</div>
+        <div style="font-size:0.875rem;color:#666;">Hallmarks, karats and fineness — everything you need to know about gold purity.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
   <p style="margin-top:.5rem">Not financial advice.</p>

--- a/22k-gold-price-per-gram.html
+++ b/22k-gold-price-per-gram.html
@@ -284,6 +284,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <a href="https://api.whatsapp.com/send?text=22K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F22k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/24k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">24K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Live 24K (pure) gold price per gram — the benchmark for all karat calculations.</div>
+      </a>
+      <a href="/18k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">18K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's 18K gold price per gram — compare with 22K purity and price.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate the value of 22K gold jewellery at today's spot price.</div>
+      </a>
+      <a href="/guides/gold-purity-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Purity Guide</div>
+        <div style="font-size:0.875rem;color:#666;">Understanding 22K gold hallmarks (916), composition and use in jewellery.</div>
+      </a>
+      <a href="/guides/how-to-calculate-scrap-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Calculate Scrap Gold Value</div>
+        <div style="font-size:0.875rem;color:#666;">Step-by-step: how to value your 22K gold pieces.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Track the live gold-to-silver ratio and what it means for precious metals investors.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/24k-gold-price-per-gram.html
+++ b/24k-gold-price-per-gram.html
@@ -284,6 +284,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <a href="https://api.whatsapp.com/send?text=24K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F24k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/22k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">22K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's 22K gold price per gram — 91.67% pure gold.</div>
+      </a>
+      <a href="/silver-price-per-kilo" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Kilo</div>
+        <div style="font-size:0.875rem;color:#666;">Live silver price per kilogram — the companion to gold for precious metals investors.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate the melt value of 24K gold coins or bars using today's live price.</div>
+      </a>
+      <a href="/guides/gold-price-history" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price History</div>
+        <div style="font-size:0.875rem;color:#666;">See how 24K gold prices have moved from 1970 to today and what drives long-term trends.</div>
+      </a>
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver Investment</div>
+        <div style="font-size:0.875rem;color:#666;">Compare 24K gold bars and silver bullion as long-term investments.</div>
+      </a>
+      <a href="/guides/how-to-invest-in-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Invest in Gold</div>
+        <div style="font-size:0.875rem;color:#666;">From 24K bullion coins to ETFs — a beginner's guide to gold investing in the UK.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/800-silver-price-per-gram.html
+++ b/800-silver-price-per-gram.html
@@ -254,6 +254,46 @@
   <a href="https://api.whatsapp.com/send?text=.800+European+Silver+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fsilver-price-per-kilo" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/900-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.900 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's .900 silver price per gram — commonly found in US coins and European flatware.</div>
+      </a>
+      <a href="/silver-price-per-kilo" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Kilo</div>
+        <div style="font-size:0.875rem;color:#666;">Live silver price per kilogram — the standard unit for wholesale silver trading.</div>
+      </a>
+      <a href="/guides/what-is-925-sterling-silver" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">What is 925 Sterling Silver?</div>
+        <div style="font-size:0.875rem;color:#666;">Learn how .925 sterling silver compares to .800 and .900 silver in purity and value.</div>
+      </a>
+      <a href="/guides/silver-price-per-gram-explained" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Gram Explained</div>
+        <div style="font-size:0.875rem;color:#666;">How silver spot prices are converted to a per-gram rate and what affects daily prices.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Metal Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate the melt value of .800 silver flatware, coins or jewellery at today's price.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Track the live gold-to-silver ratio — a key metric for silver investors.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}

--- a/900-silver-price-per-gram.html
+++ b/900-silver-price-per-gram.html
@@ -252,6 +252,46 @@
   <a href="https://api.whatsapp.com/send?text=.900+Coin+Silver+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fsilver-price-per-kilo" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/800-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.800 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's .800 silver price per gram — common in European and Middle Eastern silverware.</div>
+      </a>
+      <a href="/silver-price-per-kilo" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Kilo</div>
+        <div style="font-size:0.875rem;color:#666;">Live silver price per kilogram in GBP and USD.</div>
+      </a>
+      <a href="/guides/what-is-925-sterling-silver" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">What is 925 Sterling Silver?</div>
+        <div style="font-size:0.875rem;color:#666;">Understand the difference between .900, .925 and .800 silver purity grades.</div>
+      </a>
+      <a href="/guides/silver-price-per-gram-explained" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Gram Explained</div>
+        <div style="font-size:0.875rem;color:#666;">How silver spot prices translate to per-gram rates for coins and jewellery.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Metal Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Find the melt value of .900 silver coins or items at today's live silver price.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">The live gold-to-silver ratio — essential context for any silver price comparison.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}

--- a/9k-gold-price-per-gram.html
+++ b/9k-gold-price-per-gram.html
@@ -284,6 +284,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <a href="https://api.whatsapp.com/send?text=9K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F9k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/10k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">10K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's 10K gold price — the US equivalent of 9K, both are entry-level jewellery gold.</div>
+      </a>
+      <a href="/14k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">14K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Live 14K gold price per gram — compare with 9K purity and value.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate the scrap value of your 9K gold jewellery at today's live price.</div>
+      </a>
+      <a href="/guides/gold-purity-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Purity Guide</div>
+        <div style="font-size:0.875rem;color:#666;">Understanding 9K gold hallmarks (375), its composition, and durability compared to higher karats.</div>
+      </a>
+      <a href="/guides/how-to-sell-gold-jewellery" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Sell Gold Jewellery</div>
+        <div style="font-size:0.875rem;color:#666;">How to get the best scrap price for 9K gold — what dealers pay and how to compare offers.</div>
+      </a>
+      <a href="/guides/how-to-calculate-scrap-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Calculate Scrap Gold Value</div>
+        <div style="font-size:0.875rem;color:#666;">Work out exactly what your 9K jewellery is worth using our step-by-step method.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/how-to-invest-in-gold.html
+++ b/guides/how-to-invest-in-gold.html
@@ -282,6 +282,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver Investment</div>
+        <div style="font-size:0.875rem;color:#666;">Should you invest in gold, silver, or both? A side-by-side comparison.</div>
+      </a>
+      <a href="/guides/gold-price-history" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price History</div>
+        <div style="font-size:0.875rem;color:#666;">Historical gold price data — understand long-term trends before investing.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Track the gold-silver ratio to time your precious metals allocation.</div>
+      </a>
+      <a href="/24k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">24K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's pure gold price per gram — the benchmark for bullion investments.</div>
+      </a>
+      <a href="/guides/how-to-sell-gold-jewellery" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Sell Gold</div>
+        <div style="font-size:0.875rem;color:#666;">When you're ready to exit your gold position — how to get the best price.</div>
+      </a>
+      <a href="/silver-price-per-kilo" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Kilo</div>
+        <div style="font-size:0.875rem;color:#666;">Compare gold investment costs against silver per kilogram pricing.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/how-to-read-gold-spot-price.html
+++ b/guides/how-to-read-gold-spot-price.html
@@ -243,6 +243,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold & Silver Price Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Live gold and silver price calculator — all karats, in GBP and USD.</div>
+      </a>
+      <a href="/guides/troy-ounce-vs-gram-explained" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Troy Ounce vs Gram Explained</div>
+        <div style="font-size:0.875rem;color:#666;">Understand the difference between troy ounces and grams used in gold pricing.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Track the live gold-to-silver ratio alongside spot prices.</div>
+      </a>
+      <a href="/guides/gold-price-history" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price History</div>
+        <div style="font-size:0.875rem;color:#666;">Historical gold prices from 1970 — see how today's spot price compares.</div>
+      </a>
+      <a href="/14k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">14K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Convert today's spot price to a 14K gold per-gram rate instantly.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Apply today's spot price to calculate your gold's actual melt value.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/how-to-sell-gold-jewellery.html
+++ b/guides/how-to-sell-gold-jewellery.html
@@ -255,6 +255,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate your gold's melt value before you approach any dealer.</div>
+      </a>
+      <a href="/14k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">14K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Check today's 14K gold price so you know exactly what your jewellery is worth.</div>
+      </a>
+      <a href="/10k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">10K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's 10K gold price — the most common karat sold to scrap dealers.</div>
+      </a>
+      <a href="/guides/how-to-calculate-scrap-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Calculate Scrap Gold Value</div>
+        <div style="font-size:0.875rem;color:#666;">Step-by-step: work out the true value of your gold before selling.</div>
+      </a>
+      <a href="/guides/gold-purity-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Purity Guide</div>
+        <div style="font-size:0.875rem;color:#666;">Identify your gold's karat from hallmarks before getting a quote.</div>
+      </a>
+      <a href="/guides/best-time-to-sell-scrap-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Best Time to Sell Scrap Gold</div>
+        <div style="font-size:0.875rem;color:#666;">When is the best time to sell? How gold price cycles affect your payout.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/silver-price-per-gram-explained.html
+++ b/guides/silver-price-per-gram-explained.html
@@ -234,6 +234,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/silver-price-per-kilo" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Kilo</div>
+        <div style="font-size:0.875rem;color:#666;">Today's silver price per kilogram — live, updated every 60 seconds.</div>
+      </a>
+      <a href="/800-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.800 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Live .800 silver price per gram — European hallmark standard.</div>
+      </a>
+      <a href="/900-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.900 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's .900 silver price per gram — US coin silver standard.</div>
+      </a>
+      <a href="/guides/what-is-925-sterling-silver" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">What is 925 Sterling Silver?</div>
+        <div style="font-size:0.875rem;color:#666;">Understand .925 sterling silver — purity, hallmarks and value.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Track the live gold-to-silver ratio for silver investment context.</div>
+      </a>
+      <a href="/guides/troy-ounce-vs-gram-explained" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Troy Ounce vs Gram Explained</div>
+        <div style="font-size:0.875rem;color:#666;">Why silver is priced in troy ounces but often sold by the gram.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/troy-ounce-vs-gram-explained.html
+++ b/guides/troy-ounce-vs-gram-explained.html
@@ -247,6 +247,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/how-many-grams-in-troy-ounce" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How Many Grams in a Troy Ounce?</div>
+        <div style="font-size:0.875rem;color:#666;">The definitive answer: 1 troy oz = 31.1035g. Full converter included.</div>
+      </a>
+      <a href="/guides/how-to-read-gold-spot-price" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Read a Gold Spot Price</div>
+        <div style="font-size:0.875rem;color:#666;">How spot prices use troy ounces and how to convert to grams for jewellery.</div>
+      </a>
+      <a href="/14k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">14K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's 14K gold price per gram — the practical unit for jewellery buyers.</div>
+      </a>
+      <a href="/silver-price-per-kilo" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Kilo</div>
+        <div style="font-size:0.875rem;color:#666;">Live silver price per kilo — another common weight unit for precious metals.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate melt value by gram weight using today's live spot price.</div>
+      </a>
+      <a href="/guides/gold-purity-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Purity Guide</div>
+        <div style="font-size:0.875rem;color:#666;">Karats, fineness and hallmarks — how gold purity is measured worldwide.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/what-is-14k-gold.html
+++ b/guides/what-is-14k-gold.html
@@ -257,6 +257,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/14k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">14K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's live 14K gold price per gram — updated every 60 seconds.</div>
+      </a>
+      <a href="/10k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">10K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Compare 10K vs 14K gold price and purity.</div>
+      </a>
+      <a href="/18k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">18K Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">See how 18K compares to 14K in purity and value.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate what your 14K gold jewellery is worth today.</div>
+      </a>
+      <a href="/guides/gold-purity-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Purity Guide</div>
+        <div style="font-size:0.875rem;color:#666;">Full guide to gold karats, hallmarks and millesimal fineness.</div>
+      </a>
+      <a href="/guides/how-to-sell-gold-jewellery" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Sell Gold Jewellery</div>
+        <div style="font-size:0.875rem;color:#666;">How to get the best price when selling 14K gold pieces.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/what-is-925-sterling-silver.html
+++ b/guides/what-is-925-sterling-silver.html
@@ -239,6 +239,46 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/silver-price-per-kilo" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Kilo</div>
+        <div style="font-size:0.875rem;color:#666;">Today's live silver price per kilogram — .999 fine silver benchmark.</div>
+      </a>
+      <a href="/800-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.800 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Price comparison: .800 vs .925 sterling silver per gram.</div>
+      </a>
+      <a href="/900-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.900 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Live .900 silver price — how it compares to .925 sterling.</div>
+      </a>
+      <a href="/guides/silver-price-per-gram-explained" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Gram Explained</div>
+        <div style="font-size:0.875rem;color:#666;">How the silver spot price converts to per-gram rates for sterling silver.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">The live gold-to-silver ratio — context for .925 silver valuations.</div>
+      </a>
+      <a href="/guides/how-to-calculate-scrap-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Calculate Scrap Metal Value</div>
+        <div style="font-size:0.875rem;color:#666;">Apply the same methodology to value your .925 sterling silver items.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -222,6 +222,46 @@
   <a href="https://api.whatsapp.com/send?text=Silver+Price+Per+Kilo+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fsilver-price-per-kilo" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Gold &amp; Silver Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/800-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.800 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's .800 silver price per gram — European silver standard.</div>
+      </a>
+      <a href="/900-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.900 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Live .900 silver price per gram — common in US coins and antique silverware.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Track the live gold-to-silver ratio to time your silver purchases.</div>
+      </a>
+      <a href="/guides/silver-price-per-gram-explained" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Gram Explained</div>
+        <div style="font-size:0.875rem;color:#666;">How the silver spot price translates to per-gram and per-kilo rates.</div>
+      </a>
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver Investment</div>
+        <div style="font-size:0.875rem;color:#666;">Compare silver kilobars vs gold bars as long-term stores of value.</div>
+      </a>
+      <a href="/guides/what-is-925-sterling-silver" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">What is 925 Sterling Silver?</div>
+        <div style="font-size:0.875rem;color:#666;">Understanding silver purity grades — .800, .900, .925 and .999 fine silver.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}


### PR DESCRIPTION
## Phase 1 Related Guides — 16 Pages

Adds a tailored **Related Guides** section to every Phase 1 content page. Each section has 6 contextually-relevant cards linking to related tools, price pages and guides.

### Pages Updated
**Karat gold price pages (6):** 9K, 10K, 14K, 18K, 22K, 24K  
**Silver price pages (3):** .800 silver/gram, .900 silver/gram, silver/kilo  
**Guide articles (7):** how-to-read-spot-price, silver-price-explained, troy-ounce-vs-gram, what-is-14k-gold, what-is-925-sterling-silver, how-to-sell-gold-jewellery, how-to-invest-in-gold

### Impact
- **Internal linking**: every page now links to 6 related pages → improves crawl depth and PageRank flow across the site
- **Bounce rate**: users have clear "next step" content → reduces single-page sessions
- **AdSense quality**: Google's content quality review sees a site where pages interconnect meaningfully
- **Time on site**: cards are visually distinct and contextually matched — higher click-through than plain text links

### Closes
Closes #205, #206, #207, #208, #209, #210, #211, #215, #216, #217