### PR TITLE
feat: AdSense content optimization - unique editorial for all karat pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ __pycache__/
 
 # Node
 node_modules/
+
+# AI Skills (installed per-machine)
+.agent/
+.agents/

--- a/10k-gold-price-per-gram.html
+++ b/10k-gold-price-per-gram.html
@@ -537,10 +537,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <div class="content">
   <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
   <div class="prose">
-    <details>
-  <summary class="faq-answer-summary">What is 10K Gold?</summary>
-  <p class="faq-answer">10K gold contains 10 parts gold out of 24, giving it a purity of <strong>41.67%</strong>. It is the minimum legal standard for gold jewellery in the United States. While it has a lower gold content than 14K or 18K, it is the most durable and scratch-resistant commonly available gold alloy. The European hallmark is <strong>417</strong>.</p>
-</details>
+    <h2>What is 10K Gold?</h2>
+    <p>10K gold contains 10 parts gold out of 24, giving it a purity of <strong>41.67%</strong>. It is the minimum legal standard for gold jewellery in the United States. While it has a lower gold content than 14K or 18K, it is the most durable and scratch-resistant commonly available gold alloy. The European hallmark is <strong>417</strong>.</p>
     <h2>10kt gold price per gram</h2>
 <p class="snippet-answer">The 10kt gold price per gram is determined by multiplying the live pure gold spot price by 0.4167. 10 karat gold contains 41.67% pure gold, making it the most durable and affordable gold alloy commonly used in jewelry. Use our calculator to find today's exact value.</p>
 
@@ -568,10 +566,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         </tbody>
       </table></div>
     </figure>
-    <details>
-  <summary class="faq-answer-summary">Is 10K Gold Worth Buying?</summary>
-  <p class="faq-answer">10K gold is an economical choice for everyday jewellery. Its high alloy content (copper, silver, zinc) makes it more resistant to scratches and tarnish than 14K or 18K. However, some people with sensitive skin may experience reactions to the higher base metal content. For investment purposes, 24K bullion offers a much higher gold content per pound spent.</p>
-</details>
+    <h2>Is 10K Gold Worth Buying?</h2>
+    <p>10K gold is an economical choice for everyday jewellery. Its high alloy content (copper, silver, zinc) makes it more resistant to scratches and tarnish than 14K or 18K. However, some people with sensitive skin may experience reactions to the higher base metal content. For investment purposes, 24K bullion offers a much higher gold content per pound spent.</p>
     <h2>10K Purity Table</h2>
 <div class="data-table-wrap"><table class="data-table" aria-label="Karat purity and indicative prices">
 <thead><tr><th>Karat</th><th>Purity</th><th>GBP/gram</th><th>USD/gram</th></tr></thead>
@@ -603,30 +599,47 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices (London, Birmingham, Sheffield, or Edinburgh) under the Hallmarking Act 1973. The <strong>417 hallmark</strong> guarantees that the item contains at least 41.67% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
     <p>On older or imported items, you may also see the hallmark written as <strong>.417</strong> or stamped alongside a date letter and assay office mark. When appraising estate jewellery, always check for the 417 stamp before calculating value.</p>
 
-    <h2>Factors That Affect the 10K Gold Price</h2>
-    <p>The live 10K gold price per gram changes continuously based on the underlying gold spot price, which is driven by several macroeconomic factors:</p>
+    <h2>10K Gold and the FTC Legal Standard</h2>
+    <p>In the United States, the <strong>Federal Trade Commission (FTC)</strong> sets the legal minimum gold content for any item described or sold as "gold." Under the FTC's Jewelry Guides (16 CFR Part 23), no item may be labelled, advertised, or sold as "gold" jewellery unless it contains at least 10 karats (41.67%) of pure gold. Items below this threshold must be described as "gold-plated," "gold-filled," or "gold-tone."</p>
+    <p>This regulation is unique to the US market. In the <strong>United Kingdom</strong>, the legal minimum is <a href="/9k-gold-price-per-gram">9 karats (37.5%)</a>, established by the Hallmarking Act 1973. In many European countries, 8K (33.3%) is accepted. This means 10K gold falls in an interesting middle ground — it is legal to sell in the UK but is not a traditional UK standard, so you are less likely to find it in British high-street jewellers.</p>
+
+    <h2>Why 10K Gold Is the Most Durable Karat</h2>
+    <p>Gold in its pure form (24K) is remarkably soft — it can be scratched with a fingernail. The alloy metals added to create lower-karat gold dramatically increase hardness:</p>
     <ul>
-      <li><strong>US Dollar strength</strong> — Gold is priced globally in USD; a stronger dollar typically pushes spot prices lower, and vice versa.</li>
-      <li><strong>Central bank buying</strong> — Central banks (particularly in China, India, and Turkey) have been significant net buyers of gold since 2022, supporting prices.</li>
-      <li><strong>Inflation and interest rates</strong> — Gold is widely held as a hedge against inflation. When real interest rates are low or negative, gold becomes relatively more attractive.</li>
-      <li><strong>Geopolitical risk</strong> — Gold is a traditional safe-haven asset. Periods of geopolitical tension typically see increased demand and higher prices.</li>
-      <li><strong>Jewellery demand</strong> — India and China account for over 50% of global gold jewellery demand. Seasonal festivals such as Diwali and Lunar New Year create demand spikes.</li>
-      <li><strong>GBP/USD exchange rate</strong> — For UK buyers and sellers, the pound-dollar rate directly affects the GBP price of gold regardless of the USD spot price.</li>
+      <li><strong>10K gold</strong> — Vickers hardness ~180–200 HV. The hardest standard gold alloy. Highly resistant to scratching, bending, and denting.</li>
+      <li><strong>14K gold</strong> — Vickers hardness ~150–180 HV. Good durability, the US standard for engagement rings.</li>
+      <li><strong>18K gold</strong> — Vickers hardness ~120–150 HV. Softer, more prone to surface scratches.</li>
+      <li><strong>24K gold</strong> — Vickers hardness ~25 HV. Too soft for everyday jewellery.</li>
+    </ul>
+    <p>This makes 10K the ideal choice for jewellery that takes daily abuse — <strong>class rings, chains worn under clothing, men's wedding bands for manual workers, and children's jewellery</strong> where durability matters more than gold content.</p>
+
+    <h2>10K Gold and Skin Sensitivity</h2>
+    <p>Because 10K gold contains <strong>58.33% alloy metals</strong> (more alloy than gold), it poses a higher risk of causing <strong>contact dermatitis</strong> in people with metal allergies — particularly nickel sensitivity. White 10K gold often contains nickel as a whitening agent, which is one of the most common jewellery allergens.</p>
+    <p>If you have sensitive skin, consider the following when buying 10K gold:</p>
+    <ul>
+      <li><strong>Choose yellow or rose 10K gold</strong> — These typically use copper and silver alloys, which cause fewer reactions than nickel.</li>
+      <li><strong>Ask for nickel-free alloys</strong> — Some manufacturers produce nickel-free 10K white gold using palladium instead.</li>
+      <li><strong>Consider a higher karat</strong> — <a href="/14k-gold-price-per-gram">14K</a> or <a href="/18k-gold-price-per-gram">18K</a> gold has less alloy content and is gentler on sensitive skin.</li>
+      <li><strong>Apply clear nail polish</strong> — A coat of clear polish on the inside of a ring creates a barrier, though this is a temporary fix that wears off.</li>
     </ul>
 
-    <h2>Selling 10K Gold in the UK</h2>
-    <p>When selling 10K gold jewellery or scrap in the UK, the amount you receive depends on the dealer's <em>buy rate</em>, which is expressed as a percentage of spot melt value. Reputable UK gold buyers typically offer:</p>
+    <h2>Where 10K Gold Is Most Popular</h2>
+    <p>10K gold has distinct regional popularity patterns that differ from other karats:</p>
     <ul>
-      <li><strong>Online gold buyers</strong> (e.g. Hatton Garden Metals, Gold Buyers UK): 85%–95% of melt value</li>
-      <li><strong>High-street jewellers</strong>: 70%–85% of melt value</li>
-      <li><strong>Pawnbrokers</strong>: 50%–70% of melt value</li>
-      <li><strong>Cash4Gold-style postal services</strong>: 40%–65% of melt value</li>
+      <li><strong>United States</strong> — 10K is widely available for budget-conscious buyers. It is the most common karat for <strong>class rings, initial pendants, basic chains, and affordable earrings</strong>. Retailers like Walmart, Kay Jewelers, and Zales stock extensive 10K ranges.</li>
+      <li><strong>Canada</strong> — Similar to the US, 10K is the entry-level gold standard.</li>
+      <li><strong>United Kingdom</strong> — 10K is rare. The UK market jumps from <a href="/9k-gold-price-per-gram">9K (375)</a> directly to <a href="/14k-gold-price-per-gram">14K (585)</a>. If you encounter 10K gold in the UK, it is almost certainly an import.</li>
+      <li><strong>India and Middle East</strong> — 10K is virtually unheard of. These markets strongly prefer <a href="/22k-gold-price-per-gram">22K</a> and <a href="/24k-gold-price-per-gram">24K</a> for its higher gold content and deeper colour.</li>
     </ul>
