### PR TITLE
fix: add Auto Ads config — vignette new triggers disabled, overlays off (53 files)

### DIFF
--- a/10k-gold-price-per-gram.html
+++ b/10k-gold-price-per-gram.html
@@ -26,6 +26,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -30,6 +30,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">

--- a/18k-gold-price-per-gram.html
+++ b/18k-gold-price-per-gram.html
@@ -30,6 +30,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">

--- a/22k-gold-price-per-gram.html
+++ b/22k-gold-price-per-gram.html
@@ -30,6 +30,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">

--- a/24k-gold-price-per-gram.html
+++ b/24k-gold-price-per-gram.html
@@ -30,6 +30,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">

--- a/800-silver-price-per-gram.html
+++ b/800-silver-price-per-gram.html
@@ -28,6 +28,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/900-silver-price-per-gram.html
+++ b/900-silver-price-per-gram.html
@@ -28,6 +28,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/9k-gold-price-per-gram.html
+++ b/9k-gold-price-per-gram.html
@@ -30,6 +30,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">

--- a/about.html
+++ b/about.html
@@ -46,6 +46,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/best-gold-ira-companies.html
+++ b/best-gold-ira-companies.html
@@ -180,6 +180,17 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/blog/index.html
+++ b/blog/index.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/contact.html
+++ b/contact.html
@@ -37,6 +37,17 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/gold-bar-value.html
+++ b/gold-bar-value.html
@@ -30,6 +30,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">

--- a/gold-coins-vs-bars.html
+++ b/gold-coins-vs-bars.html
@@ -34,6 +34,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/gold-price-chart.html
+++ b/gold-price-chart.html
@@ -120,6 +120,17 @@ setInterval(updateChartPageLivePrices, 2000);
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/gold-price-per-gram.html
+++ b/gold-price-per-gram.html
@@ -30,6 +30,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">

--- a/gold-rates-today.html
+++ b/gold-rates-today.html
@@ -58,6 +58,17 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/gold-silver-test-kit-reviews.html
+++ b/gold-silver-test-kit-reviews.html
@@ -58,6 +58,17 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/difference-between-gold-filled-and-gold-plated.html
+++ b/guides/difference-between-gold-filled-and-gold-plated.html
@@ -34,6 +34,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/gold-bar-guide.html
+++ b/guides/gold-bar-guide.html
@@ -25,6 +25,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 
 <style>
 

--- a/guides/gold-hallmarks-explained.html
+++ b/guides/gold-hallmarks-explained.html
@@ -34,6 +34,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/gold-karat-explained.html
+++ b/guides/gold-karat-explained.html
@@ -25,6 +25,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 
 <style>
 

--- a/guides/gold-price-guide.html
+++ b/guides/gold-price-guide.html
@@ -25,6 +25,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 
 <style>
 

--- a/guides/gold-price-history.html
+++ b/guides/gold-price-history.html
@@ -91,6 +91,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/gold-price-prediction-2026.html
+++ b/guides/gold-price-prediction-2026.html
@@ -25,6 +25,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 
 <style>
 

--- a/guides/gold-purity-guide.html
+++ b/guides/gold-purity-guide.html
@@ -34,6 +34,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/gold-vs-silver-investment.html
+++ b/guides/gold-vs-silver-investment.html
@@ -34,6 +34,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/how-much-is-a-gold-ring-worth.html
+++ b/guides/how-much-is-a-gold-ring-worth.html
@@ -34,6 +34,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/how-to-calculate-scrap-gold.html
+++ b/guides/how-to-calculate-scrap-gold.html
@@ -46,6 +46,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/how-to-invest-in-gold.html
+++ b/guides/how-to-invest-in-gold.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/how-to-read-gold-spot-price.html
+++ b/guides/how-to-read-gold-spot-price.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/how-to-sell-gold-jewellery.html
+++ b/guides/how-to-sell-gold-jewellery.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/how-to-store-gold-silver-at-home.html
+++ b/guides/how-to-store-gold-silver-at-home.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/how-to-test-if-gold-is-real.html
+++ b/guides/how-to-test-if-gold-is-real.html
@@ -34,6 +34,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/indian-gold-silver-prices.html
+++ b/guides/indian-gold-silver-prices.html
@@ -25,6 +25,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 
 <style>
 

