### PR TITLE
Rebuild gold-hallmarks-explained.html with full article and ui-ux-pro-max styling

### DIFF
--- a/guides/gold-hallmarks-explained.html
+++ b/guides/gold-hallmarks-explained.html
@@ -2,60 +2,46 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
-  <script>
-(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
-</script>
-    <meta name="cf-no-email-obfuscation">
+<script>(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();</script>
+<meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold Hallmarks Explained: Purity, Assays & Stamps</title>
-  <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="A complete guide to gold hallmarks. Understand what stamps like 375, 585, 750, 916, and 999 mean for gold purity, and learn how to read UK assay marks.">
+<title>Gold Hallmarks Explained: Symbols, Meanings &amp; Identification Guide 2026 | GoldPriceTools</title>
+<meta name="google-adsense-account" content="ca-pub-8849494330640880">
+<meta name="description" content="Everything about gold hallmarks — UK, European, antique, foreign and rare marks explained. Identify symbols on rings, necklaces and pocket watches.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/guides/gold-hallmarks-explained">
+<link rel="alternate" hreflang="en" href="https://goldpricetools.com/guides/gold-hallmarks-explained">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/gold-hallmarks-explained">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/gold-hallmarks-explained">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/gold-hallmarks-explained">
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
-<meta property="og:title" content="Gold Hallmarks Explained">
-<meta property="og:description" content="A complete guide to gold hallmarks. Understand what stamps like 375, 585, 750, 916, and 999 mean for gold purity, and learn how to read UK assay marks.">
+<meta property="og:title" content="Gold Hallmarks Explained: Symbols, Meanings &amp; Identification Guide 2026">
+<meta property="og:description" content="Everything about gold hallmarks — UK, European, antique, foreign and rare marks explained. Identify symbols on rings, necklaces and pocket watches.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/gold-hallmarks-explained">
 <meta property="og:site_name" content="GoldPriceTools">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Gold Hallmarks Explained — GoldPriceTools">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Hallmarks Explained","description":"A complete guide to gold hallmarks. Understand what stamps like 375, 585, 750, 916, and 999 mean for gold purity, and learn how to read UK assay marks.","url":"https://goldpricetools.com/guides/gold-hallmarks-explained","datePublished":"2026-05-01","dateModified":"2026-05-01T08:21:42Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com/guides/gold-hallmarks-explained","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/guides/gold-hallmarks-explained"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-hallmarks-explained"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/guides/gold-hallmarks-explained"}}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Gold Hallmarks Explained"}]}</script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('consent', 'default', {'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
-</script>
-<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Hallmarks Explained — The Complete Identification Guide (2026)","description":"Everything about gold hallmarks — UK, European, antique, foreign and rare marks explained. Identify symbols on rings, necklaces and pocket watches.","url":"https://goldpricetools.com/guides/gold-hallmarks-explained","datePublished":"2026-05-08","dateModified":"2026-05-08T00:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-hallmarks-explained"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Gold Hallmarks Explained","item":"https://goldpricetools.com/guides/gold-hallmarks-explained"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What do gold hallmarks mean?","acceptedAnswer":{"@type":"Answer","text":"Gold hallmarks are official stamps applied by an independent assay office after testing, confirming the item's gold content (purity), the identity of the maker, and where it was tested. They are a legal guarantee of quality."}},{"@type":"Question","name":"What are the most common UK gold hallmarks?","acceptedAnswer":{"@type":"Answer","text":"The most commonly encountered UK gold hallmarks are the fineness marks 375 (9ct), 585 (14ct), and 750 (18ct), combined with an assay office symbol (leopard's head for London, anchor for Birmingham, castle for Edinburgh) and the maker's mark."}},{"@type":"Question","name":"How do I identify antique gold hallmarks?","acceptedAnswer":{"@type":"Answer","text":"Look for the pre-1975 UK crown-plus-numeral system (e.g., a crown with '18' for 18ct gold), date letters that allow precise year-dating, and assay office marks that include the now-closed Chester office (sword with wheatsheaves). Specialist reference books such as Bradbury's Book of Hallmarks are the standard resource for antique British marks."}},{"@type":"Question","name":"What are the French gold hallmarks?","acceptedAnswer":{"@type":"Answer","text":"The eagle's head (facing left) is the French guarantee mark for 18K gold and has been in use since 1838. The scallop shell indicates 14K gold; the clover (trefoil) indicates 9K gold. The owl appears on foreign items imported into France. A lozenge-shaped mark is the maker's mark, compulsory on all French pieces."}},{"@type":"Question","name":"What are Russian gold hallmarks?","acceptedAnswer":{"@type":"Answer","text":"Pre-1917 Russian gold uses the zolotnik system — the number 56 for 14K gold, 72 for 18K — alongside a city crest (St. Petersburg or Moscow) or, from 1899, a kokoshnik mark (woman's head in profile wearing a headdress). Soviet era pieces (1917–1991) use a hammer and sickle mark with millesimal fineness (583 for 14K)."}},{"@type":"Question","name":"What are Fabergé gold hallmarks?","acceptedAnswer":{"@type":"Answer","text":"Authentic Fabergé pieces carry the government assay mark (city crest or kokoshnik), the specific workmaster's initials, and the Fabergé firm name in Cyrillic or Latin script. Moscow branch pieces also carry the double-headed eagle of the Imperial Warrant."}},{"@type":"Question","name":"What is the BIS hallmark on Indian gold?","acceptedAnswer":{"@type":"Answer","text":"The BIS (Bureau of Indian Standards) hallmark has been mandatory in India since 2021. It consists of a BIS triangle logo, a purity mark (22K916, 18K750, or 14K585), an assay centre code, and a six-digit HUID number that can be verified via the BIS Care government app."}},{"@type":"Question","name":"Do white gold pieces have different hallmarks?","acceptedAnswer":{"@type":"Answer","text":"No — white gold carries identical hallmarks to yellow gold. A white gold ring hallmarked 750 is 18-carat gold; the hallmark identifies purity regardless of the metal's colour."}},{"@type":"Question","name":"What does 875 mean on gold jewellery?","acceptedAnswer":{"@type":"Answer","text":"875 is the millesimal fineness mark for 21-karat gold (87.5% pure). It is most commonly associated with Middle Eastern jewellery — particularly from the UAE, Saudi Arabia, and Egypt — and is one of the clearest regional identifiers when encountered on gold in Western markets."}}]}</script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
-<script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
+<script>(function(){function signalGooglefcPresent(){if(!window.frames['googlefcPresent']){if(document.body){const iframe=document.createElement('iframe');iframe.style='width:0;height:0;border:none;z-index:-1000;left:-1000px;top:-1000px;';iframe.style.display='none';iframe.name='googlefcPresent';document.body.appendChild(iframe);}else{setTimeout(signalGooglefcPresent,0);}}}signalGooglefcPresent();})();</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
-<script>
-(adsbygoogle = window.adsbygoogle || []).push({
-  google_ad_client: "ca-pub-8849494330640880",
-  enable_page_level_ads: true,
-  overlays: {bottom: false},
-  vignette: {
-    new_triggers: false
-  }
-});
-</script>
+<script>(adsbygoogle=window.adsbygoogle||[]).push({google_ad_client:"ca-pub-8849494330640880",enable_page_level_ads:true,overlays:{bottom:false},vignette:{new_triggers:false}});</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
-
-/* ── Guides mega panel — category links ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
 .mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
@@ -63,223 +49,28 @@
 .mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-
-
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-alt:#f4f3ef;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
 [data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-/* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
 .article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
 .article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
 .article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
 .article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
 .article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
-
-
 html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
-input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
 :focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-
-/* TICKER */
-.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
-.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
-.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
-.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
-.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
-.ticker:hover{animation-play-state:paused}
-@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
-.ticker-label{color:var(--color-text-muted)}
-.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
-.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
-@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
-
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
-
-/* AD SLOTS */
-.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
-.ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
-
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
-
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
-
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
-
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
-
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
-
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
-
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
-
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
-
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
-
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
-
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
-
-#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-
-/* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
@@ -328,45 +119,23 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
 .mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
 .mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
-.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
-
-
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
-/* FOOTER */
+.ad-slot{min-height:0!important;margin:var(--space-2) 0}
+.ad-slot:not(:has(ins[data-ad-status])){border:none!important;background:none!important;padding:0!important;min-height:0!important;margin:0!important}
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
+.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
+@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
 .footer-brand-col{max-width:260px}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col{min-width:0}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
-
-
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
-
-
-/* ── ARTICLE LAYOUT FIX (batch applied) ── */
 .breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
 .breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
 .breadcrumb li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
@@ -382,33 +151,92 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
 .prose{max-width:860px}
 .prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
 .prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
+.prose h4{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-5) 0 var(--space-2)}
 .prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
 .prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
 .prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
 .prose strong{color:var(--color-text);font-weight:700}
 .prose a{color:var(--color-primary);text-decoration:underline}
 .prose a:hover{color:var(--color-primary-hover)}
-.prose em{font-style:italic}
+.prose sup{font-size:.7em;vertical-align:super;color:var(--color-text-faint)}
 .prose table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
 .prose table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-3) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
 .prose table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
 .prose table tr:last-child td{border-bottom:none}
 .prose table td:first-child,.prose table th:first-child{padding-left:0;color:var(--color-text)}
-.ad-slot{min-height:0!important;margin:var(--space-2) 0}
-.ad-slot:not(:has(ins[data-ad-status])){border:none!important;background:none!important;padding:0!important;min-height:0!important;margin:0!important}
 .cta-box{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-8) 0}
 .cta-box h3{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:0 0 var(--space-2)}
 .cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-4)}
