### PR TITLE
fix(layout): homepage sidebar grid placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,6 +211,10 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 /* MAIN LAYOUT */
 .main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
 @media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+/* Grid placement for main-wrap children */
+.main-wrap>.karat-section,.main-wrap>#faq{grid-column:1}
+.main-wrap>aside{grid-column:2;grid-row:1/span 99}
+@media(max-width:1024px){.main-wrap>aside{grid-column:1;grid-row:auto}}
 
 /* CALCULATORS */
 .calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}


### PR DESCRIPTION
## Root cause

`.main-wrap` is a CSS grid with `grid-template-columns: 1fr 300px`. It has **3 direct children**:
1. `<section id="karat-prices">` — occupies column 1
2. `<section id="faq">` — occupies column 2 (stealing the sidebar slot!)
3. `<aside class="sidebar">` — wraps to row 2, appearing below all content

## Fix

Added explicit CSS grid placement rules:
```css
.main-wrap > .karat-section, .main-wrap > #faq { grid-column: 1 }
.main-wrap > aside { grid-column: 2; grid-row: 1 / span 99 }
@media(max-width:1024px) { .main-wrap > aside { grid-column: 1; grid-row: auto } }
```

This pins the sidebar to column 2 spanning all rows, and keeps both content sections in column 1. On mobile/tablet (≤1024px) the sidebar reverts to normal stacking flow.
