### PR TITLE
fix(layout): sidebar position on silver-purity-grades page

### DIFF
--- a/silver-purity-grades.html
+++ b/silver-purity-grades.html
@@ -497,6 +497,7 @@ details[open] .faq-q::before{content:"\25BC ";color:var(--color-gold)}
   <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Live silver spot prices for .999 Fine, .925 Sterling, .900 Coin and .800 European silver &#8212; per gram, per troy oz and per kilo. Updated every 60 seconds.</p>
 </div>
 
+<section class="main-wrap">
 <div class="content">
   <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about">About our data</a></div>
 
@@ -711,6 +712,7 @@ details[open] .faq-q::before{content:"\25BC ";color:var(--color-gold)}
     <a class="sidebar-link" href="/guides/what-is-925-sterling-silver">925 Sterling Silver Guide &#8594;</a>
   </div>
 </aside>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">


### PR DESCRIPTION
## Bug fix

**Root cause:** The `<aside class="sidebar">` was placed outside the `.main-wrap` section wrapper. The `.main-wrap` CSS rule defines `display:grid; grid-template-columns: 1fr 300px` — without being inside it, the sidebar fell out of the grid and rendered below all content with no styling context.

**Fix:** Wrapped `<div class="content">...</div>` and `<aside class="sidebar">...</aside>` inside `<section class="main-wrap">`, matching the same structure as the homepage and all other pages with sidebars.
