### PR TITLE
fix(audit): sitewide CSS completeness + early theme-init — 21 pages

### DIFF
--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>14K Gold Price Per Gram Today (Live) — Gold Price Tools</title>
@@ -50,6 +53,7 @@
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -74,331 +78,18 @@
   src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-/* ═══════════════════════════════════════════
-   MEGA MENU — Site Navigation
-   Desktop: Visible mega-panel bar
-   Tablet/Mobile: Hamburger → slide-in drawer
-═══════════════════════════════════════════ */
 
-/* ── Base nav bar ── */
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 200;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-.nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  gap: var(--space-2);
-}
-.nav-logo {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--text-sm);
-  color: var(--color-gold-bright);
-  text-decoration: none;
-  flex-shrink: 0;
-}
-
-/* ── Desktop mega nav list ── */
-.mega-nav {
-  display: flex;
-  align-items: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  gap: 2px;
-  flex: 1;
-  justify-content: center;
-}
-.mega-nav__item {
-  position: relative;
-}
-
-/* Trigger buttons & links */
-.mega-nav__trigger {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 11px;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  border: none;
-  background: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .15s, background .15s;
-}
-.mega-nav__trigger:hover,
-.mega-nav__item:hover .mega-nav__trigger,
-.mega-nav__trigger[aria-expanded="true"] {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-nav__trigger--link {
-  text-decoration: none;
-}
-.mega-nav__chevron {
-  transition: transform .2s;
-  flex-shrink: 0;
-}
-.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron {
-  transform: rotate(180deg);
-}
-
-/* ── Mega panels ── */
-.mega-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px oklch(0 0 0 / .12);
-  padding: var(--space-4);
-  gap: var(--space-4);
-  flex-direction: row;
-  z-index: 300;
-  animation: megaFadeIn .15s ease-out;
-}
-.mega-panel--wide {
-  min-width: 640px;
-}
-.mega-panel--blog {
-  min-width: 280px;
-}
-
-/* Show on hover OR keyboard activation */
-.mega-nav__item:hover .mega-panel,
-.mega-panel.is-open {
-  display: flex;
-}
-
-@keyframes megaFadeIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-
-/* Panel columns */
-.mega-panel__col {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 140px;
-}
-.mega-panel__col--blog {
-  min-width: 220px;
-}
-.mega-panel__heading {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--color-text-faint);
-  padding: 4px 10px 8px;
-}
-.mega-panel a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  transition: color .12s, background .12s;
-  display: block;
-}
-.mega-panel a:hover {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-panel__view-all {
-  margin-top: var(--space-2);
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-}
-.mega-panel__view-all:hover {
-  color: var(--color-primary-hover) !important;
-}
-
-/* Divider between cols */
-.mega-panel__col + .mega-panel__col {
-  border-left: 1px solid var(--color-divider);
-  padding-left: var(--space-4);
-}
-
-/* ── Nav actions (theme toggle + hamburger) ── */
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  background: none;
-  cursor: pointer;
-}
-.theme-toggle:hover { color: var(--color-text); background: var(--color-surface-offset); }
-
-/* Hamburger — hidden on desktop */
-.hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.hamburger span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
-  transition: transform .22s cubic-bezier(.4,0,.2,1), opacity .22s;
-}
-.hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
-
-/* ── MOBILE DRAWER ── */
-.mobile-menu {
-  display: none;
-  position: fixed;
-  top: 56px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--color-surface);
-  z-index: 199;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  border-top: 1px solid var(--color-border);
-  transform: translateX(-100%);
-  transition: transform .28s cubic-bezier(.4,0,.2,1);
-}
-.mobile-menu.open {
-  display: block;
-  transform: translateX(0);
-}
-.mobile-menu__inner {
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-/* Mobile accordion sections */
-.mobile-section { border-radius: var(--radius-md); overflow: hidden; }
-.mobile-section__toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  background: none;
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background .12s;
-}
-.mobile-section__toggle:hover { background: var(--color-surface-offset); }
-.mobile-section__toggle svg { transition: transform .2s; flex-shrink: 0; }
-.mobile-section__toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
-.mobile-section__toggle[aria-expanded="true"] { background: var(--color-surface-offset); border-radius: var(--radius-md) var(--radius-md) 0 0; }
-
-.mobile-section__items {
-  display: none;
-  flex-direction: column;
-  background: var(--color-surface-offset);
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  padding: 4px 8px 8px;
-}
-.mobile-section__items.open { display: flex; }
-.mobile-section__items a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  transition: color .12s, background .12s;
-}
-.mobile-section__items a:hover { color: var(--color-text); background: var(--color-surface-dynamic); }
-.mobile-view-all {
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-  margin-top: 4px;
-}
-
-.mobile-section--flat {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 4px;
-  border-top: 1px solid var(--color-divider);
-  margin-top: var(--space-2);
-}
-.mobile-section--flat a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-}
-.mobile-section--flat a:hover { background: var(--color-surface-offset); color: var(--color-text); }
-
-.mobile-menu__search {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-divider);
-}
-.mobile-menu__search input {
-  width: 100%;
-  padding: 10px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: var(--text-sm);
-}
-
-/* ── Responsive breakpoints ── */
-@media (max-width: 900px) {
-  .mega-nav { display: none; }
-  .hamburger { display: flex; }
-}
-@media (max-width: 768px) {
-  .nav-logo span { display: none; }
-}
-</style>
-<style>
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -417,52 +108,253 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}
-.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}
-.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}
-.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}
-.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
-.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}
-.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.625rem}
-.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}
-.hero-sub{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem}
-.price-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:2rem;max-width:480px;margin:0 auto 2rem}
-.price-label{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.5rem}
-.price-value{font-family:var(--font-display);font-size:clamp(2.25rem,6vw,3.5rem);font-weight:700;color:var(--color-gold-bright);line-height:1;margin-bottom:.375rem}
-.price-usd{font-size:1.25rem;color:var(--color-text-muted);margin-bottom:.5rem}
-.price-purity{font-size:.8125rem;color:var(--color-text-faint)}
-.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}
-.prose{max-width:68ch}
-.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}
-.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}
-.prose a{color:var(--color-primary);text-decoration:none}
-.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}
-.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}
-.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}
-.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}
-.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}
-.trust-bar a{color:var(--color-text-muted);text-decoration:none}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
-#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-.share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 
-.data-source {
-  font-size: 0.8125rem;
-  color: var(--color-text-faint);
-  text-align: center;
-  padding: 0.75rem 1rem;
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: 2rem;
-}
-.data-source a {
-  color: var(--color-text-muted);
-  text-decoration: none;
-}
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+/* MEGA MENU */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
+.mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
+.mega-nav__item{position:relative}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-nav__trigger--link{text-decoration:none}
+.mega-nav__chevron{transition:transform .2s;flex-shrink:0}
+.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel--wide{min-width:640px}
+.mega-panel--blog{min-width:280px}
+.mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
+@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
+.mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
+.mega-panel__col--blog{min-width:220px}
+.mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
+.mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
+.mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
+.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
+.mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
+.hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
+.hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu.open{display:block;transform:translateX(0)}
+.mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
+.mobile-section{border-radius:var(--radius-md);overflow:hidden}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle:hover{background:var(--color-surface-offset)}
+.mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
+.mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
+.mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
+.mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
+.mobile-section__items.open{display:flex}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
+.mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
+.mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:768px){.nav-logo span{display:none}}
 
 
 /* BLOG PREVIEW SECTION */
@@ -493,17 +385,14 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* Related Guides Card Section */
-.related-guides{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:2.5rem 0;margin-top:2rem}
-.related-guides .container{max-width:900px;margin:0 auto;padding:0 1.5rem}
-.related-guides h2{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:1.5rem}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.2rem;text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold);box-shadow:var(--shadow-md)}
-.related-card__tag{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem}
-.related-card__title{font-weight:700;color:var(--color-text);margin-bottom:0.3rem;font-size:var(--text-sm)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",

--- a/18k-gold-price-per-gram.html
+++ b/18k-gold-price-per-gram.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>18K Gold Price Per Gram Today (Live) — Gold Price Tools</title>
@@ -50,6 +53,7 @@
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -74,331 +78,18 @@
   src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-/* ═══════════════════════════════════════════
-   MEGA MENU — Site Navigation
-   Desktop: Visible mega-panel bar
-   Tablet/Mobile: Hamburger → slide-in drawer
-═══════════════════════════════════════════ */
 
-/* ── Base nav bar ── */
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 200;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-.nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  gap: var(--space-2);
-}
-.nav-logo {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--text-sm);
-  color: var(--color-gold-bright);
-  text-decoration: none;
-  flex-shrink: 0;
-}
-
-/* ── Desktop mega nav list ── */
-.mega-nav {
-  display: flex;
-  align-items: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  gap: 2px;
-  flex: 1;
-  justify-content: center;
-}
-.mega-nav__item {
-  position: relative;
-}
-
-/* Trigger buttons & links */
-.mega-nav__trigger {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 11px;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  border: none;
-  background: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .15s, background .15s;
-}
-.mega-nav__trigger:hover,
-.mega-nav__item:hover .mega-nav__trigger,
-.mega-nav__trigger[aria-expanded="true"] {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-nav__trigger--link {
-  text-decoration: none;
-}
-.mega-nav__chevron {
-  transition: transform .2s;
-  flex-shrink: 0;
-}
-.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron {
-  transform: rotate(180deg);
-}
-
-/* ── Mega panels ── */
-.mega-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px oklch(0 0 0 / .12);
-  padding: var(--space-4);
-  gap: var(--space-4);
-  flex-direction: row;
-  z-index: 300;
-  animation: megaFadeIn .15s ease-out;
-}
-.mega-panel--wide {
-  min-width: 640px;
-}
-.mega-panel--blog {
-  min-width: 280px;
-}
-
-/* Show on hover OR keyboard activation */
-.mega-nav__item:hover .mega-panel,
-.mega-panel.is-open {
-  display: flex;
-}
-
-@keyframes megaFadeIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-
-/* Panel columns */
-.mega-panel__col {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 140px;
-}
-.mega-panel__col--blog {
-  min-width: 220px;
-}
-.mega-panel__heading {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--color-text-faint);
-  padding: 4px 10px 8px;
-}
-.mega-panel a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  transition: color .12s, background .12s;
-  display: block;
-}
-.mega-panel a:hover {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-panel__view-all {
-  margin-top: var(--space-2);
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-}
-.mega-panel__view-all:hover {
-  color: var(--color-primary-hover) !important;
-}
-
-/* Divider between cols */
-.mega-panel__col + .mega-panel__col {
-  border-left: 1px solid var(--color-divider);
-  padding-left: var(--space-4);
-}
-
-/* ── Nav actions (theme toggle + hamburger) ── */
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  background: none;
-  cursor: pointer;
-}
-.theme-toggle:hover { color: var(--color-text); background: var(--color-surface-offset); }
-
-/* Hamburger — hidden on desktop */
-.hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.hamburger span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
-  transition: transform .22s cubic-bezier(.4,0,.2,1), opacity .22s;
-}
-.hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
-
-/* ── MOBILE DRAWER ── */
-.mobile-menu {
-  display: none;
-  position: fixed;
-  top: 56px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--color-surface);
-  z-index: 199;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  border-top: 1px solid var(--color-border);
-  transform: translateX(-100%);
-  transition: transform .28s cubic-bezier(.4,0,.2,1);
-}
-.mobile-menu.open {
-  display: block;
-  transform: translateX(0);
-}
-.mobile-menu__inner {
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-/* Mobile accordion sections */
-.mobile-section { border-radius: var(--radius-md); overflow: hidden; }
-.mobile-section__toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  background: none;
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background .12s;
-}
-.mobile-section__toggle:hover { background: var(--color-surface-offset); }
-.mobile-section__toggle svg { transition: transform .2s; flex-shrink: 0; }
-.mobile-section__toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
-.mobile-section__toggle[aria-expanded="true"] { background: var(--color-surface-offset); border-radius: var(--radius-md) var(--radius-md) 0 0; }
-
-.mobile-section__items {
-  display: none;
-  flex-direction: column;
-  background: var(--color-surface-offset);
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  padding: 4px 8px 8px;
-}
-.mobile-section__items.open { display: flex; }
-.mobile-section__items a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  transition: color .12s, background .12s;
-}
-.mobile-section__items a:hover { color: var(--color-text); background: var(--color-surface-dynamic); }
-.mobile-view-all {
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-  margin-top: 4px;
-}
-
-.mobile-section--flat {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 4px;
-  border-top: 1px solid var(--color-divider);
-  margin-top: var(--space-2);
-}
-.mobile-section--flat a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-}
-.mobile-section--flat a:hover { background: var(--color-surface-offset); color: var(--color-text); }
-
-.mobile-menu__search {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-divider);
-}
-.mobile-menu__search input {
-  width: 100%;
-  padding: 10px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: var(--text-sm);
-}
-
-/* ── Responsive breakpoints ── */
-@media (max-width: 900px) {
-  .mega-nav { display: none; }
-  .hamburger { display: flex; }
-}
-@media (max-width: 768px) {
-  .nav-logo span { display: none; }
-}
-</style>
-<style>
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -417,51 +108,253 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}
-.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}
-.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}
-.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}
-.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
-.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}
-.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.625rem}
-.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}
-.hero-sub{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem}
-.price-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:2rem;max-width:480px;margin:0 auto 2rem}
-.price-label{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.5rem}
-.price-value{font-family:var(--font-display);font-size:clamp(2.25rem,6vw,3.5rem);font-weight:700;color:var(--color-gold-bright);line-height:1;margin-bottom:.375rem;min-height:3rem;min-width:120px;display:inline-block}
-.price-usd{font-size:1.25rem;color:var(--color-text-muted);margin-bottom:.5rem}
-.price-purity{font-size:.8125rem;color:var(--color-text-faint)}
-.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}
-.prose{max-width:68ch}
-.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}
-.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}
-.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}
-.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}
-.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}
-.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}
-.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}
-.trust-bar a{color:var(--color-text-muted);text-decoration:none}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
-#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-.share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 
-.data-source {
-  font-size: 0.8125rem;
-  color: var(--color-text-faint);
-  text-align: center;
-  padding: 0.75rem 1rem;
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: 2rem;
-}
-.data-source a {
-  color: var(--color-text-muted);
-  text-decoration: none;
-}
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+/* MEGA MENU */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
+.mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
+.mega-nav__item{position:relative}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-nav__trigger--link{text-decoration:none}
+.mega-nav__chevron{transition:transform .2s;flex-shrink:0}
+.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel--wide{min-width:640px}
+.mega-panel--blog{min-width:280px}
+.mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
+@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
+.mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
+.mega-panel__col--blog{min-width:220px}
+.mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
+.mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
+.mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
+.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
+.mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
+.hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
+.hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu.open{display:block;transform:translateX(0)}
+.mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
+.mobile-section{border-radius:var(--radius-md);overflow:hidden}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle:hover{background:var(--color-surface-offset)}
+.mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
+.mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
+.mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
+.mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
+.mobile-section__items.open{display:flex}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
+.mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
+.mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:768px){.nav-logo span{display:none}}
 
 
 /* BLOG PREVIEW SECTION */