-    <p>Always weigh your items on a calibrated scale before approaching any buyer, and use our live calculator above to check the current melt value of your 10K gold. This gives you a reliable benchmark to negotiate from.</p>
 
-    <h2>Is 10K Gold a Good Investment?</h2>
-    <p>Investment-grade gold is typically 22K or 24K bullion, where the premium over spot is lowest. 10K gold jewellery carries a fabrication premium that you will not recover on resale — you will generally receive melt value only. However, 10K gold can still serve as a store of value over long time horizons, since the underlying gold content tracks the gold price.</p>
-    <p>For pure investment purposes, gold ETFs, LBMA-accredited bullion bars, or Royal Mint gold coins (which are VAT-exempt in the UK) typically offer better value than jewellery. For jewellery that you intend to wear and potentially resell, 10K gold at 41.67% purity represents a reasonable balance of value and durability.</p>
+    <h2>10K Gold Scrap Value: What Dealers Actually Pay</h2>
+    <p>10K gold scrap commands the <strong>lowest per-gram price</strong> of any standard karat because of its 41.67% gold content. When selling 10K scrap, keep these realities in mind:</p>
+    <ul>
+      <li><strong>Refiners prefer large lots</strong> — A single 2g ring is less attractive to a refiner than a 50g bag of mixed 10K scrap. You may get 5–10% better rates by accumulating scrap before selling.</li>
+      <li><strong>The "refining cost" discount</strong> — Refiners deduct a processing fee to extract the gold from the alloy. Because 10K has more alloy to remove, this fee is proportionally higher than for 18K or 22K scrap.</li>
+      <li><strong>Online vs local</strong> — Online gold buyers (who ship directly to refineries) typically offer 80–90% of melt value for 10K. High-street pawnbrokers may offer as low as 50–65%.</li>
+    </ul>
+    <p>Use our <a href="/scrap-gold-calculator">scrap gold calculator</a> to check the current melt value before approaching any buyer.</p>
 
     <h2>Frequently Asked Questions</h2>
     <details open>

--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -559,10 +559,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
 
   <div class="prose">
-    <details>
-  <summary class="faq-answer-summary">What is 14K Gold?</summary>
-  <p class="faq-answer">14K gold contains 14 parts gold out of 24 &mdash; a purity of <strong>58.33%</strong>. It is the most popular gold alloy for jewellery in the United States and is widely used for engagement rings and wedding bands. The hallmark you will see on European and UK pieces is <strong>585</strong>. On American pieces you will see <strong>14K</strong> or <strong>14KT</strong>.</p>
-</details>
+    <h2>What is 14K Gold?</h2>
+    <p>14K gold contains 14 parts gold out of 24 &mdash; a purity of <strong>58.33%</strong>. It is the most popular gold alloy for jewellery in the United States and is widely used for engagement rings and wedding bands. The hallmark you will see on European and UK pieces is <strong>585</strong>. On American pieces you will see <strong>14K</strong> or <strong>14KT</strong>.</p>
 
     <h2 id="14k-gold-per-gram">How much is a gram of 14K gold worth?</h2>
 <p class="snippet-answer">14K gold is worth approximately <span id="snippet-price" data-nosnippet>[live value]</span> per gram in [currency] today. This is calculated by multiplying the live 24K spot price by 0.5833 — the gold purity ratio of 14 karat gold (14 parts gold out of 24). Use our calculator below for the exact live value.</p>
@@ -591,10 +589,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       </table></div>
     </figure>
 
-    <details>
-  <summary class="faq-answer-summary">How Is the 14K Gold Price Calculated?</summary>
-  <p class="faq-answer">The 14K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>14K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 0.5833</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
-</details>
+    <h2>How Is the 14K Gold Price Calculated?</h2>
+    <p>The 14K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>14K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 0.5833</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
 
     <h2>14K vs Other Karats</h2>
     <figure itemscope itemtype="https://schema.org/Table">
@@ -643,30 +639,40 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices (London, Birmingham, Sheffield, or Edinburgh) under the Hallmarking Act 1973. The <strong>585 hallmark</strong> guarantees that the item contains at least 58.33% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
     <p>On older or imported items, you may also see the hallmark written as <strong>.585</strong> or stamped alongside a date letter and assay office mark. When appraising estate jewellery, always check for the 585 stamp before calculating value.</p>
 
-    <h2>Factors That Affect the 14K Gold Price</h2>
-    <p>The live 14K gold price per gram changes continuously based on the underlying gold spot price, which is driven by several macroeconomic factors:</p>
+    <h2>Why 14K Dominates the US Engagement Ring Market</h2>
+    <p>According to the Jewelers of America, roughly <strong>70% of all engagement rings</strong> sold in the United States are set in 14K gold. The reason is practical: 14K offers the ideal balance between gold content and structural integrity. An engagement ring must withstand decades of daily wear — washing hands, gripping objects, and accidental knocks. Higher-karat alloys like 18K (75% gold) are noticeably softer and more prone to scratching, bending, and losing prong settings that hold diamonds.</p>
+    <p>The alloy metals in 14K gold — typically copper, silver, and zinc — give it a <strong>Vickers hardness of approximately 150–180 HV</strong>, compared to around 120–150 HV for 18K and just 25 HV for pure 24K gold. This hardness directly translates to better prong retention for gemstones and greater scratch resistance for bands.</p>
+    <p>Iconic jewellers such as <strong>Tiffany & Co.</strong> and <strong>Blue Nile</strong> use 14K as their standard setting for diamond solitaires. Many designer brands offer 14K alongside 18K, with the price difference typically running 20–30% for the same design — driven entirely by the gold content difference (58.33% vs 75%).</p>
+
+    <h2>14K Gold Colour Differences: Yellow, White, and Rose</h2>
+    <p>The alloy composition of 14K gold varies depending on the colour:</p>
     <ul>
-      <li><strong>US Dollar strength</strong> — Gold is priced globally in USD; a stronger dollar typically pushes spot prices lower, and vice versa.</li>
-      <li><strong>Central bank buying</strong> — Central banks (particularly in China, India, and Turkey) have been significant net buyers of gold since 2022, supporting prices.</li>
-      <li><strong>Inflation and interest rates</strong> — Gold is widely held as a hedge against inflation. When real interest rates are low or negative, gold becomes relatively more attractive.</li>
-      <li><strong>Geopolitical risk</strong> — Gold is a traditional safe-haven asset. Periods of geopolitical tension typically see increased demand and higher prices.</li>
-      <li><strong>Jewellery demand</strong> — India and China account for over 50% of global gold jewellery demand. Seasonal festivals such as Diwali and Lunar New Year create demand spikes.</li>
-      <li><strong>GBP/USD exchange rate</strong> — For UK buyers and sellers, the pound-dollar rate directly affects the GBP price of gold regardless of the USD spot price.</li>
+      <li><strong>14K Yellow Gold</strong> — Alloyed primarily with copper and silver. Produces a warm, classic gold tone that is slightly less saturated than 18K yellow due to the lower gold content. This is the traditional choice for wedding bands.</li>
+      <li><strong>14K White Gold</strong> — Alloyed with palladium, nickel, or manganese to create a silvery-white appearance. Almost all 14K white gold is <strong>rhodium-plated</strong> — a thin layer of rhodium (a platinum-group metal) applied to the surface for a bright, reflective finish. This plating wears away over 12–18 months of daily wear and needs periodic re-plating, typically costing £25–£50 at a jeweller.</li>
+      <li><strong>14K Rose Gold</strong> — Alloyed with a higher proportion of copper (typically 33.3% copper, 8.33% silver). The result is a distinctive pink-gold hue that has grown significantly in popularity since 2015. Rose gold does not require plating and develops a subtle patina over time.</li>
     </ul>
 
