### PR TITLE
fix(nav): remove Silver Purity card from homepage; add to Silver mega-nav

### DIFF
--- a/10k-gold-price-per-gram.html
+++ b/10k-gold-price-per-gram.html
@@ -425,7 +425,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/14k-gold-price-in-usd.html
+++ b/14k-gold-price-in-usd.html
@@ -402,7 +402,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -432,7 +432,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/18k-gold-price-in-gbp.html
+++ b/18k-gold-price-in-gbp.html
@@ -402,7 +402,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/18k-gold-price-per-gram.html
+++ b/18k-gold-price-per-gram.html
@@ -432,7 +432,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/22k-gold-price-per-gram.html
+++ b/22k-gold-price-per-gram.html
@@ -432,7 +432,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/24-hour-gold-silver-prices.html
+++ b/24-hour-gold-silver-prices.html
@@ -402,7 +402,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/24k-gold-price-per-gram.html
+++ b/24k-gold-price-per-gram.html
@@ -432,7 +432,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/800-silver-price-per-gram.html
+++ b/800-silver-price-per-gram.html
@@ -427,7 +427,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/900-silver-price-per-gram.html
+++ b/900-silver-price-per-gram.html
@@ -427,7 +427,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/9k-gold-price-per-gram.html
+++ b/9k-gold-price-per-gram.html
@@ -432,7 +432,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/about.html
+++ b/about.html
@@ -433,7 +433,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/best-gold-ira-companies.html
+++ b/best-gold-ira-companies.html
@@ -801,7 +801,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/contact.html
+++ b/contact.html
@@ -437,7 +437,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-and-silver-price-today.html
+++ b/gold-and-silver-price-today.html
@@ -402,7 +402,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-bar-value.html
+++ b/gold-bar-value.html
@@ -432,7 +432,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-coins-vs-bars.html
+++ b/gold-coins-vs-bars.html
@@ -423,7 +423,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-per-gram-today.html
+++ b/gold-per-gram-today.html
@@ -402,7 +402,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-price-chart.html
+++ b/gold-price-chart.html
@@ -510,7 +510,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-price-per-gram.html
+++ b/gold-price-per-gram.html
@@ -432,7 +432,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-price-today-10k.html
+++ b/gold-price-today-10k.html
@@ -402,7 +402,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-price-today-14k.html
+++ b/gold-price-today-14k.html
@@ -402,7 +402,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-price-today-18k.html
+++ b/gold-price-today-18k.html
@@ -402,7 +402,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-rates-today.html
+++ b/gold-rates-today.html
@@ -446,7 +446,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-silver-ratio.html
+++ b/gold-silver-ratio.html
@@ -471,7 +471,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/gold-silver-test-kit-reviews.html
+++ b/gold-silver-test-kit-reviews.html
@@ -539,7 +539,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/how-many-grams-in-troy-ounce.html
+++ b/how-many-grams-in-troy-ounce.html
@@ -425,7 +425,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/index.html
+++ b/index.html
@@ -520,7 +520,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>
@@ -931,19 +931,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </section>
 
     <!-- ARTICLES SECTION -->
-
-    <!-- Silver Purity Grades — moved to dedicated page -->
-    <div style="margin:var(--space-5) 0">
-      <a class="article-card" href="/silver-purity-grades" style="display:block;max-width:480px">
-        <div class="article-tag">Silver</div>
-        <div class="article-card-title">Silver Purity Grades &amp; Live Prices</div>
-        <div class="article-card-desc">Compare live prices for .999 Fine, .925 Sterling, .900 Coin and .800 European silver — per gram, per oz and per kilo. Updated every 60 seconds.</div>
-      </a>
-    </div>
-
-    
-
-  </div>
 
   <!-- SIDEBAR -->
   <aside class="sidebar" aria-label="Quick reference prices">

--- a/live-gold-silver-price-today.html
+++ b/live-gold-silver-price-today.html
@@ -402,7 +402,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -432,7 +432,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/scrap-gold-calculator.html
+++ b/scrap-gold-calculator.html
@@ -600,7 +600,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/silver-coins-calculator.html
+++ b/silver-coins-calculator.html
@@ -439,7 +439,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -427,7 +427,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/silver-purity-grades.html
+++ b/silver-purity-grades.html
@@ -446,7 +446,7 @@ details[open] .faq-q::before{content:"\25BC ";color:var(--color-gold)}
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/terms.html
+++ b/terms.html
@@ -437,7 +437,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/us-silver-dollar-values.html
+++ b/us-silver-dollar-values.html
@@ -439,7 +439,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/where-to-sell-gold-silver.html
+++ b/where-to-sell-gold-silver.html
@@ -422,7 +422,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>

--- a/zakat-gold-silver-calculator.html
+++ b/zakat-gold-silver-calculator.html
@@ -428,7 +428,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>


### PR DESCRIPTION
## Fixes

- **Homepage** `index.html`: removed the article-card that was placed on the homepage (incorrect placement)
- **Silver mega-nav** `index.html`: added `Silver Purity Grades → /silver-purity-grades` link to the Live Prices column of the Silver dropdown
- All 37 other HTML pages already carry the updated Silver nav (link was included when silver-purity-grades.html was built from the same nav template)

The `/silver-purity-grades` page is now only accessible via the **Silver dropdown menu** as requested.