-.cta-btn{display:inline-flex;align-items:center;gap:var(--space-1);padding:var(--space-2) var(--space-5);background:var(--color-primary);color:#fff;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none;transition:background .15s}
-.cta-btn:hover{background:var(--color-primary-hover);color:#fff}
+.cta-btn{display:inline-flex;align-items:center;gap:var(--space-1);padding:var(--space-2) var(--space-5);background:var(--color-primary);color:#fff!important;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none;transition:background .15s}
+.cta-btn:hover,.cta-btn:visited{background:var(--color-primary-hover);color:#fff!important;text-decoration:none}
 .share-buttons{display:flex;flex-wrap:wrap;gap:var(--space-2);margin:var(--space-6) 0}
 .share-btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);border:1px solid var(--color-border);border-radius:var(--radius-full);background:var(--color-surface);color:var(--color-text-muted);font-size:var(--text-sm);font-weight:500;text-decoration:none;transition:border-color .15s,color .15s;white-space:nowrap}
 .share-btn:hover{border-color:var(--color-primary);color:var(--color-primary)}
 .disclaimer-box{background:var(--color-surface-alt,#f4f3ef);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
 .disclaimer-box strong{color:var(--color-text);font-weight:700}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin-top:var(--space-4)}
+.related-guides-section{max-width:860px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+.related-guides-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-4)}
+.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4)}
+.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
+.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);color:var(--color-text)}
+.related-card__tag{display:block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+.related-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+.exec-summary{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0}
+.exec-summary-intro{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-5)}
+.exec-summary-intro strong{color:var(--color-text)}
+.exec-summary-stats{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-4)}
+.exec-stat{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4)}
+.exec-stat-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
+.exec-stat-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;margin-top:var(--space-1);line-height:1.2}
+.info-callout{background:color-mix(in oklch,var(--color-primary) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 20%,var(--color-border));border-left:3px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.info-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
+.info-callout p+p{margin-top:var(--space-3)}
+.info-callout strong{color:var(--color-text)}
+.info-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0}
+.info-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
+.warning-callout{background:color-mix(in oklch,#f59e0b 8%,var(--color-surface));border:1px solid color-mix(in oklch,#f59e0b 25%,var(--color-border));border-left:3px solid #f59e0b;border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.warning-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
+.warning-callout p+p{margin-top:var(--space-3)}
+.warning-callout strong{color:var(--color-text)}
+.warning-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0}
+.warning-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
+.faq-accordion{margin:var(--space-4) 0}
+details.faq-item{border:1px solid var(--color-border);border-radius:var(--radius-lg);margin-bottom:var(--space-2);overflow:hidden;background:var(--color-surface)}
+details.faq-item summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;gap:var(--space-3);transition:background .15s}
+details.faq-item summary::-webkit-details-marker{display:none}
+details.faq-item summary:hover{background:var(--color-surface-offset)}
+.faq-chevron{flex-shrink:0;transition:transform .2s;color:var(--color-text-muted)}
+details.faq-item[open] .faq-chevron{transform:rotate(180deg)}
+details.faq-item[open]>summary{background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
+.faq-body{padding:var(--space-4) var(--space-5);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
+.faq-body p{margin:0;max-width:none}
+.faq-body p+p{margin-top:var(--space-3)}
+.faq-body strong{color:var(--color-text)}
+/* STEP BLOCKS */
+.step-list{list-style:none;padding:0;margin:var(--space-6) 0;display:flex;flex-direction:column;gap:var(--space-4)}
+.step-block{display:flex;align-items:flex-start;gap:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
+.step-number{flex-shrink:0;width:36px;height:36px;border-radius:var(--radius-full);background:var(--color-primary);color:#fff;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
+.step-content{flex:1;min-width:0}
+.step-content strong{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
+.step-content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0;max-width:none}
+/* COUNTRY CARDS — international hallmark sections */
+.country-card{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0;transition:box-shadow var(--transition)}
+.country-card:hover{box-shadow:var(--shadow-md)}
+.country-card__header{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
+.country-card__name{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text)}
+.country-card p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4);max-width:none}
+.country-card p:last-child{margin-bottom:0}
+.country-card strong{color:var(--color-text)}
+.country-card table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-3) 0}
+.country-card table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-3) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
+.country-card table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
+.country-card table tr:last-child td{border-bottom:none}
+.country-card table td:first-child,.country-card table th:first-child{padding-left:0;color:var(--color-text)}
+/* HALLMARK PILL — inline fineness badge */
+.hmark{display:inline-flex;align-items:center;padding:2px 8px;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:.04em;font-family:var(--font-display)}
 </style>
-
 <link rel="stylesheet" href="/assets/site.css">
 </head>
 <body>
@@ -437,232 +265,530 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
-          <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
-          <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Silver Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Silver Tools</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a></div>
         </div>
       </li>
-      <li class="mega-nav__item mega-nav__item--wide" role="none">
+      <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Guides <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel mega-panel--wide" role="menu" aria-label="Guides">
-          <div class="mega-panel__col"><a href="/guides/buying-investing/" class="mega-panel__category-link"><span class="mega-panel__cat-title">Buying &amp; Investing</span><span class="mega-panel__cat-desc">Bullion, ETFs, IRA &amp; more</span></a></div>
-          <div class="mega-panel__col"><a href="/guides/selling-testing/" class="mega-panel__category-link"><span class="mega-panel__cat-title">Selling &amp; Testing</span><span class="mega-panel__cat-desc">Value, sell &amp; test your gold</span></a></div>
-          <div class="mega-panel__col"><a href="/guides/market-prices/" class="mega-panel__category-link"><span class="mega-panel__cat-title">Market &amp; Prices</span><span class="mega-panel__cat-desc">Charts, history &amp; outlook</span></a></div>
-          <div class="mega-panel__col"><a href="/guides/silver-guides/" class="mega-panel__category-link"><span class="mega-panel__cat-title">Silver Guides</span><span class="mega-panel__cat-desc">Silver prices &amp; silver value</span></a></div>
-          <div class="mega-panel__col"><a href="/guides/deep-dives/" class="mega-panel__category-link"><span class="mega-panel__cat-title">Deep Dives</span><span class="mega-panel__cat-desc">Karat, purity &amp; weights</span></a></div>
-          <div class="mega-panel__col mega-panel__col--browse"><a href="/guides/" class="mega-panel__browse-all">Browse All Guides &rarr;</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Selling &amp; Testing</span><a href="/guides/how-to-sell-gold-jewellery">How to Sell Gold Jewellery</a><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a><a href="/guides/gold-hallmarks-explained">Gold Hallmarks Explained</a><a href="/guides/what-is-best-time-to-sell-scrap-gold">Best Time to Sell Gold</a><a href="/guides/how-much-is-a-gold-ring-worth">Gold Ring Worth</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Buying &amp; Investing</span><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a><a href="/guides/gold-vs-silver-investment">Gold vs Silver</a><a href="/guides/gold-bar-guide">Gold Bar Guide</a><a href="/guides/gold-purity-guide">Gold Purity Guide</a><a href="/guides/what-is-14k-gold">What is 14K Gold?</a></div>
+          <div class="mega-panel__col"><span class="mega-panel__heading">Market &amp; Prices</span><a href="/guides/gold-price-history">Gold Price History</a><a href="/guides/how-to-read-gold-spot-price">Reading Spot Prices</a><a href="/guides/what-affects-gold-price">What Affects Gold Price</a><a href="/guides/troy-ounce-vs-gram-explained">Troy Ounce vs Gram</a></div>
+          <div class="mega-panel__col--browse"><a href="/guides/" class="mega-panel__browse-all">Browse All Guides &rarr;</a></div>
         </div>
       </li>
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Blog <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel mega-panel--blog" role="menu" aria-label="Blog">
-          <div class="mega-panel__col mega-panel__col--blog"><span class="mega-panel__heading">Latest Articles</span><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers 2026</a><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026?</a><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a><a href="/blog/" class="mega-panel__view-all">View All Articles &rarr;</a></div>
+          <div class="mega-panel__col mega-panel__col--blog"><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers 2026</a><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026?</a><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a><a href="/blog/" class="mega-panel__view-all">All Articles &rarr;</a></div>
         </div>
       </li>
-      <li class="mega-nav__item mega-nav__item--plain" role="none">
-        <a href="/about" class="mega-nav__trigger mega-nav__trigger--link" role="menuitem">About</a>
-      </li>
+      <li class="mega-nav__item" role="none"><a href="/about" class="mega-nav__trigger mega-nav__trigger--link">About</a></li>
     </ul>
     <div class="nav-actions">
-      <button class="theme-toggle" data-theme-toggle aria-label="Toggle dark mode"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
-      <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
-    </div>
-  </div>
-  <div class="mobile-menu" id="mobileMenu" role="dialog" aria-label="Mobile navigation" aria-modal="true">
-    <div class="mobile-menu__inner">
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Gold Prices</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/gold-rates-today">Gold Rates Today</a><a href="/live-gold-silver-price-today">Live Gold &amp; Silver</a><a href="/gold-silver-ratio">Gold / Silver Ratio</a><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></div></div>
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Calculators</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/scrap-gold-calculator">Scrap Gold Calculator</a><a href="/gold-bar-value">Gold Bar Value</a><a href="/gold-coins-vs-bars">Gold Coins vs Bars</a><a href="/zakat-gold-silver-calculator">Zakat Calculator</a><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a><a href="/where-to-sell-gold-silver">Where to Sell Gold</a><a href="/best-gold-ira-companies">Best Gold IRA Companies</a></div></div>
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Silver</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/silver-price-guide">Silver Price Guide</a></div></div>
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Guides</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/guides/buying-investing/">Buying &amp; Investing</a><a href="/guides/selling-testing/">Selling &amp; Testing</a><a href="/guides/market-prices/">Market &amp; Prices</a><a href="/guides/silver-guides/">Silver Guides</a><a href="/guides/deep-dives/">Deep Dives</a><a href="/guides/">Browse All Guides</a></div></div>
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Blog</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers 2026</a><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026?</a><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a><a href="/blog/" class="mobile-view-all">All Articles &rarr;</a></div></div>
-      <div class="mobile-section mobile-section--flat"><a href="/about">About</a><a href="/contact">Contact</a><a href="/editorial-standards/">Editorial Standards</a></div>
-      <div class="mobile-menu__search"><form action="/" method="GET"><input type="search" name="q" placeholder="Search GoldPriceTools..." aria-label="Search site"></form></div>
+      <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark/light mode">
+        <svg id="iconSun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        <svg id="iconMoon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      </button>
+      <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
+        <span></span><span></span><span></span>
+      </button>
     </div>
   </div>
 </nav>