-    <h2>Selling 14K Gold in the UK</h2>
-    <p>When selling 14K gold jewellery or scrap in the UK, the amount you receive depends on the dealer's <em>buy rate</em>, which is expressed as a percentage of spot melt value. Reputable UK gold buyers typically offer:</p>
+    <h2>Selling 14K Gold Engagement Rings and Jewellery</h2>
+    <p>14K gold jewellery occupies a unique position in the resale market. Unlike 9K or 10K gold — which many buyers consider "scrap only" — 14K pieces can sometimes command a premium above melt value if the design, brand, or gemstones add collectible value. A Tiffany 14K ring, for example, may sell for 40–60% above its raw gold weight on secondary markets like eBay or Vestiaire Collective.</p>
+    <p>For plain 14K gold without brand or gemstone value, you should expect to receive <strong>75–90% of melt value</strong> from reputable dealers. The key factors that affect your 14K offer price:</p>
     <ul>
-      <li><strong>Online gold buyers</strong> (e.g. Hatton Garden Metals, Gold Buyers UK): 85%–95% of melt value</li>
-      <li><strong>High-street jewellers</strong>: 70%–85% of melt value</li>
-      <li><strong>Pawnbrokers</strong>: 50%–70% of melt value</li>
-      <li><strong>Cash4Gold-style postal services</strong>: 40%–65% of melt value</li>
+      <li><strong>Condition and craftsmanship</strong> — Undamaged pieces with intact hallmarks command better prices than bent, broken, or heavily worn items.</li>
+      <li><strong>Weight accuracy</strong> — Dealers price by weight, not by piece. A 3.5g ring at £90/g melt value is worth roughly £315 in gold content alone. Always weigh on a calibrated 0.01g jeweller's scale before selling.</li>
+      <li><strong>Gemstone content</strong> — Most scrap buyers pay nothing for small diamonds or gemstones under 0.25ct. Larger stones should be sold separately through a diamond dealer.</li>
+      <li><strong>White gold premium</strong> — Some refiners pay slightly more for white 14K gold due to the palladium or nickel alloy content, which has independent value.</li>
     </ul>
-    <p>Always weigh your items on a calibrated scale before approaching any buyer, and use our live calculator above to check the current melt value of your 14K gold. This gives you a reliable benchmark to negotiate from.</p>
+    <p>For the best price, get at least three quotes and use our live calculator to know your baseline melt value before negotiating.</p>
 
-    <h2>Is 14K Gold a Good Investment?</h2>
-    <p>Investment-grade gold is typically 22K or 24K bullion, where the premium over spot is lowest. 14K gold jewellery carries a fabrication premium that you will not recover on resale — you will generally receive melt value only. However, 14K gold can still serve as a store of value over long time horizons, since the underlying gold content tracks the gold price.</p>
-    <p>For pure investment purposes, gold ETFs, LBMA-accredited bullion bars, or Royal Mint gold coins (which are VAT-exempt in the UK) typically offer better value than jewellery. For jewellery that you intend to wear and potentially resell, 14K gold at 58.33% purity represents a reasonable balance of value and durability.</p>
+    <h2>14K vs 18K: Which Should You Choose?</h2>
+    <p>The choice between 14K and 18K gold is one of the most common questions in jewellery buying. Here is a practical comparison:</p>
+    <ul>
+      <li><strong>Price difference</strong> — 18K gold contains 28.6% more pure gold than 14K (75% vs 58.33%), so it costs roughly 25–30% more per gram at current spot prices. For a typical 5g engagement ring, the gold content difference is around £80–£120 at today's prices.</li>
+      <li><strong>Colour</strong> — 18K yellow gold has a richer, deeper golden hue. The difference is subtle but noticeable side by side. In white gold, the difference is hidden by rhodium plating.</li>
+      <li><strong>Durability</strong> — 14K is measurably harder and more scratch-resistant. For rings worn daily (especially by people who work with their hands), 14K is the more practical choice.</li>
+      <li><strong>Resale value</strong> — Both karats hold their value well relative to spot price. 18K jewellery is slightly easier to resell internationally (it is the global standard), while 14K dominates the US secondary market.</li>
+      <li><strong>Skin sensitivity</strong> — Both karats can contain nickel in white gold alloys. If you have a nickel allergy, look for nickel-free alloys regardless of karat.</li>
+    </ul>
+    <p>For engagement rings and daily-wear jewellery in the US or UK, 14K remains the pragmatic choice. For luxury pieces, European heritage jewellery, or items intended for the international resale market, 18K is the standard.</p>
 
     <h2>Frequently Asked Questions</h2>
     <details open>

--- a/18k-gold-price-per-gram.html
+++ b/18k-gold-price-per-gram.html
@@ -555,10 +555,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <div class="content">
   <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
   <div class="prose">
-    <details>
-  <summary class="faq-answer-summary">What is 18K Gold?</summary>
-  <p class="faq-answer">18K gold contains 18 parts gold out of 24 &mdash; a purity of <strong>75%</strong>. It is the standard for fine jewellery, high-end Swiss watches, and luxury accessories worldwide. The hallmark for 18K gold in the UK and Europe is <strong>750</strong>. In the US you will see <strong>18K</strong> or <strong>18KT</strong> stamped on items.</p>
-</details>
+    <h2>What is 18K Gold?</h2>
+    <p>18K gold contains 18 parts gold out of 24 &mdash; a purity of <strong>75%</strong>. It is the standard for fine jewellery, high-end Swiss watches, and luxury accessories worldwide. The hallmark for 18K gold in the UK and Europe is <strong>750</strong>. In the US you will see <strong>18K</strong> or <strong>18KT</strong> stamped on items.</p>
     <h2 id="q1-18K">What is gold value 18k per gram?</h2>
 <p class="snippet-answer">18K gold is worth approximately <span id="snippet-price" data-nosnippet>[live value]</span> per gram in [currency] today. This is calculated by multiplying the live 24K spot price by 0.75 — the gold purity ratio of 18 karat gold (18 parts gold out of 24). Use our calculator below for the exact live value.</p>
 
@@ -584,10 +582,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         </tbody>
       </table></div>
     </figure>
-    <details>
-  <summary class="faq-answer-summary">How Is 18K Gold Price Calculated?</summary>
-  <p class="faq-answer">The 18K price per gram = 24K spot price per troy oz &divide; 31.1035 &times; 0.75. The LBMA spot price is the global benchmark, set twice daily in London. Our calculator fetches this live and converts to GBP using the real-time exchange rate.</p>
-</details>
+    <h2>How Is the 18K Gold Price Calculated?</h2>
+    <p>The 18K price per gram = 24K spot price per troy oz &divide; 31.1035 &times; 0.75. The LBMA spot price is the global benchmark, set twice daily in London. Our calculator fetches this live and converts to GBP using the real-time exchange rate.</p>
     <h2>18K Purity Table</h2>
 <div class="data-table-wrap"><table class="data-table" aria-label="Karat purity and indicative prices">
 <thead><tr><th>Karat</th><th>Purity</th><th>GBP/gram</th><th>USD/gram</th></tr></thead>
@@ -619,30 +615,32 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices (London, Birmingham, Sheffield, or Edinburgh) under the Hallmarking Act 1973. The <strong>750 hallmark</strong> guarantees that the item contains at least 75.00% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
     <p>On older or imported items, you may also see the hallmark written as <strong>.750</strong> or stamped alongside a date letter and assay office mark. When appraising estate jewellery, always check for the 750 stamp before calculating value.</p>
 
-    <h2>Factors That Affect the 18K Gold Price</h2>
-    <p>The live 18K gold price per gram changes continuously based on the underlying gold spot price, which is driven by several macroeconomic factors:</p>
+    <h2>18K Gold in Luxury Watchmaking</h2>
+    <p>18K gold is the <strong>universal standard for luxury Swiss watches</strong>. Brands including Rolex, Patek Philippe, Audemars Piguet, and Cartier exclusively use 18K gold for their precious-metal cases, bezels, and bracelets. There are specific reasons the watch industry chose 75% purity:</p>
     <ul>
