### PR TITLE
content: Phase 2 blog articles — add FAQ sections + FAQPage schema + Related Articles to all 9 blogs

### DIFF
--- a/blog/2026-04-29-gold-silver-price-outlook.html
+++ b/blog/2026-04-29-gold-silver-price-outlook.html
@@ -23,6 +23,47 @@
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Gold & Silver Price Outlook — Week of 29 April 2026","description":"Gold prices face resistance near historical highs while silver tests key support. Read our weekly market commentary.","url":"https://goldpricetools.com/blog/2026-04-29-gold-silver-price-outlook","datePublished":"2026-04-29T09:00:00Z","dateModified":"2026-05-02T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/blog/2026-04-29-gold-silver-price-outlook"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"Gold & Silver Price Outlook"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Will gold prices keep rising in 2026?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gold prices remain supported by central bank buying, elevated geopolitical risk and persistent inflation concerns. However, any significant rise in real interest rates could pressure prices lower. Most analysts forecast a trading range of $2,800–$3,600/oz for 2026, with upside risk if global recession fears intensify."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is driving silver prices in 2026?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Silver in 2026 is driven by dual demand: industrial use (particularly solar panel manufacturing and EV components) and investment demand tracking gold. The solar industry alone accounts for over 15% of annual silver demand. Silver tends to outperform gold in bull markets due to its smaller market size."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is now a good time to buy gold?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Timing gold purchases is difficult — gold doesn't pay dividends, so returns depend entirely on price appreciation. Dollar-cost averaging (buying fixed amounts monthly) is generally recommended over trying to time the market. If you're concerned about inflation or currency debasement, a 5–10% allocation makes sense regardless of the current price."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does gold perform well during uncertainty?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gold has no counterparty risk — it cannot default, be sanctioned, or be inflated away like paper currency. During times of geopolitical stress, financial crisis, or high inflation, investors move capital into gold as a store of value. Central banks hold gold reserves for exactly this reason."
+      }
+    }
+  ]
+}
+</script>
+
 <style>
 :root{--color-bg:#faf9f6;--color-surface:#ffffff;--color-surface-offset:#f5f4f0;--color-border:#e5e4e2;--color-text:#2d2c2a;--color-text-muted:#666560;--color-text-faint:#888782;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
 [data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
@@ -183,14 +224,69 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     </div>
   </div>
 
-  <div class="related-posts">
-    <h3>Related Resources</h3>
-    <ul>
-      <li><a href="/gold-and-silver-price-today/">Live Gold &amp; Silver Prices Today</a></li>
-      <li><a href="/gold-silver-ratio">Understanding the Gold-Silver Ratio</a></li>
-      <li><a href="/blog/understanding-gold-karat-purities/">Guide to Gold Karat Purities</a></li>
-    </ul>
+  
+<!-- FAQ Section -->
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:#1a1a1a;margin-bottom:1.2rem;">Frequently Asked Questions</h2>
+  <div class="faq-container">
+    <details>
+      <summary class="faq-answer-summary">Will gold prices keep rising in 2026?</summary>
+      <p class="faq-answer">Gold prices remain supported by central bank buying, elevated geopolitical risk and persistent inflation concerns. However, any significant rise in real interest rates could pressure prices lower. Most analysts forecast a trading range of $2,800–$3,600/oz for 2026, with upside risk if global recession fears intensify.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">What is driving silver prices in 2026?</summary>
+      <p class="faq-answer">Silver in 2026 is driven by dual demand: industrial use (particularly solar panel manufacturing and EV components) and investment demand tracking gold. The solar industry alone accounts for over 15% of annual silver demand. Silver tends to outperform gold in bull markets due to its smaller market size.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Is now a good time to buy gold?</summary>
+      <p class="faq-answer">Timing gold purchases is difficult — gold doesn't pay dividends, so returns depend entirely on price appreciation. Dollar-cost averaging (buying fixed amounts monthly) is generally recommended over trying to time the market. If you're concerned about inflation or currency debasement, a 5–10% allocation makes sense regardless of the current price.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Why does gold perform well during uncertainty?</summary>
+      <p class="faq-answer">Gold has no counterparty risk — it cannot default, be sanctioned, or be inflated away like paper currency. During times of geopolitical stress, financial crisis, or high inflation, investors move capital into gold as a store of value. Central banks hold gold reserves for exactly this reason.</p>
+    </details>
   </div>
+</section>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Articles &amp; Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Track the live ratio between gold and silver prices — a key signal for precious metals investors.</div>
+      </a>
+      <a href="/guides/gold-price-history" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price History</div>
+        <div style="font-size:0.875rem;color:#666;">See how gold prices have moved from 1970 to today and understand long-term price trends.</div>
+      </a>
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver Investment</div>
+        <div style="font-size:0.875rem;color:#666;">Should you hold gold, silver, or both? A data-driven comparison.</div>
+      </a>
+      <a href="/24k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price Per Gram Today</div>
+        <div style="font-size:0.875rem;color:#666;">Today's live gold price per gram in GBP and USD across all karats.</div>
+      </a>
+      <a href="/silver-price-per-kilo" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Kilo</div>
+        <div style="font-size:0.875rem;color:#666;">Live silver price per kilogram — updated every 60 seconds.</div>
+      </a>
+      <a href="/blog/is-gold-overpriced-2026" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Is Gold Overpriced in 2026?</div>
+        <div style="font-size:0.875rem;color:#666;">Gold valuation metrics explained — P/E ratios, gold-to-oil ratio, and real rate analysis.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 </article>
 
 <footer>

--- a/blog/best-uk-gold-dealers-2026.html
+++ b/blog/best-uk-gold-dealers-2026.html
@@ -19,6 +19,47 @@
 <meta name="twitter:card" content="summary_large_image"><meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Best UK Gold Dealers 2026: Royal Mint, BullionByPost, Chards, and BullionVault Compared","description":"Compare the best UK gold dealers in 2026 \u2014 Royal Mint, BullionByPost, Chards, BullionVault, and more. Covers premiums, buyback spreads, vault storage, and BNTA membership.","datePublished":"2026-05-03","dateModified":"2026-05-03","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"url":"https://goldpricetools.com/blog/best-uk-gold-dealers-2026","image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg","width":1200,"height":630},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/blog/best-uk-gold-dealers-2026"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"Best UK Gold Dealers 2026: Royal Mint, BullionByPost, Chards, and BullionVault Compared"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What should I look for in a UK gold dealer?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Look for: FCA authorisation or BNTA/IBJA membership, transparent pricing with clear buy/sell spreads, a physical UK address, positive independent reviews (Trustpilot), and buyback programmes. Avoid dealers that don't display spreads upfront or pressure you into quick decisions."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are UK gold dealers regulated?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gold dealers are not required to be FCA-regulated to sell gold — gold is not a regulated investment. However, reputable dealers voluntarily join industry bodies like the British Numismatic Trade Association (BNTA) or hold anti-money-laundering (AML) registrations with HMRC. Always verify HMRC AML registration at minimum."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is it safe to buy gold online in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, provided you use an established dealer with verifiable UK premises, secure checkout (HTTPS), and a clear returns policy. Insured delivery is standard practice for reputable dealers. Avoid deals on marketplace sites like eBay for investment-grade gold — use dedicated bullion dealers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is a fair spread for gold coins in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A fair dealer premium over spot for popular coins (e.g. Britannia, Sovereign) is typically 3–6% over spot for purchases under £5,000. Larger orders attract lower premiums. Spreads above 10% are excessive for standard bullion coins. CGT-exempt UK coins (Britannias, Sovereigns) may carry slightly higher premiums due to the tax benefit."
+      }
+    }
+  ]
+}
+</script>
+
 <script>
 window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
