### PR TITLE
feat(homepage): declutter hero, add blog preview section, upgrade footer sitewide

### DIFF
--- a/10k-gold-price-per-gram.html
+++ b/10k-gold-price-per-gram.html
@@ -405,6 +405,35 @@
   color: var(--color-text-muted);
   text-decoration: none;
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -828,7 +857,80 @@
   </div>
 </section>
 
-<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,INR',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.rates.GBP||0.79;window._usdinr=d.rates.INR||83.5;}catch{window._gbpusd=0.79;}}
 async function fetchSpot(){const PURITY=0.4167;try{const r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();const spotUSD=d.price;const pgUSD=spotUSD/31.1035*PURITY;const pgGBP=pgUSD*(window._gbpusd||0.79);

--- a/14k-gold-price-in-usd.html
+++ b/14k-gold-price-in-usd.html
@@ -376,6 +376,35 @@
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">
@@ -690,8 +719,78 @@
 </div>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 

--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -446,6 +446,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   color: var(--color-text-muted);
   text-decoration: none;
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -903,8 +932,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 <script>

--- a/18k-gold-price-in-gbp.html
+++ b/18k-gold-price-in-gbp.html
@@ -376,6 +376,35 @@
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">
@@ -690,8 +719,78 @@
 </div>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 

--- a/18k-gold-price-per-gram.html
+++ b/18k-gold-price-per-gram.html
@@ -445,6 +445,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
   color: var(--color-text-muted);
   text-decoration: none;
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -877,8 +906,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,INR',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.rates.GBP||0.79;window._usdinr=d.rates.INR||83.5;}catch{window._gbpusd=0.79;}}

--- a/22k-gold-price-per-gram.html
+++ b/22k-gold-price-per-gram.html
@@ -432,6 +432,35 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -889,8 +918,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 <script>

--- a/24-hour-gold-silver-prices.html
+++ b/24-hour-gold-silver-prices.html
@@ -376,6 +376,35 @@
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">
@@ -696,8 +725,78 @@
 </div>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 

--- a/24k-gold-price-per-gram.html
+++ b/24k-gold-price-per-gram.html
@@ -432,6 +432,35 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -889,8 +918,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 <script>

--- a/800-silver-price-per-gram.html
+++ b/800-silver-price-per-gram.html
@@ -393,6 +393,35 @@
 </style>
 <style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.price-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1rem;max-width:700px;margin:0 auto 2rem}.price-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:.875rem;padding:1.25rem;text-align:center}.price-tile-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-faint);margin-bottom:.375rem}.price-tile-value{font-family:var(--font-display);font-size:1.5rem;color:var(--color-gold-bright);font-weight:700;min-height:2rem}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -868,7 +897,80 @@
   </div>
 </section>
 
-<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
 

--- a/900-silver-price-per-gram.html
+++ b/900-silver-price-per-gram.html
@@ -393,6 +393,35 @@
 </style>
 <style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.price-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1rem;max-width:700px;margin:0 auto 2rem}.price-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:.875rem;padding:1.25rem;text-align:center}.price-tile-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-faint);margin-bottom:.375rem}.price-tile-value{font-family:var(--font-display);font-size:1.5rem;color:var(--color-gold-bright);font-weight:700;min-height:2rem}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -866,7 +895,80 @@
   </div>
 </section>
 
-<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
 

--- a/9k-gold-price-per-gram.html
+++ b/9k-gold-price-per-gram.html
@@ -432,6 +432,35 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -889,8 +918,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 <script>

--- a/about.html
+++ b/about.html
@@ -450,6 +450,35 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-6) var(--space-4);text-align:center;font-size:var(--text-sm);color:var(--color-text-muted)}
 footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -796,14 +825,78 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <a href="/">Calculator</a>
-  <a href="/guides/">Guides</a>
-  <a href="/blog/">Blog</a>
-  <a href="/about">About</a>
-  <a href="/contact">Contact</a>
-  <a href="/privacy-policy">Privacy Policy</a>
-  <a href="/terms">Terms</a>
-  <span style="display:block;margin-top:.5rem">&copy; 2026 GoldPriceTools &mdash; Operated by DigitalCliqs, UK. Not financial advice.</span>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 </body>

--- a/authors/goldpricetools-editorial-team/index.html
+++ b/authors/goldpricetools-editorial-team/index.html
@@ -414,6 +414,8 @@ a{color:var(--color-gold-bright)}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 
     <meta property="og:title" content="GoldPriceTools Editorial Team | GoldPriceTools">
@@ -692,5 +694,80 @@ a{color:var(--color-gold-bright)}
 <p>For our full sourcing, AI-assistance disclosure and corrections policy, see <a href="/editorial-standards/">Editorial Standards</a>.</p>
 <p><a href="/authors/">&laquo; Back to all authors</a></p>
 </main>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/authors/index.html
+++ b/authors/index.html
@@ -362,6 +362,8 @@ p{margin-bottom:var(--space-4);color:var(--color-text-muted)}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 
     <meta property="og:title" content="Authors & Editorial Team | GoldPriceTools">
@@ -631,5 +633,80 @@ p{margin-bottom:var(--space-4);color:var(--color-text-muted)}
 <p>For full disclosure of our sources, AI-assistance policy, corrections process and contact route, see our <a href="/editorial-standards/">Editorial Standards</a> page.</p>
 <p><a href="/">&laquo; Back to home</a></p>
 </main>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/best-gold-ira-companies.html
+++ b/best-gold-ira-companies.html
@@ -740,6 +740,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
 
@@ -1163,47 +1165,76 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <p class="related-link">Before investing, compare: <a href="/gold-coins-vs-bars">Gold Coins vs Gold Bars</a></p>
 <footer>
   <div class="footer-inner">
-    <div>
+    <div class="footer-brand-col">
       <div class="nav-logo" style="margin-bottom:var(--space-3)">
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 10K, 14K, 18K &amp; 24K gold per gram. Scrap gold calculator, silver per troy oz, kilo and kilogram. Prices sourced from global markets, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li><a href="/14k-gold-price-per-gram">14K Gold Price Per Gram</a></li>
-        <li><a href="/18k-gold-price-per-gram">18K Gold Price Per Gram</a></li>
-        <li><a href="/10k-gold-price-per-gram">10K Gold Price Per Gram</a></li>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
         <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h4>Guides</h4>
       <ul>