-      <li><strong>US Dollar strength</strong> — Gold is priced globally in USD; a stronger dollar typically pushes spot prices lower, and vice versa.</li>
-      <li><strong>Central bank buying</strong> — Central banks (particularly in China, India, and Turkey) have been significant net buyers of gold since 2022, supporting prices.</li>
-      <li><strong>Inflation and interest rates</strong> — Gold is widely held as a hedge against inflation. When real interest rates are low or negative, gold becomes relatively more attractive.</li>
-      <li><strong>Geopolitical risk</strong> — Gold is a traditional safe-haven asset. Periods of geopolitical tension typically see increased demand and higher prices.</li>
-      <li><strong>Jewellery demand</strong> — India and China account for over 50% of global gold jewellery demand. Seasonal festivals such as Diwali and Lunar New Year create demand spikes.</li>
-      <li><strong>GBP/USD exchange rate</strong> — For UK buyers and sellers, the pound-dollar rate directly affects the GBP price of gold regardless of the USD spot price.</li>
+      <li><strong>Hardness</strong> — 18K gold is hard enough to withstand the rigours of daily wear on the wrist, yet soft enough to machine to the tight tolerances required for watch cases (often ±0.02mm).</li>
+      <li><strong>Colour consistency</strong> — Luxury brands maintain proprietary 18K alloy recipes. Rolex, for example, smelts its own gold in-house at its Plan-les-Ouates foundry and has developed "Everose" (18K rose gold with platinum traces that prevent colour fading).</li>
+      <li><strong>Corrosion resistance</strong> — At 75% purity, 18K gold resists tarnishing and skin acids far better than 14K or 10K, critical for items worn directly against the skin for years.</li>
+      <li><strong>Resale value</strong> — An 18K Rolex Daytona (case weight ~70–80g) contains approximately 52–60g of pure gold, giving it a significant intrinsic melt floor that protects the buyer's investment.</li>
     </ul>
 
-    <h2>Selling 18K Gold in the UK</h2>
-    <p>When selling 18K gold jewellery or scrap in the UK, the amount you receive depends on the dealer's <em>buy rate</em>, which is expressed as a percentage of spot melt value. Reputable UK gold buyers typically offer:</p>
+    <h2>18K vs 14K: The European and American Divide</h2>
+    <p>The jewellery world splits roughly along continental lines when it comes to gold purity preferences:</p>
     <ul>
-      <li><strong>Online gold buyers</strong> (e.g. Hatton Garden Metals, Gold Buyers UK): 85%–95% of melt value</li>
-      <li><strong>High-street jewellers</strong>: 70%–85% of melt value</li>
-      <li><strong>Pawnbrokers</strong>: 50%–70% of melt value</li>
-      <li><strong>Cash4Gold-style postal services</strong>: 40%–65% of melt value</li>
+      <li><strong>Europe, Middle East, and Asia</strong> — 18K (750) is the standard for fine jewellery. Brands like Cartier, Bvlgari, Van Cleef & Arpels, and Chopard produce almost exclusively in 18K. In Italy — the world's largest jewellery exporter — 18K accounts for over 85% of production.</li>
+      <li><strong>United States</strong> — <a href="/14k-gold-price-per-gram">14K (585)</a> dominates, particularly for engagement rings and wedding bands. The US market values durability and affordability, making 14K the pragmatic choice for everyday wear.</li>
+      <li><strong>United Kingdom</strong> — The UK sits between both markets. High-street chains (H. Samuel, Ernest Jones) stock mostly <a href="/9k-gold-price-per-gram">9K</a> and 18K, while independent jewellers and designer brands favour 18K exclusively.</li>
     </ul>
-    <p>Always weigh your items on a calibrated scale before approaching any buyer, and use our live calculator above to check the current melt value of your 18K gold. This gives you a reliable benchmark to negotiate from.</p>
+    <p>This cultural divide directly affects resale value: 18K jewellery is easier to sell internationally because 750 is the most universally recognised hallmark. If you plan to buy jewellery that holds its value across borders, 18K is the practical standard.</p>
 
-    <h2>Is 18K Gold a Good Investment?</h2>
-    <p>Investment-grade gold is typically 22K or 24K bullion, where the premium over spot is lowest. 18K gold jewellery carries a fabrication premium that you will not recover on resale — you will generally receive melt value only. However, 18K gold can still serve as a store of value over long time horizons, since the underlying gold content tracks the gold price.</p>
-    <p>For pure investment purposes, gold ETFs, LBMA-accredited bullion bars, or Royal Mint gold coins (which are VAT-exempt in the UK) typically offer better value than jewellery. For jewellery that you intend to wear and potentially resell, 18K gold at 75.00% purity represents a reasonable balance of value and durability.</p>
+    <h2>Selling 18K Gold: What Luxury Pieces Are Worth</h2>
+    <p>18K gold occupies the <strong>premium tier of the secondhand gold market</strong>. Unlike lower karats, 18K items often carry significant value beyond their melt weight:</p>
+    <ul>
+      <li><strong>Designer jewellery</strong> — A Cartier Love bracelet in 18K yellow gold (weight ~32g) contains roughly £2,400–£2,800 in gold content at current prices, but sells secondhand for £4,000–£5,500 due to brand premium. Authenticated pieces from Tiffany, Bvlgari, and Van Cleef & Arpels command similar premiums.</li>
+      <li><strong>Luxury watches</strong> — 18K gold watches from Rolex, Omega, and Patek Philippe typically sell for 200–500% above their gold melt value on the secondary market. The brand, condition, and provenance are far more important than raw gold content.</li>
+      <li><strong>Plain 18K scrap</strong> — Unbranded 18K gold without designer or collectible value typically fetches <strong>85–95% of melt value</strong> from reputable dealers — a better percentage than lower karats, because refiners prefer higher-purity scrap (less alloy to remove, lower processing cost).</li>
+    </ul>
+    <p>Before selling any 18K item, check whether it has brand, vintage, or collectible value. A £300 melt-value piece might be worth £1,000+ to the right buyer on a specialist platform.</p>
 
     <h2>Frequently Asked Questions</h2>
     <details open>

--- a/22k-gold-price-per-gram.html
+++ b/22k-gold-price-per-gram.html
@@ -559,10 +559,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about">About our data</a></div>
 
   <div class="prose">
-    <details>
-  <summary class="faq-answer-summary">What is 22K Gold?</summary>
-  <p class="faq-answer">22K gold contains 22 parts gold out of 24 &mdash; a purity of <strong>91.67%</strong>. It is the most popular gold alloy for jewellery in the United States and is widely used for engagement rings and wedding bands. The hallmark you will see on European and UK pieces is <strong>916</strong>. On American pieces you will see <strong>22K</strong> or <strong>22KT</strong>.</p>
-</details>
+    <h2>What is 22K Gold?</h2>
+    <p>22K gold contains 22 parts gold out of 24 &mdash; a purity of <strong>91.67%</strong>. It is the most popular gold alloy for jewellery in the United States and is widely used for engagement rings and wedding bands. The hallmark you will see on European and UK pieces is <strong>916</strong>. On American pieces you will see <strong>22K</strong> or <strong>22KT</strong>.</p>
 
     <h2 id="q1-22K">How much is a gram of 22k gold worth?</h2>
 <p class="snippet-answer">22K gold is worth approximately <span id="snippet-price" data-nosnippet>[current spot price]</span> per gram today. This value is calculated by multiplying the live 24K spot price by 0.9167, which represents the 91.67% gold purity of 22 karat gold. Dealers typically pay less than this melt value.</p>
@@ -591,10 +589,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       </table></div>
     </figure>
 
-    <details>
-  <summary class="faq-answer-summary">How Is the 22K Gold Price Calculated?</summary>
-  <p class="faq-answer">The 22K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>22K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 0.9167</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
-</details>
+    <h2>How Is the 22K Gold Price Calculated?</h2>
+    <p>The 22K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>22K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 0.9167</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
 
     <h2>22K vs Other Karats</h2>
     <figure itemscope itemtype="https://schema.org/Table">
@@ -643,30 +639,34 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices (London, Birmingham, Sheffield, or Edinburgh) under the Hallmarking Act 1973. The <strong>916 hallmark</strong> guarantees that the item contains at least 91.67% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
     <p>On older or imported items, you may also see the hallmark written as <strong>.916</strong> or stamped alongside a date letter and assay office mark. When appraising estate jewellery, always check for the 916 stamp before calculating value.</p>
 
-    <h2>Factors That Affect the 22K Gold Price</h2>
-    <p>The live 22K gold price per gram changes continuously based on the underlying gold spot price, which is driven by several macroeconomic factors:</p>
+    <h2>22K Gold in South Asian Bridal Traditions</h2>
+    <p>In India, Pakistan, Bangladesh, and Sri Lanka, gold jewellery is far more than decoration — it is a <strong>financial asset, cultural symbol, and integral part of marriage</strong>. South Asian families have traditionally stored wealth in gold jewellery, particularly 22K, for generations. There are specific cultural reasons why 22K dominates this market:</p>
     <ul>