@@ -178,12 +219,69 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <p><em>Premiums are indicative and change daily with market conditions. Always check live prices before purchasing. Use <a href="https://bullioncompare.co.uk">BullionCompare.co.uk</a> for real-time dealer comparisons.</em></p>
     <div class="cta-box"><h3>Check Live Gold Prices Before You Buy</h3><p>Use GoldPriceTools' free live calculator to see what 24K, 22K, 18K, and 9K gold is worth right now — before comparing dealer premiums.</p><a href="/" class="cta-btn">Check Live Prices &rarr;</a></div>
   </div>
-  <div class="related-posts"><h3>Related Resources</h3><ul>
-      <li><a href="/blog/how-to-buy-gold-royal-mint">How to Buy Gold from the Royal Mint: Step-by-Step Guide</a></li>
-      <li><a href="/blog/uk-gold-cgt-guide">Capital Gains Tax on Gold UK: Are Coins Tax-Free?</a></li>
-      <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold: Beginner's Guide 2026</a></li>
-      <li><a href="/guides/gold-bar-guide">Gold Bar Guide: Sizes, Weights & Good Delivery</a></li>
-  </ul></div>
+  
+<!-- FAQ Section -->
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:#1a1a1a;margin-bottom:1.2rem;">Frequently Asked Questions</h2>
+  <div class="faq-container">
+    <details>
+      <summary class="faq-answer-summary">What should I look for in a UK gold dealer?</summary>
+      <p class="faq-answer">Look for: FCA authorisation or BNTA/IBJA membership, transparent pricing with clear buy/sell spreads, a physical UK address, positive independent reviews (Trustpilot), and buyback programmes. Avoid dealers that don't display spreads upfront or pressure you into quick decisions.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Are UK gold dealers regulated?</summary>
+      <p class="faq-answer">Gold dealers are not required to be FCA-regulated to sell gold — gold is not a regulated investment. However, reputable dealers voluntarily join industry bodies like the British Numismatic Trade Association (BNTA) or hold anti-money-laundering (AML) registrations with HMRC. Always verify HMRC AML registration at minimum.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Is it safe to buy gold online in the UK?</summary>
+      <p class="faq-answer">Yes, provided you use an established dealer with verifiable UK premises, secure checkout (HTTPS), and a clear returns policy. Insured delivery is standard practice for reputable dealers. Avoid deals on marketplace sites like eBay for investment-grade gold — use dedicated bullion dealers.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">What is a fair spread for gold coins in the UK?</summary>
+      <p class="faq-answer">A fair dealer premium over spot for popular coins (e.g. Britannia, Sovereign) is typically 3–6% over spot for purchases under £5,000. Larger orders attract lower premiums. Spreads above 10% are excessive for standard bullion coins. CGT-exempt UK coins (Britannias, Sovereigns) may carry slightly higher premiums due to the tax benefit.</p>
+    </details>
+  </div>
+</section>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Articles &amp; Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/guides/how-to-invest-in-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Invest in Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">A complete beginner's guide to buying gold in the UK — coins, bars, ETFs and more.</div>
+      </a>
+      <a href="/blog/uk-gold-cgt-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">UK Gold CGT Guide</div>
+        <div style="font-size:0.875rem;color:#666;">Which gold coins are CGT-exempt? How capital gains tax applies to gold investments.</div>
+      </a>
+      <a href="/blog/how-to-buy-gold-royal-mint" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Buy Gold from the Royal Mint</div>
+        <div style="font-size:0.875rem;color:#666;">Step-by-step guide to purchasing gold coins and bars from the Royal Mint.</div>
+      </a>
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver Investment</div>
+        <div style="font-size:0.875rem;color:#666;">Compare gold and silver as UK investments — costs, liquidity and tax treatment.</div>
+      </a>
+      <a href="/24k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Live Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Check today's gold spot price before approaching any dealer.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Scrap Gold Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate the melt value of gold coins or jewellery at today's live price.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 </article>
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>

--- a/blog/gold-etf-vs-physical-gold-uk.html
+++ b/blog/gold-etf-vs-physical-gold-uk.html
@@ -19,6 +19,47 @@
 <meta name="twitter:card" content="summary_large_image"><meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Gold ETFs vs Physical Gold: A UK Investor's Guide for 2026","description":"Compare gold ETFs (iShares IGLN, WisdomTree PHAU, Invesco SGLD) vs physical gold coins and bars. Covers costs, ISA eligibility, CGT treatment, and the best strategy for UK investors in 2026.","datePublished":"2026-05-03","dateModified":"2026-05-03","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"url":"https://goldpricetools.com/blog/gold-etf-vs-physical-gold-uk","image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg","width":1200,"height":630},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/blog/gold-etf-vs-physical-gold-uk"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"Gold ETFs vs Physical Gold: A UK Investor's Guide for 2026"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is a gold ETF?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A gold ETF (Exchange-Traded Fund) is a fund that tracks the gold price and trades on a stock exchange like a share. Most physically-backed gold ETFs hold actual gold bars in a vault. You get gold price exposure without storage, insurance or delivery logistics. UK examples include iShares Physical Gold ETC (SGLN) and Invesco Physical Gold ETC (SGLD)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is physical gold or gold ETF better for UK investors?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It depends on your goals. ETFs are cheaper to buy (no storage costs), more liquid, and easier to hold in an ISA or SIPP. Physical gold gives you direct ownership with no counterparty risk and is portable. For most UK investors holding under £50,000 in gold, ETFs in an ISA (no CGT) are the most practical and tax-efficient choice."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I hold gold ETFs in an ISA?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. UK gold ETCs (Exchange-Traded Commodities) like SGLN, SGLD and PHAU can be held in a Stocks & Shares ISA, making gains completely free of CGT and income tax. This is a significant advantage over physical gold (which is subject to CGT at 18% or 24% depending on your tax band)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the risks of gold ETFs vs physical?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gold ETF risks include: counterparty risk (the fund provider could fail, though gold-backed ETCs typically have segregated assets), tracking error, and annual management fees (typically 0.15–0.40%). Physical gold risks include storage, insurance costs, and the premium over spot when buying/selling. Neither form protects against gold price falls."
+      }
+    }
+  ]
+}
+</script>
+
 <script>
 window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
@@ -175,12 +216,69 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <p>As a practical framework: for a first gold investment under £20,000, an ISA-wrapped gold ETC (IGLN at 0.12% TER) offers simplicity, low cost, and a complete CGT shelter. For larger sums where CGT exemption on unlimited gains matters more than annual fees, Gold Sovereigns and Britannias offer unbeatable tax efficiency. For the most comprehensive approach, combine both: ETCs in an ISA for the first £20,000 annually, then CGT-exempt coins for everything beyond the ISA limit. Gold ETCs or LBMA bars inside a SIPP are optimal for pension investors who want tax relief on contributions combined with CGT-free growth.</p>
     <div class="cta-box"><h3>See Live Gold Prices in GBP</h3><p>Track 24K, 18K, 9K gold and silver prices live. Use GoldPriceTools' free calculator to value any holding before you invest.</p><a href="/" class="cta-btn">Open Live Calculator &rarr;</a></div>
   </div>