-</nav>
-
-<div class="breadcrumb-wrap">
-  <ol class="breadcrumb" aria-label="Breadcrumb">
-    <li><a href="/">Home</a></li>
-    <li><a href="/guides/">Guides</a></li>
-    <li aria-current="page">Gold Hallmarks Explained</li>
-  </ol>
+<div class="mobile-menu" id="mobileMenu" role="dialog" aria-label="Mobile navigation">
+  <div class="mobile-menu__inner">
+    <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Gold Prices</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/gold-rates-today">Gold Rates Today</a><a href="/live-gold-silver-price-today">Live Gold &amp; Silver</a><a href="/gold-silver-ratio">Gold / Silver Ratio</a><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></div></div>
+    <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Calculators</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/scrap-gold-calculator">Scrap Gold Calculator</a><a href="/gold-bar-value">Gold Bar Value</a><a href="/gold-coins-vs-bars">Gold Coins vs Bars</a><a href="/zakat-gold-silver-calculator">Zakat Calculator</a><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a><a href="/where-to-sell-gold-silver">Where to Sell Gold</a><a href="/best-gold-ira-companies">Best Gold IRA Companies</a></div></div>
+    <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Silver</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/silver-price-guide">Silver Price Guide</a></div></div>
+    <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Guides</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/guides/buying-investing/">Buying &amp; Investing</a><a href="/guides/selling-testing/">Selling &amp; Testing</a><a href="/guides/market-prices/">Market &amp; Prices</a><a href="/guides/silver-guides/">Silver Guides</a><a href="/guides/deep-dives/">Deep Dives</a><a href="/guides/">Browse All Guides</a></div></div>
+    <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Blog</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers 2026</a><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026?</a><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a><a href="/blog/" class="mobile-view-all">All Articles &rarr;</a></div></div>
+    <div class="mobile-section mobile-section--flat"><a href="/about">About</a><a href="/contact">Contact</a><a href="/editorial-standards/">Editorial Standards</a></div>
+    <div class="mobile-menu__search"><form action="/" method="GET"><input type="search" name="q" placeholder="Search GoldPriceTools..." aria-label="Search site"></form></div>
+  </div>
 </div>
 
-<article class="article-wrap" itemscope itemtype="https://schema.org/Article">
-  <div class="article-tag">Gold Guide</div>
-  <h1 class="article-title" itemprop="headline">Gold Hallmarks Explained</h1>
+<div class="breadcrumb-wrap">
+  <nav aria-label="Breadcrumb">
+    <ol class="breadcrumb">
+      <li><a href="/">Home</a></li>
+      <li><a href="/guides/">Guides</a></li>
+      <li aria-current="page">Gold Hallmarks Explained</li>
+    </ol>
+  </nav>
+</div>
+
+<article class="article-wrap">
+  <div class="article-tag">Identification Guide</div>
+  <h1 class="article-title">Gold Hallmarks Explained — The Complete Identification Guide (2026)</h1>
   <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
+    <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
     <span>&middot;</span>
-    <span>Published <time datetime="2026-05-01" itemprop="datePublished">01 May 2026</time></span>
+    <time datetime="2026-05-08">Updated 8 May 2026</time>
     <span>&middot;</span>
-    <span>Updated <time datetime="2026-05-01" itemprop="dateModified">01 May 2026</time></span>
+    <span>21 min read</span>
+  </div>
+
+  <div class="exec-summary">
+    <p class="exec-summary-intro">Pick up almost any piece of gold jewellery and look closely — with good light and perhaps a magnifying glass — and you will find a tiny constellation of stamps somewhere on the metal. A number. A small symbol. Maybe a heraldic animal so small it seems impossible to have been stamped there at all. These are gold hallmarks, and they are <strong>one of the most useful and underappreciated pieces of information in the jewellery world.</strong> This guide covers everything — from the basics of the British system through European, Russian, Fabergé, Indian, Middle Eastern, and Chinese marks.</p>
+    <div class="exec-summary-stats">
+      <div class="exec-stat"><div class="exec-stat-label">UK law since</div><div class="exec-stat-value">1300</div></div>
+      <div class="exec-stat"><div class="exec-stat-label">UK assay offices</div><div class="exec-stat-value">4 active</div></div>
+      <div class="exec-stat"><div class="exec-stat-label">UK gold standards</div><div class="exec-stat-value">7 purities</div></div>
+      <div class="exec-stat"><div class="exec-stat-label">CCM treaty members</div><div class="exec-stat-value">19 countries</div></div>
+    </div>
   </div>
 
   <div class="prose">
 
-<p>When you examine a piece of gold jewelry, a watch, or a bullion bar, you will almost always find tiny stamps inscribed into the metal. These are hallmarks, and they serve as the vital "fingerprint" of the item. Understanding gold hallmarks is essential for anyone buying, selling, or evaluating gold, as these marks provide guaranteed information about the gold's purity, origin, and manufacturer. In this comprehensive guide, we will explain everything you need to know about gold hallmarks.</p>
+    <h2 id="what-is">What Is a Gold Hallmark?</h2>
+    <p>A gold hallmark is an official mark stamped onto a piece of gold jewellery or metalwork by an independent testing body — called an assay office — after the item has been chemically tested and confirmed to meet a legal standard of purity.</p>
+    <p>The word itself has a very specific origin. From the 16th century onwards, goldsmiths in London were required to bring their work to Goldsmiths' Hall on Foster Lane, where it would be tested and, if it met the required standard, struck with an official mark. That mark — applied at the Hall — became known as a "hall mark." The name stuck, and today it is used worldwide to describe any official precious metal certification stamp.</p>
+    <p>The purpose has always been the same: <strong>consumer protection.</strong> Gold can be alloyed with cheaper metals at any proportion — a piece that looks like solid 18-karat gold could be 9-karat, or less. Without an independent test, a buyer has no way to verify what they are actually purchasing. Hallmarks solve that problem by transferring the verification to an independent, legally accountable body whose mark carries legal weight.</p>
 
-<h2>What is a Hallmark?</h2>
-<p>A hallmark is an official mark or series of marks struck on items made of precious metals—platinum, gold, palladium, and silver. Hallmarking guarantees the purity or fineness of the metal. It is an ancient form of consumer protection, ensuring that buyers are not defrauded by counterfeiters using cheaper base metals or diluting gold with too much alloy.</p>
-<p>The practice of hallmarking dates back centuries. In the UK, it originated in the 1300s when King Edward I enacted a statute requiring silver to meet a certain standard. Today, hallmarking laws vary significantly by country. In the UK and many European nations, hallmarking is strictly regulated and mandatory for items over a certain weight. In the United States, however, hallmarking is not federally mandated, though manufacturers must accurately disclose purity if they choose to stamp the item.</p>
+    <h2 id="british-system">The British Hallmarking System: The World's Most Rigorous</h2>
+    <p>The United Kingdom operates the oldest and most comprehensive hallmarking system in the world. British hallmarking dates back to <strong>1300</strong>, when Edward I decreed that all gold and silver must be assayed before sale. In 1478, the date letter system was introduced in London, allowing items to be dated to within a year. By 1757, counterfeiting a hallmark had become a felony punishable by death — reflecting just how seriously the system was taken.</p>
+    <p>Today, the system is governed by the <strong>Hallmarking Act 1973</strong>, which requires that any item described as gold and weighing more than one gram must be hallmarked before sale in the UK. Hallmarking must be carried out by one of four UK assay offices, each supervised by the British Hallmarking Council.</p>
 
-<h2>Understanding Gold Purity Marks (Karat vs. Fineness)</h2>
-<p>The most important component of any gold hallmark is the purity mark, which indicates how much actual gold is in the item compared to alloyed metals (like copper, silver, or zinc). Purity is typically expressed in one of two ways: Karats or Millesimal Fineness.</p>
+    <h3>The Four Components of a British Hallmark</h3>
+    <p>A full UK hallmark consists of up to four distinct marks, three of which are compulsory under the 1973 Act:</p>
 