--- a/guides/scrap-gold-guide.html
+++ b/guides/scrap-gold-guide.html
@@ -25,6 +25,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 
 <style>
 

--- a/guides/silver-price-guide.html
+++ b/guides/silver-price-guide.html
@@ -25,6 +25,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 
 <style>
 

--- a/guides/silver-price-per-gram-explained.html
+++ b/guides/silver-price-per-gram-explained.html
@@ -34,6 +34,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/troy-ounce-guide.html
+++ b/guides/troy-ounce-guide.html
@@ -25,6 +25,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 
 <style>
 

--- a/guides/troy-ounce-vs-gram-explained.html
+++ b/guides/troy-ounce-vs-gram-explained.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/us-silver-dollar-values.html
+++ b/guides/us-silver-dollar-values.html
@@ -25,6 +25,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 
 <style>
 

--- a/guides/what-affects-gold-price.html
+++ b/guides/what-affects-gold-price.html
@@ -34,6 +34,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/what-is-14k-gold.html
+++ b/guides/what-is-14k-gold.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/what-is-925-sterling-silver.html
+++ b/guides/what-is-925-sterling-silver.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/guides/what-is-best-time-to-sell-scrap-gold.html
+++ b/guides/what-is-best-time-to-sell-scrap-gold.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/how-many-grams-in-troy-ounce.html
+++ b/how-many-grams-in-troy-ounce.html
@@ -26,6 +26,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/index.html
+++ b/index.html
@@ -58,6 +58,17 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="dns-prefetch" href="https://assets.goldpricetools.com">
   <link rel="dns-prefetch" href="https://api.metals.live">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -33,6 +33,17 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/scrap-gold-calculator.html
+++ b/scrap-gold-calculator.html
@@ -199,6 +199,17 @@ function fireCalcEngaged() {
 }
 
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -28,6 +28,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/terms.html
+++ b/terms.html
@@ -37,6 +37,17 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/where-to-sell-gold-silver.html
+++ b/where-to-sell-gold-silver.html
@@ -35,6 +35,17 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>

--- a/zakat-gold-silver-calculator.html
+++ b/zakat-gold-silver-calculator.html
@@ -58,6 +58,17 @@
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <!-- AdSense publisher script loaded async in head -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640886" crossorigin="anonymous"></script>
+<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640886",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: {
+    new_triggers: false
+  }
+});
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
## Fix: Auto Ads Announcements — Vignette Opt-Out & Ad Load

### Background
Two recent AdSense announcements required action:

1. **Ad load slider deprecated** — Google replaced the single Ad Load slider with per-format controls. By enabling Auto Ads with explicit config, we now have programmatic control over ad frequency per format rather than relying on the deprecated slider default.

2. **Vignette new triggers** — Google automatically enabled additional vignette ad triggers (user interactions like scroll depth, time on page) across all publishers. The opt-out is `vignette: { new_triggers: false }` in the Auto Ads push config.

### What was added
Injected immediately after the `adsbygoogle.js` script tag on all 53 HTML files:

```html
<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
<script>
(adsbygoogle = window.adsbygoogle || []).push({
  google_ad_client: "ca-pub-8849494330640886",
  enable_page_level_ads: true,
  overlays: {bottom: false},
  vignette: {
    new_triggers: false
  }
});
</script>
```

**Key settings:**
- `enable_page_level_ads: true` — enables Auto Ads alongside existing manual slots
- `overlays: {bottom: false}` — disables sticky anchor ads at bottom of screen (these can violate Better Ads Standards if they cover too much screen)
- `vignette: { new_triggers: false }` — opts out of the new vignette trigger types announced by Google

### Files Updated
All 53 HTML files that contain AdSense code.