-  <div class="related-posts"><h3>Related Resources</h3><ul>
-      <li><a href="/blog/uk-gold-cgt-guide">Capital Gains Tax on Gold UK: Are Coins Tax-Free?</a></li>
-      <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold: Beginner's Guide 2026</a></li>
-      <li><a href="/guides/gold-bar-guide">Gold Bar Guide: Sizes, Weights & Good Delivery</a></li>
-      <li><a href="/gold-silver-ratio">Live Gold-Silver Ratio Chart</a></li>
-  </ul></div>
+  
+<!-- FAQ Section -->
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:#1a1a1a;margin-bottom:1.2rem;">Frequently Asked Questions</h2>
+  <div class="faq-container">
+    <details>
+      <summary class="faq-answer-summary">What is a gold ETF?</summary>
+      <p class="faq-answer">A gold ETF (Exchange-Traded Fund) is a fund that tracks the gold price and trades on a stock exchange like a share. Most physically-backed gold ETFs hold actual gold bars in a vault. You get gold price exposure without storage, insurance or delivery logistics. UK examples include iShares Physical Gold ETC (SGLN) and Invesco Physical Gold ETC (SGLD).</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Is physical gold or gold ETF better for UK investors?</summary>
+      <p class="faq-answer">It depends on your goals. ETFs are cheaper to buy (no storage costs), more liquid, and easier to hold in an ISA or SIPP. Physical gold gives you direct ownership with no counterparty risk and is portable. For most UK investors holding under £50,000 in gold, ETFs in an ISA (no CGT) are the most practical and tax-efficient choice.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Can I hold gold ETFs in an ISA?</summary>
+      <p class="faq-answer">Yes. UK gold ETCs (Exchange-Traded Commodities) like SGLN, SGLD and PHAU can be held in a Stocks & Shares ISA, making gains completely free of CGT and income tax. This is a significant advantage over physical gold (which is subject to CGT at 18% or 24% depending on your tax band).</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">What are the risks of gold ETFs vs physical?</summary>
+      <p class="faq-answer">Gold ETF risks include: counterparty risk (the fund provider could fail, though gold-backed ETCs typically have segregated assets), tracking error, and annual management fees (typically 0.15–0.40%). Physical gold risks include storage, insurance costs, and the premium over spot when buying/selling. Neither form protects against gold price falls.</p>
+    </details>
+  </div>
+</section>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Articles &amp; Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/guides/how-to-invest-in-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Invest in Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">From ETFs to bullion coins — a complete guide to gold investment in the UK.</div>
+      </a>
+      <a href="/blog/uk-gold-cgt-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">UK Gold CGT Guide</div>
+        <div style="font-size:0.875rem;color:#666;">CGT treatment of gold ETFs, coins and bars — how to invest tax-efficiently.</div>
+      </a>
+      <a href="/blog/gold-in-a-sipp-uk" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold in a SIPP UK</div>
+        <div style="font-size:0.875rem;color:#666;">Can you hold gold ETFs or physical gold in your pension? What the rules say.</div>
+      </a>
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver Investment</div>
+        <div style="font-size:0.875rem;color:#666;">Compare the case for gold vs silver in a UK investment portfolio.</div>
+      </a>
+      <a href="/guides/gold-price-history" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price History</div>
+        <div style="font-size:0.875rem;color:#666;">Long-term gold price chart — essential context for any gold investment decision.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Track the live gold-silver ratio alongside your ETF research.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 </article>
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>

--- a/blog/gold-in-a-sipp-uk.html
+++ b/blog/gold-in-a-sipp-uk.html
@@ -19,6 +19,47 @@
 <meta name="twitter:card" content="summary_large_image"><meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Gold in a SIPP: How to Hold Gold in Your UK Pension","description":"A complete UK guide to holding gold in a Self-Invested Personal Pension (SIPP) \u2014 eligible gold types, HMRC rules, approved depositories, contribution limits, and provider options.","datePublished":"2026-05-03","dateModified":"2026-05-03","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"url":"https://goldpricetools.com/blog/gold-in-a-sipp-uk","image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg","width":1200,"height":630},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/blog/gold-in-a-sipp-uk"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"Gold in a SIPP: How to Hold Gold in Your UK Pension"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can I hold physical gold in my SIPP?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Directly holding physical gold bars or coins in a SIPP is not permitted under HMRC rules — physical gold is classified as a 'tangible moveable asset' and is an 'in-specie' contribution that fails the 'exclusively for the purpose of the scheme' test. However, you can hold gold through HMRC-approved routes: gold ETCs, mining company shares, or specialist gold SIPP providers like Talaria Capital."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are gold ETFs allowed in a SIPP?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Physically-backed gold ETCs (such as SGLN, SGLD, PHAU) are permitted in most SIPPs that allow exchange-traded securities. They're treated as shares for SIPP purposes. You benefit from gold price exposure with full pension tax relief on contributions and no CGT within the wrapper."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the tax benefit of gold in a SIPP?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Contributing to a SIPP with the intention of buying gold ETCs gives you: 20% basic rate tax relief on contributions (higher rate taxpayers can claim 40%), no CGT on gains within the pension, and no income tax on dividends. The main downside is pension tax rules apply on withdrawal (typically 25% tax-free lump sum, rest taxed as income)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which SIPP providers allow gold ETFs?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most major SIPP platforms that offer a full range of exchange-traded securities allow gold ETCs. These include Hargreaves Lansdown SIPP, AJ Bell Youinvest, Interactive Investor, and Vanguard SIPP. Check the platform's 'permitted investments' list — some low-cost SIPPs restrict to funds only."
+      }
+    }
+  ]
+}
+</script>
+
 <script>
 window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
@@ -175,12 +216,69 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     </table>
     <div class="cta-box"><h3>Track Live Gold Prices in GBP</h3><p>Use GoldPriceTools' free live calculator to value your gold holdings before deciding on your SIPP contribution.</p><a href="/" class="cta-btn">Open Calculator &rarr;</a></div>
   </div>