-<h3>The Karat System (K or Kt)</h3>
-<p>The karat system measures gold purity on a scale of 24. Pure gold is 24 karats (24K). If an item is 18K gold, it means it is composed of 18 parts gold and 6 parts alloy metals (18/24 = 75% gold). The karat system is most commonly used in the United States and parts of Asia.</p>
-<ul>
-    <li><strong>24K:</strong> 100% Pure Gold (Extremely soft, usually reserved for bullion)</li>
-    <li><strong>22K:</strong> 91.6% Gold (Common in high-end jewelry, particularly in India and the Middle East)</li>
-    <li><strong>18K:</strong> 75.0% Gold (The standard for premium fine jewelry)</li>
-    <li><strong>14K:</strong> 58.3% Gold (The most popular choice for durable everyday jewelry in the US)</li>
-    <li><strong>10K:</strong> 41.7% Gold (The minimum purity to be legally sold as "gold" in the US; highly durable)</li>
-    <li><strong>9K:</strong> 37.5% Gold (Common in the UK and Australia; very durable but lower intrinsic value)</li>
-</ul>
+    <h4>1. The Sponsor's Mark (Maker's Mark)</h4>
+    <p>The sponsor's mark identifies the company or individual who sent the item for hallmarking — typically the manufacturer, importer, or retailer. It usually consists of two or three initials in a distinctive shape (shield, lozenge, rectangle), which the sponsor has registered with their assay office. Assay offices and specialist reference books hold registration records going back centuries.</p>
 
-<h3>Millesimal Fineness (The Three-Digit Code)</h3>
-<p>Millesimal fineness is a metric system that expresses gold purity in parts per thousand. It is the standard system used in the UK, Europe, and for international bullion. It is more precise than the karat system.</p>
-<ul>
-    <li><strong>999 (or 999.9):</strong> 24 Karat (Pure Gold)</li>
-    <li><strong>916:</strong> 22 Karat (91.6% Gold)</li>
-    <li><strong>750:</strong> 18 Karat (75.0% Gold)</li>
-    <li><strong>585:</strong> 14 Karat (58.5% Gold)</li>
-    <li><strong>417:</strong> 10 Karat (41.7% Gold)</li>
-    <li><strong>375:</strong> 9 Karat (37.5% Gold)</li>
-</ul>
-<p>When you see a stamp reading "750", you immediately know the item is 18K gold. You can check the exact value of these purities using our <a href="/scrap-gold-calculator">scrap gold calculator</a>.</p>
+    <h4>2. The Fineness Mark (Purity Mark)</h4>
+    <p>The fineness mark tells you the gold content of the item, expressed in parts per thousand — a system called millesimal fineness. Common UK gold fineness marks are:</p>
+    <table>
+      <thead><tr><th>Mark</th><th>Carat</th><th>Gold Content</th><th>Use</th></tr></thead>
+      <tbody>
+        <tr><td><span class="hmark">999</span></td><td>24ct</td><td>99.9%</td><td>Investment bars &amp; coins</td></tr>
+        <tr><td><span class="hmark">958</span></td><td>23ct (Britannia)</td><td>95.8%</td><td>Specialist commemorative pieces</td></tr>
+        <tr><td><span class="hmark">916</span></td><td>22ct</td><td>91.6%</td><td>Traditional UK wedding rings</td></tr>
+        <tr><td><span class="hmark">750</span></td><td>18ct</td><td>75.0%</td><td>Fine jewellery standard</td></tr>
+        <tr><td><span class="hmark">585</span></td><td>14ct</td><td>58.5%</td><td>Popular in USA &amp; Europe</td></tr>
+        <tr><td><span class="hmark">375</span></td><td>9ct</td><td>37.5%</td><td>Most common UK jewellery</td></tr>
+      </tbody>
+    </table>
+    <p>Prior to 1975, UK gold hallmarks used a different system — a crown (indicating gold) plus the carat numeral (9, 15, 18, 22). If you find this combination on an older piece, it is the pre-decimal British purity mark. The change to millesimal fineness brought the UK into line with international standards.</p>
 
-<div class="ad-slot" data-ad-slot="YOUR_SLOT_1"></div>
+    <h4>3. The Assay Office Mark</h4>
+    <p>The assay office mark is perhaps the most visually distinctive part of a British hallmark — each of the four active UK assay offices uses a unique heraldic symbol:</p>
+    <table>
+      <thead><tr><th>Symbol</th><th>Assay Office</th><th>Notes</th></tr></thead>
+      <tbody>
+        <tr><td>Leopard's head</td><td>London</td><td>Used since the 13th century; originally facing right, now facing left</td></tr>
+        <tr><td>Anchor</td><td>Birmingham</td><td>Established 1773; the anchor is displayed on its side</td></tr>
+        <tr><td>Yorkshire rose / Crown</td><td>Sheffield</td><td>Uses a rose or crown (pre-2019) / rosette</td></tr>
+        <tr><td>Castle</td><td>Edinburgh</td><td>A three-towered castle; Scotland's oldest assay office</td></tr>
+      </tbody>
+    </table>
+    <p>A fifth office — Chester — operated until 1962, using a sword with three wheatsheaves. Dublin's office (using a crowned harp) was active until 1923. Both are perfectly valid historical hallmarks encountered on antique pieces.</p>
 
-<h2>The UK Hallmarking System</h2>
-<p>The United Kingdom has one of the oldest and most stringent hallmarking systems in the world. A complete, legally compliant UK hallmark must contain at least three compulsory marks: the Sponsor's Mark, the Standard Mark, and the Assay Office Mark. Historically, a Date Letter was also compulsory, though it is now optional.</p>
+    <h4>4. The Date Letter (Optional since 1998)</h4>
+    <p>The date letter is an alphabetically cycling letter, changed each year, which identifies when the item was hallmarked. Date letters were compulsory until 1998 and are now voluntary, though many manufacturers still use them — particularly for commemorative or high-value pieces. Each assay office uses its own date letter cycle with different typefaces and shield shapes. <em>Bradbury's Book of Hallmarks</em> contains the complete cycles for all offices and is the standard resource for dating antique British pieces.</p>
 
-<h3>1. The Sponsor's Mark (Maker's Mark)</h3>
-<p>The Sponsor's Mark identifies the company, manufacturer, or individual who submitted the item for hallmarking. It usually consists of the initials of the maker set within a specific geometric shield design. This ensures traceability and accountability.</p>
+    <h2 id="where-to-find">Where to Find Hallmarks on Gold Jewellery</h2>
+    <p>Hallmarks are small — often tiny — and placed in locations that are practical from a manufacturing standpoint but not always obvious to a buyer. Here is where to look:</p>
+    <ul>
+      <li><strong>Rings:</strong> Inside the band (inner circumference), usually near the join</li>
+      <li><strong>Necklaces and bracelets:</strong> On or very near the clasp; sometimes on a small attached tag</li>
+      <li><strong>Earrings:</strong> On the post or earring back; sometimes on the face of a stud</li>
+      <li><strong>Pendants:</strong> On the reverse of the pendant, or on the bale (the loop the chain passes through)</li>
+      <li><strong>Pocket watches:</strong> On the inner case back, sometimes also on the outer case; watch cases typically carry a full set of hallmarks</li>
+      <li><strong>Brooches:</strong> On the reverse, near the pin mechanism</li>
+      <li><strong>Bangles:</strong> On the inner surface</li>
+    </ul>
+    <p>A 10× jeweller's loupe makes a significant difference when reading small or worn hallmarks. A phone camera with zoom can also be useful for photographing marks and examining them on screen.</p>
 
-<h3>2. The Standard Mark (Fineness Mark)</h3>
-<p>The Standard Mark indicates the purity of the gold. In the UK, this is expressed using the millesimal fineness system (e.g., 375, 750, 916). The shape of the shield surrounding the number also indicates the metal type. For gold, the number is traditionally enclosed in an octagonal shield. Historically, a Crown mark was also used alongside the number to denote gold, though the rules have been modernized.</p>
+    <h2 id="reading-a-mark">Reading a Complete British Hallmark</h2>
+    <p>To make this concrete, here is how to read a complete hallmark on a hypothetical gold ring:</p>
 
-<h3>3. The Assay Office Mark</h3>
-<p>The Assay Office Mark identifies which specific UK assay office tested and hallmarked the item. The UK currently operates four assay offices, each with its unique symbol:</p>
-<ul>
-    <li><strong>London:</strong> A Leopard's Head</li>
-    <li><strong>Birmingham:</strong> An Anchor</li>
-    <li><strong>Sheffield:</strong> A Yorkshire Rose (formerly a Crown for silver)</li>
-    <li><strong>Edinburgh:</strong> A Castle</li>
-</ul>
-<p>Historically, there were other assay offices, such as Chester (Three Wheatsheaves and a Sword), Glasgow (Tree, Bird, Bell, and Fish), and Dublin (Hibernia), but these have since closed or operate under different jurisdictions.</p>
+    <div class="info-callout">
+      <p><strong>Example:</strong> A ring with the following marks inside the band: <strong>AT</strong> (in a shield) · <span class="hmark">750</span> · Leopard's head · Letter <strong>N</strong> in a plain square.</p>
+      <ul>
+        <li><strong>AT</strong> — the sponsor's mark (the maker's registered initials)</li>
+        <li><strong>750</strong> — 18-carat gold (75% pure gold)</li>
+        <li><strong>Leopard's head</strong> — London Assay Office; tested and certified in London</li>
+        <li><strong>N</strong> — the date letter, identifying the year of hallmarking by cross-reference with London's date letter cycle</li>
+      </ul>
+      <p>Taken together: solid 18-carat gold, tested by the London Assay Office, with a precisely dateable year of hallmarking — a remarkable amount of information from four tiny stamps.</p>
+    </div>
 
-<h3>4. The Date Letter (Optional)</h3>
-<p>Until 1999, the Date Letter was a compulsory part of the UK hallmark. It indicated the specific year the item was hallmarked. It consists of a single letter of the alphabet, which changes annually. The font, case (uppercase or lowercase), and the shape of the surrounding shield also change systematically to prevent confusion between different decades. While now optional, many manufacturers still include the Date Letter for tradition and historical tracking.</p>
+    <h2 id="antique">Antique Gold Hallmarks: What Changes Over Time</h2>
+    <p>Antique British gold hallmarks differ from modern ones in ways that matter to collectors and dealers. Understanding what changed — and when — helps with both identification and authentication.</p>
 
