### PR TITLE
fix(ahrefs-batch2): orphan pages, zero-inlink canonicals, single-link pages, /contact/ /privacy/ 404s

### DIFF
--- a/editorial-standards/index.html
+++ b/editorial-standards/index.html
@@ -94,13 +94,13 @@ a{color:var(--color-gold-bright)}
   <li>For material corrections — changes to a headline figure, a tax rule, a regulator name or a calculator formula — we add a short footnote at the bottom of the affected page noting what changed and when.</li>
   <li>We do not silently rewrite figures. Minor typographical or copy-edit fixes are made without a footnote.</li>
 </ol>
-<p>To report a correction, please use our <a href="/contact/">contact form</a>.</p>
+<p>To report a correction, please use our <a href="/contact">contact form</a>.</p>
 <h2>7. Independence &amp; conflicts of interest</h2>
 <p>GoldPriceTools earns revenue from display advertising and, where indicated, affiliate links to bullion dealers and brokers. Affiliate relationships never determine whether a product is mentioned, the order of any list, or the figures we publish; product specifications come from the manufacturer or the Royal Mint, and prices come from the live API. Where a link is an affiliate link, we mark it as such on the page. We do not accept paid editorial placements.</p>
 <h2>8. Privacy of contributors</h2>
 <p>We deliberately do not publish personal data (real names, photographs, qualifications, addresses, social profiles) of individual contributors. This is a UK GDPR choice and is independent of editorial responsibility, which sits with GoldPriceTools as a publisher and is set out clearly above and on the <a href="/authors/goldpricetools-editorial-team/">editorial team page</a>.</p>
 <h2>9. Contact</h2>
-<p>For corrections, source queries, takedown requests or general feedback: <a href="/contact/">contact form</a>. For privacy and data-handling enquiries: <a href="/privacy/">privacy policy</a>.</p>
+<p>For corrections, source queries, takedown requests or general feedback: <a href="/contact">contact form</a>. For privacy and data-handling enquiries: <a href="/privacy-policy">privacy policy</a>.</p>
 <p><a href="/">&laquo; Back to home</a></p>
 </main>
 </body>

--- a/gold-bar-value.html
+++ b/gold-bar-value.html
@@ -248,6 +248,15 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <a href="https://api.whatsapp.com/send?text=14K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fgold-bar-value" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+
+<div class="content" style="padding: 1rem 0; border-top: 1px solid #eee; margin-top: 1.5rem;">
+  <h3 style="font-size: 1rem; margin-bottom: 0.5rem;">Related Guides</h3>
+  <ul style="margin: 0; padding-left: 1.2rem;">
+      <li><a href="/guides/how-to-store-gold-silver-at-home">How to Store Gold &amp; Silver at Home</a> &mdash; safe storage options for bars and coins.</li>
+      <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a> &mdash; weights, premiums and what to look for when buying.</li>
+  </ul>
+</div>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/gold-price-per-gram.html
+++ b/gold-price-per-gram.html
@@ -306,6 +306,10 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <a href="https://api.whatsapp.com/send?text=18K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F18k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
+<div class="content" style="padding: 1rem 0;">
+  <p><strong>Developer Resources:</strong> Access our <a href="/data/">live gold &amp; silver price data feed</a> &mdash; free JSON API for gold and silver spot prices, updated every minute.</p>
+</div>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
   <p style="margin-top:.5rem">Not financial advice.</p>

--- a/gold-rates-today.html
+++ b/gold-rates-today.html
@@ -1090,6 +1090,15 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 </div>
 
 <!-- FOOTER -->
+
+<div class="content" style="padding: 1rem 0; border-top: 1px solid #eee; margin-top: 1.5rem;">
+  <h3 style="font-size: 1rem; margin-bottom: 0.5rem;">Related Guides</h3>
+  <ul style="margin: 0; padding-left: 1.2rem;">
+      <li><a href="/guides/gold-price-prediction-2026">Gold Price Forecast 2026</a> &mdash; See our gold price prediction and market outlook for 2026.</li>
+      <li><a href="/guides/indian-gold-silver-prices">Indian Gold &amp; Silver Prices</a> &mdash; Live gold and silver rates in INR for Indian investors.</li>
+  </ul>
+</div>
+
 <footer>
   <div class="footer-inner">
     <div>

--- a/guides/gold-vs-silver-investment.html
+++ b/guides/gold-vs-silver-investment.html
@@ -226,6 +226,15 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<div class="content" style="padding: 1rem 0; border-top: 1px solid #eee; margin-top: 1.5rem;">
+  <h3 style="font-size: 1rem; margin-bottom: 0.5rem;">Related Guides</h3>
+  <ul style="margin: 0; padding-left: 1.2rem;">
+      <li><a href="/guides/gold-price-prediction-2026">Gold Price Forecast 2026</a> &mdash; see where analysts expect prices to go.</li>
+      <li><a href="/guides/silver-price-guide">Silver Price Guide</a> &mdash; everything about silver spot prices.</li>
+  </ul>
+</div>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/how-to-sell-gold-jewellery.html
+++ b/guides/how-to-sell-gold-jewellery.html
@@ -307,6 +307,15 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   </div>
 </section>
 