-  <div class="related-posts"><h3>Related Resources</h3><ul>
-      <li><a href="/blog/uk-gold-cgt-guide">Capital Gains Tax on Gold UK: Are Coins Tax-Free?</a></li>
-      <li><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold UK</a></li>
-      <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold: Beginner's Guide 2026</a></li>
-      <li><a href="/blog/">More from the GoldPriceTools Blog</a></li>
-  </ul></div>
+  
+<!-- FAQ Section -->
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:#1a1a1a;margin-bottom:1.2rem;">Frequently Asked Questions</h2>
+  <div class="faq-container">
+    <details>
+      <summary class="faq-answer-summary">Can I hold physical gold in my SIPP?</summary>
+      <p class="faq-answer">Directly holding physical gold bars or coins in a SIPP is not permitted under HMRC rules — physical gold is classified as a 'tangible moveable asset' and is an 'in-specie' contribution that fails the 'exclusively for the purpose of the scheme' test. However, you can hold gold through HMRC-approved routes: gold ETCs, mining company shares, or specialist gold SIPP providers like Talaria Capital.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Are gold ETFs allowed in a SIPP?</summary>
+      <p class="faq-answer">Yes. Physically-backed gold ETCs (such as SGLN, SGLD, PHAU) are permitted in most SIPPs that allow exchange-traded securities. They're treated as shares for SIPP purposes. You benefit from gold price exposure with full pension tax relief on contributions and no CGT within the wrapper.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">What is the tax benefit of gold in a SIPP?</summary>
+      <p class="faq-answer">Contributing to a SIPP with the intention of buying gold ETCs gives you: 20% basic rate tax relief on contributions (higher rate taxpayers can claim 40%), no CGT on gains within the pension, and no income tax on dividends. The main downside is pension tax rules apply on withdrawal (typically 25% tax-free lump sum, rest taxed as income).</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Which SIPP providers allow gold ETFs?</summary>
+      <p class="faq-answer">Most major SIPP platforms that offer a full range of exchange-traded securities allow gold ETCs. These include Hargreaves Lansdown SIPP, AJ Bell Youinvest, Interactive Investor, and Vanguard SIPP. Check the platform's 'permitted investments' list — some low-cost SIPPs restrict to funds only.</p>
+    </details>
+  </div>
+</section>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Articles &amp; Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/blog/gold-etf-vs-physical-gold-uk" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold ETF vs Physical Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">Should you buy gold ETFs or physical bullion? A complete UK comparison.</div>
+      </a>
+      <a href="/blog/uk-gold-cgt-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">UK Gold CGT Guide</div>
+        <div style="font-size:0.875rem;color:#666;">How CGT applies to gold outside a pension — and why SIPPs can avoid it.</div>
+      </a>
+      <a href="/guides/how-to-invest-in-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Invest in Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">All the ways to invest in gold in the UK — ETFs, coins, bars and pensions.</div>
+      </a>
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver Investment</div>
+        <div style="font-size:0.875rem;color:#666;">Is gold or silver the better pension hedge? Key differences compared.</div>
+      </a>
+      <a href="/guides/gold-price-history" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price History</div>
+        <div style="font-size:0.875rem;color:#666;">Long-term gold returns context for pension investors.</div>
+      </a>
+      <a href="/24k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Live Gold Price Today</div>
+        <div style="font-size:0.875rem;color:#666;">Today's gold spot price — the benchmark for any gold investment decision.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 </article>
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>

--- a/blog/gold-vs-bitcoin-2026.html
+++ b/blog/gold-vs-bitcoin-2026.html
@@ -19,6 +19,47 @@
 <meta name="twitter:card" content="summary_large_image"><meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Gold vs Bitcoin 2026: Store of Value, Performance, and UK Tax Compared","description":"Gold is up 80% since 2025 while Bitcoin is down 14% in 2026 year-to-date. We compare gold and Bitcoin on performance, volatility, liquidity, costs, UK tax treatment, and portfolio role.","datePublished":"2026-05-03","dateModified":"2026-05-03","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"url":"https://goldpricetools.com/blog/gold-vs-bitcoin-2026","image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg","width":1200,"height":630},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/blog/gold-vs-bitcoin-2026"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"Gold vs Bitcoin 2026: Store of Value, Performance, and UK Tax Compared"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Bitcoin better than gold as a store of value?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both have merits. Gold has a 5,000-year track record, extremely low volatility compared to Bitcoin, and universal recognition. Bitcoin is more portable (borderless transfer in minutes), has a hard supply cap (21 million), and has delivered far higher returns in bull cycles. Bitcoin is roughly 5x as volatile as gold. Most institutional investors use gold for stability and Bitcoin for asymmetric upside."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Bitcoin replace gold?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unlikely in the near term. Central banks hold over 35,000 tonnes of gold as reserve assets — none hold Bitcoin as a formal reserve (though some nations have Bitcoin strategic reserves). Gold also has significant industrial demand (electronics, dentistry). For private investors, Bitcoin has become a legitimate alternative asset class alongside gold rather than a replacement."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How have gold and Bitcoin performed in 2026?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both assets performed strongly in 2025–2026. Gold reached all-time highs above $3,000/oz driven by central bank buying and geopolitical uncertainty. Bitcoin also reached new highs following the 2024 halving and increasing institutional adoption. Historically, both tend to perform well when confidence in fiat currencies is low."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Should I invest in gold or Bitcoin?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The standard advice is to hold both in small allocations (e.g. 5–10% gold, 1–3% Bitcoin) as uncorrelated assets. Gold is lower risk and suits investors seeking stability; Bitcoin suits those comfortable with high volatility for higher potential returns. Never invest more in Bitcoin than you can afford to lose entirely."
+      }
+    }
+  ]
+}
+</script>
+
 <script>
 window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
@@ -158,12 +199,69 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <p>Gold and Bitcoin are fundamentally different instruments serving different purposes. Gold is a proven, low-volatility store of value that performs best in risk-off environments — geopolitical crises, currency debasement, financial system stress. Bitcoin is a high-risk, high-potential-return speculative asset that performs best in risk-on environments when investor appetite for digital assets is strong. The 2025–2026 performance gap is a timely reminder that they are not interchangeable. For most UK investors building a diversified portfolio, a gold allocation (whether via CGT-exempt Sovereigns, ISA-wrapped ETCs, or a SIPP) provides more reliable portfolio insurance. A speculative Bitcoin allocation — sized to what you can afford to lose — is a separate decision entirely.</p>
     <div class="cta-box"><h3>Track Live Gold Prices Right Now</h3><p>Monitor live gold spot prices, the gold-silver ratio, and per-gram values in GBP at GoldPriceTools.</p><a href="/" class="cta-btn">Open Live Tracker &rarr;</a></div>
   </div>
-  <div class="related-posts"><h3>Related Resources</h3><ul>
-      <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026? Valuation Metrics Examined</a></li>
-      <li><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold UK</a></li>
-      <li><a href="/blog/uk-gold-cgt-guide">Capital Gains Tax on Gold UK: Are Coins Tax-Free?</a></li>
-      <li><a href="/gold-silver-ratio">Live Gold-Silver Ratio Chart</a></li>
-  </ul></div>
+  
+<!-- FAQ Section -->
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:#1a1a1a;margin-bottom:1.2rem;">Frequently Asked Questions</h2>
+  <div class="faq-container">
+    <details>
+      <summary class="faq-answer-summary">Is Bitcoin better than gold as a store of value?</summary>
+      <p class="faq-answer">Both have merits. Gold has a 5,000-year track record, extremely low volatility compared to Bitcoin, and universal recognition. Bitcoin is more portable (borderless transfer in minutes), has a hard supply cap (21 million), and has delivered far higher returns in bull cycles. Bitcoin is roughly 5x as volatile as gold. Most institutional investors use gold for stability and Bitcoin for asymmetric upside.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Can Bitcoin replace gold?</summary>
+      <p class="faq-answer">Unlikely in the near term. Central banks hold over 35,000 tonnes of gold as reserve assets — none hold Bitcoin as a formal reserve (though some nations have Bitcoin strategic reserves). Gold also has significant industrial demand (electronics, dentistry). For private investors, Bitcoin has become a legitimate alternative asset class alongside gold rather than a replacement.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">How have gold and Bitcoin performed in 2026?</summary>
+      <p class="faq-answer">Both assets performed strongly in 2025–2026. Gold reached all-time highs above $3,000/oz driven by central bank buying and geopolitical uncertainty. Bitcoin also reached new highs following the 2024 halving and increasing institutional adoption. Historically, both tend to perform well when confidence in fiat currencies is low.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Should I invest in gold or Bitcoin?</summary>
+      <p class="faq-answer">The standard advice is to hold both in small allocations (e.g. 5–10% gold, 1–3% Bitcoin) as uncorrelated assets. Gold is lower risk and suits investors seeking stability; Bitcoin suits those comfortable with high volatility for higher potential returns. Never invest more in Bitcoin than you can afford to lose entirely.</p>
+    </details>
+  </div>
+</section>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Articles &amp; Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/blog/is-gold-overpriced-2026" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Is Gold Overpriced in 2026?</div>
+        <div style="font-size:0.875rem;color:#666;">Gold valuation metrics — real rates, gold-to-oil ratio and what they say about current prices.</div>
+      </a>
+      <a href="/guides/gold-price-history" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price History</div>
+        <div style="font-size:0.875rem;color:#666;">Historical gold price chart — context for the gold vs Bitcoin comparison.</div>
+      </a>
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver Investment</div>
+        <div style="font-size:0.875rem;color:#666;">Compare gold vs silver before adding Bitcoin to the mix.</div>
+      </a>
+      <a href="/guides/how-to-invest-in-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Invest in Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">UK-specific gold investment options — ETFs, coins, SIPPs and more.</div>
+      </a>
+      <a href="/blog/gold-etf-vs-physical-gold-uk" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold ETF vs Physical Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">If you're choosing between gold forms, start here.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Live gold and silver prices — track how gold moves vs the broader metals market.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 </article>
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>

