### PR TITLE
Fix gold-hallmarks-explained content gaps

### DIFF
--- a/guides/gold-hallmarks-explained.html
+++ b/guides/gold-hallmarks-explained.html
@@ -363,6 +363,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
       <thead><tr><th>Mark</th><th>Carat</th><th>Gold Content</th><th>Use</th></tr></thead>
       <tbody>
         <tr><td><span class="hmark">999</span></td><td>24ct</td><td>99.9%</td><td>Investment bars &amp; coins</td></tr>
+        <tr><td><span class="hmark">990</span></td><td>23.76ct</td><td>99.0%</td><td>Rare; used in some specialist jewellery</td></tr>
         <tr><td><span class="hmark">958</span></td><td>23ct (Britannia)</td><td>95.8%</td><td>Specialist commemorative pieces</td></tr>
         <tr><td><span class="hmark">916</span></td><td>22ct</td><td>91.6%</td><td>Traditional UK wedding rings</td></tr>
         <tr><td><span class="hmark">750</span></td><td>18ct</td><td>75.0%</td><td>Fine jewellery standard</td></tr>
@@ -456,6 +457,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
         <thead><tr><th>Symbol</th><th>Metal / Standard</th><th>Meaning</th></tr></thead>
         <tbody>
           <tr><td>Eagle's head (facing left)</td><td>18K gold (750)</td><td>National guarantee mark since 1838 — the most commonly encountered French gold mark</td></tr>
+          <tr><td>Seahorse</td><td>24K gold (999)</td><td>Used for high-purity / investment-grade gold pieces</td></tr>
           <tr><td>Scallop shell</td><td>14K gold (585)</td><td>Introduced post-World War I</td></tr>
           <tr><td>Clover / Trefoil</td><td>9K gold (375)</td><td>Primarily for export pieces</td></tr>
           <tr><td>Owl</td><td>Import mark</td><td>Applied to foreign items imported into France — confirms sold in France, not made there</td></tr>
@@ -500,11 +502,23 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <div class="country-card">
       <div class="country-card__header">
-        <div class="country-card__name">Swiss, Austrian &amp; Dutch Gold Hallmarks</div>
+        <div class="country-card__name">Swiss Gold Hallmarks</div>
       </div>
-      <p><strong>Switzerland</strong> introduced gold hallmarking in 1880. Swiss pieces carry a fineness mark alongside an assay office mark and maker's mark. The most distinctive Swiss hallmark symbols are the <strong>squirrel</strong> (for gold 585/14K and above, used since 1934) and the <strong>Helvetia head</strong> (for 18ct, 750 fineness). Swiss watch cases are a rich area for hallmark study — the combination of maker's code, fineness, and assay office mark allows detailed authentication of both case and movement.</p>
-      <p><strong>Austria</strong> uses the Convention Common Control Mark alongside national marks, and uses a <strong>shield</strong> format for its assay marks. Austrian pieces typically carry millesimal fineness numbers alongside a letter-and-number code identifying the assay district.</p>
-      <p><strong>The Netherlands</strong> uses a <strong>lion rampant</strong> alongside the fineness number. The <strong>fish</strong> symbol appears on Dutch import marks, serving a similar function to the French owl — indicating an item was imported for sale in the Netherlands.</p>
+      <p>Switzerland introduced gold hallmarking in 1880. Swiss pieces carry a fineness mark alongside an assay office mark and maker's mark. The most distinctive Swiss hallmark symbols are the <strong>squirrel</strong> (for gold 585/14K and above, used since 1934) and the <strong>Helvetia head</strong> (for 18ct, 750 fineness). Swiss watch cases are a rich area for hallmark study — the combination of maker's code, fineness, and assay office mark allows detailed authentication of both case and movement.</p>
+    </div>
+
+    <div class="country-card">
+      <div class="country-card__header">
+        <div class="country-card__name">Austrian Gold Hallmarks</div>
+      </div>
+      <p>Austria uses the Convention Common Control Mark alongside national marks, and uses a <strong>shield</strong> format for its assay marks. Austrian pieces typically carry millesimal fineness numbers alongside a letter-and-number code identifying the assay district. Vienna was historically one of Europe's most important centres of fine goldsmithing, and antique Austrian pieces with clear assay marks are common in specialist markets.</p>
+    </div>
+
+    <div class="country-card">
+      <div class="country-card__header">
+        <div class="country-card__name">Dutch Gold Hallmarks</div>
+      </div>
+      <p>The Netherlands uses a <strong>lion rampant</strong> alongside the fineness number. The <strong>fish</strong> symbol appears on Dutch import marks, serving a similar function to the French owl — indicating an item was imported for sale in the Netherlands. Dutch pieces also carry a maker's mark and a millesimal fineness number. The Netherlands has a long tradition of fine goldsmithing, particularly in Amsterdam.</p>
     </div>
 
     <h2 id="russian">Russian Gold Hallmarks</h2>