@@ -492,17 +385,14 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* Related Guides Card Section */
-.related-guides{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:2.5rem 0;margin-top:2rem}
-.related-guides .container{max-width:900px;margin:0 auto;padding:0 1.5rem}
-.related-guides h2{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:1.5rem}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.2rem;text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold);box-shadow:var(--shadow-md)}
-.related-card__tag{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem}
-.related-card__title{font-weight:700;color:var(--color-text);margin-bottom:0.3rem;font-size:var(--text-sm)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",

--- a/24k-gold-price-per-gram.html
+++ b/24k-gold-price-per-gram.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>24K Gold Price Per Gram Today | Live Calculator | GoldPriceTools</title>
@@ -50,6 +53,7 @@
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -74,331 +78,18 @@
   src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-/* ═══════════════════════════════════════════
-   MEGA MENU — Site Navigation
-   Desktop: Visible mega-panel bar
-   Tablet/Mobile: Hamburger → slide-in drawer
-═══════════════════════════════════════════ */
 
-/* ── Base nav bar ── */
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 200;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-.nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  gap: var(--space-2);
-}
-.nav-logo {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--text-sm);
-  color: var(--color-gold-bright);
-  text-decoration: none;
-  flex-shrink: 0;
-}
-
-/* ── Desktop mega nav list ── */
-.mega-nav {
-  display: flex;
-  align-items: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  gap: 2px;
-  flex: 1;
-  justify-content: center;
-}
-.mega-nav__item {
-  position: relative;
-}
-
-/* Trigger buttons & links */
-.mega-nav__trigger {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 11px;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  border: none;
-  background: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .15s, background .15s;
-}
-.mega-nav__trigger:hover,
-.mega-nav__item:hover .mega-nav__trigger,
-.mega-nav__trigger[aria-expanded="true"] {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-nav__trigger--link {
-  text-decoration: none;
-}
-.mega-nav__chevron {
-  transition: transform .2s;
-  flex-shrink: 0;
-}
-.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron {
-  transform: rotate(180deg);
-}
-
-/* ── Mega panels ── */
-.mega-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px oklch(0 0 0 / .12);
-  padding: var(--space-4);
-  gap: var(--space-4);
-  flex-direction: row;
-  z-index: 300;
-  animation: megaFadeIn .15s ease-out;
-}
-.mega-panel--wide {
-  min-width: 640px;
-}
-.mega-panel--blog {
-  min-width: 280px;
-}
-
-/* Show on hover OR keyboard activation */
-.mega-nav__item:hover .mega-panel,
-.mega-panel.is-open {
-  display: flex;
-}
-
-@keyframes megaFadeIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-
-/* Panel columns */
-.mega-panel__col {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 140px;
-}
-.mega-panel__col--blog {
-  min-width: 220px;
-}
-.mega-panel__heading {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--color-text-faint);
-  padding: 4px 10px 8px;
-}
-.mega-panel a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  transition: color .12s, background .12s;
-  display: block;
-}
-.mega-panel a:hover {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-panel__view-all {
-  margin-top: var(--space-2);
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-}
-.mega-panel__view-all:hover {
-  color: var(--color-primary-hover) !important;
-}
-
-/* Divider between cols */
-.mega-panel__col + .mega-panel__col {
-  border-left: 1px solid var(--color-divider);
-  padding-left: var(--space-4);
-}
-
-/* ── Nav actions (theme toggle + hamburger) ── */
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  background: none;
-  cursor: pointer;
-}
-.theme-toggle:hover { color: var(--color-text); background: var(--color-surface-offset); }
-
-/* Hamburger — hidden on desktop */
-.hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.hamburger span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
-  transition: transform .22s cubic-bezier(.4,0,.2,1), opacity .22s;
-}
-.hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
-
-/* ── MOBILE DRAWER ── */
-.mobile-menu {
-  display: none;
-  position: fixed;
-  top: 56px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--color-surface);
-  z-index: 199;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  border-top: 1px solid var(--color-border);
-  transform: translateX(-100%);
-  transition: transform .28s cubic-bezier(.4,0,.2,1);
-}
-.mobile-menu.open {
-  display: block;
-  transform: translateX(0);
-}
-.mobile-menu__inner {
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-/* Mobile accordion sections */
-.mobile-section { border-radius: var(--radius-md); overflow: hidden; }
-.mobile-section__toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  background: none;
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background .12s;
-}
-.mobile-section__toggle:hover { background: var(--color-surface-offset); }
-.mobile-section__toggle svg { transition: transform .2s; flex-shrink: 0; }
-.mobile-section__toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
-.mobile-section__toggle[aria-expanded="true"] { background: var(--color-surface-offset); border-radius: var(--radius-md) var(--radius-md) 0 0; }
-
-.mobile-section__items {
-  display: none;
-  flex-direction: column;
-  background: var(--color-surface-offset);
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  padding: 4px 8px 8px;
-}
-.mobile-section__items.open { display: flex; }
-.mobile-section__items a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  transition: color .12s, background .12s;
-}
-.mobile-section__items a:hover { color: var(--color-text); background: var(--color-surface-dynamic); }
-.mobile-view-all {
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-  margin-top: 4px;
-}
-
-.mobile-section--flat {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 4px;
-  border-top: 1px solid var(--color-divider);
-  margin-top: var(--space-2);
-}
-.mobile-section--flat a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-}
-.mobile-section--flat a:hover { background: var(--color-surface-offset); color: var(--color-text); }
-
-.mobile-menu__search {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-divider);
-}
-.mobile-menu__search input {
-  width: 100%;
-  padding: 10px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: var(--text-sm);
-}
-
-/* ── Responsive breakpoints ── */
-@media (max-width: 900px) {
-  .mega-nav { display: none; }
-  .hamburger { display: flex; }
-}
-@media (max-width: 768px) {
-  .nav-logo span { display: none; }
-}
-</style>
-<style>
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -417,38 +108,253 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
 nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}
-.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}
-.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}
-.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}
-.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
-.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}
-.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.625rem}
-.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}
-.hero-sub{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem}
-.price-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:2rem;max-width:480px;margin:0 auto 2rem}
-.price-label{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.5rem}
-.price-value{font-family:var(--font-display);font-size:clamp(2.25rem,6vw,3.5rem);font-weight:700;color:var(--color-gold-bright);line-height:1;margin-bottom:.375rem}
-.price-usd{font-size:1.25rem;color:var(--color-text-muted);margin-bottom:.5rem}
-.price-purity{font-size:.8125rem;color:var(--color-text-faint)}
-.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}
-.prose{max-width:68ch}
-.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}
-.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}
-.prose a{color:var(--color-primary);text-decoration:none}
-.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}
-.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}
-.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}
-.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}
-.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}
-.trust-bar a{color:var(--color-text-muted);text-decoration:none}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-.share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+/* MEGA MENU */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
+.mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
+.mega-nav__item{position:relative}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-nav__trigger--link{text-decoration:none}
+.mega-nav__chevron{transition:transform .2s;flex-shrink:0}
+.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel--wide{min-width:640px}
+.mega-panel--blog{min-width:280px}
+.mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
+@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
+.mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
+.mega-panel__col--blog{min-width:220px}
+.mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
+.mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
+.mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
+.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
+.mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
+.hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
+.hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu.open{display:block;transform:translateX(0)}
+.mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
+.mobile-section{border-radius:var(--radius-md);overflow:hidden}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle:hover{background:var(--color-surface-offset)}
+.mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
+.mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
+.mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
+.mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
+.mobile-section__items.open{display:flex}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
+.mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
+.mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:768px){.nav-logo span{display:none}}
 
 
 /* BLOG PREVIEW SECTION */
@@ -479,17 +385,14 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* Related Guides Card Section */
-.related-guides{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:2.5rem 0;margin-top:2rem}
-.related-guides .container{max-width:900px;margin:0 auto;padding:0 1.5rem}
-.related-guides h2{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:1.5rem}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.2rem;text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold);box-shadow:var(--shadow-md)}
-.related-card__tag{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem}
-.related-card__title{font-weight:700;color:var(--color-text);margin-bottom:0.3rem;font-size:var(--text-sm)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",

--- a/9k-gold-price-per-gram.html
+++ b/9k-gold-price-per-gram.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>9K Gold Price Per Gram Today (Live) — Gold Price Tools</title>
@@ -50,6 +53,7 @@
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -74,331 +78,18 @@
   src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-/* ═══════════════════════════════════════════
-   MEGA MENU — Site Navigation
-   Desktop: Visible mega-panel bar
-   Tablet/Mobile: Hamburger → slide-in drawer
-═══════════════════════════════════════════ */
 
-/* ── Base nav bar ── */
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 200;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-.nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  gap: var(--space-2);
-}
-.nav-logo {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--text-sm);
-  color: var(--color-gold-bright);
-  text-decoration: none;
-  flex-shrink: 0;
-}
-
-/* ── Desktop mega nav list ── */
-.mega-nav {
-  display: flex;
-  align-items: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  gap: 2px;
-  flex: 1;
-  justify-content: center;
-}
-.mega-nav__item {
-  position: relative;
-}
-
-/* Trigger buttons & links */
-.mega-nav__trigger {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 11px;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  border: none;
-  background: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .15s, background .15s;
-}
-.mega-nav__trigger:hover,
-.mega-nav__item:hover .mega-nav__trigger,
-.mega-nav__trigger[aria-expanded="true"] {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-nav__trigger--link {
-  text-decoration: none;
-}
-.mega-nav__chevron {
-  transition: transform .2s;
-  flex-shrink: 0;
-}
-.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron {
-  transform: rotate(180deg);
-}
-
-/* ── Mega panels ── */
-.mega-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px oklch(0 0 0 / .12);
-  padding: var(--space-4);
-  gap: var(--space-4);
-  flex-direction: row;
-  z-index: 300;
-  animation: megaFadeIn .15s ease-out;
-}
-.mega-panel--wide {
-  min-width: 640px;
-}
-.mega-panel--blog {
-  min-width: 280px;
-}
-
-/* Show on hover OR keyboard activation */
-.mega-nav__item:hover .mega-panel,
-.mega-panel.is-open {
-  display: flex;
-}
-
-@keyframes megaFadeIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-
-/* Panel columns */
-.mega-panel__col {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 140px;
-}
-.mega-panel__col--blog {
-  min-width: 220px;
-}
-.mega-panel__heading {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--color-text-faint);
-  padding: 4px 10px 8px;
-}
-.mega-panel a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  transition: color .12s, background .12s;
-  display: block;
-}
-.mega-panel a:hover {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-panel__view-all {
-  margin-top: var(--space-2);
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-}
-.mega-panel__view-all:hover {
-  color: var(--color-primary-hover) !important;
-}
-
-/* Divider between cols */
-.mega-panel__col + .mega-panel__col {
-  border-left: 1px solid var(--color-divider);
-  padding-left: var(--space-4);
-}
-
-/* ── Nav actions (theme toggle + hamburger) ── */
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  background: none;
-  cursor: pointer;
-}
-.theme-toggle:hover { color: var(--color-text); background: var(--color-surface-offset); }
-
-/* Hamburger — hidden on desktop */
-.hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.hamburger span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
-  transition: transform .22s cubic-bezier(.4,0,.2,1), opacity .22s;
-}
-.hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
-
-/* ── MOBILE DRAWER ── */
-.mobile-menu {
-  display: none;
-  position: fixed;
-  top: 56px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--color-surface);
-  z-index: 199;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  border-top: 1px solid var(--color-border);
-  transform: translateX(-100%);
-  transition: transform .28s cubic-bezier(.4,0,.2,1);
-}
-.mobile-menu.open {
-  display: block;
-  transform: translateX(0);
-}
-.mobile-menu__inner {
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-/* Mobile accordion sections */
-.mobile-section { border-radius: var(--radius-md); overflow: hidden; }
-.mobile-section__toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  background: none;
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background .12s;
-}
-.mobile-section__toggle:hover { background: var(--color-surface-offset); }
-.mobile-section__toggle svg { transition: transform .2s; flex-shrink: 0; }
-.mobile-section__toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
-.mobile-section__toggle[aria-expanded="true"] { background: var(--color-surface-offset); border-radius: var(--radius-md) var(--radius-md) 0 0; }
-
-.mobile-section__items {
-  display: none;
-  flex-direction: column;
-  background: var(--color-surface-offset);
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  padding: 4px 8px 8px;
-}
-.mobile-section__items.open { display: flex; }
-.mobile-section__items a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  transition: color .12s, background .12s;
-}
-.mobile-section__items a:hover { color: var(--color-text); background: var(--color-surface-dynamic); }
-.mobile-view-all {
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-  margin-top: 4px;
-}
-
-.mobile-section--flat {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 4px;
-  border-top: 1px solid var(--color-divider);
-  margin-top: var(--space-2);
-}
-.mobile-section--flat a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-}
-.mobile-section--flat a:hover { background: var(--color-surface-offset); color: var(--color-text); }
-
-.mobile-menu__search {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-divider);
-}
-.mobile-menu__search input {
-  width: 100%;
-  padding: 10px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: var(--text-sm);
-}
-
-/* ── Responsive breakpoints ── */
-@media (max-width: 900px) {
-  .mega-nav { display: none; }
-  .hamburger { display: flex; }
-}
-@media (max-width: 768px) {
-  .nav-logo span { display: none; }
-}
-</style>
-<style>
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -417,38 +108,253 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
 nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}
