### PR TITLE
fix(sitemap): add /guides/gold-karat-explained missing from sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1148,4 +1148,10 @@
     <xhtml:link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/terms"/>
   </url>
 
+
+  <url>
+    <loc>https://goldpricetools.com/guides/gold-karat-explained</loc>
+    <lastmod>2026-05-03</lastmod>
+    <changefreq>weekly</changefreq>
+  </url>
 </urlset>


### PR DESCRIPTION
Adds `https://goldpricetools.com/guides/gold-karat-explained` to sitemap.xml.

This indexable page was missing from the sitemap. `offline.html` was correctly excluded (noindex).

All 13 pages previously flagged in Batch 6 are confirmed present in the sitemap.