-        <li><a href="/guides/what-is-14k-gold">What Is 14K Gold?</a></li>
-        <li><a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold</a></li>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
         <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
-        <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a></li>
-        <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
-        <li><a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Info</h4>
+      <h4>Blog</h4>
       <ul>
-        <li><a href="/blog/">Blog</a></li>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
         <li><a href="/privacy-policy">Privacy Policy</a></li>
         <li><a href="/terms">Terms of Use</a></li>
       </ul>
     </div>
   </div>
   <div class="footer-bottom">
-    <span>&copy; 2026 GoldPriceTools — goldpricetools.com. Prices are indicative and for reference only. Not financial advice.</span>
-    <span>Spot data refreshes every 60 seconds.</span>
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 </body>

--- a/blog/2026-04-29-gold-silver-price-outlook.html
+++ b/blog/2026-04-29-gold-silver-price-outlook.html
@@ -438,6 +438,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -842,8 +871,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </article>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>

--- a/blog/best-uk-gold-dealers-2026.html
+++ b/blog/best-uk-gold-dealers-2026.html
@@ -474,6 +474,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -871,8 +900,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 
 </article>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js");});}
 </script>

--- a/blog/gold-etf-vs-physical-gold-uk.html
+++ b/blog/gold-etf-vs-physical-gold-uk.html
@@ -474,6 +474,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -868,8 +897,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 
 </article>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js");});}
 </script>

--- a/blog/gold-in-a-sipp-uk.html
+++ b/blog/gold-in-a-sipp-uk.html
@@ -474,6 +474,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -868,8 +897,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 
 </article>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js");});}
 </script>

--- a/blog/gold-vs-bitcoin-2026.html
+++ b/blog/gold-vs-bitcoin-2026.html
@@ -474,6 +474,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -851,8 +880,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 
 </article>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js");});}
 </script>

--- a/blog/how-to-buy-gold-royal-mint.html
+++ b/blog/how-to-buy-gold-royal-mint.html
@@ -474,6 +474,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -871,8 +900,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 
 </article>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js");});}
 </script>

--- a/blog/index.html
+++ b/blog/index.html
@@ -440,6 +440,35 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -844,8 +873,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>

--- a/blog/is-gold-overpriced-2026.html
+++ b/blog/is-gold-overpriced-2026.html
@@ -474,6 +474,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -858,8 +887,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 
 </article>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js");});}
 </script>

--- a/blog/silver-coins-for-investors-uk.html
+++ b/blog/silver-coins-for-investors-uk.html
@@ -474,6 +474,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -864,8 +893,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 
 </article>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js");});}
 </script>

--- a/blog/uk-gold-cgt-guide.html
+++ b/blog/uk-gold-cgt-guide.html
@@ -474,6 +474,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -868,8 +897,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 
 </article>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js");});}
 </script>

--- a/blog/understanding-gold-karat-purities/index.html
+++ b/blog/understanding-gold-karat-purities/index.html
@@ -791,6 +791,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -897,8 +926,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </article>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>