-.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}
-.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}
-.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}
-.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
-.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}
-.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.625rem}
-.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}
-.hero-sub{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem}
-.price-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:2rem;max-width:480px;margin:0 auto 2rem}
-.price-label{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.5rem}
-.price-value{font-family:var(--font-display);font-size:clamp(2.25rem,6vw,3.5rem);font-weight:700;color:var(--color-gold-bright);line-height:1;margin-bottom:.375rem}
-.price-usd{font-size:1.25rem;color:var(--color-text-muted);margin-bottom:.5rem}
-.price-purity{font-size:.8125rem;color:var(--color-text-faint)}
-.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}
-.prose{max-width:68ch}
-.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}
-.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}
-.prose a{color:var(--color-primary);text-decoration:none}
-.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}
-.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}
-.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}
-.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}
-.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}
-.trust-bar a{color:var(--color-text-muted);text-decoration:none}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-.share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
+
+/* MEGA MENU */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
+.mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
+.mega-nav__item{position:relative}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-nav__trigger--link{text-decoration:none}
+.mega-nav__chevron{transition:transform .2s;flex-shrink:0}
+.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel--wide{min-width:640px}
+.mega-panel--blog{min-width:280px}
+.mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
+@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
+.mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
+.mega-panel__col--blog{min-width:220px}
+.mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
+.mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
+.mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
+.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
+.mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
+.hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
+.hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu.open{display:block;transform:translateX(0)}
+.mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
+.mobile-section{border-radius:var(--radius-md);overflow:hidden}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle:hover{background:var(--color-surface-offset)}
+.mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
+.mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
+.mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
+.mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
+.mobile-section__items.open{display:flex}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
+.mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
+.mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:768px){.nav-logo span{display:none}}
 
 
 /* BLOG PREVIEW SECTION */
@@ -479,17 +385,14 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* Related Guides Card Section */
-.related-guides{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:2.5rem 0;margin-top:2rem}
-.related-guides .container{max-width:900px;margin:0 auto;padding:0 1.5rem}
-.related-guides h2{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:1.5rem}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.2rem;text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold);box-shadow:var(--shadow-md)}
-.related-card__tag{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem}
-.related-card__title{font-weight:700;color:var(--color-text);margin-bottom:0.3rem;font-size:var(--text-sm)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",

--- a/about.html
+++ b/about.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>About GoldPriceTools | Live Gold & Silver Prices</title>
@@ -63,6 +66,7 @@
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -87,328 +91,6 @@
   src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
-
-/* ═══════════════════════════════════════════
-   MEGA MENU — Site Navigation
-   Desktop: Visible mega-panel bar
-   Tablet/Mobile: Hamburger → slide-in drawer
-═══════════════════════════════════════════ */
-
-/* ── Base nav bar ── */
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 200;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-.nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  gap: var(--space-2);
-}
-.nav-logo {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--text-sm);
-  color: var(--color-gold-bright);
-  text-decoration: none;
-  flex-shrink: 0;
-}
-
-/* ── Desktop mega nav list ── */
-.mega-nav {
-  display: flex;
-  align-items: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  gap: 2px;
-  flex: 1;
-  justify-content: center;
-}
-.mega-nav__item {
-  position: relative;
-}
-
-/* Trigger buttons & links */
-.mega-nav__trigger {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 11px;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  border: none;
-  background: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .15s, background .15s;
-}
-.mega-nav__trigger:hover,
-.mega-nav__item:hover .mega-nav__trigger,
-.mega-nav__trigger[aria-expanded="true"] {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-nav__trigger--link {
-  text-decoration: none;
-}
-.mega-nav__chevron {
-  transition: transform .2s;
-  flex-shrink: 0;
-}
-.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron {
-  transform: rotate(180deg);
-}
-
-/* ── Mega panels ── */
-.mega-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px oklch(0 0 0 / .12);
-  padding: var(--space-4);
-  gap: var(--space-4);
-  flex-direction: row;
-  z-index: 300;
-  animation: megaFadeIn .15s ease-out;
-}
-.mega-panel--wide {
-  min-width: 640px;
-}
-.mega-panel--blog {
-  min-width: 280px;
-}
-
-/* Show on hover OR keyboard activation */
-.mega-nav__item:hover .mega-panel,
-.mega-panel.is-open {
-  display: flex;
-}
-
-@keyframes megaFadeIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-
-/* Panel columns */
-.mega-panel__col {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 140px;
-}
-.mega-panel__col--blog {
-  min-width: 220px;
-}
-.mega-panel__heading {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--color-text-faint);
-  padding: 4px 10px 8px;
-}
-.mega-panel a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  transition: color .12s, background .12s;
-  display: block;
-}
-.mega-panel a:hover {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-panel__view-all {
-  margin-top: var(--space-2);
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-}
-.mega-panel__view-all:hover {
-  color: var(--color-primary-hover) !important;
-}
-
-/* Divider between cols */
-.mega-panel__col + .mega-panel__col {
-  border-left: 1px solid var(--color-divider);
-  padding-left: var(--space-4);
-}
-
-/* ── Nav actions (theme toggle + hamburger) ── */
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  background: none;
-  cursor: pointer;
-}
-.theme-toggle:hover { color: var(--color-text); background: var(--color-surface-offset); }
-
-/* Hamburger — hidden on desktop */
-.hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.hamburger span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
-  transition: transform .22s cubic-bezier(.4,0,.2,1), opacity .22s;
-}
-.hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
-
-/* ── MOBILE DRAWER ── */
-.mobile-menu {
-  display: none;
-  position: fixed;
-  top: 56px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--color-surface);
-  z-index: 199;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  border-top: 1px solid var(--color-border);
-  transform: translateX(-100%);
-  transition: transform .28s cubic-bezier(.4,0,.2,1);
-}
-.mobile-menu.open {
-  display: block;
-  transform: translateX(0);
-}
-.mobile-menu__inner {
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-/* Mobile accordion sections */
-.mobile-section { border-radius: var(--radius-md); overflow: hidden; }
-.mobile-section__toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  background: none;
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background .12s;
-}
-.mobile-section__toggle:hover { background: var(--color-surface-offset); }
-.mobile-section__toggle svg { transition: transform .2s; flex-shrink: 0; }
-.mobile-section__toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
-.mobile-section__toggle[aria-expanded="true"] { background: var(--color-surface-offset); border-radius: var(--radius-md) var(--radius-md) 0 0; }
-
-.mobile-section__items {
-  display: none;
-  flex-direction: column;
-  background: var(--color-surface-offset);
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  padding: 4px 8px 8px;
-}
-.mobile-section__items.open { display: flex; }
-.mobile-section__items a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  transition: color .12s, background .12s;
-}
-.mobile-section__items a:hover { color: var(--color-text); background: var(--color-surface-dynamic); }
-.mobile-view-all {
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-  margin-top: 4px;
-}
-
-.mobile-section--flat {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 4px;
-  border-top: 1px solid var(--color-divider);
-  margin-top: var(--space-2);
-}
-.mobile-section--flat a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-}
-.mobile-section--flat a:hover { background: var(--color-surface-offset); color: var(--color-text); }
-
-.mobile-menu__search {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-divider);
-}
-.mobile-menu__search input {
-  width: 100%;
-  padding: 10px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: var(--text-sm);
-}
-
-/* ── Responsive breakpoints ── */
-@media (max-width: 900px) {
-  .mega-nav { display: none; }
-  .hamburger { display: flex; }
-}
-@media (max-width: 768px) {
-  .nav-logo span { display: none; }
-}
-
 /* ── Guides mega panel — category links ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
@@ -417,10 +99,10 @@
 .mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-</style>
-<style>
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-primary:#01696f;--color-gold:#b07a00;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--space-2:.5rem;--space-3:.75rem;--space-4:1rem;--space-6:1.5rem;--space-8:2rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--radius-md:0.5rem;--radius-lg:0.75rem;--shadow-sm:0 1px 2px rgba(0,0,0,.06)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-primary:#4f98a3;--color-gold-bright:#e8af34;--shadow-sm:0 1px 2px rgba(0,0,0,.3)}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -439,43 +121,253 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-html{-webkit-font-smoothing:antialiased;scroll-behavior:smooth}
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
 nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:900px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;gap:var(--space-4)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.nav-links a:hover{color:var(--color-text)}
-.breadcrumb{max-width:900px;margin:0 auto;padding:.75rem var(--space-4) 0;list-style:none;display:flex;gap:.5rem;font-size:.8125rem;color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"\203A";margin-right:.5rem}
-.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
-.hero{max-width:900px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-8)}
-.hero h1{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-4)}
-.hero p{font-size:var(--text-base);color:var(--color-text-muted);max-width:65ch;line-height:1.75}
-.features{max-width:900px;margin:0 auto;padding:0 var(--space-4) var(--space-8);display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:var(--space-4)}
-.feature-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-6);box-shadow:var(--shadow-sm)}
-.feature-icon{font-size:1.75rem;margin-bottom:var(--space-3)}
-.feature-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
-.feature-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65}
-.prose{max-width:900px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
-.prose h2{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:var(--space-8) 0 var(--space-4)}
-.prose p,.prose li{font-size:var(--text-base);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:72ch;line-height:1.75}
-.prose ul{padding-left:1.5rem;margin-bottom:var(--space-4)}
-.prose li{margin-bottom:.5rem}
-.prose a{color:var(--color-primary)}
-.prose a:hover{text-decoration:underline}
-.trust-box{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0}
-.trust-box h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.trust-box p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:.5rem}
-.trust-box p:last-child{margin-bottom:0}
-.cta-block{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-8);margin:var(--space-8) 0;text-align:center}
-.cta-block h2{font-family:var(--font-display);font-size:var(--text-lg);margin-bottom:var(--space-4)}
-.btn{display:inline-block;background:var(--color-gold-bright);color:#0f0e0c;font-weight:700;font-size:var(--text-sm);padding:.75rem 2rem;border-radius:9999px;text-decoration:none}
-.btn:hover{opacity:.9}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-6) var(--space-4);text-align:center;font-size:var(--text-sm);color:var(--color-text-muted)}
-footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+/* MEGA MENU */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
+.mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
+.mega-nav__item{position:relative}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-nav__trigger--link{text-decoration:none}
+.mega-nav__chevron{transition:transform .2s;flex-shrink:0}
+.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel--wide{min-width:640px}
+.mega-panel--blog{min-width:280px}
+.mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
+@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
+.mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
+.mega-panel__col--blog{min-width:220px}
+.mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
+.mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
+.mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
+.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
+.mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
+.hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
+.hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu.open{display:block;transform:translateX(0)}
+.mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
+.mobile-section{border-radius:var(--radius-md);overflow:hidden}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle:hover{background:var(--color-surface-offset)}
+.mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
+.mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
+.mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
+.mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
+.mobile-section__items.open{display:flex}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
+.mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
+.mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:768px){.nav-logo span{display:none}}
 
 
 /* BLOG PREVIEW SECTION */
@@ -505,7 +397,15 @@ footer a{color:var(--color-primary);text-decoration:none;margin:0 .5rem}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
+
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+
 </head>
 <body>
 <nav class="site-nav" role="navigation" aria-label="Main navigation">

--- a/blog/best-uk-gold-dealers-2026.html
+++ b/blog/best-uk-gold-dealers-2026.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation"><meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Best UK Gold Dealers 2026 | GoldPriceTools</title>
 <meta name="description" content="Compare the best UK gold dealers in 2026: Royal Mint, BullionByPost, Chards, BullionVault. Covers premiums, buyback spreads and BNTA membership.">
@@ -102,8 +105,43 @@ window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8',{'anonymize_ip':true});</script>
 <style>
-:root{--color-bg:#faf9f6;--color-surface:#ffffff;--color-surface-offset:#f5f4f0;--color-border:#e5e4e2;--color-text:#2d2c2a;--color-text-muted:#666560;--color-text-faint:#888782;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
+
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+}
+
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -122,8 +160,19 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-html{-webkit-font-smoothing:antialiased;scroll-behavior:smooth}
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
 .ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
 .ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
 .ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
@@ -131,366 +180,233 @@ body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--
 .ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
 .ticker:hover{animation-play-state:paused}
 @keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:.5rem;padding:0 1.5rem;font-size:.75rem;font-weight:500}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
 .ticker-label{color:var(--color-text-muted)}
 .ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
 .live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
 nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
 
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
 