-<h2>International Hallmarks and Conventions</h2>
-<p>Because hallmarking laws vary globally, international trade of precious metals can be complex. To streamline this, several European nations signed the Vienna Convention on the Control and Marking of Articles of Precious Metals in 1972.</p>
-<p>Countries that are signatories to the Vienna Convention use a standardized "Common Control Mark" (CCM). For gold, the CCM is represented by a stylized balance scales symbol accompanied by the fineness number (e.g., 750) and the assayer's mark. Items bearing the CCM can be imported and sold in other signatory countries without requiring further testing and hallmarking.</p>
-<p>In contrast, items produced in countries without mandatory independent hallmarking (like the USA, India, or China) often only carry a simple purity stamp (e.g., "14K") applied by the manufacturer. While usually accurate, these manufacturer-applied marks do not offer the same level of independent verification as a true assay office hallmark.</p>
+    <h3>Pre-1975: Crown and Carat Numeral System</h3>
+    <p>Antique gold of 18ct and 22ct will typically show a crown symbol followed by the numeral 18 or 22 — this was the British gold standard mark used up to 1975. After 1854, the standards were broadened to include 15ct, 12ct, and 9ct in addition to the traditional 18ct and 22ct. Finding a 15ct hallmark dates a piece to <strong>between 1854 and 1932</strong>, when the 15ct and 12ct standards were discontinued and replaced with 14ct.</p>
 
-<h2>Plated and Rolled Gold Marks</h2>
-<p>It is vital to distinguish solid gold hallmarks from marks indicating gold plating. If you see marks such as <strong>EP</strong> (Electroplated), <strong>GP</strong> (Gold Plated), <strong>GEP</strong> (Gold Electroplated), <strong>HGE</strong> (Heavy Gold Electroplate), or <strong>GF</strong> (Gold Filled), the item is not solid gold. It consists of a base metal core covered by a thin layer of gold.</p>
-<p>For example, a stamp of "14K GF" means 14K Gold Filled. The gold layer is thicker than standard plating but the item is still fundamentally a base metal piece. Similarly, "925" indicates Sterling Silver, even if the item appears gold (this is known as gold vermeil). If you are looking to sell, you should review our guide on <a href="/guides/how-to-sell-gold-jewellery">selling gold jewellery</a> to ensure you get the best price.</p>
+    <h3>Victorian Gold Hallmarks (1837–1901)</h3>
+    <p>Victorian jewellery is among the most actively collected antique category in the world, and Victorian gold hallmarks are consequently one of the most commonly researched topics. Key characteristics:</p>
+    <ul>
+      <li>The crown-plus-numeral purity system was in universal use throughout the Victorian period</li>
+      <li>Date letters allow precise dating of Victorian pieces to individual years</li>
+      <li><strong>15-carat gold</strong> is particularly characteristic of later Victorian work — widely used for sentimental lockets, brooches, and chains</li>
+      <li>18-carat and 22-carat were used for fine jewellery and high-quality work</li>
+      <li>Some small, delicate Victorian items were exempt from hallmarking on the grounds of size — genuine period pieces may carry no marks</li>
+    </ul>
 
-<h2>Conclusion</h2>
-<p>Gold hallmarks are a fascinating and essential aspect of the precious metals industry. They offer a window into the history, origin, and exact composition of gold items. By learning how to read hallmarks—whether it's understanding the difference between karats and millesimal fineness or deciphering a historic UK assay mark—you empower yourself as a consumer, collector, or investor.</p>
-<p>Always examine gold items closely with a jeweler's loupe or magnifying glass. If a hallmark is present, it provides significant assurance of the item's value. However, if a mark is missing, blurry, or accompanied by terms like "GP" or "GF," proceed with caution and consider having the item professionally tested to confirm its authenticity and true worth.</p>
+    <h3>Georgian Gold Hallmarks (1714–1837)</h3>
+    <p>Georgian jewellery presents a particular challenge because compulsory hallmarking of all precious metals did not begin until the later Victorian period. Some Georgian pieces carry clear assay office marks and date letters; others — particularly small or delicate items — were made without marks entirely and are authenticated on stylistic, constructional, and provenance grounds.</p>
+    <p>When Georgian pieces do carry marks, <strong>18ct and 22ct</strong> are the most common standards — Georgian goldsmiths typically worked with higher purities than is standard today. The presence of a date letter from the Georgian period on a well-executed piece can date the item to within one year.</p>
 
-  </div><!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
-  <a class="share-btn" href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/gold-hallmarks-explained&text=Gold+Hallmarks+Explained" target="_blank" rel="noopener noreferrer" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
-  <a class="share-btn" href="https://www.reddit.com/submit?url=https://goldpricetools.com/guides/gold-hallmarks-explained&title=Gold+Hallmarks+Explained" target="_blank" rel="noopener noreferrer" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a class="share-btn" href="https://wa.me/?text=Gold+Hallmarks+Explained+https://goldpricetools.com/guides/gold-hallmarks-explained" target="_blank" rel="noopener noreferrer" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
-</div>
-  <script>
-  document.querySelectorAll('.share-buttons a').forEach(btn => {
-    btn.addEventListener('click', () => {
-      if (typeof gtag === 'function') {
-        gtag('event', 'share', { method: btn.dataset.platform, content_type: 'article', item_id: window.location.pathname });
-      }
-    });
-  });
-  </script>
+    <h2 id="rare-marks">Rare and Unusual British Hallmarks</h2>
+    <p>Beyond the standard four marks, British jewellery sometimes carries additional marks:</p>
+    <ul>
+      <li><strong>The Lion Passant:</strong> A walking lion in profile, primarily associated with English sterling silver but occasionally appearing on pre-decimal gold pieces as a traditional mark.</li>
+      <li><strong>Coronation and Jubilee Marks:</strong> Special commemorative marks struck in specific years — for Queen Elizabeth II's coronations and jubilees. Voluntary additional marks of interest to collectors that can confirm a piece as an authentic period item.</li>
+      <li><strong>Convention Common Control Mark (CCM):</strong> A scale-of-balance mark used on items certified under the Vienna Convention — an international hallmarking treaty involving 19 member countries. Items bearing a CCM are recognised across all member states without requiring local re-hallmarking.</li>
+      <li><strong>Chester Assay Office Mark:</strong> A sword with three wheatsheaves, used from the 17th century until Chester's closure in 1962. Pieces bearing this mark are authentic British hallmarks and relatively uncommon.</li>
+    </ul>
 