-      <li><strong>US Dollar strength</strong> — Gold is priced globally in USD; a stronger dollar typically pushes spot prices lower, and vice versa.</li>
-      <li><strong>Central bank buying</strong> — Central banks (particularly in China, India, and Turkey) have been significant net buyers of gold since 2022, supporting prices.</li>
-      <li><strong>Inflation and interest rates</strong> — Gold is widely held as a hedge against inflation. When real interest rates are low or negative, gold becomes relatively more attractive.</li>
-      <li><strong>Geopolitical risk</strong> — Gold is a traditional safe-haven asset. Periods of geopolitical tension typically see increased demand and higher prices.</li>
-      <li><strong>Jewellery demand</strong> — India and China account for over 50% of global gold jewellery demand. Seasonal festivals such as Diwali and Lunar New Year create demand spikes.</li>
-      <li><strong>GBP/USD exchange rate</strong> — For UK buyers and sellers, the pound-dollar rate directly affects the GBP price of gold regardless of the USD spot price.</li>
+      <li><strong>Streedhan (women's wealth)</strong> — In Hindu tradition, gold gifted to a bride is her legal property (<em>streedhan</em>), independent of her husband's assets. This is codified in the Hindu Succession Act. A typical middle-class Indian wedding involves 30–100g of 22K gold jewellery.</li>
+      <li><strong>Colour and prestige</strong> — 22K gold has a deep, rich yellow colour that is culturally prized across South Asia. Lower karats (14K, 10K) are considered too pale and are associated with Western markets.</li>
+      <li><strong>Near-pure investment</strong> — At 91.67% purity, 22K jewellery retains excellent melt value. Families view bridal gold as a portable savings account that can be liquidated in emergencies.</li>
+      <li><strong>Making charges</strong> — Indian jewellers charge a "making charge" (fabrication fee) of 8–20% above the gold weight price. When buying 22K jewellery, always negotiate the making charge separately from the gold rate.</li>
     </ul>
 
-    <h2>Selling 22K Gold in the UK</h2>
-    <p>When selling 22K gold jewellery or scrap in the UK, the amount you receive depends on the dealer's <em>buy rate</em>, which is expressed as a percentage of spot melt value. Reputable UK gold buyers typically offer:</p>
+    <h2>Seasonal Buying Patterns: Diwali, Akshaya Tritiya, and Wedding Season</h2>
+    <p>India is the world's <strong>second-largest gold consumer</strong> (after China), and 22K demand follows predictable seasonal patterns that influence global gold prices:</p>
     <ul>
-      <li><strong>Online gold buyers</strong> (e.g. Hatton Garden Metals, Gold Buyers UK): 85%–95% of melt value</li>
-      <li><strong>High-street jewellers</strong>: 70%–85% of melt value</li>
-      <li><strong>Pawnbrokers</strong>: 50%–70% of melt value</li>
-      <li><strong>Cash4Gold-style postal services</strong>: 40%–65% of melt value</li>
+      <li><strong>Diwali (October–November)</strong> — The festival of lights is considered the most auspicious time to buy gold. Indian gold imports typically spike 30–50% in the weeks before Diwali, which can push spot prices higher globally.</li>
+      <li><strong>Akshaya Tritiya (April–May)</strong> — This Hindu festival is believed to bring perpetual prosperity. Gold purchases on this day are considered especially auspicious, creating another seasonal demand peak.</li>
+      <li><strong>Wedding season (November–February)</strong> — India hosts approximately 10 million weddings per year, with the peak season running from late November through February. Each wedding typically involves significant 22K gold purchases.</li>
+      <li><strong>Dhanteras (2 days before Diwali)</strong> — A single-day gold buying festival where Indians purchase an estimated 30–40 tonnes of gold in 24 hours.</li>
     </ul>
-    <p>Always weigh your items on a calibrated scale before approaching any buyer, and use our live calculator above to check the current melt value of your 22K gold. This gives you a reliable benchmark to negotiate from.</p>
+    <p>For UK-based buyers and sellers, understanding these seasonal patterns can help time purchases and sales. Gold prices often rise slightly in September–October as Indian demand builds ahead of Diwali.</p>
 
-    <h2>Is 22K Gold a Good Investment?</h2>
-    <p>Investment-grade gold is typically 22K or 24K bullion, where the premium over spot is lowest. 22K gold jewellery carries a fabrication premium that you will not recover on resale — you will generally receive melt value only. However, 22K gold can still serve as a store of value over long time horizons, since the underlying gold content tracks the gold price.</p>
-    <p>For pure investment purposes, gold ETFs, LBMA-accredited bullion bars, or Royal Mint gold coins (which are VAT-exempt in the UK) typically offer better value than jewellery. For jewellery that you intend to wear and potentially resell, 22K gold at 91.67% purity represents a reasonable balance of value and durability.</p>
+    <h2>22K Gold Sovereign and Britannia Coins</h2>
+    <p>The UK's <strong>Royal Mint Gold Sovereign</strong> is one of the world's most recognised 22K gold coins. First minted in 1489, the modern sovereign contains <strong>7.322g of pure gold</strong> (7.988g total weight at 22K purity). Key facts for buyers and sellers:</p>
+    <ul>
+      <li><strong>CGT exemption</strong> — Gold Sovereigns are UK legal tender and are therefore <strong>exempt from Capital Gains Tax (CGT)</strong>. This makes them one of the most tax-efficient ways to hold physical gold in the UK.</li>
+      <li><strong>VAT exemption</strong> — As investment-grade gold coins, Sovereigns are also exempt from VAT under EU/UK gold investment regulations.</li>
+      <li><strong>Premium over spot</strong> — Sovereigns typically sell for 5–15% above their gold melt value, depending on year, condition, and rarity. Proof and limited-edition Sovereigns can command 50–200%+ premiums.</li>
+      <li><strong>Liquidity</strong> — Sovereigns are among the most liquid gold coins in the world. Any reputable dealer in the UK, Europe, or Middle East will buy them at competitive rates.</li>
+    </ul>
+    <p>For those considering 22K gold as an investment, Sovereigns offer a superior option compared to jewellery — lower premiums, tax advantages, and universal recognition. Use our <a href="/gold-bar-value">gold bar value calculator</a> to compare with bullion options.</p>
 
     <h2>Frequently Asked Questions</h2>
     <details open>

--- a/24k-gold-price-per-gram.html
+++ b/24k-gold-price-per-gram.html
@@ -559,10 +559,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about">About our data</a></div>
 
   <div class="prose">
-    <details>
-  <summary class="faq-answer-summary">What is 24K Gold?</summary>
-  <p class="faq-answer">24K gold contains 24 parts gold out of 24 &mdash; a purity of <strong>99.9%</strong>. It is the purest commercially available form of gold. Because it is 99.9% pure, it is very soft and malleable. It is typically used for investment purposes such as bullion bars and coins, and occasionally for high-end traditional jewellery. The hallmark you will see on European and UK pieces is <strong>999</strong>. It is also often referred to as "pure gold" or "fine gold".</p>
-</details>
+    <h2>What is 24K Gold?</h2>
+    <p>24K gold contains 24 parts gold out of 24 &mdash; a purity of <strong>99.9%</strong>. It is the purest commercially available form of gold. Because it is 99.9% pure, it is very soft and malleable. It is typically used for investment purposes such as bullion bars and coins, and occasionally for high-end traditional jewellery. The hallmark you will see on European and UK pieces is <strong>999</strong>. It is also often referred to as "pure gold" or "fine gold".</p>
 
     <h2 id="q1-24K">How much is a gram of 24k gold worth?</h2>
 <p class="snippet-answer">24K gold is worth approximately <span id="snippet-price" data-nosnippet>[current spot price]</span> per gram today. This value is calculated by multiplying the live 24K spot price by 1.0, which represents the 99.9% gold purity of 24 karat gold. Dealers typically pay less than this melt value.</p>
@@ -591,10 +589,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       </table></div>
     </figure>
 
-    <details>
-  <summary class="faq-answer-summary">How Is the 24K Gold Price Calculated?</summary>
-  <p class="faq-answer">The 24K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>24K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 1.0</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
-</details>
+    <h2>How Is the 24K Gold Price Calculated?</h2>
+    <p>The 24K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>24K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 1.0</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
 
     <h2>24K vs Other Karats</h2>
     <figure itemscope itemtype="https://schema.org/Table">
@@ -643,30 +639,33 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices (London, Birmingham, Sheffield, or Edinburgh) under the Hallmarking Act 1973. The <strong>999 hallmark</strong> guarantees that the item contains at least 99.90% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
     <p>On older or imported items, you may also see the hallmark written as <strong>.999</strong> or stamped alongside a date letter and assay office mark. When appraising estate jewellery, always check for the 999 stamp before calculating value.</p>
 
-    <h2>Factors That Affect the 24K Gold Price</h2>
-    <p>The live 24K gold price per gram changes continuously based on the underlying gold spot price, which is driven by several macroeconomic factors:</p>
+    <h2>LBMA Good Delivery: The Global Gold Standard</h2>
+    <p>The <strong>London Bullion Market Association (LBMA)</strong> sets the global benchmark for gold quality and trading. When people refer to the "gold spot price," they mean the LBMA price — the price at which 24K gold trades between accredited refiners, banks, and dealers. Here’s how the system works:</p>
     <ul>
-      <li><strong>US Dollar strength</strong> — Gold is priced globally in USD; a stronger dollar typically pushes spot prices lower, and vice versa.</li>
-      <li><strong>Central bank buying</strong> — Central banks (particularly in China, India, and Turkey) have been significant net buyers of gold since 2022, supporting prices.</li>
-      <li><strong>Inflation and interest rates</strong> — Gold is widely held as a hedge against inflation. When real interest rates are low or negative, gold becomes relatively more attractive.</li>
-      <li><strong>Geopolitical risk</strong> — Gold is a traditional safe-haven asset. Periods of geopolitical tension typically see increased demand and higher prices.</li>
-      <li><strong>Jewellery demand</strong> — India and China account for over 50% of global gold jewellery demand. Seasonal festivals such as Diwali and Lunar New Year create demand spikes.</li>
-      <li><strong>GBP/USD exchange rate</strong> — For UK buyers and sellers, the pound-dollar rate directly affects the GBP price of gold regardless of the USD spot price.</li>
+      <li><strong>Good Delivery bars</strong> — The standard unit of trade is the 400 troy ounce (~12.4kg) bar, refined to a minimum 995 fineness. Only bars produced by LBMA-accredited refiners are accepted. As of 2024, there are approximately 70 accredited refiners worldwide.</li>
+      <li><strong>Price fixing</strong> — The LBMA Gold Price is set twice daily (10:30 AM and 3:00 PM London time) through an electronic auction run by ICE Benchmark Administration. This auction replaced the historic "London Gold Fix" telephone process in 2015.</li>
+      <li><strong>Clearing</strong> — The London gold market clears approximately $30–40 billion of gold trades daily through the London Precious Metals Clearing Limited (LPMCL), making it the world's deepest and most liquid gold market.</li>
+      <li><strong>Retail bars</strong> — For individual investors, 24K gold is available in smaller denominations: 1g, 5g, 10g, 1oz, 50g, 100g, 250g, 500g, and 1kg bars. LBMA-accredited bars from refiners like PAMP, Valcambi, Umicore, and the Royal Mint carry the lowest premiums over spot.</li>
     </ul>
 
-    <h2>Selling 24K Gold in the UK</h2>
-    <p>When selling 24K gold jewellery or scrap in the UK, the amount you receive depends on the dealer's <em>buy rate</em>, which is expressed as a percentage of spot melt value. Reputable UK gold buyers typically offer:</p>
+    <h2>Central Bank Gold Reserves: Why Nations Hoard 24K</h2>
+    <p>Central banks are the world’s largest holders of physical 24K gold. As of early 2025, global central bank reserves total approximately <strong>36,700 tonnes</strong> of gold, worth over $2.8 trillion. Key facts about sovereign gold holdings:</p>
     <ul>
-      <li><strong>Online gold buyers</strong> (e.g. Hatton Garden Metals, Gold Buyers UK): 85%–95% of melt value</li>
-      <li><strong>High-street jewellers</strong>: 70%–85% of melt value</li>
-      <li><strong>Pawnbrokers</strong>: 50%–70% of melt value</li>
-      <li><strong>Cash4Gold-style postal services</strong>: 40%–65% of melt value</li>
+      <li><strong>Top 5 holders</strong> — The United States (8,133t), Germany (3,352t), Italy (2,452t), France (2,437t), and Russia (2,333t). China officially reports ~2,264t but is widely believed to hold significantly more.</li>
+      <li><strong>Net buying since 2022</strong> — Central banks have been net buyers of gold every year since 2010, but the pace accelerated sharply in 2022–2024, with annual net purchases exceeding 1,000 tonnes — roughly double the historical average. This structural demand has been a major driver of higher gold prices.</li>
+      <li><strong>De-dollarisation</strong> — Many central banks (particularly China, India, Poland, and Turkey) are diversifying reserves away from US dollar assets and into physical gold, driven by geopolitical risk and the freezing of Russian central bank assets in 2022.</li>
+      <li><strong>UK reserves</strong> — The Bank of England holds approximately 310 tonnes of its own gold, plus ~5,600 tonnes in custody for other central banks, stored in vaults beneath Threadneedle Street. The UK controversially sold 395 tonnes between 1999–2002 ("Brown’s Bottom") at an average price of $275/oz.</li>
     </ul>
-    <p>Always weigh your items on a calibrated scale before approaching any buyer, and use our live calculator above to check the current melt value of your 24K gold. This gives you a reliable benchmark to negotiate from.</p>
 
-    <h2>Is 24K Gold a Good Investment?</h2>
-    <p>Investment-grade gold is typically 22K or 24K bullion, where the premium over spot is lowest. 24K gold jewellery carries a fabrication premium that you will not recover on resale — you will generally receive melt value only. However, 24K gold can still serve as a store of value over long time horizons, since the underlying gold content tracks the gold price.</p>
-    <p>For pure investment purposes, gold ETFs, LBMA-accredited bullion bars, or Royal Mint gold coins (which are VAT-exempt in the UK) typically offer better value than jewellery. For jewellery that you intend to wear and potentially resell, 24K gold at 99.90% purity represents a reasonable balance of value and durability.</p>
+    <h2>Investing in 24K Gold: Physical vs Paper</h2>
+    <p>24K gold is <strong>the only purity used for investment-grade bullion</strong>. If you’re buying gold as an investment (rather than jewellery), you have several options, each with distinct trade-offs:</p>
+    <ul>
+      <li><strong>Physical bullion bars</strong> — Lowest premiums (typically 2–5% over spot for 100g+ bars). Must be stored securely. LBMA-accredited bars from PAMP, Valcambi, or the Royal Mint are most liquid. VAT-exempt as investment gold in the UK.</li>
+      <li><strong>Gold coins</strong> — UK Gold Britannia coins (24K, 1oz) are CGT-exempt as legal tender. Sovereigns (<a href="/22k-gold-price-per-gram">22K</a>) also qualify. Premiums are slightly higher than bars (5–12%), but liquidity is excellent.</li>
+      <li><strong>Gold ETFs</strong> — The easiest way to get exposure to the 24K gold price without physical storage. Popular options include iShares Physical Gold ETC (SGLN), Invesco Physical Gold (SGLD), and WisdomTree Physical Gold (PHAU). Management fees are typically 0.12–0.25% per year.</li>
+      <li><strong>Allocated storage</strong> — Services like BullionVault and The Royal Mint’s DigiGold let you buy 24K gold stored in LBMA-accredited vaults. You own specific bars, and storage costs are ~0.12% per year. This combines the low premium of bars with the convenience of digital access.</li>
+    </ul>
+    <p>For most UK investors, the choice between physical gold and ETFs comes down to tax efficiency: Britannia coins and Sovereigns are CGT-exempt, while ETF gains are taxable. For detailed comparison, see our <a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a> guide.</p>
 
     <h2>Frequently Asked Questions</h2>
     <details open>

--- a/9k-gold-price-per-gram.html
+++ b/9k-gold-price-per-gram.html
@@ -561,10 +561,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about">About our data</a></div>
 
   <div class="prose">
-    <details>
-  <summary class="faq-answer-summary">What is 9K Gold?</summary>
-  <p class="faq-answer">9K gold contains 9 parts gold out of 24 &mdash; a purity of <strong>37.5%</strong>. It is the most popular gold alloy for jewellery in the United States and is widely used for engagement rings and wedding bands. The hallmark you will see on European and UK pieces is <strong>375</strong>. On American pieces you will see <strong>9K</strong> or <strong>9KT</strong>.</p>
-</details>
+    <h2>What is 9K Gold?</h2>
+    <p>9K gold contains 9 parts gold out of 24 &mdash; a purity of <strong>37.5%</strong>. It is the most popular gold alloy for jewellery in the United States and is widely used for engagement rings and wedding bands. The hallmark you will see on European and UK pieces is <strong>375</strong>. On American pieces you will see <strong>9K</strong> or <strong>9KT</strong>.</p>
 
     <h2 id="q1-9K">How much is a gram of 9k gold worth?</h2>
 <p class="snippet-answer">9K gold is worth approximately <span id="snippet-price" data-nosnippet>[current spot price]</span> per gram today. This value is calculated by multiplying the live 24K spot price by 0.375, which represents the 37.5% gold purity of 9 karat gold. Dealers typically pay less than this melt value.</p>
@@ -593,10 +591,8 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       </table></div>
     </figure>
 
-    <details>
-  <summary class="faq-answer-summary">How Is the 9K Gold Price Calculated?</summary>
-  <p class="faq-answer">The 9K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>9K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 0.375</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
-</details>
+    <h2>How Is the 9K Gold Price Calculated?</h2>
+    <p>The 9K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>9K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 0.375</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
 
     <h2>9K vs Other Karats</h2>
     <figure itemscope itemtype="https://schema.org/Table">
@@ -645,30 +641,38 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices (London, Birmingham, Sheffield, or Edinburgh) under the Hallmarking Act 1973. The <strong>375 hallmark</strong> guarantees that the item contains at least 37.50% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
     <p>On older or imported items, you may also see the hallmark written as <strong>.375</strong> or stamped alongside a date letter and assay office mark. When appraising estate jewellery, always check for the 375 stamp before calculating value.</p>
 
-    <h2>Factors That Affect the 9K Gold Price</h2>
-    <p>The live 9K gold price per gram changes continuously based on the underlying gold spot price, which is driven by several macroeconomic factors:</p>
+    <h2>Why 9K Gold Dominates the UK High Street</h2>
+    <p>9K gold holds a <strong>unique position in the global jewellery market</strong>. While most countries set their minimum legal gold standard at 10K (US), 14K (much of Europe), or even 18K (France, Italy), the UK’s minimum is 9K — established by the <strong>Hallmarking Act 1973</strong>. This has shaped the entire UK jewellery industry:</p>
     <ul>
-      <li><strong>US Dollar strength</strong> — Gold is priced globally in USD; a stronger dollar typically pushes spot prices lower, and vice versa.</li>
-      <li><strong>Central bank buying</strong> — Central banks (particularly in China, India, and Turkey) have been significant net buyers of gold since 2022, supporting prices.</li>
-      <li><strong>Inflation and interest rates</strong> — Gold is widely held as a hedge against inflation. When real interest rates are low or negative, gold becomes relatively more attractive.</li>
-      <li><strong>Geopolitical risk</strong> — Gold is a traditional safe-haven asset. Periods of geopolitical tension typically see increased demand and higher prices.</li>
-      <li><strong>Jewellery demand</strong> — India and China account for over 50% of global gold jewellery demand. Seasonal festivals such as Diwali and Lunar New Year create demand spikes.</li>
-      <li><strong>GBP/USD exchange rate</strong> — For UK buyers and sellers, the pound-dollar rate directly affects the GBP price of gold regardless of the USD spot price.</li>
+      <li><strong>Affordability</strong> — 9K gold contains only 37.5% pure gold, making it significantly cheaper than <a href="/14k-gold-price-per-gram">14K</a> (58.3%) or <a href="/18k-gold-price-per-gram">18K</a> (75%). A 9K ring weighing 5g contains just 1.875g of pure gold, compared to 3.75g in an 18K ring of the same weight.</li>
+      <li><strong>Exceptional durability</strong> — With 62.5% of its composition being alloy metals (typically copper, silver, and zinc), 9K gold is the <strong>hardest and most scratch-resistant</strong> gold alloy. It’s ideal for rings, bracelets, and chains that endure daily wear.</li>
+      <li><strong>Market dominance</strong> — Major UK high-street chains including H. Samuel, Ernest Jones, Goldsmiths, and Argos stock predominantly 9K gold in their entry-to-mid-range collections. An estimated 60–70% of gold jewellery sold in UK shops is 9K.</li>
+      <li><strong>Colour difference</strong> — 9K yellow gold has a noticeably lighter, paler yellow compared to 18K or 22K. Some buyers prefer this subtler tone; others find it less “golden.” 9K rose gold and white gold are also popular and maintain excellent colour stability.</li>
     </ul>
 
-    <h2>Selling 9K Gold in the UK</h2>
-    <p>When selling 9K gold jewellery or scrap in the UK, the amount you receive depends on the dealer's <em>buy rate</em>, which is expressed as a percentage of spot melt value. Reputable UK gold buyers typically offer:</p>
+    <h2>9K Gold and the UK Scrap Gold Economy</h2>
+    <p>Because 9K is the most common gold alloy in UK households, it dominates the <strong>scrap gold recycling market</strong>. The economics of selling 9K scrap are different from higher karats:</p>
     <ul>
-      <li><strong>Online gold buyers</strong> (e.g. Hatton Garden Metals, Gold Buyers UK): 85%–95% of melt value</li>
-      <li><strong>High-street jewellers</strong>: 70%–85% of melt value</li>
-      <li><strong>Pawnbrokers</strong>: 50%–70% of melt value</li>
-      <li><strong>Cash4Gold-style postal services</strong>: 40%–65% of melt value</li>
+      <li><strong>Lower per-gram value</strong> — At 37.5% purity, a gram of 9K gold is worth roughly half of a gram of <a href="/18k-gold-price-per-gram">18K gold</a>. This means you need more weight to reach the same total value. A typical 9K chain (15–25g) might have a melt value of £225–£375 at current prices.</li>
+      <li><strong>Higher processing margins</strong> — Refiners incur higher costs processing 9K scrap because 62.5% of the material is base metal that must be separated. This is why buy rates for 9K scrap tend to be slightly lower (as a percentage of melt) than for higher karats.</li>
+      <li><strong>Typical UK buy rates for 9K scrap</strong>:</li>
     </ul>
-    <p>Always weigh your items on a calibrated scale before approaching any buyer, and use our live calculator above to check the current melt value of your 9K gold. This gives you a reliable benchmark to negotiate from.</p>
+    <ul>
+      <li>Online specialist gold buyers: <strong>80–90%</strong> of melt value</li>
+      <li>High-street jewellers: <strong>65–80%</strong> of melt value</li>
+      <li>Pawnbrokers: <strong>45–65%</strong> of melt value</li>
+      <li>Postal gold-buying services: <strong>35–60%</strong> of melt value</li>
+    </ul>
+    <p>Always use our <a href="/scrap-gold-calculator">scrap gold calculator</a> to check the melt value before selling, and get quotes from at least three buyers. The difference between the best and worst offers can be 30%+ on 9K gold.</p>
 
-    <h2>Is 9K Gold a Good Investment?</h2>
-    <p>Investment-grade gold is typically 22K or 24K bullion, where the premium over spot is lowest. 9K gold jewellery carries a fabrication premium that you will not recover on resale — you will generally receive melt value only. However, 9K gold can still serve as a store of value over long time horizons, since the underlying gold content tracks the gold price.</p>
-    <p>For pure investment purposes, gold ETFs, LBMA-accredited bullion bars, or Royal Mint gold coins (which are VAT-exempt in the UK) typically offer better value than jewellery. For jewellery that you intend to wear and potentially resell, 9K gold at 37.50% purity represents a reasonable balance of value and durability.</p>
+    <h2>9K vs 10K Gold: UK vs US Standards</h2>
+    <p>9K (375) and <a href="/10k-gold-price-per-gram">10K</a> (417) gold are often compared as they serve similar roles in their respective markets — affordable, durable, entry-level gold jewellery. Here’s how they differ:</p>
+    <ul>
+      <li><strong>Legal status</strong> — 9K is the minimum standard in the UK, Ireland, Australia, and New Zealand. 10K is the minimum in the US and Canada. In France and Italy, neither would legally qualify as "gold" (minimum 18K required).</li>
+      <li><strong>Price difference</strong> — 10K gold contains 41.7% gold vs 9K’s 37.5% — about 11% more gold per gram. This is reflected in the per-gram price.</li>
+      <li><strong>Durability</strong> — Both are excellent for daily wear. 9K is marginally harder due to higher alloy content, but the difference is negligible in practice.</li>
+      <li><strong>Resale</strong> — In the UK, 9K has strong resale because dealers expect it. Selling 10K in the UK can be slightly harder as it’s less common in the domestic market, though any gold buyer will accept it based on weight and purity.</li>
+    </ul>
 
     <h2>Frequently Asked Questions</h2>
     <details open>

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,251 @@
+{
+  "version": 1,
+  "skills": {
+    "ab-test-setup": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/ab-test-setup/SKILL.md",
+      "computedHash": "94f339d57c3a89fc1c813f2769ca504967fb90aeac63f4aed8fa42d489b968dc"
+    },
+    "ad-creative": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/ad-creative/SKILL.md",
+      "computedHash": "660ef74aba893d23335366c5bcc11faf7701ce9f441d9450bc80ab53dccbf21e"
+    },
+    "ai-seo": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/ai-seo/SKILL.md",
+      "computedHash": "ede5108491794bd39caf5f673ecfd2349e5a398e7034d1beedc615ef59c74958"
+    },
+    "analytics-tracking": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/analytics-tracking/SKILL.md",
+      "computedHash": "6ea7d8bb78cacaec93f61c953807e35446304f5c6374fda4b190c76c4281fd4d"
+    },
+    "aso-audit": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/aso-audit/SKILL.md",
+      "computedHash": "5d55b51399d1a2411db2fdbc8c63317f106216c74c40638a55ced127b622dac3"
+    },
+    "churn-prevention": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/churn-prevention/SKILL.md",
+      "computedHash": "e1f4abdffeae2104cecd05d87fbe4c752c6fbcf6a6e856ad584493ed99a69e75"
+    },
+    "co-marketing": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/co-marketing/SKILL.md",
+      "computedHash": "4c7122f33b880eafa38d1549f279c0874da89453af0c728ebe1cc8f8242b8ac5"
+    },
+    "cold-email": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/cold-email/SKILL.md",
+      "computedHash": "bd2738a0d28bad7e344de0712feb718637c1259ee91ae48fb1f6895f64f3204c"
+    },
+    "community-marketing": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/community-marketing/SKILL.md",
+      "computedHash": "68adcc990a6c2b2d32893d149767f60b0487998ec353b5059c3c7a7a529a2b72"
+    },
+    "competitor-alternatives": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/competitor-alternatives/SKILL.md",
+      "computedHash": "d763652f36568b03d8daec3e1e98ac2cc730dcab663d87e2560acee3b9af1a3c"
+    },
+    "competitor-profiling": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/competitor-profiling/SKILL.md",
+      "computedHash": "136d695426bc414e691bf3fd636901bc13f9655b8f33932bb26bc9fdaca9280a"
+    },
+    "content-strategy": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/content-strategy/SKILL.md",
+      "computedHash": "e1ab02527702ead90a9e5774cfe1be9a222bdcc6e861f2cae778ad7cc293f225"
+    },
+    "copy-editing": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/copy-editing/SKILL.md",
+      "computedHash": "cf63a13e3b5c25f5125afefa437999d5ea280b52f74508366a2f342e935c5c09"
+    },
+    "copywriting": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/copywriting/SKILL.md",
+      "computedHash": "c008c80aff1eec1aba190edf421772a3f350e91405d4207575092b663c3702a7"
+    },
+    "customer-research": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/customer-research/SKILL.md",
+      "computedHash": "f080ef2f66e3a42581ea4a8eb3188e97334e20eb28314a77e3f006a4d9ee0173"
+    },
+    "directory-submissions": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/directory-submissions/SKILL.md",
+      "computedHash": "646a49dbdf56ca4e38b877fc793fb2257d079a319ce2f46292fa846aca5b0f11"
+    },
+    "email-sequence": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/email-sequence/SKILL.md",
+      "computedHash": "f4513ca015f509187ec39bff603663ffc82bcd078b9e22bd26ef87dce4e36a7c"
+    },
+    "form-cro": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/form-cro/SKILL.md",
+      "computedHash": "9eb72b95e9e1df985af42541c498cdd11aca914da97a59d07f397d77f17519a1"
+    },
+    "free-tool-strategy": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/free-tool-strategy/SKILL.md",
+      "computedHash": "c9ac82b87836d26f69dd21c9f9a9a03d6398a723ed360f275ab5cc1d70c5c4c7"
+    },
+    "image": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/image/SKILL.md",
+      "computedHash": "e523486265386513350d99d822d90778441ab19347baf7437aa81efbdfe27f47"
+    },
+    "launch-strategy": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/launch-strategy/SKILL.md",
+      "computedHash": "d4a9f5152ff8cdc5cb62b02a753a2909e28e4a01bf3dfce66f9437f5b81999b9"
+    },
+    "lead-magnets": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/lead-magnets/SKILL.md",
+      "computedHash": "927819fe8960471cbc1af903534ea6f0633992441de205105e599e79886c0f90"
+    },
+    "marketing-ideas": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/marketing-ideas/SKILL.md",
+      "computedHash": "ece95da6d74dc84deb45035109311748697b7b074af1a78e111299464306cad2"
+    },
+    "marketing-psychology": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/marketing-psychology/SKILL.md",
+      "computedHash": "5b8654c4d6db63d9da55f7cd56f2babd92e602b089e96a86ef38c7f547f51d52"
+    },
+    "onboarding-cro": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/onboarding-cro/SKILL.md",
+      "computedHash": "b051b45c234c59f97e0e1d365a81cae46adcb75baa95260299f617d80c1cb378"
+    },
+    "page-cro": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/page-cro/SKILL.md",
+      "computedHash": "97fa14549ae123830f1096821a0aadc898f48542c0473897e0bc3d0c90b024f4"
+    },
+    "paid-ads": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/paid-ads/SKILL.md",
+      "computedHash": "d5cca601726231474022b777724e4323efcc52acfabab1fa929ba60c3dc51de7"
+    },
+    "paywall-upgrade-cro": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/paywall-upgrade-cro/SKILL.md",
+      "computedHash": "16ba56a987c0df61653de6401ba2702f74e9b3e281a651619020677ea123e416"
+    },
+    "popup-cro": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/popup-cro/SKILL.md",
+      "computedHash": "d62750cd309aaae426bdc91b267199169f1799edd5dcfb3b5526e08505a1b0e7"
+    },
+    "pricing-strategy": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/pricing-strategy/SKILL.md",
+      "computedHash": "45dcee6fb615d7db2ed85764a91c57b6f6806cbca92b0a348fc901aeda02b10b"
+    },
+    "product-marketing-context": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/product-marketing-context/SKILL.md",
+      "computedHash": "e0c954d8b63d562b997fe6d60f0b39aef49517bdbb93ad67e61989ecbc647cf8"
+    },
+    "programmatic-seo": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/programmatic-seo/SKILL.md",
+      "computedHash": "c6384f24bb0203f8aa98b23b55d35b9e6721b94532a0e7965215c340ae96f1e0"
+    },
+    "referral-program": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/referral-program/SKILL.md",
+      "computedHash": "32d66dac06f00b18f6e9077053ce7de6d2c5a4bee3a7ef50a5eb9dc5c5412746"
+    },
+    "revops": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/revops/SKILL.md",
+      "computedHash": "df5a86fa12fc9f0200c040f319b70d149b33a07228a6692648e30e15e38e6b84"
+    },
+    "sales-enablement": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/sales-enablement/SKILL.md",
+      "computedHash": "827c4d55e07a5a4cfc6c956d0cff44b4a04c39a037f2f109b0b0b530025527d9"
+    },
+    "schema-markup": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/schema-markup/SKILL.md",
+      "computedHash": "7e94629c1bafd6459b4f113237655a98761438eb1b26aa15c440351f79a86d2e"
+    },
+    "seo-audit": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/seo-audit/SKILL.md",
+      "computedHash": "8d29f46f5d494dd41d65b7d1539b0e4bd7e1b5f4d73b8316cd1e744764705594"
+    },
+    "signup-flow-cro": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/signup-flow-cro/SKILL.md",
+      "computedHash": "9ed0af5cecc6d6b9956a7ffd79c15cb18e5a19d3249bb760418a9b763eb21503"
+    },
+    "site-architecture": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/site-architecture/SKILL.md",
+      "computedHash": "040cf6fcceb0d57322c97aff2e75e1f8d2bf49df7a4e1faccd6f34ebf7f3fab1"
+    },
+    "social-content": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/social-content/SKILL.md",
+      "computedHash": "c141cd0a4cbd8ce1b9ead79ada85ea349d794119c3cb730c3def3f689022bfb1"
+    },
+    "video": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "skillPath": "skills/video/SKILL.md",
+      "computedHash": "6bd8dc2c4d9a78820065c3e724b23ae19e03020af37fa0667281e5c318cd131d"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Resolves Google AdSense Low Value Content rejection by replacing templated content with unique editorial across all 6 karat pages.

### Changes
- Un-collapsed hidden details sections on 9K, 10K, 14K, 18K, 22K, 24K pages
- Replaced identical boilerplate with unique editorial (400-600 words each)
- 9K: UK high-street, Hallmarking Act, scrap gold economy
- 10K: FTC minimum standard, durability science
- 14K: Engagement ring market, US vs UK preferences
- 18K: Luxury watchmaking, European standards
- 22K: South Asian bridal traditions, Gold Sovereign coins
- 24K: LBMA Good Delivery, central bank reserves, physical vs paper investing
- Updated .gitignore for AI skill directories
- Added skills-lock.json