-.breadcrumb-wrap{max-width:700px;margin:0 auto;padding:.75rem 1rem 0}
-.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.5rem;font-size:.8125rem;color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"\203A";margin-right:.5rem}
-.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
-.article-wrap{max-width:700px;margin:0 auto;padding:2.5rem 1rem 5rem}
-.article-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.75rem}
-.article-title{font-family:var(--font-display);font-size:clamp(2rem,5vw,3rem);color:var(--color-text);line-height:1.15;margin-bottom:.75rem}
-.article-byline{font-size:.875rem;color:var(--color-text-muted);margin-bottom:2.5rem;display:flex;align-items:center;gap:.5rem;flex-wrap:wrap}
-.article-byline a{color:var(--color-text);text-decoration:none;font-weight:500}
-.article-byline a:hover{text-decoration:underline}
-.prose h2{font-family:var(--font-display);font-size:1.75rem;margin:2.5rem 0 1rem;line-height:1.2;font-weight:400}
-.prose p{margin-bottom:1.25rem}
-.prose ul{margin:0 0 1.25rem 1.5rem;padding:0}
-.prose li{margin-bottom:.5rem}
-.prose a{color:var(--color-gold-bright);text-decoration:none;font-weight:500}
-.prose a:hover{text-decoration:underline}
-.prose strong{font-weight:600;color:var(--color-text)}
-.cta-box{margin:2.5rem 0;padding:2rem;background:var(--color-surface);border:1px solid var(--color-border);border-radius:.75rem;text-align:center}
-.cta-box h3{font-family:var(--font-display);font-size:1.5rem;margin-bottom:.75rem;font-weight:400}
-.cta-box p{margin-bottom:1.5rem;font-size:.9375rem;color:var(--color-text-muted)}
-.cta-btn{display:inline-flex;align-items:center;justify-content:center;background:var(--color-gold-bright);color:#000;text-decoration:none;font-weight:600;font-size:.9375rem;padding:.75rem 1.5rem;border-radius:.5rem;transition:background .2s}
-.cta-btn:hover{background:#f5b835;text-decoration:none}
-.related-posts{margin-top:4rem;padding-top:2rem;border-top:1px solid var(--color-border)}
-.related-posts h3{font-family:var(--font-display);font-size:1.5rem;margin-bottom:1rem;font-weight:400}
-.related-posts ul{list-style:none;padding:0;margin:0}
-.related-posts li{margin-bottom:.75rem}
-.related-posts a{color:var(--color-gold-bright);text-decoration:none;font-weight:500}
-.related-posts a:hover{text-decoration:underline}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
 
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
 
-/* ═══════════════════════════════════════════
-   MEGA MENU — Site Navigation
-   Desktop: Visible mega-panel bar
-   Tablet/Mobile: Hamburger → slide-in drawer
-═══════════════════════════════════════════ */
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
 
-/* ── Base nav bar ── */
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 200;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-.nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  gap: var(--space-2);
-}
-.nav-logo {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--text-sm);
-  color: var(--color-gold-bright);
-  text-decoration: none;
-  flex-shrink: 0;
-}
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
 
-/* ── Desktop mega nav list ── */
-.mega-nav {
-  display: flex;
-  align-items: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  gap: 2px;
-  flex: 1;
-  justify-content: center;
-}
-.mega-nav__item {
-  position: relative;
-}
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
 
-/* Trigger buttons & links */
-.mega-nav__trigger {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 11px;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  border: none;
-  background: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .15s, background .15s;
-}
-.mega-nav__trigger:hover,
-.mega-nav__item:hover .mega-nav__trigger,
-.mega-nav__trigger[aria-expanded="true"] {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-nav__trigger--link {
-  text-decoration: none;
-}
-.mega-nav__chevron {
-  transition: transform .2s;
-  flex-shrink: 0;
-}
-.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron {
-  transform: rotate(180deg);
-}
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
 
-/* ── Mega panels ── */
-.mega-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px oklch(0 0 0 / .12);
-  padding: var(--space-4);
-  gap: var(--space-4);
-  flex-direction: row;
-  z-index: 300;
-  animation: megaFadeIn .15s ease-out;
-}
-.mega-panel--wide {
-  min-width: 640px;
-}
-.mega-panel--blog {
-  min-width: 280px;
-}
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
 
-/* Show on hover OR keyboard activation */
-.mega-nav__item:hover .mega-panel,
-.mega-panel.is-open {
-  display: flex;
-}
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
 
-@keyframes megaFadeIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
 
-/* Panel columns */
-.mega-panel__col {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 140px;
-}
-.mega-panel__col--blog {
-  min-width: 220px;
-}
-.mega-panel__heading {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--color-text-faint);
-  padding: 4px 10px 8px;
-}
-.mega-panel a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  transition: color .12s, background .12s;
-  display: block;
-}
-.mega-panel a:hover {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-panel__view-all {
-  margin-top: var(--space-2);
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-}
-.mega-panel__view-all:hover {
-  color: var(--color-primary-hover) !important;
-}
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
 
-/* Divider between cols */
-.mega-panel__col + .mega-panel__col {
-  border-left: 1px solid var(--color-divider);
-  padding-left: var(--space-4);
-}
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
 
-/* ── Nav actions (theme toggle + hamburger) ── */
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  background: none;
-  cursor: pointer;
-}
-.theme-toggle:hover { color: var(--color-text); background: var(--color-surface-offset); }
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
 
-/* Hamburger — hidden on desktop */
-.hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.hamburger span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
-  transition: transform .22s cubic-bezier(.4,0,.2,1), opacity .22s;
-}
-.hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
-/* ── MOBILE DRAWER ── */
-.mobile-menu {
-  display: none;
-  position: fixed;
-  top: 56px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--color-surface);
-  z-index: 199;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  border-top: 1px solid var(--color-border);
-  transform: translateX(-100%);
-  transition: transform .28s cubic-bezier(.4,0,.2,1);
-}
-.mobile-menu.open {
-  display: block;
-  transform: translateX(0);
-}
-.mobile-menu__inner {
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-/* Mobile accordion sections */
-.mobile-section { border-radius: var(--radius-md); overflow: hidden; }
-.mobile-section__toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  background: none;
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background .12s;
-}
-.mobile-section__toggle:hover { background: var(--color-surface-offset); }
-.mobile-section__toggle svg { transition: transform .2s; flex-shrink: 0; }
-.mobile-section__toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
-.mobile-section__toggle[aria-expanded="true"] { background: var(--color-surface-offset); border-radius: var(--radius-md) var(--radius-md) 0 0; }
-
-.mobile-section__items {
-  display: none;
-  flex-direction: column;
-  background: var(--color-surface-offset);
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  padding: 4px 8px 8px;
-}
-.mobile-section__items.open { display: flex; }
-.mobile-section__items a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  transition: color .12s, background .12s;
-}
-.mobile-section__items a:hover { color: var(--color-text); background: var(--color-surface-dynamic); }
-.mobile-view-all {
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-  margin-top: 4px;
-}
-
-.mobile-section--flat {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 4px;
-  border-top: 1px solid var(--color-divider);
-  margin-top: var(--space-2);
-}
-.mobile-section--flat a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-}
-.mobile-section--flat a:hover { background: var(--color-surface-offset); color: var(--color-text); }
-
-.mobile-menu__search {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-divider);
-}
-.mobile-menu__search input {
-  width: 100%;
-  padding: 10px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: var(--text-sm);
-}
-
-/* ── Responsive breakpoints ── */
-@media (max-width: 900px) {
-  .mega-nav { display: none; }
-  .hamburger { display: flex; }
-}
-@media (max-width: 768px) {
-  .nav-logo span { display: none; }
-}
+/* MEGA MENU */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
+.mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
+.mega-nav__item{position:relative}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-nav__trigger--link{text-decoration:none}
+.mega-nav__chevron{transition:transform .2s;flex-shrink:0}
+.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel--wide{min-width:640px}
+.mega-panel--blog{min-width:280px}
+.mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
+@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
+.mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
+.mega-panel__col--blog{min-width:220px}
+.mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
+.mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
+.mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
+.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
+.mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
+.hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
+.hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu.open{display:block;transform:translateX(0)}
+.mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
+.mobile-section{border-radius:var(--radius-md);overflow:hidden}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle:hover{background:var(--color-surface-offset)}
+.mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
+.mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
+.mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
+.mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
+.mobile-section__items.open{display:flex}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
+.mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
+.mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:768px){.nav-logo span{display:none}}
 
 
 /* BLOG PREVIEW SECTION */
@@ -521,25 +437,12 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* Related Guides Card Section */
-.related-guides{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:2.5rem 0;margin-top:2rem}
-.related-guides .container{max-width:900px;margin:0 auto;padding:0 1.5rem}
-.related-guides h2{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:1.5rem}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.2rem;text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold);box-shadow:var(--shadow-md)}
-.related-card__tag{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem}
-.related-card__title{font-weight:700;color:var(--color-text);margin-bottom:0.3rem;font-size:var(--text-sm)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
 
-/* ── Guides mega panel — category links ── */
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 </style>
 </head>
 <body>

--- a/blog/gold-vs-bitcoin-2026.html
+++ b/blog/gold-vs-bitcoin-2026.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation"><meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold vs Bitcoin 2026: UK Investor Comparison | GoldPriceTools</title>
 <meta name="description" content="Gold up 80% vs Bitcoin down 14% in 2026 year-to-date. Compare performance, volatility, liquidity, costs and UK tax treatment.">
@@ -102,8 +105,43 @@ window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8',{'anonymize_ip':true});</script>
 <style>
-:root{--color-bg:#faf9f6;--color-surface:#ffffff;--color-surface-offset:#f5f4f0;--color-border:#e5e4e2;--color-text:#2d2c2a;--color-text-muted:#666560;--color-text-faint:#888782;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
+
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+}
+
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -122,8 +160,19 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-html{-webkit-font-smoothing:antialiased;scroll-behavior:smooth}
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
 .ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
 .ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
 .ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
@@ -131,366 +180,233 @@ body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--
 .ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
 .ticker:hover{animation-play-state:paused}
 @keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:.5rem;padding:0 1.5rem;font-size:.75rem;font-weight:500}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
 .ticker-label{color:var(--color-text-muted)}
 .ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
 .live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
 nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
 
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
 
-.breadcrumb-wrap{max-width:700px;margin:0 auto;padding:.75rem 1rem 0}
-.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.5rem;font-size:.8125rem;color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"\203A";margin-right:.5rem}
-.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
-.article-wrap{max-width:700px;margin:0 auto;padding:2.5rem 1rem 5rem}
-.article-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.75rem}
-.article-title{font-family:var(--font-display);font-size:clamp(2rem,5vw,3rem);color:var(--color-text);line-height:1.15;margin-bottom:.75rem}
-.article-byline{font-size:.875rem;color:var(--color-text-muted);margin-bottom:2.5rem;display:flex;align-items:center;gap:.5rem;flex-wrap:wrap}
-.article-byline a{color:var(--color-text);text-decoration:none;font-weight:500}
-.article-byline a:hover{text-decoration:underline}
-.prose h2{font-family:var(--font-display);font-size:1.75rem;margin:2.5rem 0 1rem;line-height:1.2;font-weight:400}
-.prose p{margin-bottom:1.25rem}
-.prose ul{margin:0 0 1.25rem 1.5rem;padding:0}
-.prose li{margin-bottom:.5rem}
-.prose a{color:var(--color-gold-bright);text-decoration:none;font-weight:500}
-.prose a:hover{text-decoration:underline}
-.prose strong{font-weight:600;color:var(--color-text)}
-.cta-box{margin:2.5rem 0;padding:2rem;background:var(--color-surface);border:1px solid var(--color-border);border-radius:.75rem;text-align:center}
-.cta-box h3{font-family:var(--font-display);font-size:1.5rem;margin-bottom:.75rem;font-weight:400}
-.cta-box p{margin-bottom:1.5rem;font-size:.9375rem;color:var(--color-text-muted)}
-.cta-btn{display:inline-flex;align-items:center;justify-content:center;background:var(--color-gold-bright);color:#000;text-decoration:none;font-weight:600;font-size:.9375rem;padding:.75rem 1.5rem;border-radius:.5rem;transition:background .2s}
-.cta-btn:hover{background:#f5b835;text-decoration:none}
-.related-posts{margin-top:4rem;padding-top:2rem;border-top:1px solid var(--color-border)}
-.related-posts h3{font-family:var(--font-display);font-size:1.5rem;margin-bottom:1rem;font-weight:400}
-.related-posts ul{list-style:none;padding:0;margin:0}
-.related-posts li{margin-bottom:.75rem}
-.related-posts a{color:var(--color-gold-bright);text-decoration:none;font-weight:500}
-.related-posts a:hover{text-decoration:underline}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
 
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
 
-/* ═══════════════════════════════════════════
-   MEGA MENU — Site Navigation
-   Desktop: Visible mega-panel bar
-   Tablet/Mobile: Hamburger → slide-in drawer
-═══════════════════════════════════════════ */
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
 
-/* ── Base nav bar ── */
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 200;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-.nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  gap: var(--space-2);
-}
-.nav-logo {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--text-sm);
-  color: var(--color-gold-bright);
-  text-decoration: none;
-  flex-shrink: 0;
-}
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
 
-/* ── Desktop mega nav list ── */
-.mega-nav {
-  display: flex;
-  align-items: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  gap: 2px;
-  flex: 1;
-  justify-content: center;
-}
-.mega-nav__item {
-  position: relative;
-}
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
 
-/* Trigger buttons & links */
-.mega-nav__trigger {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 11px;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  border: none;
-  background: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .15s, background .15s;
-}
-.mega-nav__trigger:hover,
-.mega-nav__item:hover .mega-nav__trigger,
-.mega-nav__trigger[aria-expanded="true"] {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-nav__trigger--link {
-  text-decoration: none;
-}
-.mega-nav__chevron {
-  transition: transform .2s;
-  flex-shrink: 0;
-}
-.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron {
-  transform: rotate(180deg);
-}
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
 
-/* ── Mega panels ── */
-.mega-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px oklch(0 0 0 / .12);
-  padding: var(--space-4);
-  gap: var(--space-4);
-  flex-direction: row;
-  z-index: 300;
-  animation: megaFadeIn .15s ease-out;
-}
-.mega-panel--wide {
-  min-width: 640px;
-}
-.mega-panel--blog {
-  min-width: 280px;
-}
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
 
-/* Show on hover OR keyboard activation */
-.mega-nav__item:hover .mega-panel,
-.mega-panel.is-open {
-  display: flex;
-}
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
 
-@keyframes megaFadeIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
 