--- a/blog/how-to-buy-gold-royal-mint.html
+++ b/blog/how-to-buy-gold-royal-mint.html
@@ -19,6 +19,47 @@
 <meta name="twitter:card" content="summary_large_image"><meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"How to Buy Gold from the Royal Mint: A UK Step-by-Step Guide","description":"A complete guide to buying gold from the Royal Mint \u2014 account setup, product range (Sovereigns, Britannias, bars, DigiGold), premiums, Vault storage, and how to compare with commercial dealers.","datePublished":"2026-05-03","dateModified":"2026-05-03","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"url":"https://goldpricetools.com/blog/how-to-buy-gold-royal-mint","image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg","width":1200,"height":630},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/blog/how-to-buy-gold-royal-mint"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"How to Buy Gold from the Royal Mint: A UK Step-by-Step Guide"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is the Royal Mint a good place to buy gold?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The Royal Mint is the UK's official coin manufacturer, founded in 886 AD, and is considered the most trusted source for investment gold coins in the UK. Prices are competitive with other major dealers, and coins purchased directly carry the full Royal Mint guarantee of authenticity and purity. They also offer a DigiGold service for fractional gold ownership."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What gold products does the Royal Mint sell?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The Royal Mint sells Britannia gold coins (1oz, 1/2oz, 1/4oz, 1/10oz), Sovereign gold coins (full, half, quarter), gold bars (1g to 1kg), and collectable commemorative coins. Britannias and Sovereigns are CGT-exempt for UK investors, making them particularly tax-efficient."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are Royal Mint gold coins CGT free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Gold Britannias and gold Sovereigns are classified as 'coin of the realm' and legal tender, making any gains from their sale completely exempt from Capital Gains Tax for UK investors. This is a significant advantage over gold bars or foreign gold coins, which are subject to standard CGT rates (18% or 24%)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does Royal Mint DigiGold work?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "DigiGold lets you buy fractions of a gold bar from as little as £25, with your gold physically stored at the Royal Mint's vault in Llantrisant, Wales. You own actual allocated gold, not a financial instrument. You can convert to physical delivery (coins or bars) at any time. Storage fees apply (0.5% per year)."
+      }
+    }
+  ]
+}
+</script>
+
 <script>
 window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
@@ -178,12 +219,69 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <p>The Royal Mint is not always the best choice. Consider commercial alternatives (all BNTA members) when buying large gold bars (commercial dealers typically offer tighter premiums on 100g+ sizes), when selling back (check buyback spreads — some dealers beat the Royal Mint), or when seeking foreign coins such as Canadian Maple Leafs, Krugerrands, or American Eagles. Reputable UK commercial dealers include BullionByPost, Chards, Atkinsons, Gold.co.uk, and Sharps Pixley. Always verify BNTA or IBMA membership before purchasing from any dealer.</p>
     <div class="cta-box"><h3>Check Today's Gold Price in GBP</h3><p>See live 24K, 22K, 18K, and 9K gold prices per gram and per troy oz in GBP. Useful for comparing Royal Mint premiums against the current spot price before you buy.</p><a href="/" class="cta-btn">See Live Gold Prices &rarr;</a></div>
   </div>
-  <div class="related-posts"><h3>Related Resources</h3><ul>
-      <li><a href="/blog/uk-gold-cgt-guide">Capital Gains Tax on Gold UK: Are Coins Tax-Free?</a></li>
-      <li><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold UK</a></li>
-      <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold: Beginner's Guide 2026</a></li>
-      <li><a href="/guides/gold-hallmarks-explained">Gold Hallmarks Explained</a></li>
-  </ul></div>
+  
+<!-- FAQ Section -->
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:#1a1a1a;margin-bottom:1.2rem;">Frequently Asked Questions</h2>
+  <div class="faq-container">
+    <details>
+      <summary class="faq-answer-summary">Is the Royal Mint a good place to buy gold?</summary>
+      <p class="faq-answer">Yes. The Royal Mint is the UK's official coin manufacturer, founded in 886 AD, and is considered the most trusted source for investment gold coins in the UK. Prices are competitive with other major dealers, and coins purchased directly carry the full Royal Mint guarantee of authenticity and purity. They also offer a DigiGold service for fractional gold ownership.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">What gold products does the Royal Mint sell?</summary>
+      <p class="faq-answer">The Royal Mint sells Britannia gold coins (1oz, 1/2oz, 1/4oz, 1/10oz), Sovereign gold coins (full, half, quarter), gold bars (1g to 1kg), and collectable commemorative coins. Britannias and Sovereigns are CGT-exempt for UK investors, making them particularly tax-efficient.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Are Royal Mint gold coins CGT free?</summary>
+      <p class="faq-answer">Yes. Gold Britannias and gold Sovereigns are classified as 'coin of the realm' and legal tender, making any gains from their sale completely exempt from Capital Gains Tax for UK investors. This is a significant advantage over gold bars or foreign gold coins, which are subject to standard CGT rates (18% or 24%).</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">How does Royal Mint DigiGold work?</summary>
+      <p class="faq-answer">DigiGold lets you buy fractions of a gold bar from as little as £25, with your gold physically stored at the Royal Mint's vault in Llantrisant, Wales. You own actual allocated gold, not a financial instrument. You can convert to physical delivery (coins or bars) at any time. Storage fees apply (0.5% per year).</p>
+    </details>
+  </div>
+</section>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Articles &amp; Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/blog/uk-gold-cgt-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">UK Gold CGT Guide</div>
+        <div style="font-size:0.875rem;color:#666;">Which Royal Mint products are CGT-exempt? Full guide to gold capital gains tax.</div>
+      </a>
+      <a href="/blog/best-uk-gold-dealers-2026" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Best UK Gold Dealers 2026</div>
+        <div style="font-size:0.875rem;color:#666;">How the Royal Mint compares to other UK dealers — spread, range and service.</div>
+      </a>
+      <a href="/guides/how-to-invest-in-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Invest in Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">Beyond the Royal Mint — all UK gold investment options compared.</div>
+      </a>
+      <a href="/guides/gold-price-history" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price History</div>
+        <div style="font-size:0.875rem;color:#666;">Check long-term gold price performance before buying from any dealer.</div>
+      </a>
+      <a href="/24k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Live Gold Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Today's gold spot price — use this to assess Royal Mint premiums.</div>
+      </a>
+      <a href="/scrap-gold-calculator" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Value Calculator</div>
+        <div style="font-size:0.875rem;color:#666;">Calculate the melt value of any Royal Mint coin at today's spot price.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 </article>
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>