+
+<div class="content" style="padding: 1rem 0; border-top: 1px solid #eee; margin-top: 1.5rem;">
+  <h3 style="font-size: 1rem; margin-bottom: 0.5rem;">Related Guides</h3>
+  <ul style="margin: 0; padding-left: 1.2rem;">
+      <li><a href="/where-to-sell-gold-silver">Where To Sell Gold And Silver</a> &mdash; compare dealers and platforms.</li>
+      <li><a href="/gold-bar-value">Gold Bar Calculator</a> &mdash; check today's value before selling.</li>
+  </ul>
+</div>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/how-to-test-if-gold-is-real.html
+++ b/guides/how-to-test-if-gold-is-real.html
@@ -244,6 +244,15 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<div class="content" style="padding: 1rem 0; border-top: 1px solid #eee; margin-top: 1.5rem;">
+  <h3 style="font-size: 1rem; margin-bottom: 0.5rem;">Related Guides</h3>
+  <ul style="margin: 0; padding-left: 1.2rem;">
+      <li><a href="/guides/how-much-is-a-gold-ring-worth">How Much Is a Gold Ring Worth?</a> &mdash; calculate the melt value of your jewellery.</li>
+      <li><a href="/gold-silver-test-kit-reviews">Gold Testing Kit Reviews</a> &mdash; compare acid test kits and electronic testers.</li>
+  </ul>
+</div>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/troy-ounce-vs-gram-explained.html
+++ b/guides/troy-ounce-vs-gram-explained.html
@@ -299,6 +299,15 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   </div>
 </section>
 
+
+<div class="content" style="padding: 1rem 0; border-top: 1px solid #eee; margin-top: 1.5rem;">
+  <h3 style="font-size: 1rem; margin-bottom: 0.5rem;">Related Guides</h3>
+  <ul style="margin: 0; padding-left: 1.2rem;">
+      <li><a href="/guides/troy-ounce-guide">Troy Ounce Guide</a> &mdash; History of the troy ounce, conversions and why it&apos;s used for precious metals.</li>
+      <li><a href="/guides/gold-price-prediction-2026">Gold Price Prediction 2026</a> &mdash; Expert gold price forecasts and market outlook for the year ahead.</li>
+  </ul>
+</div>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/guides/what-is-best-time-to-sell-scrap-gold.html
+++ b/guides/what-is-best-time-to-sell-scrap-gold.html
@@ -270,6 +270,15 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
 
+
+<div class="content" style="padding: 1rem 0; border-top: 1px solid #eee; margin-top: 1.5rem;">
+  <h3 style="font-size: 1rem; margin-bottom: 0.5rem;">Related Guides</h3>
+  <ul style="margin: 0; padding-left: 1.2rem;">
+      <li><a href="/where-to-sell-gold-silver">Where To Sell Scrap Gold</a> &mdash; find the best buyers near you.</li>
+      <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a> &mdash; understand how dealers value your gold.</li>
+  </ul>
+</div>
+
 <footer>
   <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
   <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>

--- a/index.html
+++ b/index.html
@@ -1072,6 +1072,27 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
           <div class="article-title">Silver Price Per Gram Explained — Live Calculation Guide</div>
           <div class="article-excerpt">How the silver price per gram is derived from the troy oz spot price, with live examples for fine and sterling silver.</div>
         </a>
+      
+        <a href="/gold-coins-vs-bars" class="article-card">
+          <div class="article-tag">Buying Guide</div>
+          <div class="article-title">Gold Coins vs Gold Bars &mdash; Which Should You Buy?</div>
+          <div class="article-excerpt">Compare gold coins and gold bars for investment. Pros, cons, premiums, and which is better for UK buyers in 2026.</div>
+        </a>
+        <a href="/where-to-sell-gold-silver" class="article-card">
+          <div class="article-tag">Selling Guide</div>
+          <div class="article-title">Where to Sell Gold and Silver in 2026</div>
+          <div class="article-excerpt">Best places to sell gold and silver in the UK &mdash; dealers, online buyers, pawnbrokers, and Royal Mint compared.</div>
+        </a>
+        <a href="/best-gold-ira-companies" class="article-card">
+          <div class="article-tag">Investment</div>
+          <div class="article-title">Best Gold IRA Companies in 2026</div>
+          <div class="article-excerpt">Reviewed: the top gold IRA custodians for US investors holding physical gold in a tax-advantaged account.</div>
+        </a>
+        <a href="/gold-silver-test-kit-reviews" class="article-card">
+          <div class="article-tag">Reviews</div>
+          <div class="article-title">Best Gold &amp; Silver Testing Kits &mdash; Reviewed</div>
+          <div class="article-excerpt">Acid test kits, electronic testers and XRF guns reviewed. Find the right kit to verify your gold and silver at home.</div>
+        </a>
       </div>
     </section>
 