-/* Panel columns */
-.mega-panel__col {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 140px;
-}
-.mega-panel__col--blog {
-  min-width: 220px;
-}
-.mega-panel__heading {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--color-text-faint);
-  padding: 4px 10px 8px;
-}
-.mega-panel a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  transition: color .12s, background .12s;
-  display: block;
-}
-.mega-panel a:hover {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-panel__view-all {
-  margin-top: var(--space-2);
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-}
-.mega-panel__view-all:hover {
-  color: var(--color-primary-hover) !important;
-}
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
 
-/* Divider between cols */
-.mega-panel__col + .mega-panel__col {
-  border-left: 1px solid var(--color-divider);
-  padding-left: var(--space-4);
-}
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
 
-/* ── Nav actions (theme toggle + hamburger) ── */
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  background: none;
-  cursor: pointer;
-}
-.theme-toggle:hover { color: var(--color-text); background: var(--color-surface-offset); }
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
 
-/* Hamburger — hidden on desktop */
-.hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.hamburger span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
-  transition: transform .22s cubic-bezier(.4,0,.2,1), opacity .22s;
-}
-.hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
-/* ── MOBILE DRAWER ── */
-.mobile-menu {
-  display: none;
-  position: fixed;
-  top: 56px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--color-surface);
-  z-index: 199;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  border-top: 1px solid var(--color-border);
-  transform: translateX(-100%);
-  transition: transform .28s cubic-bezier(.4,0,.2,1);
-}
-.mobile-menu.open {
-  display: block;
-  transform: translateX(0);
-}
-.mobile-menu__inner {
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-/* Mobile accordion sections */
-.mobile-section { border-radius: var(--radius-md); overflow: hidden; }
-.mobile-section__toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  background: none;
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background .12s;
-}
-.mobile-section__toggle:hover { background: var(--color-surface-offset); }
-.mobile-section__toggle svg { transition: transform .2s; flex-shrink: 0; }
-.mobile-section__toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
-.mobile-section__toggle[aria-expanded="true"] { background: var(--color-surface-offset); border-radius: var(--radius-md) var(--radius-md) 0 0; }
-
-.mobile-section__items {
-  display: none;
-  flex-direction: column;
-  background: var(--color-surface-offset);
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  padding: 4px 8px 8px;
-}
-.mobile-section__items.open { display: flex; }
-.mobile-section__items a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  transition: color .12s, background .12s;
-}
-.mobile-section__items a:hover { color: var(--color-text); background: var(--color-surface-dynamic); }
-.mobile-view-all {
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-  margin-top: 4px;
-}
-
-.mobile-section--flat {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 4px;
-  border-top: 1px solid var(--color-divider);
-  margin-top: var(--space-2);
-}
-.mobile-section--flat a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-}
-.mobile-section--flat a:hover { background: var(--color-surface-offset); color: var(--color-text); }
-
-.mobile-menu__search {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-divider);
-}
-.mobile-menu__search input {
-  width: 100%;
-  padding: 10px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: var(--text-sm);
-}
-
-/* ── Responsive breakpoints ── */
-@media (max-width: 900px) {
-  .mega-nav { display: none; }
-  .hamburger { display: flex; }
-}
-@media (max-width: 768px) {
-  .nav-logo span { display: none; }
-}
+/* MEGA MENU */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
+.mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
+.mega-nav__item{position:relative}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-nav__trigger--link{text-decoration:none}
+.mega-nav__chevron{transition:transform .2s;flex-shrink:0}
+.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel--wide{min-width:640px}
+.mega-panel--blog{min-width:280px}
+.mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
+@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
+.mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
+.mega-panel__col--blog{min-width:220px}
+.mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
+.mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
+.mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
+.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
+.mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
+.hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
+.hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu.open{display:block;transform:translateX(0)}
+.mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
+.mobile-section{border-radius:var(--radius-md);overflow:hidden}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle:hover{background:var(--color-surface-offset)}
+.mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
+.mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
+.mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
+.mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
+.mobile-section__items.open{display:flex}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
+.mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
+.mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:768px){.nav-logo span{display:none}}
 
 
 /* BLOG PREVIEW SECTION */
@@ -521,25 +437,12 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* Related Guides Card Section */
-.related-guides{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:2.5rem 0;margin-top:2rem}
-.related-guides .container{max-width:900px;margin:0 auto;padding:0 1.5rem}
-.related-guides h2{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:1.5rem}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.2rem;text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold);box-shadow:var(--shadow-md)}
-.related-card__tag{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem}
-.related-card__title{font-weight:700;color:var(--color-text);margin-bottom:0.3rem;font-size:var(--text-sm)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
 
-/* ── Guides mega panel — category links ── */
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 </style>
 </head>
 <body>

--- a/blog/index.html
+++ b/blog/index.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold &amp; Silver Blog — Market Insights &amp; Guides | GoldPriceTools</title>
@@ -52,6 +55,7 @@
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -76,328 +80,6 @@
   src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
-
-/* ═══════════════════════════════════════════
-   MEGA MENU — Site Navigation
-   Desktop: Visible mega-panel bar
-   Tablet/Mobile: Hamburger → slide-in drawer
-═══════════════════════════════════════════ */
-
-/* ── Base nav bar ── */
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 200;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-.nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  gap: var(--space-2);
-}
-.nav-logo {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--text-sm);
-  color: var(--color-gold-bright);
-  text-decoration: none;
-  flex-shrink: 0;
-}
-
-/* ── Desktop mega nav list ── */
-.mega-nav {
-  display: flex;
-  align-items: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  gap: 2px;
-  flex: 1;
-  justify-content: center;
-}
-.mega-nav__item {
-  position: relative;
-}
-
-/* Trigger buttons & links */
-.mega-nav__trigger {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 11px;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  border: none;
-  background: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .15s, background .15s;
-}
-.mega-nav__trigger:hover,
-.mega-nav__item:hover .mega-nav__trigger,
-.mega-nav__trigger[aria-expanded="true"] {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-nav__trigger--link {
-  text-decoration: none;
-}
-.mega-nav__chevron {
-  transition: transform .2s;
-  flex-shrink: 0;
-}
-.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron {
-  transform: rotate(180deg);
-}
-
-/* ── Mega panels ── */
-.mega-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px oklch(0 0 0 / .12);
-  padding: var(--space-4);
-  gap: var(--space-4);
-  flex-direction: row;
-  z-index: 300;
-  animation: megaFadeIn .15s ease-out;
-}
-.mega-panel--wide {
-  min-width: 640px;
-}
-.mega-panel--blog {
-  min-width: 280px;
-}
-
-/* Show on hover OR keyboard activation */
-.mega-nav__item:hover .mega-panel,
-.mega-panel.is-open {
-  display: flex;
-}
-
-@keyframes megaFadeIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-
-/* Panel columns */
-.mega-panel__col {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 140px;
-}
-.mega-panel__col--blog {
-  min-width: 220px;
-}
-.mega-panel__heading {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--color-text-faint);
-  padding: 4px 10px 8px;
-}
-.mega-panel a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  transition: color .12s, background .12s;
-  display: block;
-}
-.mega-panel a:hover {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-panel__view-all {
-  margin-top: var(--space-2);
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-}
-.mega-panel__view-all:hover {
-  color: var(--color-primary-hover) !important;
-}
-
-/* Divider between cols */
-.mega-panel__col + .mega-panel__col {
-  border-left: 1px solid var(--color-divider);
-  padding-left: var(--space-4);
-}
-
-/* ── Nav actions (theme toggle + hamburger) ── */
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  background: none;
-  cursor: pointer;
-}
-.theme-toggle:hover { color: var(--color-text); background: var(--color-surface-offset); }
-
-/* Hamburger — hidden on desktop */
-.hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.hamburger span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
-  transition: transform .22s cubic-bezier(.4,0,.2,1), opacity .22s;
-}
-.hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
-
-/* ── MOBILE DRAWER ── */
-.mobile-menu {
-  display: none;
-  position: fixed;
-  top: 56px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--color-surface);
-  z-index: 199;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  border-top: 1px solid var(--color-border);
-  transform: translateX(-100%);
-  transition: transform .28s cubic-bezier(.4,0,.2,1);
-}
-.mobile-menu.open {
-  display: block;
-  transform: translateX(0);
-}
-.mobile-menu__inner {
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-/* Mobile accordion sections */
-.mobile-section { border-radius: var(--radius-md); overflow: hidden; }
-.mobile-section__toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  background: none;
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background .12s;
-}
-.mobile-section__toggle:hover { background: var(--color-surface-offset); }
-.mobile-section__toggle svg { transition: transform .2s; flex-shrink: 0; }
-.mobile-section__toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
-.mobile-section__toggle[aria-expanded="true"] { background: var(--color-surface-offset); border-radius: var(--radius-md) var(--radius-md) 0 0; }
-
-.mobile-section__items {
-  display: none;
-  flex-direction: column;
-  background: var(--color-surface-offset);
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  padding: 4px 8px 8px;
-}
-.mobile-section__items.open { display: flex; }
-.mobile-section__items a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  transition: color .12s, background .12s;
-}
-.mobile-section__items a:hover { color: var(--color-text); background: var(--color-surface-dynamic); }
-.mobile-view-all {
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-  margin-top: 4px;
-}
-
-.mobile-section--flat {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 4px;
-  border-top: 1px solid var(--color-divider);
-  margin-top: var(--space-2);
-}
-.mobile-section--flat a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-}
-.mobile-section--flat a:hover { background: var(--color-surface-offset); color: var(--color-text); }
-
-.mobile-menu__search {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-divider);
-}
-.mobile-menu__search input {
-  width: 100%;
-  padding: 10px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: var(--text-sm);
-}
-
-/* ── Responsive breakpoints ── */
-@media (max-width: 900px) {
-  .mega-nav { display: none; }
-  .hamburger { display: flex; }
-}
-@media (max-width: 768px) {
-  .nav-logo span { display: none; }
-}
-
 /* ── Guides mega panel — category links ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
@@ -406,10 +88,10 @@
 .mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-</style>
-<style>
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -428,8 +110,19 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-html{-webkit-font-smoothing:antialiased;scroll-behavior:smooth}
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
 .ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
 .ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
 .ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
@@ -437,35 +130,233 @@ body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--
 .ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
 .ticker:hover{animation-play-state:paused}
 @keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:.5rem;padding:0 1.5rem;font-size:.75rem;font-weight:500}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
 .ticker-label{color:var(--color-text-muted)}
 .ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
 .live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
 nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}
-.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.75rem 1rem 0}
-.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.5rem;font-size:.8125rem;color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"\203A";margin-right:.5rem}
-.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
-.page-wrap{max-width:900px;margin:0 auto;padding:2.5rem 1rem 5rem}
-.page-header{margin-bottom:2.5rem}
-.page-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.75rem}
-.page-title{font-family:var(--font-display);font-size:clamp(2rem,5vw,3rem);color:var(--color-text);line-height:1.15;margin-bottom:.75rem}
-.page-desc{font-size:.9375rem;color:var(--color-text-muted);max-width:60ch;line-height:1.7}
-.post-grid{display:grid;gap:1.5rem}
-.post-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:.75rem;padding:1.75rem;text-decoration:none;color:inherit;display:block;transition:border-color .2s,background .2s}
-.post-card:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset)}
-.post-meta{display:flex;align-items:center;gap:.75rem;margin-bottom:.875rem;flex-wrap:wrap}
-.post-date{font-size:.75rem;color:var(--color-text-faint);font-variant-numeric:tabular-nums}
-.post-tag{font-size:.6875rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.07em;background:color-mix(in srgb,var(--color-gold-bright) 12%,transparent);padding:.2rem .5rem;border-radius:.25rem}
-.post-title{font-family:var(--font-display);font-size:1.3125rem;color:var(--color-text);line-height:1.3;margin-bottom:.625rem}
-.post-excerpt{font-size:.9rem;color:var(--color-text-muted);line-height:1.7;max-width:68ch}
-.post-read-more{display:inline-block;margin-top:1rem;font-size:.8125rem;font-weight:600;color:var(--color-gold-bright)}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+/* MEGA MENU */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
+.mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
+.mega-nav__item{position:relative}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-nav__trigger--link{text-decoration:none}
+.mega-nav__chevron{transition:transform .2s;flex-shrink:0}
+.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel--wide{min-width:640px}
+.mega-panel--blog{min-width:280px}
+.mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
+@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
+.mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
+.mega-panel__col--blog{min-width:220px}
+.mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
+.mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
+.mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
+.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
+.mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
+.hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
+.hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu.open{display:block;transform:translateX(0)}
+.mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
+.mobile-section{border-radius:var(--radius-md);overflow:hidden}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle:hover{background:var(--color-surface-offset)}
+.mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
+.mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
+.mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
+.mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
+.mobile-section__items.open{display:flex}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
+.mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
+.mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:768px){.nav-logo span{display:none}}
 
 
 /* BLOG PREVIEW SECTION */
@@ -495,7 +386,15 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
+
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+
 </head>
 <body>
 

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Contact Us | GoldPriceTools</title>
@@ -54,6 +57,7 @@
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -78,328 +82,6 @@
   src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
