### PR TITLE
Fix ring calculator: add gold price fetch script

### DIFF
--- a/guides/how-much-is-a-gold-ring-worth.html
+++ b/guides/how-much-is-a-gold-ring-worth.html
@@ -921,6 +921,22 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 </script>
 
 <script>
+/* Fetch live gold spot price and GBP/USD rate — same pattern as scrap-gold-calculator */
+window._spot=null;
+window._gbpusd=0.79;
+(function(){
+  async function fetchFx(){
+    try{var r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();var d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch(e){window._gbpusd=0.79;}
+  }
+  async function fetchSpot(){
+    try{var r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});if(!r.ok)throw new Error();var d=await r.json();window._spot=d.price;window.dispatchEvent(new Event('goldprice_updated'));}catch(e){console.warn('Gold price API unavailable',e);}
+  }
+  Promise.all([fetchFx(),fetchSpot()]);
+  setInterval(fetchSpot,60000);
+})();
+</script>
+
+<script>
 (function(){
   /* Ring calculator */
   var TROY=31.1035;


### PR DESCRIPTION
The calculator was stuck on "Connecting..." because the guide page had no code to fetch window._spot / window._gbpusd. Each page must fetch its own prices; these are not global. Added the same fetchFx() + fetchSpot() pattern used by scrap-gold-calculator.html, pulling from goldpricetoolsworker.io (FX) and gold-api.com (XAU spot), with a 60-second setInterval refresh and goldprice_updated event dispatch.

https://claude.ai/code/session_01RjL9E8KdGdWtC7F8BPEHDP