--- a/scrap-gold-calculator.html
+++ b/scrap-gold-calculator.html
@@ -331,6 +331,15 @@ function fireCalcEngaged() {
 <div class="disclaimer"><strong>Disclaimer:</strong> Melt values are indicative only and do not constitute financial advice. Always verify prices with your chosen dealer before selling. Prices fluctuate continuously with the live gold spot price.</div>
   </div>
 </div>
+
+<div class="content" style="padding: 1rem 0; border-top: 1px solid #eee; margin-top: 1.5rem;">
+  <h3 style="font-size: 1rem; margin-bottom: 0.5rem;">Related Guides</h3>
+  <ul style="margin: 0; padding-left: 1.2rem;">
+      <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a> &mdash; How scrap gold is valued and what affects the price dealers pay.</li>
+      <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a> &mdash; Calculate Zakat due on your gold and silver holdings using live prices.</li>
+  </ul>
+</div>
+
 <footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
 <script>
 let _scrapIntentFired = false;

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -274,6 +274,15 @@
   </div>
 </section>
 
+
+<div class="content" style="padding: 1rem 0; border-top: 1px solid #eee; margin-top: 1.5rem;">
+  <h3 style="font-size: 1rem; margin-bottom: 0.5rem;">Related Guides</h3>
+  <ul style="margin: 0; padding-left: 1.2rem;">
+      <li><a href="/guides/silver-price-guide">Silver Price Guide</a> &mdash; Everything about silver spot prices, 925 sterling value and investing.</li>
+      <li><a href="/guides/indian-gold-silver-prices">Indian Silver Prices</a> &mdash; Live silver rates in INR — today&apos;s price per gram, tola and kilogram.</li>
+  </ul>
+</div>
+
 <footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}


### PR DESCRIPTION
## Ahrefs Audit Batch 2 — Internal Linking & Orphan Pages

### E4: Orphan Pages Fixed (5 pages now have inbound internal links)
Added 4 article cards to homepage `articles-grid`:
- `/gold-coins-vs-bars` — Buying Guide card
- `/where-to-sell-gold-silver` — Selling Guide card
- `/best-gold-ira-companies` — Investment card
- `/gold-silver-test-kit-reviews` — Reviews card

Added API data feed link from `gold-price-per-gram.html`:
- `/data/` — Developer Resources contextual link

### E5: Canonical URLs with Zero Incoming Internal Links (6 pages fixed)
Added "Related Guides" sections to 4 donor pages:
- `gold-rates-today.html` → links to `/guides/gold-price-prediction-2026` + `/guides/indian-gold-silver-prices`
- `scrap-gold-calculator.html` → links to `/guides/scrap-gold-guide` + `/zakat-gold-silver-calculator`
- `silver-price-per-kilo.html` → links to `/guides/silver-price-guide` + `/guides/indian-gold-silver-prices`
- `guides/troy-ounce-vs-gram-explained.html` → links to `/guides/troy-ounce-guide` + `/guides/gold-price-prediction-2026`

### E2 Continuation: /contact/ and /privacy/ 404 Links
Fixed 3 broken trailing-slash hrefs in `editorial-standards/index.html`:
- `href="/contact/"` → `href="/contact"` (×2)
- `href="/privacy/"` → `href="/privacy-policy"` (×1)

### L4: Single-Dofollow Internal Link Pages
Added "Related Guides" cross-link sections to improve internal link equity:
- `guides/how-to-sell-gold-jewellery.html` → /where-to-sell-gold-silver + /gold-bar-value
- `guides/what-is-best-time-to-sell-scrap-gold.html` → /where-to-sell-gold-silver + /guides/scrap-gold-guide
- `guides/gold-vs-silver-investment.html` → /guides/gold-price-prediction-2026 + /guides/silver-price-guide
- `gold-bar-value.html` → /guides/how-to-store-gold-silver-at-home + /guides/gold-bar-guide
- `guides/how-to-test-if-gold-is-real.html` → /guides/how-much-is-a-gold-ring-worth + /gold-silver-test-kit-reviews

### ⚠️ Manual Action Required
**Cloudflare Dashboard → Scrape Shield → Email Address Obfuscation → DISABLE**
This is the root cause of all `/cdn-cgi/l/email-protection` 404 errors. The `cf-no-email-obfuscation` meta tag added in Batch 1 helps, but disabling it at dashboard level fully resolves it.