### PR TITLE
Fix countdown timer not counting down in gold ring calculator

### DIFF
--- a/guides/how-much-is-a-gold-ring-worth.html
+++ b/guides/how-much-is-a-gold-ring-worth.html
@@ -1051,8 +1051,27 @@ window._gbpusd=0.79;
     rcPlaceholder.style.display='none';
   }
 
+  var _cdInterval=null;
+  var _cdSecs=60;
+
+  function updateCountdown(){
+    var m=Math.floor(_cdSecs/60);
+    var s=_cdSecs%60;
+    rcStatus.textContent='Live · '+String(m).padStart(2,'0')+':'+String(s).padStart(2,'0');
+  }
+
+  function startCountdown(){
+    if(_cdInterval)clearInterval(_cdInterval);
+    _cdSecs=60;
+    updateCountdown();
+    _cdInterval=setInterval(function(){
+      if(_cdSecs>0)_cdSecs--;
+      updateCountdown();
+    },1000);
+  }
+
   function onPriceReady(){
-    rcStatus.textContent='Live · '+new Date().toLocaleTimeString('en-GB',{hour:'2-digit',minute:'2-digit'});
+    startCountdown();
     calc();
   }
 


### PR DESCRIPTION
## Summary

- The "Live · 01:00" badge in the gold ring calculator was showing a static timestamp (time of last fetch) instead of counting down
- Replaced the static `toLocaleTimeString` display with a proper 60-second countdown that resets on each price fetch
- The countdown now ticks MM:SS from `01:00` → `00:00` every second, giving users a clear visual cue for when the next update fires

## Root cause

`onPriceReady()` was calling `new Date().toLocaleTimeString(...)` which just stamped the clock time — it never decremented. There was no `setInterval` driving the display between fetches.

## Fix

Added `startCountdown()` which:
1. Clears any existing interval
2. Resets `_cdSecs` to 60
3. Starts a 1-second interval that decrements the counter and updates the badge text in `MM:SS` format

## Test plan

- [ ] Open `/guides/how-much-is-a-gold-ring-worth` and confirm the badge reads `Live · 01:00` immediately after page load
- [ ] Watch the badge tick down each second (`01:00`, `00:59`, `00:58` …)
- [ ] Confirm it resets to `01:00` when the 60-second price fetch fires
- [ ] Confirm it reaches `00:00` and holds there until the next fetch resets it

https://claude.ai/code/session_01Q9frfVnwTiFiKtKqhy2fSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9frfVnwTiFiKtKqhy2fSz)_