--- a/contact.html
+++ b/contact.html
@@ -439,6 +439,35 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 footer a:hover{color:var(--color-text)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 
     <meta property="og:title" content="Contact Us | GoldPriceTools">
@@ -739,7 +768,78 @@ footer a:hover{color:var(--color-text)}
 </main>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 

--- a/editorial-standards/index.html
+++ b/editorial-standards/index.html
@@ -361,6 +361,8 @@ a{color:var(--color-gold-bright)}
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 
     <meta property="og:title" content="Editorial Standards & Methodology | GoldPriceTools">
@@ -670,5 +672,80 @@ a{color:var(--color-gold-bright)}
 <p>For corrections, source queries, takedown requests or general feedback: <a href="/contact">contact form</a>. For privacy and data-handling enquiries: <a href="/privacy-policy">privacy policy</a>.</p>
 <p><a href="/">&laquo; Back to home</a></p>
 </main>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/gold-and-silver-price-today.html
+++ b/gold-and-silver-price-today.html
@@ -376,6 +376,35 @@
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">
@@ -690,8 +719,78 @@
 </div>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 

--- a/gold-and-silver-price-today/index.html
+++ b/gold-and-silver-price-today/index.html
@@ -404,6 +404,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#goog
 @media (max-width: 768px) {
   .nav-logo span { display: none; }
 }
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -715,7 +744,80 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#goog
   <a href="https://api.whatsapp.com/send?text=Gold+and+Silver+Price+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fgold-and-silver-price-today%2F" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
-<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
 async function fetchPrices(){

--- a/gold-bar-value.html
+++ b/gold-bar-value.html
@@ -432,6 +432,35 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 .share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -810,8 +839,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 <script>

--- a/gold-coins-vs-bars.html
+++ b/gold-coins-vs-bars.html
@@ -441,6 +441,35 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
 footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Are gold bars or coins better for beginners?","acceptedAnswer":{"@type":"Answer","text":"Gold coins are generally better for beginners. They are easier to authenticate, highly liquid, and can be purchased in smaller fractional sizes (like 1/10 oz or 1/4 oz), making them accessible for smaller budgets."}},{"@type":"Question","name":"Is it harder to sell gold bars than coins?","acceptedAnswer":{"@type":"Answer","text":"Large gold bars can be slightly harder to sell locally, as fewer buyers have the cash on hand or the equipment to test a thick 1 kg bar. However, online dealers and refineries will readily buy both bars and coins."}},{"@type":"Question","name":"Do gold coins hold their value better than bars?","acceptedAnswer":{"@type":"Answer","text":"Both hold the intrinsic value of their gold content perfectly. However, gold coins often retain their premium over spot when resold, whereas gold bars are typically sold back very close to the raw spot price."}},{"@type":"Question","name":"Can I keep gold bars at home?","acceptedAnswer":{"@type":"Answer","text":"Yes, but it is highly recommended to use a high-security safe and declare the holding on your home insurance policy. For large quantities, professional third-party vaulted storage is much safer."}}]}</script>
@@ -778,8 +807,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </article>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/gold-per-gram-today.html
+++ b/gold-per-gram-today.html
@@ -108,6 +108,35 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">
@@ -243,8 +272,78 @@
 </div>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 

--- a/gold-price-chart.html
+++ b/gold-price-chart.html
@@ -412,6 +412,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
 </head>
@@ -1006,47 +1008,76 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <!-- FOOTER -->
 <footer>
   <div class="footer-inner">
-    <div>
+    <div class="footer-brand-col">
       <div class="nav-logo" style="margin-bottom:var(--space-3)">
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 10K, 14K, 18K &amp; 24K gold per gram. Scrap gold calculator, silver per troy oz, kilo and kilogram. Prices sourced from global markets, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li><a href="/14k-gold-price-per-gram">14K Gold Price Per Gram</a></li>
-        <li><a href="/18k-gold-price-per-gram">18K Gold Price Per Gram</a></li>
-        <li><a href="/10k-gold-price-per-gram">10K Gold Price Per Gram</a></li>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
         <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h4>Guides</h4>
       <ul>
-        <li><a href="/guides/what-is-14k-gold">What Is 14K Gold?</a></li>
-        <li><a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold</a></li>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
         <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
-        <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a></li>
-        <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
-        <li><a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Info</h4>
+      <h4>Blog</h4>
       <ul>
-        <li><a href="/blog/">Blog</a></li>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
         <li><a href="/privacy-policy">Privacy Policy</a></li>
         <li><a href="/terms">Terms of Use</a></li>
       </ul>
     </div>
   </div>
   <div class="footer-bottom">
-    <span>&copy; 2026 GoldPriceTools — goldpricetools.com. Prices are indicative and for reference only. Not financial advice.</span>
-    <span>Spot data refreshes every 60 seconds.</span>
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 
@@ -1489,47 +1520,76 @@ const chartPoll=setInterval(()=>{if(typeof Chart!=='undefined'&&goldSpotOz){clea
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <footer>
   <div class="footer-inner">
-    <div>
+    <div class="footer-brand-col">
       <div class="nav-logo" style="margin-bottom:var(--space-3)">
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 10K, 14K, 18K &amp; 24K gold per gram. Scrap gold calculator, silver per troy oz, kilo and kilogram. Prices sourced from global markets, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li><a href="/14k-gold-price-per-gram">14K Gold Price Per Gram</a></li>
-        <li><a href="/18k-gold-price-per-gram">18K Gold Price Per Gram</a></li>
-        <li><a href="/10k-gold-price-per-gram">10K Gold Price Per Gram</a></li>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
         <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h4>Guides</h4>
       <ul>
-        <li><a href="/guides/what-is-14k-gold">What Is 14K Gold?</a></li>
-        <li><a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold</a></li>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
         <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
-        <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a></li>
-        <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
-        <li><a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Info</h4>
+      <h4>Blog</h4>
       <ul>
-        <li><a href="/blog/">Blog</a></li>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
         <li><a href="/privacy-policy">Privacy Policy</a></li>
         <li><a href="/terms">Terms of Use</a></li>
       </ul>
     </div>
   </div>
   <div class="footer-bottom">
-    <span>&copy; 2026 GoldPriceTools — goldpricetools.com. Prices are indicative and for reference only. Not financial advice.</span>
-    <span>Spot data refreshes every 60 seconds.</span>
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 

--- a/gold-price-per-gram.html
+++ b/gold-price-per-gram.html
@@ -163,6 +163,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -416,8 +445,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>
 const TROY_OZ_TO_GRAM = 31.1035;

--- a/gold-price-today-10k.html
+++ b/gold-price-today-10k.html
@@ -108,6 +108,35 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">
@@ -243,8 +272,78 @@
 </div>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 

--- a/gold-price-today-14k.html
+++ b/gold-price-today-14k.html
@@ -108,6 +108,35 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">
@@ -243,8 +272,78 @@
 </div>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 

--- a/gold-price-today-18k.html
+++ b/gold-price-today-18k.html
@@ -108,6 +108,35 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">
@@ -243,8 +272,78 @@
 </div>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 

--- a/gold-rates-today.html
+++ b/gold-rates-today.html
@@ -350,6 +350,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
 
@@ -1153,52 +1155,76 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 
 <footer>
   <div class="footer-inner">
-    <div>
+    <div class="footer-brand-col">
       <div class="nav-logo" style="margin-bottom:var(--space-3)">
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 10K, 14K, 18K &amp; 24K gold per gram. Scrap gold calculator, silver per troy oz, kilo and kilogram. Prices sourced from global markets, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li><a href="/14k-gold-price-per-gram">14K Gold Price Per Gram</a></li>
-        <li><a href="/18k-gold-price-per-gram">18K Gold Price Per Gram</a></li>
-        <li><a href="/10k-gold-price-per-gram">10K Gold Price Per Gram</a></li>
-        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a>
-  <a href="/gold-price-chart">Gold Price Chart</a></li>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h4>Guides</h4>
       <ul>
-        <li><a href="/guides/what-is-14k-gold">What Is 14K Gold?</a></li>
-        <li><a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold</a></li>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
         <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
-        <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a></li>
-        <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
-        <li><a href="/us-silver-dollar-values.html">US Silver Dollar Values</a></li>
-                <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
-        <li><a href="/900-silver-price-per-gram">.900 Coin Silver Price</a></li>
-        <li><a href="/800-silver-price-per-gram">.800 European Silver Price</a></li>
-        <li><a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Info</h4>
+      <h4>Blog</h4>
       <ul>
-        <li><a href="/blog/">Blog</a></li>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
         <li><a href="/privacy-policy">Privacy Policy</a></li>
         <li><a href="/terms">Terms of Use</a></li>
       </ul>
     </div>
   </div>
   <div class="footer-bottom">
-    <span>&copy; 2026 GoldPriceTools — goldpricetools.com. Prices are indicative and for reference only. Not financial advice.</span>
-    <span>Spot data refreshes every 60 seconds.</span>
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 

--- a/gold-silver-ratio.html
+++ b/gold-silver-ratio.html
@@ -234,6 +234,35 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -494,9 +523,76 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 
 <footer>
   <div class="footer-inner">
-    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy"> GoldPriceTools</a>
-    <div class="footer-links"><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/terms.html">Terms</a><a href="/privacy-policy.html">Privacy</a><a href="/contact.html">Contact</a></div>
-    <div class="footer-copy">&copy; 2026 GoldPriceTools. All rights reserved. Data is provided "as is" for informational purposes.</div>
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 

--- a/gold-silver-test-kit-reviews.html
+++ b/gold-silver-test-kit-reviews.html
@@ -350,6 +350,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
 
@@ -711,48 +713,76 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 
 <footer>
   <div class="footer-inner">
-    <div>
+    <div class="footer-brand-col">
       <div class="nav-logo" style="margin-bottom:var(--space-3)">
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 10K, 14K, 18K &amp; 24K gold per gram. Scrap gold calculator, silver per troy oz, kilo and kilogram. Prices sourced from global markets, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li><a href="/14k-gold-price-per-gram">14K Gold Price Per Gram</a></li>
-        <li><a href="/18k-gold-price-per-gram">18K Gold Price Per Gram</a></li>
-        <li><a href="/10k-gold-price-per-gram">10K Gold Price Per Gram</a></li>
-        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a>
-  <a href="/gold-price-chart">Gold Price Chart</a></li>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h4>Guides</h4>
       <ul>
-        <li><a href="/guides/what-is-14k-gold">What Is 14K Gold?</a></li>
-        <li><a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold</a></li>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
         <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
-        <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a></li>
-        <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
-        <li><a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Info</h4>
+      <h4>Blog</h4>
       <ul>
-        <li><a href="/blog/">Blog</a></li>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
         <li><a href="/privacy-policy">Privacy Policy</a></li>
         <li><a href="/terms">Terms of Use</a></li>
       </ul>
     </div>
   </div>
   <div class="footer-bottom">
-    <span>&copy; 2026 GoldPriceTools — goldpricetools.com. Prices are indicative and for reference only. Not financial advice.</span>
-    <span>Spot data refreshes every 60 seconds.</span>
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 </body>

--- a/guides/difference-between-gold-filled-and-gold-plated.html
+++ b/guides/difference-between-gold-filled-and-gold-plated.html
@@ -178,6 +178,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -371,8 +400,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/gold-bar-guide.html
+++ b/guides/gold-bar-guide.html
@@ -125,6 +125,8 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 </head>
 <body>
@@ -388,5 +390,80 @@ document.addEventListener('DOMContentLoaded', fetchPrices);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/guides/gold-hallmarks-explained.html
+++ b/guides/gold-hallmarks-explained.html
@@ -178,6 +178,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -364,8 +393,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/gold-karat-explained.html
+++ b/guides/gold-karat-explained.html
@@ -125,6 +125,8 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 </head>
 <body>
@@ -388,5 +390,80 @@ document.addEventListener('DOMContentLoaded', fetchPrices);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/guides/gold-price-guide.html
+++ b/guides/gold-price-guide.html
@@ -125,6 +125,8 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 </head>
 <body>
@@ -413,5 +415,80 @@ document.addEventListener('DOMContentLoaded', fetchPrices);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/guides/gold-price-history.html
+++ b/guides/gold-price-history.html
@@ -244,6 +244,35 @@ footer a:hover{color:var(--color-text)}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -478,8 +507,78 @@ footer a:hover{color:var(--color-text)}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/gold-price-prediction-2026.html
+++ b/guides/gold-price-prediction-2026.html
@@ -125,6 +125,8 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 </head>
 <body>
@@ -388,5 +390,80 @@ document.addEventListener('DOMContentLoaded', fetchPrices);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/guides/gold-purity-guide.html
+++ b/guides/gold-purity-guide.html
@@ -180,6 +180,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -348,8 +377,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/gold-vs-silver-investment.html
+++ b/guides/gold-vs-silver-investment.html
@@ -182,6 +182,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -346,8 +375,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/how-much-is-a-gold-ring-worth.html
+++ b/guides/how-much-is-a-gold-ring-worth.html
@@ -178,6 +178,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -344,8 +373,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/how-to-calculate-scrap-gold.html
+++ b/guides/how-to-calculate-scrap-gold.html
@@ -207,6 +207,35 @@ footer a:hover{color:var(--color-text)}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -470,8 +499,78 @@ footer a:hover{color:var(--color-text)}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; Operated by DigitalCliqs, UK &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 <script>

--- a/guides/how-to-invest-in-gold.html
+++ b/guides/how-to-invest-in-gold.html
@@ -186,6 +186,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the easiest way to start investing in gold in the UK?","acceptedAnswer":{"@type":"Answer","text":"The easiest entry point is a gold ETC (Exchange Traded Commodity) held inside a Stocks and Shares ISA. The iShares Physical Gold ETC (IGLN) has a TER of just 0.12% per annum and can be purchased through any major UK broker (Hargreaves Lansdown, AJ Bell, Interactive Investor, Fidelity). It tracks the gold spot price, is fully backed by physical gold, and inside an ISA all gains are permanently free from Capital Gains Tax."}},{"@type":"Question","name":"How much of my portfolio should I hold in gold?","acceptedAnswer":{"@type":"Answer","text":"Most financial planners suggest a gold allocation of 5\u201315% of a diversified portfolio. Gold serves primarily as a hedge against inflation, currency debasement, and financial system stress \u2014 not as a growth asset. The right allocation depends on your risk tolerance and investment horizon. A 10% allocation to gold has historically improved portfolio risk-adjusted returns by reducing drawdowns during equity bear markets, without significantly reducing long-term gains."}},{"@type":"Question","name":"Are Gold Sovereigns and Britannias really CGT-exempt?","acceptedAnswer":{"@type":"Answer","text":"Yes. Under TCGA 1992 s21(1)(b) and HMRC's own guidance at CG78305, Gold Sovereigns (minted 1837 onwards) and Gold Britannia coins are sterling currency \u2014 not chargeable assets for CGT purposes. This means any profit from selling them, no matter how large, is completely outside the scope of Capital Gains Tax in the UK. There is no limit on the amount or number of coins. This makes them one of the most tax-efficient investment assets available to UK investors."}},{"@type":"Question","name":"What is the difference between allocated and unallocated gold storage?","acceptedAnswer":{"@type":"Answer","text":"Allocated gold means you own specific, individually identified bars or coins held in your name at a vault \u2014 your gold is segregated from the custodian's own assets and cannot be lent out or used as collateral. Unallocated gold means you have a claim against a pool of gold \u2014 you are technically an unsecured creditor of the custodian for the equivalent amount of gold. BullionVault and the Royal Mint Vault both offer allocated storage. Always prefer allocated storage for investment holdings above small amounts."}}]}</script>
 </head>
@@ -445,8 +474,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/how-to-read-gold-spot-price.html
+++ b/guides/how-to-read-gold-spot-price.html
@@ -180,6 +180,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the gold spot price?","acceptedAnswer":{"@type":"Answer","text":"The gold spot price is the current market price for immediate delivery of one troy ounce of pure (24K/999) gold, quoted in US dollars. It is determined by continuous trading on global futures exchanges \u2014 primarily COMEX in New York and OTC markets in London \u2014 and changes second by second during trading hours."}},{"@type":"Question","name":"What is the difference between the gold spot price and the price I pay at a dealer?","acceptedAnswer":{"@type":"Answer","text":"The dealer price is the spot price plus a premium. This premium covers the dealer's costs, profit margin, and in some cases government mint charges. For 1 oz Gold Britannias from the Royal Mint, the premium is typically 2\u20134% above spot. For 1 kg gold bars, the premium is around 0.5\u20131% above spot. The bid-ask spread (the difference between the buy and sell price) is also a cost \u2014 typically 0.5\u20132% on coins."}},{"@type":"Question","name":"What time does the gold market open and close?","acceptedAnswer":{"@type":"Answer","text":"The gold spot market trades essentially 24 hours a day from Sunday evening (New York time) through Friday evening, as trading passes between Sydney, Tokyo, London, and New York sessions. The London Bullion Market Association (LBMA) publishes the official Gold Price benchmark twice daily: the AM Fix at approximately 10:30 GMT and the PM Fix at approximately 15:00 GMT. The COMEX gold futures market opens at 18:00 ET Sunday and closes at 17:00 ET Friday."}},{"@type":"Question","name":"Is gold quoted per troy ounce or per gram?","acceptedAnswer":{"@type":"Answer","text":"Internationally, gold is quoted per troy ounce (31.1035 grams). However, jewellers and scrap gold buyers typically quote prices per gram. To convert: divide the spot price per troy ounce by 31.1035 to get the 24K price per gram. Then multiply by the karat purity factor \u2014 0.75 for 18K, 0.5833 for 14K, 0.375 for 9K \u2014 to get the gold content value per gram for each karat."}}]}</script>
 </head>
@@ -406,8 +435,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/how-to-sell-gold-jewellery.html
+++ b/guides/how-to-sell-gold-jewellery.html
@@ -180,6 +180,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the best way to sell gold jewellery in the UK?","acceptedAnswer":{"@type":"Answer","text":"The best route depends on the piece. For plain gold with mainly melt value, a BNTA-member scrap gold dealer (BullionByPost, Hatton Garden Metals, or Gold.co.uk) typically pays 95\u201399% of the live melt value. For branded or designer jewellery (Tiffany, Cartier, Bulgari), selling at auction (Christie's, Bonhams, Sotheby's, or online auction) or a specialist pre-owned jeweller often realises a significant premium over melt. Never sell to a high-street pawnbroker or postal cash-for-gold service without comparing multiple quotes."}},{"@type":"Question","name":"How do I calculate what my gold jewellery is worth before selling?","acceptedAnswer":{"@type":"Answer","text":"First, identify the karat (look for hallmarks: 375=9K, 585=14K, 750=18K, 916=22K). Then weigh the piece in grams (a digital kitchen scale works; accuracy to 0.1g is sufficient). Multiply the weight by the purity factor (0.375 for 9K, 0.5833 for 14K, etc.) to get the pure gold content. Multiply the gold content in grams by the current 24K gold price per gram (available on GoldPriceTools). This is the melt value \u2014 the minimum you should accept."}},{"@type":"Question","name":"Do I pay Capital Gains Tax when selling gold jewellery?","acceptedAnswer":{"@type":"Answer","text":"In most cases, no \u2014 because the CGT chattel exemption applies to tangible personal items worth less than \u00a36,000. If your gold jewellery piece is worth less than \u00a36,000 at the time of sale, any gain is fully exempt from CGT. If it is worth more than \u00a36,000, CGT applies to the portion above the exemption. Note that this is different from investment gold coins (Sovereigns and Britannias), which are entirely CGT-exempt regardless of value."}},{"@type":"Question","name":"Should I get my gold jewellery valued before selling?","acceptedAnswer":{"@type":"Answer","text":"Yes \u2014 especially for pieces that might have collector, antique, or designer value beyond the melt value. A free valuation from a local BNTA-member jeweller takes 15 minutes and can reveal whether a piece is worth significantly more than its gold content. Antique hallmarked pieces by notable makers, heavy Victorian jewellery, or branded pieces can sell for 2\u20135\u00d7 melt value at auction."}}]}</script>
 </head>
@@ -427,8 +456,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/how-to-store-gold-silver-at-home.html
+++ b/guides/how-to-store-gold-silver-at-home.html
@@ -169,6 +169,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -328,8 +357,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </article>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/how-to-test-if-gold-is-real.html
+++ b/guides/how-to-test-if-gold-is-real.html
@@ -178,6 +178,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -364,8 +393,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/index.html
+++ b/guides/index.html
@@ -125,6 +125,35 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -408,8 +437,78 @@
   <p><strong>Disclaimer:</strong> Guides are for informational purposes only and do not constitute financial or investment advice. Always seek independent professional advice before making investment decisions.</p>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/privacy-policy">Privacy</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 </body>
 </html>

--- a/guides/indian-gold-silver-prices.html
+++ b/guides/indian-gold-silver-prices.html
@@ -125,6 +125,8 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 </head>
 <body>
@@ -396,5 +398,80 @@ document.addEventListener('DOMContentLoaded', fetchPrices);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/guides/scrap-gold-guide.html
+++ b/guides/scrap-gold-guide.html
@@ -125,6 +125,8 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 </head>
 <body>
@@ -388,5 +390,80 @@ document.addEventListener('DOMContentLoaded', fetchPrices);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/guides/silver-price-guide.html
+++ b/guides/silver-price-guide.html
@@ -125,6 +125,8 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 </head>
 <body>
@@ -388,5 +390,80 @@ document.addEventListener('DOMContentLoaded', fetchPrices);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/guides/silver-price-per-gram-explained.html
+++ b/guides/silver-price-per-gram-explained.html
@@ -179,6 +179,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How is the silver price per gram calculated?","acceptedAnswer":{"@type":"Answer","text":"Divide the silver spot price per troy ounce by 31.1035 (grams per troy ounce). For example, if silver is $74 per troy ounce, the price per gram is $74 \u00f7 31.1035 = $2.38 per gram. For sterling silver (.925), multiply by 0.925 to get the silver content value per gram: $2.38 \u00d7 0.925 = $2.20 per gram."}},{"@type":"Question","name":"Why is silver sold per gram in jewellery but quoted per troy ounce in markets?","acceptedAnswer":{"@type":"Answer","text":"Financial markets quote precious metals in troy ounces because that is the international standard set by the London Bullion Market Association (LBMA). However, jewellers and consumers work with small pieces measured in grams, so they convert the spot price to grams for practical pricing. This difference often causes confusion \u2014 always check whether a quoted price is per gram or per troy ounce."}},{"@type":"Question","name":"Does VAT apply to silver per gram prices in the UK?","acceptedAnswer":{"@type":"Answer","text":"Yes. Unlike investment gold (which is VAT-exempt under UK law), silver is subject to 20% VAT at the point of sale for UK retail buyers. This means the price you actually pay per gram is approximately 20% higher than the spot silver content value. For example, if 999 fine silver is worth \u00a32.38/g based on spot, you would typically pay \u00a32.86/g or more at retail after VAT and dealer premium."}},{"@type":"Question","name":"What is the difference between 999 fine silver and 925 sterling silver per gram?","acceptedAnswer":{"@type":"Answer","text":"999 fine silver (99.9% pure) contains 0.999g of silver per gram \u2014 essentially pure. 925 sterling silver contains 0.925g of silver per gram, with the remainder being alloy (typically copper). At a spot price of $74/oz, 999 fine is worth approximately $2.38/g; 925 sterling is worth approximately $2.20/g. The GoldPriceTools calculator shows live values for both purities."}}]}</script>
 </head>
@@ -398,8 +427,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/troy-ounce-guide.html
+++ b/guides/troy-ounce-guide.html
@@ -125,6 +125,8 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 </head>
 <body>
@@ -388,5 +390,80 @@ document.addEventListener('DOMContentLoaded', fetchPrices);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/guides/troy-ounce-vs-gram-explained.html
+++ b/guides/troy-ounce-vs-gram-explained.html
@@ -180,6 +180,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -419,8 +448,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/us-silver-dollar-values.html
+++ b/guides/us-silver-dollar-values.html
@@ -125,6 +125,8 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 </head>
 <body>
@@ -388,5 +390,80 @@ document.addEventListener('DOMContentLoaded', fetchPrices);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 </body>
 </html>

--- a/guides/what-affects-gold-price.html
+++ b/guides/what-affects-gold-price.html
@@ -178,6 +178,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -347,8 +376,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/what-is-14k-gold.html
+++ b/guides/what-is-14k-gold.html
@@ -179,6 +179,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -420,8 +449,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/what-is-925-sterling-silver.html
+++ b/guides/what-is-925-sterling-silver.html
@@ -179,6 +179,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -402,8 +431,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </section>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/guides/what-is-best-time-to-sell-scrap-gold.html
+++ b/guides/what-is-best-time-to-sell-scrap-gold.html
@@ -189,6 +189,35 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -390,8 +419,78 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 </div>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a><a href="/terms">Terms of Use</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>

--- a/how-many-grams-in-troy-ounce.html
+++ b/how-many-grams-in-troy-ounce.html
@@ -123,6 +123,35 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -318,7 +347,80 @@
   <a href="https://api.whatsapp.com/send?text=How+Many+Grams+in+a+Troy+Ounce%3F+%2831.1035g+Explained%29%20https%3A%2F%2Fgoldpricetools.com%2Fhow-many-grams-in-troy-ounce" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
-<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p></footer>
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 
 <script>
 let goldSpotOz = null;

--- a/index.html
+++ b/index.html
@@ -353,6 +353,35 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script>
 // Lazy-load Chart.js only when chart container is visible
@@ -1220,67 +1249,114 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
 </div>
 
-<section class="more-tools" style="max-width:860px;margin:2rem auto;padding:0 1rem">
-  <h2 style="font-size:1.1rem;font-weight:600;margin-bottom:0.75rem">More Tools &amp; Guides</h2>
-  <ul style="list-style:none;padding:0;display:flex;flex-wrap:wrap;gap:0.5rem 1.5rem">
-    <li><a href="/gold-and-silver-price-today">Gold &amp; Silver Price Today</a></li>
-    <li><a href="/guides/what-affects-gold-price">What Affects the Gold Price?</a></li>
-    <li><a href="/guides/gold-bar-guide.html">Gold Bar Guide</a></li>
-    <li><a href="/data/">Live Price Data Feed</a></li>
-    <li><a href="/9k-gold-price-per-gram">9K Gold Price Per Gram</a></li>
-  </ul>
-</section>
 
+
+
+<!-- LATEST BLOG POSTS -->
+<section class="blog-preview-section" aria-label="Latest articles from GoldPriceTools blog">
+  <div class="blog-preview-inner">
+    <div class="blog-preview-header">
+      <h2 class="blog-preview-title">Latest from the Blog</h2>
+      <a href="/blog/" class="blog-preview-all">View all articles &rarr;</a>
+    </div>
+    <div class="blog-preview-grid">
+      <a href="/blog/gold-vs-bitcoin-2026" class="blog-preview-card">
+        <span class="blog-preview-tag">Investing</span>
+        <h3>Gold vs Bitcoin 2026: UK Investor Comparison</h3>
+        <p>Gold up 80% vs Bitcoin down 14% YTD. We compare performance, volatility and UK tax treatment.</p>
+      </a>
+      <a href="/blog/best-uk-gold-dealers-2026" class="blog-preview-card">
+        <span class="blog-preview-tag">Buying</span>
+        <h3>Best UK Gold Dealers 2026</h3>
+        <p>Royal Mint, BullionByPost, Chards and BullionVault compared on premiums, spreads and storage.</p>
+      </a>
+      <a href="/blog/uk-gold-cgt-guide" class="blog-preview-card">
+        <span class="blog-preview-tag">Tax</span>
+        <h3>Gold CGT UK 2026: Are Gold Coins Tax-Free?</h3>
+        <p>Capital Gains Tax on gold explained — which coins qualify for CGT exemption and why.</p>
+      </a>
+      <a href="/blog/is-gold-overpriced-2026" class="blog-preview-card">
+        <span class="blog-preview-tag">Analysis</span>
+        <h3>Is Gold Overpriced in 2026?</h3>
+        <p>Five data-driven frameworks — real yields, M2 ratio, gold-silver ratio — to assess current valuations.</p>
+      </a>
+    </div>
+  </div>
+</section>
 
 <!-- FOOTER -->
 <footer>
   <div class="footer-inner">
-    <div>
+    <div class="footer-brand-col">
       <div class="nav-logo" style="margin-bottom:var(--space-3)">
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 10K, 14K, 18K &amp; 24K gold per gram. Scrap gold calculator, silver per troy oz, kilo and kilogram. Prices sourced from global markets, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li><a href="/14k-gold-price-per-gram">14K Gold Price Per Gram</a></li>
-        <li><a href="/18k-gold-price-per-gram">18K Gold Price Per Gram</a></li>
-        <li><a href="/10k-gold-price-per-gram">10K Gold Price Per Gram</a></li>
-        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a>
-  <a href="/gold-price-chart">Gold Price Chart</a></li>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h4>Guides</h4>
       <ul>
-        <li><a href="/guides/what-is-14k-gold">What Is 14K Gold?</a></li>
-        <li><a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold</a></li>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
         <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
-        <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a></li>
-        <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
-        <li><a href="/us-silver-dollar-values.html">US Silver Dollar Values</a></li>
-                <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
-        <li><a href="/900-silver-price-per-gram">.900 Coin Silver Price</a></li>
-        <li><a href="/800-silver-price-per-gram">.800 European Silver Price</a></li>
-        <li><a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Info</h4>
+      <h4>Blog</h4>
       <ul>
-        <li><a href="/blog/">Blog</a></li>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
         <li><a href="/privacy-policy">Privacy Policy</a></li>
         <li><a href="/terms">Terms of Use</a></li>
       </ul>
     </div>
   </div>
   <div class="footer-bottom">
-    <span>&copy; 2026 GoldPriceTools — goldpricetools.com. Prices are indicative and for reference only. Not financial advice.</span>
-    <span>Spot data refreshes every 60 seconds.</span>
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 

--- a/live-gold-silver-price-today.html
+++ b/live-gold-silver-price-today.html
@@ -108,6 +108,35 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">
@@ -243,8 +272,78 @@
 </div>
 </div>
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p>
-  <p style="margin-top:.5rem">Prices are indicative only. Not financial advice.</p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -153,6 +153,35 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 
     <meta property="og:title" content="Privacy Policy | GoldPriceTools">
@@ -306,14 +335,78 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
   <p>This Privacy Policy was last updated on <strong>30 April 2026</strong> and applies to goldpricetools.com.</p>
 </div>
 <footer>
-  <a href="/">Calculator</a>
-  <a href="/blog/">Blog</a>
-  <a href="/about">About</a>
-  <a href="/privacy-policy">Privacy Policy</a>
-  <a href="/14k-gold-price-per-gram">14K Gold</a>
-  <a href="/10k-gold-price-per-gram">10K Gold</a>
-  <a href="/18k-gold-price-per-gram">18K Gold</a>
-  <span style="display:block;margin-top:.5rem">&copy; 2026 Gold Price Tools &mdash; goldpricetools.com. Not financial advice.</span>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>(function(){

--- a/scrap-gold-calculator.html
+++ b/scrap-gold-calculator.html
@@ -311,6 +311,35 @@ function fireCalcEngaged() {
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -457,7 +486,80 @@ function fireCalcEngaged() {
   </ul>
 </div>
 
-<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 <script>
 let _scrapIntentFired = false;
 document.addEventListener("DOMContentLoaded", () => { document.querySelectorAll('a[href*="/scrap-gold-calculator"]').forEach(a => { a.addEventListener('click', fireScrapIntent); }); });

--- a/silver-coins-calculator.html
+++ b/silver-coins-calculator.html
@@ -210,6 +210,35 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -380,9 +409,76 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 
 <footer>
   <div class="footer-inner">
-    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy"> GoldPriceTools</a>
-    <div class="footer-links"><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/terms.html">Terms</a><a href="/privacy-policy.html">Privacy</a><a href="/contact.html">Contact</a></div>
-    <div class="footer-copy">&copy; 2026 GoldPriceTools. All rights reserved. Data is provided "as is" for informational purposes.</div>
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -139,6 +139,35 @@
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 <script type="application/ld+json">
 {
@@ -398,7 +427,80 @@
   </ul>
 </div>
 
-<footer><p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/guides/">Guides</a><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/contact.html">Contact</a><a href="/privacy-policy.html">Privacy</a><a href="/terms.html">Terms</a></p><p style="margin-top:.5rem">Not financial advice.</p></footer>
+<footer>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
+</footer>
 <script>
 async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
 async function fetchSpot(){try{const r=await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();const ozUSD=d.price;const gbpusd=window._gbpusd||0.79;const perG_USD=ozUSD/31.1035;const perG_GBP=perG_USD*gbpusd;const perKg_USD=perG_USD*1000;const perKg_GBP=perG_GBP*1000;document.getElementById('p-kg-gbp').textContent='£'+perKg_GBP.toFixed(2);document.getElementById('p-kg-usd').textContent='$'+perKg_USD.toFixed(2);document.getElementById('p-oz-gbp').textContent='£'+(ozUSD*gbpusd).toFixed(2);document.getElementById('p-g-gbp').textContent='£'+perG_GBP.toFixed(3);

--- a/terms.html
+++ b/terms.html
@@ -158,6 +158,35 @@ footer a:hover{color:var(--color-text)}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 
     <meta property="og:title" content="Terms of Use | GoldPriceTools">
@@ -296,7 +325,78 @@ footer a:hover{color:var(--color-text)}
 </main>
 
 <footer>
-  <p>&copy; 2026 GoldPriceTools &mdash; <a href="/">Home</a><a href="/blog/">Blog</a><a href="/about">About</a><a href="/contact">Contact</a><a href="/privacy-policy">Privacy Policy</a></p>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>(function(){

--- a/us-silver-dollar-values.html
+++ b/us-silver-dollar-values.html
@@ -210,6 +210,35 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -378,9 +407,76 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <div class="related-guides" style="margin:2rem 0;padding:1rem;background:#f9f7f0;border-radius:8px"><p><strong>Related Guide:</strong> <a href="/guides/us-silver-dollar-values">US Silver Dollar Values: Coin Prices &amp; Melt Values Guide</a></p></div>
 <footer>
   <div class="footer-inner">
-    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy"> GoldPriceTools</a>
-    <div class="footer-links"><a href="/blog/">Blog</a><a href="/about.html">About</a><a href="/terms.html">Terms</a><a href="/privacy-policy.html">Privacy</a><a href="/contact.html">Contact</a></div>
-    <div class="footer-copy">&copy; 2026 GoldPriceTools. All rights reserved. Data is provided "as is" for informational purposes.</div>
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 

--- a/where-to-sell-gold-silver.html
+++ b/where-to-sell-gold-silver.html
@@ -171,6 +171,35 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
 .mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
+
+
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
 </style>
 </head>
 <body>
@@ -337,14 +366,78 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
   </div>
 </article>
 <footer>
-  <a href="/">Calculator</a>
-  <a href="/guides/">Guides</a>
-  <a href="/blog/">Blog</a>
-  <a href="/about">About</a>
-  <a href="/contact">Contact</a>
-  <a href="/privacy-policy">Privacy Policy</a>
-  <a href="/terms">Terms</a>
-  <span style="display:block;margin-top:.5rem">&copy; 2026 GoldPriceTools &mdash; Operated by DigitalCliqs, UK. Not financial advice.</span>
+  <div class="footer-inner">
+    <div class="footer-brand-col">
+      <div class="nav-logo" style="margin-bottom:var(--space-3)">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700">GoldPriceTools</span>
+      </div>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+    </div>
+    <div class="footer-col">
+      <h4>Gold Prices</h4>
+      <ul>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Guides</h4>
+      <ul>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
+        <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Blog</h4>
+      <ul>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
+        <li><a href="/about">About</a></li>
+        <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
+        <li><a href="/privacy-policy">Privacy Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+  </div>
 </footer>
 </body>
 </html>

--- a/zakat-gold-silver-calculator.html
+++ b/zakat-gold-silver-calculator.html
@@ -466,6 +466,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   .zakat-status-badge { display: inline-block; padding: var(--space-1) var(--space-3); border-radius: var(--radius-full); font-size: var(--text-sm); font-weight: 700; margin-top: var(--space-3); }
   .zakat-status-above { background: rgba(74, 222, 128, 0.2); color: #4ade80; border: 1px solid rgba(74, 222, 128, 0.5); }
   .zakat-status-below { background: rgba(248, 113, 113, 0.2); color: #f87171; border: 1px solid rgba(248, 113, 113, 0.5); }
+
+.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 </style>
 
 <div class="main-wrap" style="display: block;">
@@ -691,48 +693,76 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <!-- FOOTER -->
 <footer>
   <div class="footer-inner">
-    <div>
+    <div class="footer-brand-col">
       <div class="nav-logo" style="margin-bottom:var(--space-3)">
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 10K, 14K, 18K &amp; 24K gold per gram. Scrap gold calculator, silver per troy oz, kilo and kilogram. Prices sourced from global markets, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li><a href="/14k-gold-price-per-gram">14K Gold Price Per Gram</a></li>
-        <li><a href="/18k-gold-price-per-gram">18K Gold Price Per Gram</a></li>
-        <li><a href="/10k-gold-price-per-gram">10K Gold Price Per Gram</a></li>
-        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a>
-  <a href="/gold-price-chart">Gold Price Chart</a></li>
+        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
+        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
+        <li><a href="/gold-price-chart">Gold Price Chart</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h4>Calculators</h4>
+      <ul>
+        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
+        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
+        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h4>Guides</h4>
       <ul>
-        <li><a href="/guides/what-is-14k-gold">What Is 14K Gold?</a></li>
-        <li><a href="/guides/how-to-calculate-scrap-gold">Calculate Scrap Gold</a></li>
+        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
         <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
-        <li><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a></li>
-        <li><a href="/silver-price-per-kilo">Silver Price Per Kilo</a></li>
-        <li><a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce</a></li>
+        <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
+        <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
+        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
+        <li><a href="/guides/scrap-gold-guide">Scrap Gold Guide</a></li>
+        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
+        <li><a href="/guides/">All Guides</a></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Info</h4>
+      <h4>Blog</h4>
       <ul>
-        <li><a href="/blog/">Blog</a></li>
+        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
+        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
+        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
+        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
+        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
+        <li><a href="/blog/">All Articles</a></li>
+      </ul>
+      <h4 style="margin-top:var(--space-4)">Info</h4>
+      <ul>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
+        <li><a href="/editorial-standards/">Editorial Standards</a></li>
         <li><a href="/privacy-policy">Privacy Policy</a></li>
         <li><a href="/terms">Terms of Use</a></li>
       </ul>
     </div>
   </div>
   <div class="footer-bottom">
-    <span>&copy; 2026 GoldPriceTools — goldpricetools.com. Prices are indicative and for reference only. Not financial advice.</span>
-    <span>Spot data refreshes every 60 seconds.</span>
+    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
 


### PR DESCRIPTION
## Homepage Declutter & Sitewide Footer Upgrade

### Homepage changes
- ❌ **Removed** redundant "More Tools & Guides" section (5 nav links now covered by mega menu)
- ✅ **Added** "Latest from the Blog" 4-card preview grid above the footer
  - 4 cards in responsive grid (4-col desktop → 2-col tablet → 1-col mobile)
  - Each card has a category tag, title, and excerpt
  - Links to: Gold vs Bitcoin 2026, Best UK Gold Dealers, Gold CGT Guide, Is Gold Overpriced?
  - "View all articles →" CTA

### Footer upgrade (all 80 pages)
**Before:** Single copyright line with 6 plain links  
**After:** Full 5-column rich footer:
- Brand column: logo, tagline, disclaimer
- Gold Prices column: 9K–24K, ratio, chart (8 links)
- Calculators column: scrap gold, silver, zakat, troy oz converter (8 links)
- Guides column: top 7 guides + All Guides (8 links)
- Blog + Info column: 5 blog posts + about/contact/editorial/legal (11 links)

**Also fixed:** Duplicate "Silver Price Per Kilo" entry removed from old homepage footer  
**Also fixed:** 12 guide/author pages that had NO footer now have the full footer