--- a/blog/is-gold-overpriced-2026.html
+++ b/blog/is-gold-overpriced-2026.html
@@ -19,6 +19,47 @@
 <meta name="twitter:card" content="summary_large_image"><meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Is Gold Overpriced in 2026? Five Valuation Frameworks Examined","description":"Gold hit record highs above $5,500 in 2026. We examine five data-driven frameworks \u2014 real yields, inflation-adjusted price, M2 ratio, gold-silver ratio, and GBP pricing \u2014 to assess whether gold is overvalued.","datePublished":"2026-05-03","dateModified":"2026-05-03","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"url":"https://goldpricetools.com/blog/is-gold-overpriced-2026","image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg","width":1200,"height":630},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/blog/is-gold-overpriced-2026"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"Is Gold Overpriced in 2026? Five Valuation Frameworks Examined"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do analysts value gold?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unlike stocks, gold has no earnings or dividends, so traditional P/E ratios don't apply. Common valuation methods include: (1) Gold-to-oil ratio — gold should buy roughly 20–25 barrels of oil historically; (2) Real interest rates — gold tends to be fairly valued when 10-year TIPS yields are negative; (3) Gold-to-S&P 500 ratio; (4) Gold as % of total global financial assets (historically ~1–2%)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is gold in a bubble?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "By most historical metrics, gold is elevated but not in a classic bubble. Bubbles are characterised by retail speculation and leverage — gold's current rally is driven by central bank buying (a structural, long-term demand source) rather than retail frenzy. Sentiment indicators are elevated but not at the extremes seen in 1980. Most analysts see gold as fairly valued to moderately expensive."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What would cause gold to fall significantly?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The main bearish scenarios for gold are: (1) Sharp rise in real interest rates (making bonds and cash more attractive); (2) Resolution of major geopolitical conflicts; (3) A strong US dollar rally; (4) Forced selling during a broad market liquidity crisis (as happened briefly in March 2020). Gold's correlation with risk assets turns positive during acute crises."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Should I wait for gold to fall before buying?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Timing gold is notoriously difficult. Missing the best months of gold performance can significantly reduce long-term returns. Dollar-cost averaging — buying a fixed amount monthly — removes the need to time entry and reduces the impact of short-term volatility. If you plan to hold for 5–10 years, entry price matters less than consistency."
+      }
+    }
+  ]
+}
+</script>
+
 <script>
 window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
@@ -165,12 +206,69 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <p>The intellectually honest answer: gold is expensive by historical metrics, but those metrics may be anchored to a monetary regime that no longer exists. Investors should calibrate their gold allocation to its role in their portfolio — as an insurance policy, a currency hedge, and a tail-risk diversifier — rather than as a bet on further nominal appreciation. The frameworks above are tools for context, not price targets.</p>
     <div class="cta-box"><h3>Track the Live Gold-Silver Ratio</h3><p>Monitor the gold-silver ratio and live spot prices updated every 60 seconds at GoldPriceTools.</p><a href="/gold-silver-ratio" class="cta-btn">See Live Ratio &rarr;</a></div>
   </div>
-  <div class="related-posts"><h3>Related Resources</h3><ul>
-      <li><a href="/guides/gold-price-prediction-2026">Gold Price Prediction 2026: Forecast & Outlook</a></li>
-      <li><a href="/guides/gold-price-history">Gold Price History: All-Time Highs & Milestones</a></li>
-      <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver Investment 2026</a></li>
-      <li><a href="/blog/">More from the GoldPriceTools Blog</a></li>
-  </ul></div>
+  
+<!-- FAQ Section -->
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:#1a1a1a;margin-bottom:1.2rem;">Frequently Asked Questions</h2>
+  <div class="faq-container">
+    <details>
+      <summary class="faq-answer-summary">How do analysts value gold?</summary>
+      <p class="faq-answer">Unlike stocks, gold has no earnings or dividends, so traditional P/E ratios don't apply. Common valuation methods include: (1) Gold-to-oil ratio — gold should buy roughly 20–25 barrels of oil historically; (2) Real interest rates — gold tends to be fairly valued when 10-year TIPS yields are negative; (3) Gold-to-S&P 500 ratio; (4) Gold as % of total global financial assets (historically ~1–2%).</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Is gold in a bubble?</summary>
+      <p class="faq-answer">By most historical metrics, gold is elevated but not in a classic bubble. Bubbles are characterised by retail speculation and leverage — gold's current rally is driven by central bank buying (a structural, long-term demand source) rather than retail frenzy. Sentiment indicators are elevated but not at the extremes seen in 1980. Most analysts see gold as fairly valued to moderately expensive.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">What would cause gold to fall significantly?</summary>
+      <p class="faq-answer">The main bearish scenarios for gold are: (1) Sharp rise in real interest rates (making bonds and cash more attractive); (2) Resolution of major geopolitical conflicts; (3) A strong US dollar rally; (4) Forced selling during a broad market liquidity crisis (as happened briefly in March 2020). Gold's correlation with risk assets turns positive during acute crises.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Should I wait for gold to fall before buying?</summary>
+      <p class="faq-answer">Timing gold is notoriously difficult. Missing the best months of gold performance can significantly reduce long-term returns. Dollar-cost averaging — buying a fixed amount monthly — removes the need to time entry and reduces the impact of short-term volatility. If you plan to hold for 5–10 years, entry price matters less than consistency.</p>
+    </details>
+  </div>
+</section>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Articles &amp; Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/guides/gold-price-history" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold Price History</div>
+        <div style="font-size:0.875rem;color:#666;">Historical gold prices — essential context for valuation analysis.</div>
+      </a>
+      <a href="/gold-silver-ratio" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Tool</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold-Silver Ratio</div>
+        <div style="font-size:0.875rem;color:#666;">Track the gold-silver ratio alongside valuation metrics.</div>
+      </a>
+      <a href="/blog/gold-vs-bitcoin-2026" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Bitcoin 2026</div>
+        <div style="font-size:0.875rem;color:#666;">Compare gold and Bitcoin as stores of value and inflation hedges.</div>
+      </a>
+      <a href="/guides/how-to-invest-in-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Invest in Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">UK-specific gold investment options regardless of where prices are.</div>
+      </a>
+      <a href="/blog/gold-etf-vs-physical-gold-uk" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold ETF vs Physical Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">Choosing the right form of gold investment for your portfolio.</div>
+      </a>
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver</div>
+        <div style="font-size:0.875rem;color:#666;">If gold seems expensive, is silver the better value? Comparison guide.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 </article>
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>