-  <div class="cta-box">
-    <h3>Gold Value Calculator</h3>
-    <p>Identify your gold hallmark? Use our calculator to find out exactly how much your gold is worth based on its purity.</p>
-    <a href="/gold-price-per-gram" class="cta-btn">Open Calculator &rarr;</a>
+    <h2 id="european">European Gold Hallmarks: A Country-by-Country Guide</h2>
+    <p>European hallmarking varies significantly by country — some operate government-mandated assay systems similar to the UK; others use self-declaration by manufacturers; some use pictorial symbols; others rely purely on numeric fineness marks.</p>
+
+    <div class="country-card">
+      <div class="country-card__header">
+        <div class="country-card__name">French Gold Hallmarks</div>
+      </div>
+      <p>France developed one of the most elegant hallmarking systems in the world, built around pictorial symbols rather than numbers. The system was standardised in 1838 and remains largely unchanged today.</p>
+      <table>
+        <thead><tr><th>Symbol</th><th>Metal / Standard</th><th>Meaning</th></tr></thead>
+        <tbody>
+          <tr><td>Eagle's head (facing left)</td><td>18K gold (750)</td><td>National guarantee mark since 1838 — the most commonly encountered French gold mark</td></tr>
+          <tr><td>Scallop shell</td><td>14K gold (585)</td><td>Introduced post-World War I</td></tr>
+          <tr><td>Clover / Trefoil</td><td>9K gold (375)</td><td>Primarily for export pieces</td></tr>
+          <tr><td>Owl</td><td>Import mark</td><td>Applied to foreign items imported into France — confirms sold in France, not made there</td></tr>
+          <tr><td>Lozenge (diamond shape)</td><td>Maker's mark</td><td>Identifies the manufacturer; compulsory on all French pieces</td></tr>
+        </tbody>
+      </table>
+      <p>The <strong>eagle's head</strong> is the mark most collectors and buyers encounter on antique French jewellery — tiny, discreet, but decisive. It appears on virtually all 18-karat French gold from 1838 onwards. Historically, different animals were used for 18K gold at different periods — the horse's head, rhinoceros head, and even the weevil were all used before the standardisation of the eagle. The <strong>owl mark</strong> on a piece confirms it was sold in France but made elsewhere.</p>
+    </div>
+
+    <div class="country-card">
+      <div class="country-card__header">
+        <div class="country-card__name">German Gold Hallmarks</div>
+      </div>
+      <p>Germany does not operate a compulsory government hallmarking system for gold. Instead, manufacturers use the millesimal fineness system (<span class="hmark">375</span> <span class="hmark">585</span> <span class="hmark">750</span> <span class="hmark">999</span>) with their own maker's marks. The <strong>crescent moon and crown</strong> symbol was historically used as the German assay guarantee mark for gold and silver. Items carrying this symbol alongside a fineness number are reliably identifiable as German-certified precious metal.</p>
+    </div>
+
+    <div class="country-card">
+      <div class="country-card__header">
+        <div class="country-card__name">Italian Gold Hallmarks</div>
+      </div>
+      <p>Italy has one of the world's most prolific gold jewellery manufacturing industries — Arezzo, Vicenza, and Valenza are among the world's leading production centres — but Italy does not require government assay hallmarking in the same way the UK does. Italian pieces carry a <strong>maker's mark</strong> (a number identifying the manufacturer, registered with the state) and a <strong>fineness mark</strong> (<span class="hmark">375</span> <span class="hmark">585</span> <span class="hmark">750</span> <span class="hmark">999</span>). The shape of the cartouche around the fineness mark differs: pieces above 750 fineness use a star-shaped or oval cartouche; pieces at or below 750 use a different shape.</p>
+      <p>Arezzo in Tuscany is historically significant as one of Italy's oldest goldsmithing centres, recognised globally for quality. The numeric maker's code is the key identifier — registries are held by the Italian Chamber of Commerce.</p>
+    </div>
+
+    <div class="country-card">
+      <div class="country-card__header">
+        <div class="country-card__name">Spanish Gold Hallmarks</div>
+      </div>
+      <p>Spain operates a dual hallmarking system: government assay offices in major regions certify gold, and manufacturers must also register their mark. The system uses millesimal fineness (<span class="hmark">375</span> <span class="hmark">585</span> <span class="hmark">750</span>) with regional assay codes that make Spanish gold particularly informative for tracing provenance:</p>
+      <table>
+        <thead><tr><th>Code</th><th>Region</th></tr></thead>
+        <tbody>
+          <tr><td>V1</td><td>Valencia</td></tr>
+          <tr><td>M1</td><td>Madrid</td></tr>
+          <tr><td>A1</td><td>Andalusia</td></tr>
+          <tr><td>G1</td><td>Galicia</td></tr>
+          <tr><td>C1 / C2</td><td>Catalonia</td></tr>
+          <tr><td>B2</td><td>Balearic Islands</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="country-card">
+      <div class="country-card__header">
+        <div class="country-card__name">Swiss, Austrian &amp; Dutch Gold Hallmarks</div>
+      </div>
+      <p><strong>Switzerland</strong> introduced gold hallmarking in 1880. Swiss pieces carry a fineness mark alongside an assay office mark and maker's mark. The most distinctive Swiss hallmark symbols are the <strong>squirrel</strong> (for gold 585/14K and above, used since 1934) and the <strong>Helvetia head</strong> (for 18ct, 750 fineness). Swiss watch cases are a rich area for hallmark study — the combination of maker's code, fineness, and assay office mark allows detailed authentication of both case and movement.</p>
+      <p><strong>Austria</strong> uses the Convention Common Control Mark alongside national marks, and uses a <strong>shield</strong> format for its assay marks. Austrian pieces typically carry millesimal fineness numbers alongside a letter-and-number code identifying the assay district.</p>
+      <p><strong>The Netherlands</strong> uses a <strong>lion rampant</strong> alongside the fineness number. The <strong>fish</strong> symbol appears on Dutch import marks, serving a similar function to the French owl — indicating an item was imported for sale in the Netherlands.</p>
+    </div>
+
+    <h2 id="russian">Russian Gold Hallmarks</h2>
+    <p>Russia has one of the most historically layered hallmarking systems in the world, and one of the most sought-after by collectors — primarily because of the extraordinary work produced in the Tsarist era and the specific marks associated with Fabergé.</p>
+
+    <h3>Pre-Revolutionary Russia (Before 1917)</h3>
+    <p>Imperial Russian gold was marked using the <strong>zolotnik system</strong> — a unit of purity based on a traditional Russian weight. The numeral appears alongside a city crest identifying the assay office location. <strong>St. Petersburg</strong> pieces carry two crossed anchors and a sceptre; <strong>Moscow</strong> pieces show St. George slaying the dragon.</p>
+    <table>
+      <thead><tr><th>Zolotnik Mark</th><th>Modern Equivalent</th><th>Fineness</th></tr></thead>
+      <tbody>
+        <tr><td><span class="hmark">56</span></td><td>14K gold</td><td>583 / 585</td></tr>
+        <tr><td><span class="hmark">72</span></td><td>18K gold</td><td>750</td></tr>
+        <tr><td><span class="hmark">92</span></td><td>22K gold</td><td>916</td></tr>
+        <tr><td><span class="hmark">96</span></td><td>24K gold</td><td>999</td></tr>
+      </tbody>
+    </table>
+    <p>From <strong>1899</strong>, the iconic <strong>kokoshnik mark</strong> was introduced — a woman's head shown in left profile wearing a traditional kokoshnik headdress. This single mark replaced the old city crests, combining purity and assay location into one symbol. A Greek letter next to the kokoshnik identifies the specific assay office — the letter Iota (І) indicates St. Petersburg.</p>
+    <p>The kokoshnik is one of the most important dating tools for Russian antiques. Its presence confirms a piece was made <strong>in 1899 or later</strong>. Its absence — with a city crest instead — indicates pre-1899 manufacture.</p>
+
+    <h3>Soviet Era (1917–1991)</h3>
+    <p>After the 1917 Revolution, the zolotnik system was replaced with millesimal fineness. Soviet gold marks use a <strong>hammer and sickle within a star</strong> (appearing on items from 1927 onwards), a Cyrillic letter identifying the assay office, and a three-digit fineness number. The <span class="hmark">583</span> mark is particularly characteristic of Soviet gold — it was the standard used throughout the USSR period for what is elsewhere called 14-karat gold. Soviet pieces are frequently encountered in antique markets and are generally well-made, with clear, readable marks.</p>
+
+    <h2 id="faberge">Fabergé Gold Hallmarks: The Collector's Holy Grail</h2>
+    <p>No discussion of gold hallmarks would be complete without addressing Fabergé — the St. Petersburg goldsmith firm that became synonymous with the highest expression of Imperial Russian decorative arts, and whose marks are among the most scrutinised in the antique world.</p>
+    <p>Authentic Fabergé pieces carry a specific combination of marks:</p>
+    <ol>
+      <li><strong>The Government Assay Mark</strong> — a city crest (pre-1899) or kokoshnik mark (post-1899), confirming the metal was tested by the state. The zolotnik purity number appears alongside — 56 for 14K gold, 72 for 18K.</li>
+      <li><strong>The Workmaster's Initials</strong> — Fabergé did not work alone. Each specialist workmaster registered their initials. The most celebrated include Henrik Wigström (<strong>HW</strong>), Michael Perchin (<strong>MP</strong>), and Erik Kollin (<strong>EK</strong>). These initials are a critical authentication marker.</li>
+      <li><strong>The Fabergé Firm Mark</strong> — the name "FABERGÉ" (or "К. ФАБЕРЖЕ" in Cyrillic) appears on most significant pieces. St. Petersburg pieces typically use Cyrillic; Moscow branch pieces use "К. ФАБЕРЖЕ" alongside the double-headed eagle.</li>
+      <li><strong>The Imperial Warrant (Double-Headed Eagle)</strong> — the Romanov double-headed eagle, indicating Fabergé held the title of official supplier to the Imperial Court since 1885. Typically appears on Moscow branch pieces and highest-prestige St. Petersburg work.</li>
+    </ol>
+
+    <div class="warning-callout">
+      <p><strong>Fabergé fakes are unfortunately common.</strong> The most reliable authentication red flags are:</p>
+      <ul>
+        <li>Incorrect combinations of marks — Moscow eagle on a piece with St. Petersburg workmaster initials</li>
+        <li>Zolotnik numbers that do not match the stated quality</li>
+        <li>Kokoshnik marks on pieces claiming pre-1899 manufacture</li>
+        <li>Maker's initials not corresponding to any registered Fabergé workmaster</li>
+      </ul>
+    </div>
+
+    <h2 id="india">Gold Hallmarks in India: The BIS System</h2>
+    <p>India is the world's second-largest gold jewellery market, and its hallmarking system underwent a fundamental transformation in 2021. <strong>BIS hallmarking became mandatory</strong> across 256 notified districts from 16 June 2021, with subsequent expansion to 288 districts in 2022 and HUID strictly enforced from September 2023.</p>
+    <p>The current BIS hallmark consists of four elements:</p>
+    <ol>
+      <li><strong>BIS Triangle Logo</strong> — a triangle with a tick mark inside, confirming BIS certification</li>
+      <li><strong>Purity/Fineness Mark</strong> — expressed both as karat and fineness: <span class="hmark">22K916</span>, <span class="hmark">18K750</span>, or <span class="hmark">14K585</span></li>
+      <li><strong>Assaying &amp; Hallmarking Centre Mark</strong> — a unique code identifying the certified centre where the item was tested</li>
+      <li><strong>HUID (Hallmark Unique Identification Number)</strong> — a six-digit alphanumeric code unique to each piece, verifiable via the government's BIS Care app</li>
+    </ol>
+    <p>The HUID system is particularly innovative — it creates a digital record for every hallmarked piece of gold jewellery sold in India, allowing buyers to verify authenticity instantly on their phone. The <span class="hmark">22K/916</span> standard dominates Indian jewellery production, reflecting the traditional preference for high-purity gold in South Asian jewellery culture.</p>
+
+    <h2 id="middle-east">Middle Eastern and Arabic Gold Hallmarks</h2>
+    <p>Gold is central to the culture and economy of the Middle East — Dubai is one of the world's most important gold trading hubs. All gold sold legally in the UAE must be marked with official purity stamps applied after testing by government-approved bodies. The most common karats in the region are:</p>
+    <table>
+      <thead><tr><th>Mark</th><th>Karat</th><th>Purity</th><th>Notes</th></tr></thead>
+      <tbody>
+        <tr><td><span class="hmark">999</span></td><td>24K</td><td>99.9%</td><td>Pure investment gold</td></tr>
+        <tr><td><span class="hmark">916</span></td><td>22K</td><td>91.6%</td><td>Traditional Middle Eastern jewellery standard</td></tr>
+        <tr><td><span class="hmark">875</span></td><td>21K</td><td>87.5%</td><td>Dominant Gulf standard — most distinctive regional identifier</td></tr>
+        <tr><td><span class="hmark">750</span></td><td>18K</td><td>75.0%</td><td>Modern, Western-influenced designs</td></tr>
+      </tbody>
+    </table>
+    <p>The <span class="hmark">875</span> fineness mark is one of the clearest indicators of Middle Eastern origin when encountered on gold in Western markets. Saudi Arabia and Egypt follow the same conventions — Egyptian gold is typically <span class="hmark">750</span> or <span class="hmark">875</span> and carries an official government assay stamp alongside the fineness mark.</p>
+
+    <h2 id="chinese">Chinese Gold Hallmarks</h2>
+    <p>Chinese gold jewellery uses the millesimal fineness system, with <span class="hmark">999</span> and <span class="hmark">9999</span> being particularly common — reflecting China's preference for high-purity gold jewellery, particularly in 24-karat forms. Common Chinese gold marks include:</p>
+    <ul>
+      <li><strong>999</strong> — 24-karat gold (99.9% pure); the standard for most Chinese gold jewellery</li>
+      <li><strong>9999</strong> — investment-grade pure gold (99.99% fine)</li>
+      <li><strong>足金 (Zú jīn)</strong> — Chinese characters meaning "full gold" or 24K gold</li>
+      <li><strong>千足金 (Qiān zú jīn)</strong> — "thousand full gold," indicating 999.9 fine</li>
+    </ul>
+    <p>The <span class="hmark">999</span> mark is the most commonly encountered in Western markets and is straightforward to identify — it is pure 24-karat gold.</p>
+
+    <h2 id="white-gold">White Gold Hallmarks: What to Look For</h2>
+    <p>White gold is an alloy of gold with white metals — typically palladium, nickel, or silver — creating a pale, silver-coloured appearance. It is not a separate standard from yellow gold; it is the same purity levels (9ct, 14ct, 18ct) in a different alloy composition.</p>
+
+    <div class="info-callout">
+      <p><strong>White gold carries exactly the same hallmarks as yellow gold.</strong> A white gold ring hallmarked <span class="hmark">750</span> is 18-carat gold — the 750 mark identifies the gold content regardless of colour. There is no special white gold hallmark.</p>
+      <p>The confusion arises because many people assume white gold must carry a different mark — perhaps "WG" or a special symbol. It does not. If a piece is white-coloured and carries a 375, 585, or 750 hallmark with a UK assay office mark, it is hallmarked solid white gold. White gold jewellery is often rhodium-plated for a brighter finish — this plating does not affect the hallmark or the gold's value.</p>
+    </div>
+
+    <h2 id="pocket-watches">Gold Hallmarks on Pocket Watches</h2>
+    <p>Pocket watch hallmarking is a subject of considerable depth. The case of a pocket watch — distinct from the movement — was manufactured and hallmarked separately from the movement itself. A watch can therefore have a case made in a different year, and even a different city, from the mechanism inside it.</p>
+    <p>A standard British gold pocket watch case carries:</p>
+    <ol>
+      <li>The <strong>fineness mark</strong> — 9ct, 14ct, or 18ct are all found on British pocket watches; 18ct being the most prestigious</li>
+      <li>The <strong>assay office mark</strong> — London, Birmingham, and Chester are the most commonly encountered; Sheffield rarely hallmarked watch cases</li>
+      <li>The <strong>date letter</strong> — particularly useful for watch collectors, as it can date the case to a specific year for cross-reference with the movement's serial number</li>
+      <li>The <strong>sponsor's mark</strong> — the case maker's initials, often different from the movement maker</li>
+    </ol>
+    <p>Gold-plated pocket watch cases carry no gold hallmarks — the absence of purity marks on a gold-coloured case is a reliable indicator of plating. Cases may be marked <strong>GF</strong> (gold filled), <strong>RGP</strong> (rolled gold plate), or show no gold standard mark at all.</p>
+
+    <h2 id="foreign-in-uk">Foreign Gold Hallmarks in the UK</h2>
+    <p>When gold jewellery made abroad is imported into the UK for sale, the importer has two choices: either submit the item to a UK assay office for hallmarking, or sell it as unhallmarked (which is only legal if it is not described as gold).</p>
+    <p>The UK recognises hallmarks from countries that are members of the <strong>Vienna Convention Common Control Mark (CCM)</strong> system — currently 19 member states — whose marks are accepted without re-hallmarking. Countries outside these agreements — China, much of the Middle East, India — are not automatically recognised under UK law. A piece of Arabic or Indian gold with a <span class="hmark">916</span> or <span class="hmark">750</span> stamp is genuine gold, but it may lack the specific legal recognition that a UK or CCM hallmark provides. A UK assay office will test and confirm it.</p>
+
+    <div class="cta-box">
+      <h3>Know Your Gold's Melt Value Before You Buy or Sell</h3>
+      <p>Once you've identified the fineness mark on your gold, use our free calculator to find out exactly what it's worth at today's live spot price.</p>
+      <a href="/scrap-gold-calculator" class="cta-btn">Calculate Gold Value &rarr;</a>
+    </div>
+
+    <h2 id="how-to-identify">How to Identify Gold Hallmarks: A Practical Method</h2>
+    <ol class="step-list">
+      <li class="step-block">
+        <div class="step-number">1</div>
+        <div class="step-content">
+          <strong>Find the mark</strong>
+          <p>Look with a 10× loupe or magnifying glass inside the ring band, at the clasp of a necklace or bracelet, on the back of a pendant, or on the post of an earring. Good light is essential — natural sunlight or a strong LED torch held at an angle will reveal marks that are invisible in overhead indoor lighting.</p>
+        </div>
+      </li>
+      <li class="step-block">
+        <div class="step-number">2</div>
+        <div class="step-content">
+          <strong>Identify the fineness number</strong>
+          <p>This is always the most important mark. Look for a three-digit number — <span class="hmark">375</span>, <span class="hmark">585</span>, <span class="hmark">750</span>, <span class="hmark">875</span>, <span class="hmark">916</span>, or <span class="hmark">999</span>. This tells you the gold content before anything else. If you see a zolotnik number (56, 72, 92), the piece is Imperial Russian.</p>
+        </div>
+      </li>
+      <li class="step-block">
+        <div class="step-number">3</div>
+        <div class="step-content">
+          <strong>Identify the assay office symbol</strong>
+          <p>If the piece is British, look for the leopard's head (London), anchor (Birmingham), rose or crown (Sheffield), or castle (Edinburgh). If it is European, compare against the symbols in this guide — an eagle's head points to French, a crescent moon and crown to German.</p>
+        </div>
+      </li>
+      <li class="step-block">
+        <div class="step-number">4</div>
+        <div class="step-content">
+          <strong>Look for the maker's mark</strong>
+          <p>Usually two or three initials in a shaped cartouche or shield. If you want to research the maker, this mark — combined with the assay office — narrows your search significantly. Assay offices hold registration records going back centuries.</p>
+        </div>
+      </li>
+      <li class="step-block">
+        <div class="step-number">5</div>
+        <div class="step-content">
+          <strong>Check for a date letter</strong>
+          <p>On pre-1998 British pieces especially, a single letter in a specific typeface and shield shape indicates the year of hallmarking. Reference books or online date letter tables will give you the exact year. A kokoshnik on Russian gold means 1899 or later.</p>
+        </div>
+      </li>
+      <li class="step-block">
+        <div class="step-number">6</div>
+        <div class="step-content">
+          <strong>If no hallmark is found</strong>
+          <p>The piece may be pre-1973 and legitimately exempt, it may be gold-plated, it may be foreign gold that was not re-hallmarked for UK sale, or it may not be gold at all. A reputable jeweller or buyer will test the piece with acid or an XRF scanner and provide confirmation.</p>
+        </div>
+      </li>
+    </ol>
+
+    <h2 id="faq">Frequently Asked Questions</h2>
+    <div class="faq-accordion">
+      <details class="faq-item">
+        <summary>What do gold hallmarks mean?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+        <div class="faq-body"><p>Gold hallmarks are official stamps applied by an independent assay office after testing, confirming the item's gold content (purity), the identity of the maker, and where it was tested. They are a legal guarantee of quality. In the UK, any item described as gold and weighing more than one gram must be hallmarked before sale.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary>What are the most common UK gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+        <div class="faq-body"><p>The most commonly encountered UK gold hallmarks are the fineness marks <strong>375</strong> (9ct), <strong>585</strong> (14ct), and <strong>750</strong> (18ct), combined with an assay office symbol (leopard's head for London, anchor for Birmingham, castle for Edinburgh) and the maker's mark. The 375 / 9ct standard is by far the most common standard in everyday UK gold jewellery.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary>How do I identify antique gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+        <div class="faq-body"><p>Look for the pre-1975 UK crown-plus-numeral system (e.g., a crown with "18" for 18ct gold), date letters that allow precise year-dating, and assay office marks that include the now-closed Chester office (sword with wheatsheaves). <em>Bradbury's Book of Hallmarks</em> is the standard reference for antique British marks. Finding a 15ct mark dates a piece to between 1854 and 1932.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary>What are the French gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+        <div class="faq-body"><p>The <strong>eagle's head</strong> (facing left) is the French guarantee mark for 18K gold and has been in use since 1838. The <strong>scallop shell</strong> indicates 14K gold; the <strong>clover (trefoil)</strong> indicates 9K gold. The <strong>owl</strong> appears on foreign items imported into France. A lozenge-shaped mark is the maker's mark, compulsory on all French pieces.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary>What are Russian gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+        <div class="faq-body"><p>Pre-1917 Russian gold uses the <strong>zolotnik system</strong> — the number 56 for 14K gold, 72 for 18K — alongside a city crest (St. Petersburg or Moscow) or, from 1899, a <strong>kokoshnik mark</strong> (woman's head in profile wearing a headdress). Soviet era pieces (1917–1991) use a hammer and sickle mark with millesimal fineness — 583 for 14K.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary>What are Fabergé gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+        <div class="faq-body"><p>Authentic Fabergé pieces carry the government assay mark (city crest or kokoshnik), the <strong>specific workmaster's initials</strong> (HW for Wigström, MP for Perchin, EK for Kollin), and the Fabergé firm name in Cyrillic or Latin script. Moscow branch pieces also carry the <strong>double-headed eagle</strong> of the Imperial Warrant. Fakes are common — incorrect mark combinations are the most reliable red flag.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary>What is the BIS hallmark on Indian gold?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+        <div class="faq-body"><p>The BIS (Bureau of Indian Standards) hallmark has been mandatory in India since 2021. It consists of a <strong>BIS triangle logo</strong>, a purity mark (22K916, 18K750, or 14K585), an assay centre code, and a <strong>six-digit HUID number</strong> that can be verified instantly via the BIS Care government app. Only HUID-marked jewellery can be sold by registered Indian jewellers since April 2023.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary>Do white gold pieces have different hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+        <div class="faq-body"><p>No — white gold carries <strong>identical hallmarks to yellow gold</strong>. A white gold ring hallmarked 750 is 18-carat gold; the hallmark identifies purity regardless of the metal's colour. There is no special "WG" mark or separate white gold standard. If a white-coloured piece carries 375, 585, or 750 with a UK assay office mark, it is hallmarked solid white gold.</p></div>
+      </details>
+      <details class="faq-item">
+        <summary>What does 875 mean on gold jewellery?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+        <div class="faq-body"><p><strong>875</strong> is the millesimal fineness mark for 21-karat gold (87.5% pure). It is most commonly associated with Middle Eastern jewellery — particularly from the UAE, Saudi Arabia, and Egypt — and is one of the clearest regional identifiers when encountered on gold in Western markets. You will rarely see 875 on British-made gold jewellery.</p></div>
+      </details>
+    </div>
+
+  </div><!-- /prose -->
+
+  <div class="disclaimer-box">
+    <strong>Editorial note:</strong> This guide reflects hallmarking systems as of 2026. Regulations and standards are subject to change. For formal authentication of valuable antique pieces, consult a qualified jewellery appraiser or contact the relevant assay office directly.
   </div>
+
 </article>
 
-
-<div style="max-width:860px;margin:0 auto var(--space-10);padding:0 var(--space-4)">
-  <div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
-    <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+<section class="related-guides-section">
+  <h2>Related Gold &amp; Silver Guides</h2>
+  <div class="related-guides-grid">
+    <a href="/guides/gold-purity-guide" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Gold Purity Guide</div>
+      <div class="related-card__desc">9K to 24K explained — what each karat means for value, durability, and jewellery type.</div>
+    </a>
+    <a href="/guides/how-to-sell-gold-jewellery" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">How to Sell Gold Jewellery</div>
+      <div class="related-card__desc">Get the best price for your gold — which buyers pay more and how to compare offers.</div>
+    </a>
+    <a href="/guides/how-to-test-if-gold-is-real" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">How to Test if Gold Is Real</div>
+      <div class="related-card__desc">Acid tests, magnet tests and electronic testers — which works best for verifying gold purity.</div>
+    </a>
+    <a href="/scrap-gold-calculator" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">Scrap Gold Calculator</div>
+      <div class="related-card__desc">Enter your gold's karat and weight to find its live melt value at today's spot price.</div>
+    </a>
+    <a href="/guides/difference-between-gold-filled-and-gold-plated" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Gold Filled vs Gold Plated</div>
+      <div class="related-card__desc">The difference between solid gold, gold filled, and gold plated — and what each is worth.</div>
+    </a>
+    <a href="/guides/what-is-best-time-to-sell-scrap-gold" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Best Time to Sell Scrap Gold</div>
+      <div class="related-card__desc">How to time your gold sale to maximise the spot price you receive from dealers.</div>
+    </a>
   </div>
-</div>
+</section>
 
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">
-      <div class="nav-logo" style="margin-bottom:var(--space-3)">
-        <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
-        <span style="font-weight:700">GoldPriceTools</span>
-      </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
-      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+      <a href="/" class="nav-logo" style="text-decoration:none">
+        <img src="https://assets.goldpricetools.com/logo.svg" width="28" height="28" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
+        <span style="font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright)">GoldPriceTools</span>
+      </a>
+      <p class="footer-brand">Live gold and silver prices. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Updated every 60 seconds.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
-        <li><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a></li>
-        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
-        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
-        <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
-        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
+        <li><a href="/gold-rates-today">Gold Rates Today</a></li>
+        <li><a href="/live-gold-silver-price-today">Live Gold &amp; Silver</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
+        <li><a href="/gold-and-silver-price-today">24hr Gold &amp; Silver</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h4>Calculators</h4>
       <ul>
         <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
-        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
-        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
-        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
-        <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
-        <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
+        <li><a href="/gold-bar-value">Gold Bar Value</a></li>
         <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
-        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
       </ul>
     </div>
     <div class="footer-col">
       <h4>Guides</h4>
       <ul>
-        <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
         <li><a href="/guides/gold-purity-guide">Gold Purity Guide</a></li>
         <li><a href="/guides/gold-bar-guide">Gold Bar Guide</a></li>
         <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
-        <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
         <li><a href="/guides/gold-hallmarks-explained">Gold Hallmarks Explained</a></li>
         <li><a href="/guides/gold-price-history">Gold Price History</a></li>
         <li><a href="/guides/">All Guides</a></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Blog</h4>
+      <h4>Silver</h4>
       <ul>
-        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
-        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
-        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
-        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
-        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
-        <li><a href="/blog/">All Articles</a></li>
+        <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
+        <li><a href="/guides/silver-price-guide">Silver Price Guide</a></li>
+        <li><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Info</h4>
+      <h4>Company</h4>
       <ul>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -673,34 +799,43 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
     </div>
   </div>
   <div class="footer-bottom">
-    <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
-    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+    <span>&copy; 2026 GoldPriceTools. All rights reserved.</span>
+    <span>Prices sourced via LBMA. Not financial advice.</span>
   </div>
 </footer>
-<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+
 <script>
-let _deepReadFired = false;
-window.addEventListener('scroll', () => {
-  if (_deepReadFired) return;
-  const scrollTop = window.scrollY || document.documentElement.scrollTop;
-  const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-  if (scrollHeight > 0 && (scrollTop / scrollHeight) > 0.75) {
-    gtag('event', 'guide_deep_read');
-    _deepReadFired = true;
+(function(){
+  var toggle=document.getElementById('themeToggle');
+  var sun=document.getElementById('iconSun');
+  var moon=document.getElementById('iconMoon');
+  function applyTheme(t){
+    document.documentElement.setAttribute('data-theme',t);
+    localStorage.setItem('gpt-theme',t);
+    if(sun)sun.style.display=t==='dark'?'none':'block';
+    if(moon)moon.style.display=t==='dark'?'block':'none';
   }
-}, { passive: true });
+  var saved=localStorage.getItem('gpt-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+  applyTheme(saved);
+  if(toggle)toggle.addEventListener('click',function(){applyTheme(document.documentElement.getAttribute('data-theme')==='dark'?'light':'dark');});
+  var ham=document.getElementById('hamburger');
+  var menu=document.getElementById('mobileMenu');
+  if(ham&&menu){
+    ham.addEventListener('click',function(){
+      var open=menu.classList.toggle('open');
+      ham.setAttribute('aria-expanded',open);
+      document.body.style.overflow=open?'hidden':'';
+    });
+  }
+  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){
+    btn.addEventListener('click',function(){
+      var items=this.nextElementSibling;
+      var expanded=this.getAttribute('aria-expanded')==='true';
+      this.setAttribute('aria-expanded',!expanded);
+      if(items)items.classList.toggle('open',!expanded);
+    });
+  });
+})();
 </script>
-<script>(function(){
-  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
-  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
-  root.setAttribute('data-theme',theme);
-  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
-  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
-  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
-  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
-  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
-  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
-  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
-})();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Complete rebuild of `guides/gold-hallmarks-explained.html` using the site's ui-ux-pro-max design system
- Full article content: UK British system, European country-by-country, Russian/Fabergé, Indian BIS, Middle Eastern, Chinese, white gold, pocket watches, and how-to-identify guide
- New CSS components: `.country-card` (gold left-border cards for international sections) and `.hmark` (inline fineness number badges)
- 9-item FAQ accordion with JSON-LD FAQPage schema
- 6-step identification method using `.step-block` components
- Executive summary stats panel, info callouts, warning callout (Fabergé fakes)
- Canonical URL, Article + BreadcrumbList + FAQPage structured data

## Test plan

- [ ] Page renders correctly at `/guides/gold-hallmarks-explained`
- [ ] Dark/light mode toggle works
- [ ] All tables display correctly on mobile
- [ ] FAQ accordion opens/closes
- [ ] Fineness mark badges (`.hmark`) render in gold colour
- [ ] Country cards have correct gold left border
- [ ] CTA box links to `/scrap-gold-calculator`

https://claude.ai/code/session_01RjL9E8KdGdWtC7F8BPEHDP

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjL9E8KdGdWtC7F8BPEHDP)_