### PR TITLE
fix: duplicate footer + chart-btn light-mode colour across all guide pages

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -90,6 +90,19 @@ label {
   cursor: pointer;
 }
 
+/* ── 3d. Chart button active/hover text colour — use token not bare hex ── */
+/*
+ * Every page inline-defines `.chart-btn:hover { color:#0f0e0c }` which is the
+ * raw dark-theme background value. In light mode this makes the active button
+ * text invisible (dark text on a gold background is fine, but the value must
+ * track the actual background token). site.css loads after inline <style>
+ * blocks, so this rule wins and fixes the colour on all pages at once.
+ */
+.chart-btn:hover,
+.chart-btn.active {
+  color: var(--color-bg);
+}
+
 /* ── 4. Overscroll — prevent accidental pull-to-refresh in mobile menu ── */
 .mobile-menu {
   overscroll-behavior: contain;

--- a/guides/buying-investing/index.html
+++ b/guides/buying-investing/index.html
@@ -329,9 +329,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/deep-dives/index.html
+++ b/guides/deep-dives/index.html
@@ -329,9 +329,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/difference-between-gold-filled-and-gold-plated.html
+++ b/guides/difference-between-gold-filled-and-gold-plated.html
@@ -351,9 +351,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/gold-hallmarks-explained.html
+++ b/guides/gold-hallmarks-explained.html
@@ -351,9 +351,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/gold-price-guide.html
+++ b/guides/gold-price-guide.html
@@ -340,9 +340,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/gold-price-history.html
+++ b/guides/gold-price-history.html
@@ -408,9 +408,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/gold-price-prediction-2026.html
+++ b/guides/gold-price-prediction-2026.html
@@ -340,9 +340,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/gold-vs-silver-investment.html
+++ b/guides/gold-vs-silver-investment.html
@@ -351,9 +351,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/how-much-is-a-gold-ring-worth.html
+++ b/guides/how-much-is-a-gold-ring-worth.html
@@ -351,9 +351,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/how-to-calculate-scrap-gold.html
+++ b/guides/how-to-calculate-scrap-gold.html
@@ -363,9 +363,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/how-to-invest-in-gold.html
+++ b/guides/how-to-invest-in-gold.html
@@ -352,9 +352,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/how-to-read-gold-spot-price.html
+++ b/guides/how-to-read-gold-spot-price.html
@@ -352,9 +352,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/how-to-sell-gold-jewellery.html
+++ b/guides/how-to-sell-gold-jewellery.html
@@ -352,9 +352,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/how-to-store-gold-silver-at-home.html
+++ b/guides/how-to-store-gold-silver-at-home.html
@@ -352,9 +352,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/how-to-test-if-gold-is-real.html
+++ b/guides/how-to-test-if-gold-is-real.html
@@ -351,9 +351,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/index.html
+++ b/guides/index.html
@@ -326,9 +326,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/indian-gold-silver-prices.html
+++ b/guides/indian-gold-silver-prices.html
@@ -340,9 +340,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/market-prices/index.html
+++ b/guides/market-prices/index.html
@@ -329,9 +329,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/scrap-gold-guide.html
+++ b/guides/scrap-gold-guide.html
@@ -340,9 +340,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/selling-testing/index.html
+++ b/guides/selling-testing/index.html
@@ -329,9 +329,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/silver-guides/index.html
+++ b/guides/silver-guides/index.html
@@ -329,9 +329,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/silver-price-guide.html
+++ b/guides/silver-price-guide.html
@@ -337,9 +337,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/silver-price-per-gram-explained.html
+++ b/guides/silver-price-per-gram-explained.html
@@ -351,9 +351,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/troy-ounce-guide.html
+++ b/guides/troy-ounce-guide.html
@@ -340,9 +340,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/troy-ounce-vs-gram-explained.html
+++ b/guides/troy-ounce-vs-gram-explained.html
@@ -352,9 +352,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/us-silver-dollar-values.html
+++ b/guides/us-silver-dollar-values.html
@@ -340,9 +340,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col-heading{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:var(--space-3);}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/what-affects-gold-price.html
+++ b/guides/what-affects-gold-price.html
@@ -351,9 +351,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/what-is-14k-gold.html
+++ b/guides/what-is-14k-gold.html
@@ -352,9 +352,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/what-is-925-sterling-silver.html
+++ b/guides/what-is-925-sterling-silver.html
@@ -352,9 +352,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}

--- a/guides/what-is-best-time-to-sell-scrap-gold.html
+++ b/guides/what-is-best-time-to-sell-scrap-gold.html
@@ -352,9 +352,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}


### PR DESCRIPTION
## Summary

- **Duplicate `.footer-inner` removed from 30 guide pages** — each guide page contained two conflicting `.footer-inner` CSS definitions inside its inline `<style>` block. The second (stale) definition used `1fr repeat(4,auto)` and collapsed the footer to 2 columns at ≥900px, overriding the correct 6-column layout. Removed the stale block from all 30 affected files.
- **`.chart-btn` active/hover colour fixed in `site.css`** — every page hard-coded `color:#0f0e0c` (raw dark-theme background) on `.chart-btn:hover` / `.chart-btn.active`, making the label invisible in light mode. Added `color:var(--color-bg)` to `site.css` (which loads after each page's inline `<style>`), fixing all pages with a single rule.

## Files changed
- `assets/site.css` — new section 3d with `.chart-btn:hover / .active` colour token
- 30 × `guides/**/*.html` — stale `.footer-inner` block stripped

## Test plan
- [ ] `/guides/gold-price-guide` in **light mode**: chart range buttons (1W, 1M, etc.) show dark text on gold background when active — not invisible
- [ ] `/guides/gold-price-guide` in **dark mode**: same buttons still look correct
- [ ] Footer at 900px–1023px viewport: shows **3 columns**, not 2
- [ ] Footer at ≤600px: shows **2 columns**
- [ ] Spot-check two other guide pages (e.g. `/guides/gold-hallmarks-explained`, `/guides/scrap-gold-guide`) for same footer and button behaviour

https://claude.ai/code/session_01NKyMqqcaZC6a2bJqXQoF3n

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKyMqqcaZC6a2bJqXQoF3n)_