--- a/blog/silver-coins-for-investors-uk.html
+++ b/blog/silver-coins-for-investors-uk.html
@@ -19,6 +19,47 @@
 <meta name="twitter:card" content="summary_large_image"><meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Silver Coins for UK Investors: Junk Silver, Britannias, and Maple Leafs Compared","description":"A UK investor's guide to silver coins in 2026 \u2014 junk silver, pre-decimal sterling, Silver Britannias (CGT-exempt), Canadian Maple Leafs, and how to calculate silver coin melt value.","datePublished":"2026-05-03","dateModified":"2026-05-03","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"url":"https://goldpricetools.com/blog/silver-coins-for-investors-uk","image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg","width":1200,"height":630},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/blog/silver-coins-for-investors-uk"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"Silver Coins for UK Investors: Junk Silver, Britannias, and Maple Leafs Compared"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is junk silver?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Junk silver refers to pre-1965 US coins (dimes, quarters, half-dollars) that contain 90% silver but have no numismatic premium — they're traded purely for their silver content. The term is misleading: this silver is far from junk. UK equivalent: pre-1920 British coins (50% silver) and 1920–1946 British coins (50% silver). Junk silver offers a cheap way to buy silver near spot price."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are silver coins CGT-exempt in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "UK legal tender silver coins — including Silver Britannias — are CGT-exempt as 'coin of the realm', the same as gold Britannias and Sovereigns. Foreign silver coins (e.g. Canadian Maple Leafs, American Eagles) are not CGT-exempt and any gains are subject to UK CGT at 18% or 24%. This makes Silver Britannias particularly attractive for UK investors."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best silver coin to buy in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For UK investors, the Silver Britannia (1oz .999 fine silver) is generally the best choice: CGT-exempt, VAT-free (as legal tender), recognisable worldwide, and available from the Royal Mint and major dealers. The Silver Sovereign is another option. For maximum silver content per £, silver bars typically have lower premiums than coins."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does silver have VAT but gold doesn't?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Investment gold (coins and bars of ≥99.5% purity) is VAT-exempt in the UK under EU-inherited legislation. Silver, platinum and palladium do not benefit from this exemption — standard 20% VAT applies. This significantly increases the effective cost of buying silver coins or bars, and makes silver ETCs (which don't attract VAT) more cost-effective for pure investment exposure."
+      }
+    }
+  ]
+}
+</script>
+
 <script>
 window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
@@ -171,12 +212,69 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <p>The melt value formula for any silver coin: multiply the coin's <strong>pure silver weight in troy oz</strong> by the <strong>current silver spot price in GBP per troy oz</strong>. For sterling (.925) coins: multiply the total weight in grams by 0.925, then divide by 31.1035 to get troy oz. For 50% silver coins: use 0.500 instead of 0.925. Our <a href="/silver-price-per-kilo">silver price calculator</a> can check live prices in GBP instantly.</p>
     <div class="cta-box"><h3>Calculate Your Silver's Live Value</h3><p>Check the current price of 925 sterling, 999 fine silver, and pre-decimal coins using GoldPriceTools' live silver calculator.</p><a href="/silver-price-per-kilo" class="cta-btn">Open Silver Calculator &rarr;</a></div>
   </div>
-  <div class="related-posts"><h3>Related Resources</h3><ul>
-      <li><a href="/guides/us-silver-dollar-values">US Silver Dollar Values: Coin Prices & Melt Values</a></li>
-      <li><a href="/guides/silver-price-guide">Silver Price Guide: Spot Price & 925 Sterling Value</a></li>
-      <li><a href="/guides/what-is-925-sterling-silver">What Is 925 Sterling Silver?</a></li>
-      <li><a href="/blog/uk-gold-cgt-guide">Capital Gains Tax on Gold UK: Are Coins Tax-Free?</a></li>
-  </ul></div>
+  
+<!-- FAQ Section -->
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:#1a1a1a;margin-bottom:1.2rem;">Frequently Asked Questions</h2>
+  <div class="faq-container">
+    <details>
+      <summary class="faq-answer-summary">What is junk silver?</summary>
+      <p class="faq-answer">Junk silver refers to pre-1965 US coins (dimes, quarters, half-dollars) that contain 90% silver but have no numismatic premium — they're traded purely for their silver content. The term is misleading: this silver is far from junk. UK equivalent: pre-1920 British coins (50% silver) and 1920–1946 British coins (50% silver). Junk silver offers a cheap way to buy silver near spot price.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Are silver coins CGT-exempt in the UK?</summary>
+      <p class="faq-answer">UK legal tender silver coins — including Silver Britannias — are CGT-exempt as 'coin of the realm', the same as gold Britannias and Sovereigns. Foreign silver coins (e.g. Canadian Maple Leafs, American Eagles) are not CGT-exempt and any gains are subject to UK CGT at 18% or 24%. This makes Silver Britannias particularly attractive for UK investors.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">What is the best silver coin to buy in the UK?</summary>
+      <p class="faq-answer">For UK investors, the Silver Britannia (1oz .999 fine silver) is generally the best choice: CGT-exempt, VAT-free (as legal tender), recognisable worldwide, and available from the Royal Mint and major dealers. The Silver Sovereign is another option. For maximum silver content per £, silver bars typically have lower premiums than coins.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Why does silver have VAT but gold doesn't?</summary>
+      <p class="faq-answer">Investment gold (coins and bars of ≥99.5% purity) is VAT-exempt in the UK under EU-inherited legislation. Silver, platinum and palladium do not benefit from this exemption — standard 20% VAT applies. This significantly increases the effective cost of buying silver coins or bars, and makes silver ETCs (which don't attract VAT) more cost-effective for pure investment exposure.</p>
+    </details>
+  </div>
+</section>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Articles &amp; Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/silver-price-per-kilo" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Silver Price Per Kilo</div>
+        <div style="font-size:0.875rem;color:#666;">Today's live silver price per kilogram in GBP and USD.</div>
+      </a>
+      <a href="/800-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.800 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Price for .800 coin silver — common in junk silver from Europe.</div>
+      </a>
+      <a href="/900-silver-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">.900 Silver Price Per Gram</div>
+        <div style="font-size:0.875rem;color:#666;">Price for .900 coin silver — US 90% junk silver standard.</div>
+      </a>
+      <a href="/blog/uk-gold-cgt-guide" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">UK Gold CGT Guide</div>
+        <div style="font-size:0.875rem;color:#666;">CGT rules for silver coins — which are exempt and which aren't.</div>
+      </a>
+      <a href="/guides/what-is-925-sterling-silver" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">What is 925 Sterling Silver?</div>
+        <div style="font-size:0.875rem;color:#666;">Understand silver purity grades: .800, .900, .925 and .999 compared.</div>
+      </a>
+      <a href="/guides/gold-vs-silver-investment" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold vs Silver Investment</div>
+        <div style="font-size:0.875rem;color:#666;">Should you buy silver coins or gold coins? Investment comparison.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 </article>
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>

--- a/blog/uk-gold-cgt-guide.html
+++ b/blog/uk-gold-cgt-guide.html
@@ -19,6 +19,47 @@
 <meta name="twitter:card" content="summary_large_image"><meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BlogPosting","headline":"Capital Gains Tax on Gold UK: Are Gold Coins Tax-Free?","description":"Discover which UK gold coins are CGT-exempt, how HMRC taxes gold bars and ETFs, the \u00a33,000 annual allowance, and how to use ISAs and SIPPs to shelter gains.","datePublished":"2026-05-03","dateModified":"2026-05-03","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"url":"https://goldpricetools.com/blog/uk-gold-cgt-guide","image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg","width":1200,"height":630},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/blog/uk-gold-cgt-guide"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"Capital Gains Tax on Gold UK: Are Gold Coins Tax-Free?"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Which gold coins are CGT-exempt in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "UK legal tender gold coins are exempt from Capital Gains Tax. This includes: Gold Britannia (all sizes from 1/10oz to 1oz), Gold Sovereign (full, half, quarter), and any other gold coin that is UK legal tender. Foreign coins — even popular bullion coins like the Canadian Maple Leaf or South African Krugerrand — are NOT CGT-exempt and gains are subject to standard CGT."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the CGT rate on gold in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For gold assets that are not CGT-exempt (bars, foreign coins, ETFs outside an ISA), gains are taxed at 18% (basic rate taxpayers) or 24% (higher/additional rate taxpayers) as of 2024–25. You also have an annual CGT allowance (£3,000 for 2024–25) that can offset gains. Losses on gold can be offset against other capital gains."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is gold in an ISA CGT-free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Gold ETCs (Exchange-Traded Commodities) held in a Stocks & Shares ISA are completely free of CGT regardless of gains. This makes ISA-held gold ETCs more tax-efficient than physical gold bars for most UK investors. The annual ISA allowance is £20,000."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to declare gold sales to HMRC?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "You must report gold sales on your Self Assessment tax return if: (1) your total gains exceed the annual CGT allowance (£3,000 for 2024–25), (2) your total proceeds from all asset sales exceed £50,000, or (3) you made a loss you want to carry forward. CGT-exempt coins (Britannias, Sovereigns) don't count toward these thresholds."
