### PR TITLE
fix(homepage): remove redundant '3 grams of gold price' SEO section

### DIFF
--- a/index.html
+++ b/index.html
@@ -891,12 +891,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       </section>
     </section>
 
-    <!-- 3 GRAMS SEO SECTION -->
-    <section class="faq-section" style="margin-bottom:2rem;">
-      <h2>3 grams of gold price</h2>
-      <p class="snippet-answer">The 3 grams of gold price is calculated by multiplying the live gold spot price per gram by three. Depending on the karat purity (such as 14K, 18K, or 24K), the value will change. Enter 3 in our gold calculator above to see the exact live price today.</p>
-    </section>
-
     <!-- FAQ / SEO SECTION -->
     <section id="faq" class="faq-section" aria-label="Frequently asked questions">
       <h2>Frequently Asked Questions</h2>


### PR DESCRIPTION
## Remove: `<!-- 3 GRAMS SEO SECTION -->`

**Reason:** Completely redundant.
- The Gold Quick Reference sidebar already shows per-gram prices for all karats
- The calculator handles any weight input including 3g
- The FAQ section below provides structured SEO signals properly
- Section was static filler copy with no live data or user value

No replacement needed — the existing page content covers every use case.