@@ -525,7 +539,14 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     <p>The kokoshnik is one of the most important dating tools for Russian antiques. Its presence confirms a piece was made <strong>in 1899 or later</strong>. Its absence — with a city crest instead — indicates pre-1899 manufacture.</p>
 
     <h3>Soviet Era (1917–1991)</h3>
-    <p>After the 1917 Revolution, the zolotnik system was replaced with millesimal fineness. Soviet gold marks use a <strong>hammer and sickle within a star</strong> (appearing on items from 1927 onwards), a Cyrillic letter identifying the assay office, and a three-digit fineness number. The <span class="hmark">583</span> mark is particularly characteristic of Soviet gold — it was the standard used throughout the USSR period for what is elsewhere called 14-karat gold. Soviet pieces are frequently encountered in antique markets and are generally well-made, with clear, readable marks.</p>
+    <p>After the 1917 Revolution, the zolotnik system was replaced with millesimal fineness. Soviet gold marks typically include:</p>
+    <ul>
+      <li><strong>Hammer and sickle within a star</strong> — state assay mark appearing on items from 1927 onwards</li>
+      <li><strong>Worker's head in profile</strong> — a facing-right profile mark used from 1958, replacing the earlier star-and-hammer design; the most commonly encountered Soviet-era assay mark</li>
+      <li>A Cyrillic letter identifying the specific assay office</li>
+      <li>A three-digit fineness number</li>
+    </ul>
+    <p>The <span class="hmark">583</span> mark is particularly characteristic of Soviet gold — it was the standard used throughout the USSR period for what is elsewhere called 14-karat gold. Soviet pieces are frequently encountered in antique markets and are generally well-made, with clear, readable marks.</p>
 
     <h2 id="faberge">Fabergé Gold Hallmarks: The Collector's Holy Grail</h2>
     <p>No discussion of gold hallmarks would be complete without addressing Fabergé — the St. Petersburg goldsmith firm that became synonymous with the highest expression of Imperial Russian decorative arts, and whose marks are among the most scrutinised in the antique world.</p>
@@ -575,6 +596,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     <p>Chinese gold jewellery uses the millesimal fineness system, with <span class="hmark">999</span> and <span class="hmark">9999</span> being particularly common — reflecting China's preference for high-purity gold jewellery, particularly in 24-karat forms. Common Chinese gold marks include:</p>
     <ul>
       <li><strong>999</strong> — 24-karat gold (99.9% pure); the standard for most Chinese gold jewellery</li>
+      <li><strong>999.5</strong> — high-purity gold (99.95% fine); less common but found on specialist pieces</li>
       <li><strong>9999</strong> — investment-grade pure gold (99.99% fine)</li>
       <li><strong>足金 (Zú jīn)</strong> — Chinese characters meaning "full gold" or 24K gold</li>
       <li><strong>千足金 (Qiān zú jīn)</strong> — "thousand full gold," indicating 999.9 fine</li>


### PR DESCRIPTION
## Summary

- Add `990` fineness row to UK purity table (99.0% gold)
- Add `Seahorse` row (24K pure gold) to French hallmarks table
- Split combined Swiss/Austrian/Dutch country-card into three separate cards
- Expand Soviet era section with worker's head in profile bullet point
- Add `999.5` entry to Chinese hallmarks section

## Test plan
- [ ] Fineness table shows 990 row between 999 and 958
- [ ] French table shows Seahorse row for 24K gold
- [ ] Swiss, Austrian, Dutch each have their own country-card
- [ ] Soviet section lists worker's head in profile mark
- [ ] Chinese section includes 999.5 entry

https://claude.ai/code/session_01RjL9E8KdGdWtC7F8BPEHDP

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjL9E8KdGdWtC7F8BPEHDP)_