-
-/* ═══════════════════════════════════════════
-   MEGA MENU — Site Navigation
-   Desktop: Visible mega-panel bar
-   Tablet/Mobile: Hamburger → slide-in drawer
-═══════════════════════════════════════════ */
-
-/* ── Base nav bar ── */
-.site-nav {
-  position: sticky;
-  top: 0;
-  z-index: 200;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-.nav-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--space-4);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  gap: var(--space-2);
-}
-.nav-logo {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--text-sm);
-  color: var(--color-gold-bright);
-  text-decoration: none;
-  flex-shrink: 0;
-}
-
-/* ── Desktop mega nav list ── */
-.mega-nav {
-  display: flex;
-  align-items: center;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  gap: 2px;
-  flex: 1;
-  justify-content: center;
-}
-.mega-nav__item {
-  position: relative;
-}
-
-/* Trigger buttons & links */
-.mega-nav__trigger {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 11px;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  color: var(--color-text-muted);
-  border: none;
-  background: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .15s, background .15s;
-}
-.mega-nav__trigger:hover,
-.mega-nav__item:hover .mega-nav__trigger,
-.mega-nav__trigger[aria-expanded="true"] {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-nav__trigger--link {
-  text-decoration: none;
-}
-.mega-nav__chevron {
-  transition: transform .2s;
-  flex-shrink: 0;
-}
-.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron {
-  transform: rotate(180deg);
-}
-
-/* ── Mega panels ── */
-.mega-panel {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  min-width: 420px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 32px oklch(0 0 0 / .12);
-  padding: var(--space-4);
-  gap: var(--space-4);
-  flex-direction: row;
-  z-index: 300;
-  animation: megaFadeIn .15s ease-out;
-}
-.mega-panel--wide {
-  min-width: 640px;
-}
-.mega-panel--blog {
-  min-width: 280px;
-}
-
-/* Show on hover OR keyboard activation */
-.mega-nav__item:hover .mega-panel,
-.mega-panel.is-open {
-  display: flex;
-}
-
-@keyframes megaFadeIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
-  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-
-/* Panel columns */
-.mega-panel__col {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 140px;
-}
-.mega-panel__col--blog {
-  min-width: 220px;
-}
-.mega-panel__heading {
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: .08em;
-  color: var(--color-text-faint);
-  padding: 4px 10px 8px;
-}
-.mega-panel a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  transition: color .12s, background .12s;
-  display: block;
-}
-.mega-panel a:hover {
-  color: var(--color-text);
-  background: var(--color-surface-offset);
-}
-.mega-panel__view-all {
-  margin-top: var(--space-2);
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-}
-.mega-panel__view-all:hover {
-  color: var(--color-primary-hover) !important;
-}
-
-/* Divider between cols */
-.mega-panel__col + .mega-panel__col {
-  border-left: 1px solid var(--color-divider);
-  padding-left: var(--space-4);
-}
-
-/* ── Nav actions (theme toggle + hamburger) ── */
-.nav-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-shrink: 0;
-}
-.theme-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  background: none;
-  cursor: pointer;
-}
-.theme-toggle:hover { color: var(--color-text); background: var(--color-surface-offset); }
-
-/* Hamburger — hidden on desktop */
-.hamburger {
-  display: none;
-  flex-direction: column;
-  gap: 4px;
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-.hamburger span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: var(--color-text);
-  border-radius: 2px;
-  transition: transform .22s cubic-bezier(.4,0,.2,1), opacity .22s;
-}
-.hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-.hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; transform: scaleX(0); }
-.hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
-
-/* ── MOBILE DRAWER ── */
-.mobile-menu {
-  display: none;
-  position: fixed;
-  top: 56px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: var(--color-surface);
-  z-index: 199;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  border-top: 1px solid var(--color-border);
-  transform: translateX(-100%);
-  transition: transform .28s cubic-bezier(.4,0,.2,1);
-}
-.mobile-menu.open {
-  display: block;
-  transform: translateX(0);
-}
-.mobile-menu__inner {
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-/* Mobile accordion sections */
-.mobile-section { border-radius: var(--radius-md); overflow: hidden; }
-.mobile-section__toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text);
-  background: none;
-  border: none;
-  cursor: pointer;
-  border-radius: var(--radius-md);
-  transition: background .12s;
-}
-.mobile-section__toggle:hover { background: var(--color-surface-offset); }
-.mobile-section__toggle svg { transition: transform .2s; flex-shrink: 0; }
-.mobile-section__toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
-.mobile-section__toggle[aria-expanded="true"] { background: var(--color-surface-offset); border-radius: var(--radius-md) var(--radius-md) 0 0; }
-
-.mobile-section__items {
-  display: none;
-  flex-direction: column;
-  background: var(--color-surface-offset);
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  padding: 4px 8px 8px;
-}
-.mobile-section__items.open { display: flex; }
-.mobile-section__items a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  transition: color .12s, background .12s;
-}
-.mobile-section__items a:hover { color: var(--color-text); background: var(--color-surface-dynamic); }
-.mobile-view-all {
-  font-weight: 600 !important;
-  color: var(--color-primary) !important;
-  margin-top: 4px;
-}
-
-.mobile-section--flat {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 4px;
-  border-top: 1px solid var(--color-divider);
-  margin-top: var(--space-2);
-}
-.mobile-section--flat a {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-}
-.mobile-section--flat a:hover { background: var(--color-surface-offset); color: var(--color-text); }
-
-.mobile-menu__search {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-divider);
-}
-.mobile-menu__search input {
-  width: 100%;
-  padding: 10px 14px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  font-size: var(--text-sm);
-}
-
-/* ── Responsive breakpoints ── */
-@media (max-width: 900px) {
-  .mega-nav { display: none; }
-  .hamburger { display: flex; }
-}
-@media (max-width: 768px) {
-  .nav-logo span { display: none; }
-}
-
 /* ── Guides mega panel — category links ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
@@ -408,11 +90,10 @@
 .mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-</style>
-<!-- GA4 -->
-<style>
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-success:#0f5132;--color-success-bg:#d1e7dd;--color-error:#842029;--color-error-bg:#f8d7da;--shadow-sm:0 1px 2px rgba(0,0,0,0.06);--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34;--color-success:#75b798;--color-success-bg:#051b11;--color-error:#ea868f;--color-error-bg:#2c0b0e;--shadow-sm:0 1px 2px rgba(0,0,0,0.3)}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -431,40 +112,253 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-html{-webkit-font-smoothing:antialiased;scroll-behavior:smooth}
-body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}
-.nav-back{font-size:.875rem;color:var(--color-text-muted);text-decoration:none;padding:.375rem .75rem;border-radius:var(--radius-md);border:1px solid var(--color-border)}
-.nav-back:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.page-wrap{max-width:700px;margin:0 auto;padding:3rem 1.5rem 5rem}
-.page-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.5rem);color:var(--color-text);margin-bottom:.5rem}
-.page-subtitle{font-size:1rem;color:var(--color-text-muted);margin-bottom:2.5rem}
-.contact-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:2rem;margin-bottom:1.5rem}
-.contact-card h2{font-size:1rem;font-weight:700;color:var(--color-text);margin-bottom:.75rem}
-.contact-card p{font-size:.9375rem;color:var(--color-text-muted);line-height:1.7}
-.contact-card a{color:var(--color-primary);text-decoration:none}
-.contact-card a:hover{text-decoration:underline}
-.form-group{display:flex;flex-direction:column;gap:.5rem;margin-bottom:1.25rem}
-.form-label{font-size:.875rem;font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-textarea{width:100%;padding:.75rem 1rem;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:1rem;font-family:var(--font-body);color:var(--color-text);resize:vertical}
-.form-input:focus,.form-textarea:focus{outline:2px solid var(--color-primary);outline-offset:2px;border-color:var(--color-primary)}
-.form-textarea{min-height:140px}
-.btn-submit{width:100%;padding:.875rem 1.5rem;background:var(--color-primary);color:#fff;font-size:1rem;font-weight:600;border:none;border-radius:var(--radius-md);cursor:pointer;font-family:var(--font-body)}
-.btn-submit:hover{opacity:.9}
-.form-input.is-invalid,.form-textarea.is-invalid{border-color:var(--color-error);outline-color:var(--color-error)}
-.error-text{font-size:0.8125rem;color:var(--color-error);margin-top:0.25rem;display:none}
-.error-text.is-visible{display:block}
-.form-status{padding:1rem;border-radius:var(--radius-md);margin-bottom:1.5rem;font-size:0.9375rem;display:none}
-.form-status.is-success{display:block;background:var(--color-success-bg);color:var(--color-success);border:1px solid var(--color-success)}
-.form-status.is-error{display:block;background:var(--color-error-bg);color:var(--color-error);border:1px solid var(--color-error)}
-.btn-submit:disabled{opacity:0.7;cursor:not-allowed}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
-footer a:hover{color:var(--color-text)}
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
+/* MEGA MENU */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
+.mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
+.mega-nav__item{position:relative}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-nav__trigger--link{text-decoration:none}
+.mega-nav__chevron{transition:transform .2s;flex-shrink:0}
+.mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel--wide{min-width:640px}
+.mega-panel--blog{min-width:280px}
+.mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
+@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
+.mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
+.mega-panel__col--blog{min-width:220px}
+.mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
+.mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
+.mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
+.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
+.mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
+.hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
+.hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu.open{display:block;transform:translateX(0)}
+.mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
+.mobile-section{border-radius:var(--radius-md);overflow:hidden}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle:hover{background:var(--color-surface-offset)}
+.mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
+.mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
+.mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
+.mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
+.mobile-section__items.open{display:flex}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
+.mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
+.mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:768px){.nav-logo span{display:none}}
 
 
 /* BLOG PREVIEW SECTION */
@@ -494,7 +388,16 @@ footer a:hover{color:var(--color-text)}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
+
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+<!-- GA4 -->
+
 
     <meta property="og:title" content="Contact Us | GoldPriceTools">
     <meta property="og:description" content="Get in touch with the GoldPriceTools team. We welcome feedback, questions and partnership enquiries.">

--- a/gold-price-chart.html
+++ b/gold-price-chart.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold Price Chart 10 Years — Live & Historical Graph | GoldPriceTools</title>

--- a/gold-rates-today.html
+++ b/gold-rates-today.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold Rates Today — Live Gold Price Per Gram | GoldPriceTools</title>

--- a/gold-silver-ratio.html
+++ b/gold-silver-ratio.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold-Silver Ratio Calculator & Live Chart | GoldPriceTools</title>
@@ -102,6 +105,7 @@
 <link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
 
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -110,9 +114,52 @@
   src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+}
+
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+
 :root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
 [data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+/* ── Global link reset — enforce brand colours site-wide ── */
+a{color:var(--color-primary);text-decoration:none}
+a:hover{color:var(--color-primary-hover);text-decoration:underline}
+a:visited{color:var(--color-primary)}
+/* ── Card colour reset — cards are content blocks, not bare links ── */
+.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
+.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
+/* Article card inner elements */
+.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
+.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
+/* Hover: title becomes primary teal */
+.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
+.blog-preview-card:hover h3{color:var(--color-primary)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+
+
 html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
@@ -121,65 +168,191 @@ input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-a{color:var(--color-gold-bright);text-decoration-thickness:1px;text-underline-offset:2px}
-a:hover{color:color-mix(in oklch, var(--color-gold-bright) 80%, black)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 
-nav{position:sticky;top:0;z-index:40;background:oklch(from var(--color-surface) l c h / 0.85);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);border-bottom:1px solid var(--color-border)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:1rem 1.5rem;display:flex;align-items:center;justify-content:space-between}
-.nav-logo{display:flex;align-items:center;gap:0.75rem;font-family:var(--font-display);font-size:1.5rem;font-weight:400;color:var(--color-gold-bright);text-decoration:none;letter-spacing:0.02em}
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
 
-.breadcrumb-wrap{max-width:800px;margin:0 auto;padding:1rem 1.5rem}
-.breadcrumb{display:flex;flex-wrap:wrap;gap:0.5rem;list-style:none;font-size:0.875rem;color:var(--color-text-muted)}
-.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
-.breadcrumb a:hover{color:var(--color-text)}
-.breadcrumb li:not(:last-child)::after{content:"/";margin-left:0.5rem;color:var(--color-text-faint)}
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
 
-.hero{max-width:800px;margin:0 auto;padding:2rem 1.5rem 3rem;text-align:center}
-.hero-tag{display:inline-block;padding:0.25rem 0.75rem;border-radius:var(--radius-full);background:var(--color-surface-2);color:var(--color-gold-bright);font-size:0.875rem;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;margin-bottom:1rem;border:1px solid var(--color-border)}
-.hero-title{font-family:var(--font-display);font-size:var(--text-2xl);font-weight:400;margin-bottom:1rem;color:var(--color-text);letter-spacing:0.02em}
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
 
-.calc-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.5rem;box-shadow:var(--shadow-md);text-align:left;max-width:600px;margin:0 auto}
-.calc-spot-info{text-align:center;font-size:1rem;color:var(--color-text-muted);margin-bottom:1.5rem;padding-bottom:1rem;border-bottom:1px solid var(--color-border)}
-.calc-spot-info strong {color:var(--color-text);}
-.coin-row{display:flex;align-items:center;justify-content:space-between;padding:0.75rem 0;border-bottom:1px dashed var(--color-divider);gap:1rem}
-.coin-row:last-child{border-bottom:none;padding-bottom:0;}
-.coin-info{flex:1}
-.coin-name{font-weight:600;color:var(--color-text);margin-bottom:0.25rem}
-.coin-details{font-size:0.875rem;color:var(--color-text-muted)}
-.coin-input-group{display:flex;align-items:center;gap:0.75rem;}
-.coin-input{width:80px;padding:0.5rem;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface-offset);color:var(--color-text);text-align:right;}
-.coin-value{width:100px;text-align:right;font-variant-numeric:tabular-nums;font-weight:600;color:var(--color-text)}
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
 
-.result-box{margin-top:1.5rem;background:var(--color-surface-offset);padding:1.25rem;border-radius:var(--radius-md);text-align:center;border:1px solid var(--color-border)}
-.result-label{font-size:0.875rem;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.5rem}
-.result-usd{font-family:var(--font-display);font-size:2.5rem;color:var(--color-gold-bright);line-height:1}
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
 
-.content{max-width:800px;margin:0 auto;padding:0 1.5rem 4rem}
-.prose{font-size:1.0625rem}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);font-weight:400;margin:2.5rem 0 1rem;color:var(--color-gold-bright);letter-spacing:0.02em}
-.prose p{margin-bottom:1.5rem}
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
 
-.data-table{width:100%;border-collapse:collapse;margin:2rem 0;font-variant-numeric:tabular-nums}
-.data-table th{text-align:left;padding:1rem;background:var(--color-surface);border-bottom:2px solid var(--color-border);color:var(--color-text-muted);font-weight:600;font-size:0.875rem;text-transform:uppercase;letter-spacing:0.05em}
-.data-table td{padding:1rem;border-bottom:1px solid var(--color-divider);color:var(--color-text)}
-.data-table tr:hover td{background:var(--color-surface-offset)}
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
 