+      }
+    }
+  ]
+}
+</script>
+
 <script>
 window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
@@ -175,12 +216,69 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
     <p>The simplest CGT-efficient strategy is to hold <strong>Gold Sovereigns or Britannias for any amount where tax efficiency matters</strong>. For larger holdings, Royal Mint Vault storage (0.5% p.a.) maintains the coin's physical allocated ownership and CGT-exempt status without requiring home storage. For smaller sums or pension accounts, ISA-wrapped gold ETCs eliminate CGT at low annual cost (0.12% p.a. for iShares IGLN). Combining both approaches maximises tax efficiency as your gold holding grows.</p>
     <div class="cta-box"><h3>Calculate Your Gold's Current Value</h3><p>Use GoldPriceTools' free live calculator to find the current melt value of Sovereigns, Britannias, and gold bars in GBP.</p><a href="/" class="cta-btn">Open Calculator &rarr;</a></div>
   </div>
-  <div class="related-posts"><h3>Related Resources</h3><ul>
-      <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold: Beginner's Guide 2026</a></li>
-      <li><a href="/guides/gold-bar-guide">Gold Bar Guide: Sizes, Weights & Good Delivery</a></li>
-      <li><a href="/guides/gold-hallmarks-explained">Gold Hallmarks Explained</a></li>
-      <li><a href="/blog/">More from the GoldPriceTools Blog</a></li>
-  </ul></div>
+  
+<!-- FAQ Section -->
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:#1a1a1a;margin-bottom:1.2rem;">Frequently Asked Questions</h2>
+  <div class="faq-container">
+    <details>
+      <summary class="faq-answer-summary">Which gold coins are CGT-exempt in the UK?</summary>
+      <p class="faq-answer">UK legal tender gold coins are exempt from Capital Gains Tax. This includes: Gold Britannia (all sizes from 1/10oz to 1oz), Gold Sovereign (full, half, quarter), and any other gold coin that is UK legal tender. Foreign coins — even popular bullion coins like the Canadian Maple Leaf or South African Krugerrand — are NOT CGT-exempt and gains are subject to standard CGT.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">What is the CGT rate on gold in the UK?</summary>
+      <p class="faq-answer">For gold assets that are not CGT-exempt (bars, foreign coins, ETFs outside an ISA), gains are taxed at 18% (basic rate taxpayers) or 24% (higher/additional rate taxpayers) as of 2024–25. You also have an annual CGT allowance (£3,000 for 2024–25) that can offset gains. Losses on gold can be offset against other capital gains.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Is gold in an ISA CGT-free?</summary>
+      <p class="faq-answer">Yes. Gold ETCs (Exchange-Traded Commodities) held in a Stocks & Shares ISA are completely free of CGT regardless of gains. This makes ISA-held gold ETCs more tax-efficient than physical gold bars for most UK investors. The annual ISA allowance is £20,000.</p>
+    </details>
+    <details>
+      <summary class="faq-answer-summary">Do I need to declare gold sales to HMRC?</summary>
+      <p class="faq-answer">You must report gold sales on your Self Assessment tax return if: (1) your total gains exceed the annual CGT allowance (£3,000 for 2024–25), (2) your total proceeds from all asset sales exceed £50,000, or (3) you made a loss you want to carry forward. CGT-exempt coins (Britannias, Sovereigns) don't count toward these thresholds.</p>
+    </details>
+  </div>
+</section>
+
+<!-- Related Guides Section -->
+<section class="related-guides" style="background:#faf9f6;border-top:1px solid #e8e2d4;padding:2.5rem 0;margin-top:2rem;">
+  <div class="container" style="max-width:900px;margin:0 auto;padding:0 1.5rem;">
+    <h2 style="font-size:1.4rem;font-weight:700;color:#1a1a1a;margin-bottom:1.5rem;">Related Articles &amp; Guides</h2>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+      <a href="/blog/how-to-buy-gold-royal-mint" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Buy Gold from the Royal Mint</div>
+        <div style="font-size:0.875rem;color:#666;">Buy CGT-exempt Britannias and Sovereigns directly from the Royal Mint.</div>
+      </a>
+      <a href="/blog/gold-etf-vs-physical-gold-uk" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold ETF vs Physical Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">Compare CGT treatment of ETFs (ISA-sheltered) vs physical gold coins.</div>
+      </a>
+      <a href="/blog/gold-in-a-sipp-uk" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Gold in a SIPP UK</div>
+        <div style="font-size:0.875rem;color:#666;">Another CGT-free route to gold — holding ETCs inside a pension.</div>
+      </a>
+      <a href="/guides/how-to-invest-in-gold" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Guide</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">How to Invest in Gold UK</div>
+        <div style="font-size:0.875rem;color:#666;">All UK gold investment options — with tax efficiency considered.</div>
+      </a>
+      <a href="/blog/best-uk-gold-dealers-2026" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Article</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Best UK Gold Dealers 2026</div>
+        <div style="font-size:0.875rem;color:#666;">Where to buy CGT-exempt Britannias and Sovereigns at fair prices.</div>
+      </a>
+      <a href="/24k-gold-price-per-gram" style="display:block;background:#fff;border:1px solid #e0d8c8;border-radius:8px;padding:1.2rem;text-decoration:none;transition:border-color 0.2s;" onmouseover="this.style.borderColor='#c9a84c'" onmouseout="this.style.borderColor='#e0d8c8'">
+        <div style="font-size:0.75rem;font-weight:600;color:#c9a84c;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem;">Live Price</div>
+        <div style="font-weight:700;color:#1a1a1a;margin-bottom:0.3rem;">Live Gold Price Today</div>
+        <div style="font-size:0.875rem;color:#666;">Today's spot price — essential before calculating CGT on gold sales.</div>
+      </a>
+    </div>
+  </div>
+</section>
+
 </article>
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>


### PR DESCRIPTION
## Phase 2 Blog Articles — Complete

Adds **FAQPage JSON-LD schema**, **4-question FAQ section**, and **6-card Related Articles grid** to all 9 blog articles.

### Word Counts After Update
| Article | Before | After |
|---------|--------|-------|
| gold-silver-price-outlook | 1,480w | 2,071w |
| best-uk-gold-dealers-2026 | 1,143w ⚠️ | 1,701w ✅ |
| gold-etf-vs-physical-gold-uk | 1,192w | 1,822w |
| gold-in-a-sipp-uk | 1,253w | 1,866w |
| gold-vs-bitcoin-2026 | 1,253w | 1,873w |
| how-to-buy-gold-royal-mint | 1,287w | 1,895w |
| is-gold-overpriced-2026 | 1,269w | 1,913w |
| silver-coins-for-investors-uk | 1,344w | 1,985w |
| uk-gold-cgt-guide | 1,277w | 1,904w |

All 9 articles now: ≥1,700 words ✅ | FAQPage schema ✅ | Internal links ✅

Closes #220, #221, #222, #223, #224, #225, #226, #227, #228