### PR TITLE
Fix double >> closing tag in gold-price-guide.html meta og:title

### DIFF
--- a/guides/gold-price-guide.html
+++ b/guides/gold-price-guide.html
@@ -15,7 +15,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
-<meta property="og:title" content="Gold Price Guide 2026 | GoldPriceTools">>
+<meta property="og:title" content="Gold Price Guide 2026 | GoldPriceTools">
 <meta property="og:description" content="The ultimate gold price pillar guide. Learn how prices are set, factors affecting gold, chart reading, and purity impacts.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/gold-price-guide.html">


### PR DESCRIPTION
## Summary

- Fixes `guides/gold-price-guide.html` line 18: `<meta property="og:title" content="...">>`  →  `<meta property="og:title" content="...">`
- The trailing `>` was causing browsers to prematurely close `<head>`, rendering a stray `>` character at the top of the page and breaking `<head>` structure

## Test plan

- [ ] Verify https://goldpricetools.com/guides/gold-price-guide has no stray `>` character at the top of the page
- [ ] Verify page renders with no visible artefacts above the nav

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjL9E8KdGdWtC7F8BPEHDP)_