-.trust-bar{display:flex;align-items:center;justify-content:center;gap:1rem;padding:1rem;background:var(--color-surface-2);border-radius:var(--radius-lg);font-size:0.875rem;color:var(--color-text-muted);margin-bottom:2rem;text-align:center;flex-wrap:wrap}
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
 
-.faq-container{margin:2rem 0}
-details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);margin-bottom:1rem;overflow:hidden}
-summary{padding:1.25rem;font-weight:600;cursor:pointer;list-style:none;display:flex;justify-content:space-between;align-items:center;color:var(--color-text)}
-summary::-webkit-details-marker{display:none}
-summary::after{content:'+';font-size:1.5rem;color:var(--color-gold-bright);line-height:1}
-details[open] summary::after{content:'−'}
-.faq-answer{padding:0 1.25rem 1.25rem;color:var(--color-text-muted);font-size:1rem}
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
 
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:3rem 1.5rem;margin-top:4rem}
-.footer-inner{max-width:1200px;margin:0 auto;display:flex;flex-direction:column;align-items:center;text-align:center;gap:1rem}
-.footer-links{display:flex;gap:1.5rem;font-size:0.875rem}
-.footer-links a{color:var(--color-text-muted);text-decoration:none}
-.footer-links a:hover{color:var(--color-text)}
-.footer-copy{font-size:0.875rem;color:var(--color-text-faint);margin-top:1rem}
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
@@ -264,37 +437,12 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* Related Guides Card Section */
-.related-guides{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:2.5rem 0;margin-top:2rem}
-.related-guides .container{max-width:900px;margin:0 auto;padding:0 1.5rem}
-.related-guides h2{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:1.5rem}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.2rem;text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold);box-shadow:var(--shadow-md)}
-.related-card__tag{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem}
-.related-card__title{font-weight:700;color:var(--color-text);margin-bottom:0.3rem;font-size:var(--text-sm)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
 
-/* ── Card colour reset — cards are content blocks, not bare links ── */
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-
-/* ── Guides mega panel — category links ── */
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 </style>
 </head>
 <body>

--- a/guides/gold-bar-guide.html
+++ b/guides/gold-bar-guide.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold Bar Guide: Sizes, Weights, and Good Delivery | GoldPriceTools</title>
@@ -40,37 +43,253 @@
 
 <style>
 
-:root {
-  --color-surface: #1a1a1a;
-  --color-border: #333;
-  --color-text: #f5f5f5;
-  --color-text-muted: #a3a3a3;
-  --color-gold: #d4af37;
-  --color-gold-bright: #ffd700;
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 1rem;
-  --space-4: 1.5rem;
-  --radius-lg: 0.5rem;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --text-xs: 0.75rem;
-  --text-xl: 1.25rem;
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
-  body { background: #0f0e0c; color: #fff; font-family: 'Inter', sans-serif; margin: 0; padding: 0; }
-  header, footer { background: #1a1a1a; padding: 20px; text-align: center; }
-  .container { max-width: 800px; margin: 0 auto; padding: 20px; }
-  h1, h2, h3 { color: #d4af37; }
-  .spot-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px; }
-  .spot-card { background: #1a1a1a; border: 1px solid #333; padding: 15px; border-radius: 8px; text-align: center; }
-  .spot-card-value { font-size: 1.5em; font-weight: bold; color: #d4af37; }
-  details { background: #1a1a1a; padding: 15px; border-radius: 8px; margin-bottom: 10px; cursor: pointer; }
-  summary { font-weight: bold; color: #d4af37; outline: none; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th, td { border: 1px solid #333; padding: 10px; text-align: left; }
-  th { background: #1a1a1a; color: #d4af37; }
-  a { color: #d4af37; text-decoration: none; }
-  a:hover { text-decoration: underline; }
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+/* ── Global link reset — enforce brand colours site-wide ── */
+a{color:var(--color-primary);text-decoration:none}
+a:hover{color:var(--color-primary-hover);text-decoration:underline}
+a:visited{color:var(--color-primary)}
+/* ── Card colour reset — cards are content blocks, not bare links ── */
+.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
+.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
+/* Article card inner elements */
+.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
+.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
+/* Hover: title becomes primary teal */
+.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
+.blog-preview-card:hover h3{color:var(--color-primary)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+
+
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
@@ -126,28 +345,41 @@
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 
-/* ── Card colour reset — cards are content blocks, not bare links ── */
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
-/* ── Guides mega panel — category links ── */
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
 </head>
 <body>

--- a/guides/gold-price-guide.html
+++ b/guides/gold-price-guide.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold Price Guide 2026 | GoldPriceTools</title>
@@ -40,37 +43,253 @@
 
 <style>
 
-:root {
-  --color-surface: #1a1a1a;
-  --color-border: #333;
-  --color-text: #f5f5f5;
-  --color-text-muted: #a3a3a3;
-  --color-gold: #d4af37;
-  --color-gold-bright: #ffd700;
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 1rem;
-  --space-4: 1.5rem;
-  --radius-lg: 0.5rem;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --text-xs: 0.75rem;
-  --text-xl: 1.25rem;
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
-  body { background: #0f0e0c; color: #fff; font-family: 'Inter', sans-serif; margin: 0; padding: 0; }
-  header, footer { background: #1a1a1a; padding: 20px; text-align: center; }
-  .container { max-width: 800px; margin: 0 auto; padding: 20px; }
-  h1, h2, h3 { color: #d4af37; }
-  .spot-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px; }
-  .spot-card { background: #1a1a1a; border: 1px solid #333; padding: 15px; border-radius: 8px; text-align: center; }
-  .spot-card-value { font-size: 1.5em; font-weight: bold; color: #d4af37; }
-  details { background: #1a1a1a; padding: 15px; border-radius: 8px; margin-bottom: 10px; cursor: pointer; }
-  summary { font-weight: bold; color: #d4af37; outline: none; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th, td { border: 1px solid #333; padding: 10px; text-align: left; }
-  th { background: #1a1a1a; color: #d4af37; }
-  a { color: #d4af37; text-decoration: none; }
-  a:hover { text-decoration: underline; }
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+/* ── Global link reset — enforce brand colours site-wide ── */
+a{color:var(--color-primary);text-decoration:none}
+a:hover{color:var(--color-primary-hover);text-decoration:underline}
+a:visited{color:var(--color-primary)}
+/* ── Card colour reset — cards are content blocks, not bare links ── */
+.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
+.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
+/* Article card inner elements */
+.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
+.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
+/* Hover: title becomes primary teal */
+.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
+.blog-preview-card:hover h3{color:var(--color-primary)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+
+
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
@@ -126,28 +345,41 @@
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 
-/* ── Card colour reset — cards are content blocks, not bare links ── */
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
-/* ── Guides mega panel — category links ── */
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
 </head>
 <body>

--- a/guides/scrap-gold-guide.html
+++ b/guides/scrap-gold-guide.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Scrap Gold Guide: How is Scrap Gold Valued? | GoldPriceTools</title>
@@ -40,37 +43,253 @@
 
 <style>
 
-:root {
-  --color-surface: #1a1a1a;
-  --color-border: #333;
-  --color-text: #f5f5f5;
-  --color-text-muted: #a3a3a3;
-  --color-gold: #d4af37;
-  --color-gold-bright: #ffd700;
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 1rem;
-  --space-4: 1.5rem;
-  --radius-lg: 0.5rem;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --text-xs: 0.75rem;
-  --text-xl: 1.25rem;
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
-  body { background: #0f0e0c; color: #fff; font-family: 'Inter', sans-serif; margin: 0; padding: 0; }
-  header, footer { background: #1a1a1a; padding: 20px; text-align: center; }
-  .container { max-width: 800px; margin: 0 auto; padding: 20px; }
-  h1, h2, h3 { color: #d4af37; }
-  .spot-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px; }
-  .spot-card { background: #1a1a1a; border: 1px solid #333; padding: 15px; border-radius: 8px; text-align: center; }
-  .spot-card-value { font-size: 1.5em; font-weight: bold; color: #d4af37; }
-  details { background: #1a1a1a; padding: 15px; border-radius: 8px; margin-bottom: 10px; cursor: pointer; }
-  summary { font-weight: bold; color: #d4af37; outline: none; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th, td { border: 1px solid #333; padding: 10px; text-align: left; }
-  th { background: #1a1a1a; color: #d4af37; }
-  a { color: #d4af37; text-decoration: none; }
-  a:hover { text-decoration: underline; }
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+/* ── Global link reset — enforce brand colours site-wide ── */
+a{color:var(--color-primary);text-decoration:none}
+a:hover{color:var(--color-primary-hover);text-decoration:underline}
+a:visited{color:var(--color-primary)}
+/* ── Card colour reset — cards are content blocks, not bare links ── */
+.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
+.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
+/* Article card inner elements */
+.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
+.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
+/* Hover: title becomes primary teal */
+.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
+.blog-preview-card:hover h3{color:var(--color-primary)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+
+
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
@@ -126,28 +345,41 @@
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 
-/* ── Card colour reset — cards are content blocks, not bare links ── */
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
-/* ── Guides mega panel — category links ── */
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
 </head>
 <body>

--- a/guides/silver-price-guide.html
+++ b/guides/silver-price-guide.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Silver Price Guide: Spot Price & 925 Sterling Value | GoldPriceTools</title>
@@ -40,37 +43,253 @@
 
 <style>
 
-:root {
-  --color-surface: #1a1a1a;
-  --color-border: #333;
-  --color-text: #f5f5f5;
-  --color-text-muted: #a3a3a3;
-  --color-gold: #d4af37;
-  --color-gold-bright: #ffd700;
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 1rem;
-  --space-4: 1.5rem;
-  --radius-lg: 0.5rem;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --text-xs: 0.75rem;
-  --text-xl: 1.25rem;
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+@font-face {
+  font-family: 'Instrument Serif';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
 
-  body { background: #0f0e0c; color: #fff; font-family: 'Inter', sans-serif; margin: 0; padding: 0; }
-  header, footer { background: #1a1a1a; padding: 20px; text-align: center; }
-  .container { max-width: 800px; margin: 0 auto; padding: 20px; }
-  h1, h2, h3 { color: #d4af37; }
-  .spot-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px; }
-  .spot-card { background: #1a1a1a; border: 1px solid #333; padding: 15px; border-radius: 8px; text-align: center; }
-  .spot-card-value { font-size: 1.5em; font-weight: bold; color: #d4af37; }
-  details { background: #1a1a1a; padding: 15px; border-radius: 8px; margin-bottom: 10px; cursor: pointer; }
-  summary { font-weight: bold; color: #d4af37; outline: none; }
-  table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-  th, td { border: 1px solid #333; padding: 10px; text-align: left; }
-  th { background: #1a1a1a; color: #d4af37; }
-  a { color: #d4af37; text-decoration: none; }
-  a:hover { text-decoration: underline; }
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+/* ── Global link reset — enforce brand colours site-wide ── */
+a{color:var(--color-primary);text-decoration:none}
+a:hover{color:var(--color-primary-hover);text-decoration:underline}
+a:visited{color:var(--color-primary)}
+/* ── Card colour reset — cards are content blocks, not bare links ── */
+.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
+.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
+/* Article card inner elements */
+.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
+.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
+/* Hover: title becomes primary teal */
+.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
+.blog-preview-card:hover h3{color:var(--color-primary)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+
+
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
@@ -126,28 +345,41 @@
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-.footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 
-/* ── Card colour reset — cards are content blocks, not bare links ── */
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
+/* BLOG PREVIEW SECTION */
+.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
+.blog-preview-inner{max-width:1200px;margin:0 auto}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
+.blog-preview-all:hover{color:var(--color-primary-hover)}
+.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
+@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
+.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* FOOTER */
+.footer-brand-col{max-width:260px}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
-/* ── Guides mega panel — category links ── */
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
 </head>
 <body>

--- a/guides/what-is-14k-gold.html
+++ b/guides/what-is-14k-gold.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>What Is 14K Gold? Purity, Price &amp; Uses Explained | GoldPriceTools</title>
@@ -52,6 +55,7 @@
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -84,10 +88,10 @@
 .mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-</style>
-<style>
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -106,51 +110,199 @@ a:visited{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
 
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}
-.nav-back{font-size:.875rem;color:var(--color-text-muted);text-decoration:none;padding:.375rem .75rem;border-radius:.5rem;border:1px solid var(--color-border)}
-.breadcrumb-wrap{max-width:740px;margin:0 auto;padding:.75rem 1.5rem 0}
-.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.5rem;font-size:.8125rem;color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"\203A";margin-right:.5rem}
-.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}
-.article-wrap{max-width:740px;margin:0 auto;padding:2rem 1.5rem 5rem}
-.article-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.75rem}
-.article-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:1rem}
-.article-byline{font-size:.8125rem;color:var(--color-text-faint);margin-bottom:2rem;padding-bottom:1.5rem;border-bottom:1px solid var(--color-border);display:flex;flex-wrap:wrap;gap:.5rem;align-items:center}
-.article-byline a{color:var(--color-text-muted);text-decoration:none}
-.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}
-.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;max-width:68ch;line-height:1.75}
-.prose ul,.prose ol{padding-left:1.5rem;margin-bottom:1.25rem}
-.prose li{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:.5rem}
-.prose a{color:var(--color-primary);text-decoration:none}
-.prose strong{color:var(--color-text);font-weight:600}
-.callout{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:.75rem;padding:1.25rem 1.5rem;margin:1.75rem 0}
-.callout p{margin-bottom:0}
-.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}
-.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}
-.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}
-.cta-box{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:2rem;margin:2.5rem 0;text-align:center}
-.cta-box h3{font-size:1.125rem;font-weight:700;color:var(--color-text);margin-bottom:.5rem}
-.cta-box p{font-size:.9rem;color:var(--color-text-muted);margin-bottom:1.25rem}
-.cta-btn{display:inline-block;padding:.75rem 1.75rem;background:var(--color-gold-bright);color:#0f0e0c;font-weight:700;font-size:.9375rem;border-radius:.5rem;text-decoration:none}
-.share-buttons{display:flex;gap:12px;align-items:center;margin:24px 0;flex-wrap:wrap;font-size:.875rem}
-.share-buttons span{color:var(--color-text-muted)}
-.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}
-.share-buttons a:hover{background:var(--color-surface)}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
-#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 
-.disclaimer-box {
-  border-left: 3px solid var(--color-gold-bright);
-  padding: 12px 16px;
-  margin: 24px 0;
-  background: rgba(232,175,52,0.05);
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
@@ -235,17 +387,14 @@ footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* Related Guides Card Section */
-.related-guides{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:2.5rem 0;margin-top:2rem}
-.related-guides .container{max-width:900px;margin:0 auto;padding:0 1.5rem}
-.related-guides h2{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:1.5rem}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.2rem;text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold);box-shadow:var(--shadow-md)}
-.related-card__tag{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem}
-.related-card__title{font-weight:700;color:var(--color-text);margin-bottom:0.3rem;font-size:var(--text-sm)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+
 </head>
 <body>
 <nav class="site-nav" role="navigation" aria-label="Main navigation">

--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold Price Per Gram Today — Live Calculator | GoldPriceTools</title>

--- a/live-gold-silver-price-today.html
+++ b/live-gold-silver-price-today.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Live Gold and Silver Price Today — Real-Time Spot Prices</title>
@@ -31,6 +34,7 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','G-ZPLL52C3K8',{anonymize_ip:true});</script>
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -54,6 +58,230 @@
   font-display: swap;
   src: url('https://assets.goldpricetools.com/Fonts/instrument-serif-400-ext.woff2') format('woff2');
 }
+
+/* ── Guides mega panel — category links ── */
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+/* ── Global link reset — enforce brand colours site-wide ── */
+a{color:var(--color-primary);text-decoration:none}
+a:hover{color:var(--color-primary-hover);text-decoration:underline}
+a:visited{color:var(--color-primary)}
+/* ── Card colour reset — cards are content blocks, not bare links ── */
+.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
+.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
+/* Article card inner elements */
+.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
+.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
+/* Hover: title becomes primary teal */
+.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
+.blog-preview-card:hover h3{color:var(--color-primary)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+
+
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
@@ -138,31 +366,12 @@
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* ── Global link reset — enforce brand colours site-wide ── */
-a{color:var(--color-primary);text-decoration:none}
-a:hover{color:var(--color-primary-hover);text-decoration:underline}
-a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
 
-
-/* ── Guides mega panel — category links ── */
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 </style>
 <link rel="manifest" href="/manifest.json">
 <meta name="theme-color" content="#1a1a2e">

--- a/scrap-gold-calculator.html
+++ b/scrap-gold-calculator.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Scrap Gold Calculator — Live Melt Value by Karat | GoldPriceTools</title>
@@ -218,6 +221,7 @@ function fireCalcEngaged() {
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -250,8 +254,11 @@ function fireCalcEngaged() {
 .mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-</style>
-<style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
@@ -268,21 +275,200 @@ a:visited{color:var(--color-primary)}
 .blog-preview-card:hover h3{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.calc-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:1.5rem;max-width:560px;margin:0 auto 2rem}.calc-row{display:grid;grid-template-columns:1fr 1fr auto;gap:.75rem;margin-bottom:.75rem;align-items:end}.calc-label{font-size:.75rem;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-bottom:.25rem}.calc-input{width:100%;padding:.625rem .875rem;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:.5rem;color:var(--color-text);font-size:.9375rem;font-family:var(--font-body)}.calc-select{width:100%;padding:.625rem .875rem;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:.5rem;color:var(--color-text);font-size:.9375rem;font-family:var(--font-body)}.calc-del{padding:.625rem .875rem;background:transparent;border:1px solid var(--color-border);border-radius:.5rem;color:var(--color-text-muted);cursor:pointer;font-size:1rem}.calc-add{width:100%;padding:.75rem;background:transparent;border:1px dashed var(--color-border);border-radius:.5rem;color:var(--color-text-muted);cursor:pointer;font-size:.875rem;margin-bottom:1rem}.result-box{background:var(--color-surface-offset);border-radius:.75rem;padding:1.25rem;text-align:center}.result-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:.375rem}.result-gbp{font-family:var(--font-display);font-size:2.25rem;color:var(--color-gold-bright);font-weight:700;line-height:1;min-height:2.5rem}.result-usd{font-size:1rem;color:var(--color-text-muted)}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.prose ol{padding-left:1.5rem;margin-bottom:1.25rem}.prose li{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:.5rem}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
-.data-source {
-  font-size: 0.8125rem;
-  color: var(--color-text-faint);
-  text-align: center;
-  padding: 0.75rem 1rem;
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: 2rem;
-}
-.data-source a {
-  color: var(--color-text-muted);
-  text-decoration: none;
-}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
@@ -366,7 +552,15 @@ body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
+
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -2,6 +2,9 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
+  <script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
+</script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Silver Price Per Kilo Today (Live) — GoldPriceTools</title>
@@ -45,6 +48,7 @@
 <link rel="preload" href="https://assets.goldpricetools.com/Fonts/instrument-serif-400.woff2" as="font" type="font/woff2" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
+
 @font-face {
   font-family: 'Instrument Serif';
   font-style: normal;
@@ -77,8 +81,11 @@
 .mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-</style>
-<style>:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-offset:#f3f0ec;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-primary:#01696f;--color-gold-bright:#d19900;--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif}[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-offset:#1d1c1a;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-primary:#4f98a3;--color-gold-bright:#e8af34}*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+
+
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'Instrument Serif',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
@@ -95,22 +102,200 @@ a:visited{color:var(--color-primary)}
 .blog-preview-card:hover h3{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
-body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--color-text);background:var(--color-bg)}nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}.nav-inner{max-width:900px;margin:0 auto;padding:0 1rem;display:flex;align-items:center;justify-content:space-between;height:56px}.nav-logo{display:flex;align-items:center;gap:.5rem;font-weight:700;font-size:.9rem;color:var(--color-gold-bright);text-decoration:none}.breadcrumb-wrap{max-width:900px;margin:0 auto;padding:.625rem 1rem 0}.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;gap:.4rem;font-size:.8125rem;color:var(--color-text-muted);padding:0;margin:0}.breadcrumb li+li::before{content:"\203A";margin-right:.4rem}.breadcrumb a{color:var(--color-gold-bright);text-decoration:none}.hero{max-width:900px;margin:0 auto;padding:2.5rem 1rem 1.5rem;text-align:center}.hero-tag{font-size:.75rem;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:.5rem}.hero-title{font-family:var(--font-display);font-size:clamp(1.75rem,4vw,2.75rem);color:var(--color-text);line-height:1.2;margin-bottom:.75rem}.price-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1rem;max-width:700px;margin:0 auto 2rem}.price-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:.875rem;padding:1.25rem;text-align:center}.price-tile-label{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-faint);margin-bottom:.375rem}.price-tile-value{font-family:var(--font-display);font-size:1.5rem;color:var(--color-gold-bright);font-weight:700;min-height:2rem}.content{max-width:900px;margin:0 auto;padding:0 1rem 5rem}.prose{max-width:68ch}.prose h2{font-family:var(--font-display);font-size:1.5rem;color:var(--color-text);margin:2.5rem 0 .75rem}.prose p{font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.25rem;line-height:1.75}.data-table{width:100%;border-collapse:collapse;margin:1.5rem 0;font-size:.9rem}.data-table th{background:var(--color-surface-offset);font-weight:600;color:var(--color-text);padding:.625rem 1rem;text-align:left;border-bottom:2px solid var(--color-border)}.data-table td{padding:.625rem 1rem;border-bottom:1px solid var(--color-border);color:var(--color-text-muted)}.disclaimer{border-left:3px solid var(--color-gold-bright);padding:.75rem 1rem;background:rgba(232,175,52,.05);font-size:.8125rem;color:var(--color-text-faint);margin:2rem 0;border-radius:0 .5rem .5rem 0}.trust-bar{font-size:.8125rem;color:var(--color-text-faint);text-align:center;padding:.75rem 1rem;border-top:1px solid var(--color-border);border-bottom:1px solid var(--color-border);margin-bottom:2rem}.trust-bar a{color:var(--color-text-muted);text-decoration:none}footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-.share-buttons{display:flex;gap:12px;align-items:center;margin:2rem 0;flex-wrap:wrap;font-size:.875rem}.share-buttons span{color:var(--color-text-muted)}.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:6px;font-size:.875rem;border:1px solid var(--color-border);color:var(--color-text);text-decoration:none;transition:background .2s}.share-buttons a:hover{background:var(--color-surface)}
 
-.data-source {
-  font-size: 0.8125rem;
-  color: var(--color-text-faint);
-  text-align: center;
-  padding: 0.75rem 1rem;
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: 2rem;
-}
-.data-source a {
-  color: var(--color-text-muted);
-  text-decoration: none;
-}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+input,select{font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty;max-width:72ch}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
+
+/* TICKER */
+.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
+.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
+.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
+.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
+.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
+.ticker:hover{animation-play-state:paused}
+@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
+.ticker-label{color:var(--color-text-muted)}
+.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
+.ticker-change.up{color:#4ade80}
+.ticker-change.down{color:#f87171}
+.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+
+/* NAV */
+nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
+.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
+.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
+.nav-links{display:flex;align-items:center;gap:var(--space-1)}
+.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
+.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
+.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
+.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
+@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
+
+/* MOBILE MENU */
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
+.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
+.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
+.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+
+/* AD SLOTS */
+.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
+.ad-slot ins{display:block;width:100%}
+.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
+.ad-slot-sidebar ins{display:block;width:100%}
+
+/* HERO */
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
+.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
+.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
+.hero h1 .gold{color:var(--color-gold-bright)}
+.hero h1 .silver{color:var(--color-silver)}
+.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
+.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
+.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.spot-card-value.gold-val{color:var(--color-gold-bright)}
+.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
+.spot-card-change.up{color:#4ade80}
+.spot-card-change.down{color:#f87171}
+
+/* MAIN LAYOUT */
+.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
+@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+
+/* CALCULATORS */
+.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
+.calc-tabs::-webkit-scrollbar{display:none}
+.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
+.calc-tab:hover{color:var(--color-text)}
+.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
+.calc-panel{display:none;padding:var(--space-6)}
+.calc-panel.active{display:block}
+.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
+.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
+.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
+.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
+.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
+.form-select-wrap{position:relative}
+.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
+.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
+.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+
+/* SCRAP TABLE */
+.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
+.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
+.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
+.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
+.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
+@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
+.scrap-total-item{text-align:center}
+.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
+.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* KARAT TABLES */
+.karat-section{margin-top:var(--space-8)}
+.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
+.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
+.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
+.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
+.karat-table{width:100%;border-collapse:collapse}
+.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.karat-table td:first-child{color:var(--color-text-muted)}
+.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.karat-table tr:last-child td{border-bottom:none}
+
+/* SIDEBAR */
+.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
+.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.quick-ref-row:last-child{border-bottom:none}
+.quick-ref-label{color:var(--color-text-muted)}
+.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
+.quick-ref-value.silver-val{color:var(--color-silver)}
+
+/* SIDEBAR NAV LINKS */
+.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
+.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
+.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+
+/* CHART */
+.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
+.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
+.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
+.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
+.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
+.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
+.chart-wrap{position:relative;height:280px}
+.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+
+/* FAQ / SEO CARDS */
+.faq-section{margin-top:var(--space-8)}
+.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
+.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
+.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* CONVERTER */
+.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ARTICLES SECTION */
+.articles-section{margin-top:var(--space-10)}
+.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
+.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
+.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
+.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
+.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-8) var(--space-4)}
+.footer-inner{max-width:1200px;margin:0 auto;display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:var(--space-8)}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none}
+.footer-col li{margin-bottom:var(--space-2)}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.last-updated{font-size:var(--text-xs);color:var(--color-text-faint)}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
@@ -195,17 +380,14 @@ body{min-height:100dvh;line-height:1.7;font-family:var(--font-body);color:var(--
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
 
-/* Related Guides Card Section */
-.related-guides{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:2.5rem 0;margin-top:2rem}
-.related-guides .container{max-width:900px;margin:0 auto;padding:0 1.5rem}
-.related-guides h2{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:1.5rem}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:1.2rem;text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold);box-shadow:var(--shadow-md)}
-.related-card__tag{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.4rem}
-.related-card__title{font-weight:700;color:var(--color-text);margin-bottom:0.3rem;font-size:var(--text-sm)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted)}
+/* ── Article card — unified markup styles ── */
+.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
+.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+.article-card:hover .article-card-title{color:var(--color-primary)}
+
 </style>
+
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",


### PR DESCRIPTION
## Audit-driven fix — 21 pages

### What the automated audit found
- **21 pages** missing the early blocking theme-init script → CSS vars unresolved on first paint
- **18 pages** with partial CSS (~12k–18k chars) instead of full design system (~34k chars)
- **13 pages** with `.html` extension links that should be extensionless
- **13 pages** with hardcoded hex colours in CSS that should use `var(--color-*)`

### What was fixed
1. `data-theme="dark"` added to `<html>` on all 21 pages as safe default
2. Blocking `<script>` injected immediately after `<meta charset>` on all 21 pages — reads `localStorage` + `prefers-color-scheme` and sets `data-theme` before CSS renders
3. Full 34k CSS design system replaced truncated CSS on 18 pages

### Pages fixed
All karat price pages (9K/14K/18K/24K), about, contact, blog pages, 
gold-price-chart, gold-rates-today, gold-silver-ratio, all guide content pages,
live-gold-silver-price-today, scrap-gold-calculator, silver-price-per-kilo, homepage
