### PR TITLE
fix: un-collapse FAQ sections across all 9 blog posts

### DIFF
--- a/blog/2026-04-29-gold-silver-price-outlook.html
+++ b/blog/2026-04-29-gold-silver-price-outlook.html
@@ -555,22 +555,22 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <section style="padding:2rem 0 0;">
   <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
   <div class="faq-container">
-    <details>
-      <summary class="faq-answer-summary">Will gold prices keep rising in 2026?</summary>
+    <div class="faq-card">
+      <h3 class="faq-q">Will gold prices keep rising in 2026?</h3>
       <p class="faq-answer">Gold prices remain supported by central bank buying, elevated geopolitical risk and persistent inflation concerns. However, any significant rise in real interest rates could pressure prices lower. Most analysts forecast a trading range of $2,800–$3,600/oz for 2026, with upside risk if global recession fears intensify.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">What is driving silver prices in 2026?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">What is driving silver prices in 2026?</h3>
       <p class="faq-answer">Silver in 2026 is driven by dual demand: industrial use (particularly solar panel manufacturing and EV components) and investment demand tracking gold. The solar industry alone accounts for over 15% of annual silver demand. Silver tends to outperform gold in bull markets due to its smaller market size.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Is now a good time to buy gold?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Is now a good time to buy gold?</h3>
       <p class="faq-answer">Timing gold purchases is difficult — gold doesn't pay dividends, so returns depend entirely on price appreciation. Dollar-cost averaging (buying fixed amounts monthly) is generally recommended over trying to time the market. If you're concerned about inflation or currency debasement, a 5–10% allocation makes sense regardless of the current price.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Why does gold perform well during uncertainty?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Why does gold perform well during uncertainty?</h3>
       <p class="faq-answer">Gold has no counterparty risk — it cannot default, be sanctioned, or be inflated away like paper currency. During times of geopolitical stress, financial crisis, or high inflation, investors move capital into gold as a store of value. Central banks hold gold reserves for exactly this reason.</p>
-    </details>
+    </div>
   </div>
 </section>
 

--- a/blog/best-uk-gold-dealers-2026.html
+++ b/blog/best-uk-gold-dealers-2026.html
@@ -585,22 +585,22 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <section style="padding:2rem 0 0;">
   <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
   <div class="faq-container">
-    <details>
-      <summary class="faq-answer-summary">What should I look for in a UK gold dealer?</summary>
+    <div class="faq-card">
+      <h3 class="faq-q">What should I look for in a UK gold dealer?</h3>
       <p class="faq-answer">Look for: FCA authorisation or BNTA/IBJA membership, transparent pricing with clear buy/sell spreads, a physical UK address, positive independent reviews (Trustpilot), and buyback programmes. Avoid dealers that don't display spreads upfront or pressure you into quick decisions.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Are UK gold dealers regulated?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Are UK gold dealers regulated?</h3>
       <p class="faq-answer">Gold dealers are not required to be FCA-regulated to sell gold — gold is not a regulated investment. However, reputable dealers voluntarily join industry bodies like the British Numismatic Trade Association (BNTA) or hold anti-money-laundering (AML) registrations with HMRC. Always verify HMRC AML registration at minimum.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Is it safe to buy gold online in the UK?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Is it safe to buy gold online in the UK?</h3>
       <p class="faq-answer">Yes, provided you use an established dealer with verifiable UK premises, secure checkout (HTTPS), and a clear returns policy. Insured delivery is standard practice for reputable dealers. Avoid deals on marketplace sites like eBay for investment-grade gold — use dedicated bullion dealers.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">What is a fair spread for gold coins in the UK?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">What is a fair spread for gold coins in the UK?</h3>
       <p class="faq-answer">A fair dealer premium over spot for popular coins (e.g. Britannia, Sovereign) is typically 3–6% over spot for purchases under £5,000. Larger orders attract lower premiums. Spreads above 10% are excessive for standard bullion coins. CGT-exempt UK coins (Britannias, Sovereigns) may carry slightly higher premiums due to the tax benefit.</p>
-    </details>
+    </div>
   </div>
 </section>
 

--- a/blog/gold-etf-vs-physical-gold-uk.html
+++ b/blog/gold-etf-vs-physical-gold-uk.html
@@ -582,22 +582,22 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <section style="padding:2rem 0 0;">
   <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
   <div class="faq-container">
-    <details>
-      <summary class="faq-answer-summary">What is a gold ETF?</summary>
+    <div class="faq-card">
+      <h3 class="faq-q">What is a gold ETF?</h3>
       <p class="faq-answer">A gold ETF (Exchange-Traded Fund) is a fund that tracks the gold price and trades on a stock exchange like a share. Most physically-backed gold ETFs hold actual gold bars in a vault. You get gold price exposure without storage, insurance or delivery logistics. UK examples include iShares Physical Gold ETC (SGLN) and Invesco Physical Gold ETC (SGLD).</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Is physical gold or gold ETF better for UK investors?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Is physical gold or gold ETF better for UK investors?</h3>
       <p class="faq-answer">It depends on your goals. ETFs are cheaper to buy (no storage costs), more liquid, and easier to hold in an ISA or SIPP. Physical gold gives you direct ownership with no counterparty risk and is portable. For most UK investors holding under £50,000 in gold, ETFs in an ISA (no CGT) are the most practical and tax-efficient choice.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Can I hold gold ETFs in an ISA?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Can I hold gold ETFs in an ISA?</h3>
       <p class="faq-answer">Yes. UK gold ETCs (Exchange-Traded Commodities) like SGLN, SGLD and PHAU can be held in a Stocks & Shares ISA, making gains completely free of CGT and income tax. This is a significant advantage over physical gold (which is subject to CGT at 18% or 24% depending on your tax band).</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">What are the risks of gold ETFs vs physical?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">What are the risks of gold ETFs vs physical?</h3>
       <p class="faq-answer">Gold ETF risks include: counterparty risk (the fund provider could fail, though gold-backed ETCs typically have segregated assets), tracking error, and annual management fees (typically 0.15–0.40%). Physical gold risks include storage, insurance costs, and the premium over spot when buying/selling. Neither form protects against gold price falls.</p>
-    </details>
+    </div>
   </div>
 </section>
 

--- a/blog/gold-in-a-sipp-uk.html
+++ b/blog/gold-in-a-sipp-uk.html
@@ -582,22 +582,22 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <section style="padding:2rem 0 0;">
   <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
   <div class="faq-container">
-    <details>
-      <summary class="faq-answer-summary">Can I hold physical gold in my SIPP?</summary>
+    <div class="faq-card">
+      <h3 class="faq-q">Can I hold physical gold in my SIPP?</h3>
       <p class="faq-answer">Directly holding physical gold bars or coins in a SIPP is not permitted under HMRC rules — physical gold is classified as a 'tangible moveable asset' and is an 'in-specie' contribution that fails the 'exclusively for the purpose of the scheme' test. However, you can hold gold through HMRC-approved routes: gold ETCs, mining company shares, or specialist gold SIPP providers like Talaria Capital.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Are gold ETFs allowed in a SIPP?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Are gold ETFs allowed in a SIPP?</h3>
       <p class="faq-answer">Yes. Physically-backed gold ETCs (such as SGLN, SGLD, PHAU) are permitted in most SIPPs that allow exchange-traded securities. They're treated as shares for SIPP purposes. You benefit from gold price exposure with full pension tax relief on contributions and no CGT within the wrapper.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">What is the tax benefit of gold in a SIPP?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">What is the tax benefit of gold in a SIPP?</h3>
       <p class="faq-answer">Contributing to a SIPP with the intention of buying gold ETCs gives you: 20% basic rate tax relief on contributions (higher rate taxpayers can claim 40%), no CGT on gains within the pension, and no income tax on dividends. The main downside is pension tax rules apply on withdrawal (typically 25% tax-free lump sum, rest taxed as income).</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Which SIPP providers allow gold ETFs?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Which SIPP providers allow gold ETFs?</h3>
       <p class="faq-answer">Most major SIPP platforms that offer a full range of exchange-traded securities allow gold ETCs. These include Hargreaves Lansdown SIPP, AJ Bell Youinvest, Interactive Investor, and Vanguard SIPP. Check the platform's 'permitted investments' list — some low-cost SIPPs restrict to funds only.</p>
-    </details>
+    </div>
   </div>
 </section>
 

--- a/blog/gold-vs-bitcoin-2026.html
+++ b/blog/gold-vs-bitcoin-2026.html
@@ -565,22 +565,22 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <section style="padding:2rem 0 0;">
   <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
   <div class="faq-container">
-    <details>
-      <summary class="faq-answer-summary">Is Bitcoin better than gold as a store of value?</summary>
+    <div class="faq-card">
+      <h3 class="faq-q">Is Bitcoin better than gold as a store of value?</h3>
       <p class="faq-answer">Both have merits. Gold has a 5,000-year track record, extremely low volatility compared to Bitcoin, and universal recognition. Bitcoin is more portable (borderless transfer in minutes), has a hard supply cap (21 million), and has delivered far higher returns in bull cycles. Bitcoin is roughly 5x as volatile as gold. Most institutional investors use gold for stability and Bitcoin for asymmetric upside.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Can Bitcoin replace gold?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Can Bitcoin replace gold?</h3>
       <p class="faq-answer">Unlikely in the near term. Central banks hold over 35,000 tonnes of gold as reserve assets — none hold Bitcoin as a formal reserve (though some nations have Bitcoin strategic reserves). Gold also has significant industrial demand (electronics, dentistry). For private investors, Bitcoin has become a legitimate alternative asset class alongside gold rather than a replacement.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">How have gold and Bitcoin performed in 2026?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">How have gold and Bitcoin performed in 2026?</h3>
       <p class="faq-answer">Both assets performed strongly in 2025–2026. Gold reached all-time highs above $3,000/oz driven by central bank buying and geopolitical uncertainty. Bitcoin also reached new highs following the 2024 halving and increasing institutional adoption. Historically, both tend to perform well when confidence in fiat currencies is low.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Should I invest in gold or Bitcoin?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Should I invest in gold or Bitcoin?</h3>
       <p class="faq-answer">The standard advice is to hold both in small allocations (e.g. 5–10% gold, 1–3% Bitcoin) as uncorrelated assets. Gold is lower risk and suits investors seeking stability; Bitcoin suits those comfortable with high volatility for higher potential returns. Never invest more in Bitcoin than you can afford to lose entirely.</p>
-    </details>
+    </div>
   </div>
 </section>
 

--- a/blog/how-to-buy-gold-royal-mint.html
+++ b/blog/how-to-buy-gold-royal-mint.html
@@ -585,22 +585,22 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <section style="padding:2rem 0 0;">
   <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
   <div class="faq-container">
-    <details>
-      <summary class="faq-answer-summary">Is the Royal Mint a good place to buy gold?</summary>
+    <div class="faq-card">
+      <h3 class="faq-q">Is the Royal Mint a good place to buy gold?</h3>
       <p class="faq-answer">Yes. The Royal Mint is the UK's official coin manufacturer, founded in 886 AD, and is considered the most trusted source for investment gold coins in the UK. Prices are competitive with other major dealers, and coins purchased directly carry the full Royal Mint guarantee of authenticity and purity. They also offer a DigiGold service for fractional gold ownership.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">What gold products does the Royal Mint sell?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">What gold products does the Royal Mint sell?</h3>
       <p class="faq-answer">The Royal Mint sells Britannia gold coins (1oz, 1/2oz, 1/4oz, 1/10oz), Sovereign gold coins (full, half, quarter), gold bars (1g to 1kg), and collectable commemorative coins. Britannias and Sovereigns are CGT-exempt for UK investors, making them particularly tax-efficient.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Are Royal Mint gold coins CGT free?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Are Royal Mint gold coins CGT free?</h3>
       <p class="faq-answer">Yes. Gold Britannias and gold Sovereigns are classified as 'coin of the realm' and legal tender, making any gains from their sale completely exempt from Capital Gains Tax for UK investors. This is a significant advantage over gold bars or foreign gold coins, which are subject to standard CGT rates (18% or 24%).</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">How does Royal Mint DigiGold work?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">How does Royal Mint DigiGold work?</h3>
       <p class="faq-answer">DigiGold lets you buy fractions of a gold bar from as little as £25, with your gold physically stored at the Royal Mint's vault in Llantrisant, Wales. You own actual allocated gold, not a financial instrument. You can convert to physical delivery (coins or bars) at any time. Storage fees apply (0.5% per year).</p>
-    </details>
+    </div>
   </div>
 </section>
 

--- a/blog/is-gold-overpriced-2026.html
+++ b/blog/is-gold-overpriced-2026.html
@@ -572,22 +572,22 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <section style="padding:2rem 0 0;">
   <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
   <div class="faq-container">
-    <details>
-      <summary class="faq-answer-summary">How do analysts value gold?</summary>
+    <div class="faq-card">
+      <h3 class="faq-q">How do analysts value gold?</h3>
       <p class="faq-answer">Unlike stocks, gold has no earnings or dividends, so traditional P/E ratios don't apply. Common valuation methods include: (1) Gold-to-oil ratio — gold should buy roughly 20–25 barrels of oil historically; (2) Real interest rates — gold tends to be fairly valued when 10-year TIPS yields are negative; (3) Gold-to-S&P 500 ratio; (4) Gold as % of total global financial assets (historically ~1–2%).</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Is gold in a bubble?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Is gold in a bubble?</h3>
       <p class="faq-answer">By most historical metrics, gold is elevated but not in a classic bubble. Bubbles are characterised by retail speculation and leverage — gold's current rally is driven by central bank buying (a structural, long-term demand source) rather than retail frenzy. Sentiment indicators are elevated but not at the extremes seen in 1980. Most analysts see gold as fairly valued to moderately expensive.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">What would cause gold to fall significantly?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">What would cause gold to fall significantly?</h3>
       <p class="faq-answer">The main bearish scenarios for gold are: (1) Sharp rise in real interest rates (making bonds and cash more attractive); (2) Resolution of major geopolitical conflicts; (3) A strong US dollar rally; (4) Forced selling during a broad market liquidity crisis (as happened briefly in March 2020). Gold's correlation with risk assets turns positive during acute crises.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Should I wait for gold to fall before buying?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Should I wait for gold to fall before buying?</h3>
       <p class="faq-answer">Timing gold is notoriously difficult. Missing the best months of gold performance can significantly reduce long-term returns. Dollar-cost averaging — buying a fixed amount monthly — removes the need to time entry and reduces the impact of short-term volatility. If you plan to hold for 5–10 years, entry price matters less than consistency.</p>
-    </details>
+    </div>
   </div>
 </section>
 

--- a/blog/silver-coins-for-investors-uk.html
+++ b/blog/silver-coins-for-investors-uk.html
@@ -578,22 +578,22 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <section style="padding:2rem 0 0;">
   <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
   <div class="faq-container">
-    <details>
-      <summary class="faq-answer-summary">What is junk silver?</summary>
+    <div class="faq-card">
+      <h3 class="faq-q">What is junk silver?</h3>
       <p class="faq-answer">Junk silver refers to pre-1965 US coins (dimes, quarters, half-dollars) that contain 90% silver but have no numismatic premium — they're traded purely for their silver content. The term is misleading: this silver is far from junk. UK equivalent: pre-1920 British coins (50% silver) and 1920–1946 British coins (50% silver). Junk silver offers a cheap way to buy silver near spot price.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Are silver coins CGT-exempt in the UK?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Are silver coins CGT-exempt in the UK?</h3>
       <p class="faq-answer">UK legal tender silver coins — including Silver Britannias — are CGT-exempt as 'coin of the realm', the same as gold Britannias and Sovereigns. Foreign silver coins (e.g. Canadian Maple Leafs, American Eagles) are not CGT-exempt and any gains are subject to UK CGT at 18% or 24%. This makes Silver Britannias particularly attractive for UK investors.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">What is the best silver coin to buy in the UK?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">What is the best silver coin to buy in the UK?</h3>
       <p class="faq-answer">For UK investors, the Silver Britannia (1oz .999 fine silver) is generally the best choice: CGT-exempt, VAT-free (as legal tender), recognisable worldwide, and available from the Royal Mint and major dealers. The Silver Sovereign is another option. For maximum silver content per £, silver bars typically have lower premiums than coins.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Why does silver have VAT but gold doesn't?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Why does silver have VAT but gold doesn't?</h3>
       <p class="faq-answer">Investment gold (coins and bars of ≥99.5% purity) is VAT-exempt in the UK under EU-inherited legislation. Silver, platinum and palladium do not benefit from this exemption — standard 20% VAT applies. This significantly increases the effective cost of buying silver coins or bars, and makes silver ETCs (which don't attract VAT) more cost-effective for pure investment exposure.</p>
-    </details>
+    </div>
   </div>
 </section>
 

--- a/blog/uk-gold-cgt-guide.html
+++ b/blog/uk-gold-cgt-guide.html
@@ -582,22 +582,22 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <section style="padding:2rem 0 0;">
   <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
   <div class="faq-container">
-    <details>
-      <summary class="faq-answer-summary">Which gold coins are CGT-exempt in the UK?</summary>
+    <div class="faq-card">
+      <h3 class="faq-q">Which gold coins are CGT-exempt in the UK?</h3>
       <p class="faq-answer">UK legal tender gold coins are exempt from Capital Gains Tax. This includes: Gold Britannia (all sizes from 1/10oz to 1oz), Gold Sovereign (full, half, quarter), and any other gold coin that is UK legal tender. Foreign coins — even popular bullion coins like the Canadian Maple Leaf or South African Krugerrand — are NOT CGT-exempt and gains are subject to standard CGT.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">What is the CGT rate on gold in the UK?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">What is the CGT rate on gold in the UK?</h3>
       <p class="faq-answer">For gold assets that are not CGT-exempt (bars, foreign coins, ETFs outside an ISA), gains are taxed at 18% (basic rate taxpayers) or 24% (higher/additional rate taxpayers) as of 2024–25. You also have an annual CGT allowance (£3,000 for 2024–25) that can offset gains. Losses on gold can be offset against other capital gains.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Is gold in an ISA CGT-free?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Is gold in an ISA CGT-free?</h3>
       <p class="faq-answer">Yes. Gold ETCs (Exchange-Traded Commodities) held in a Stocks & Shares ISA are completely free of CGT regardless of gains. This makes ISA-held gold ETCs more tax-efficient than physical gold bars for most UK investors. The annual ISA allowance is £20,000.</p>
-    </details>
-    <details>
-      <summary class="faq-answer-summary">Do I need to declare gold sales to HMRC?</summary>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Do I need to declare gold sales to HMRC?</h3>
       <p class="faq-answer">You must report gold sales on your Self Assessment tax return if: (1) your total gains exceed the annual CGT allowance (£3,000 for 2024–25), (2) your total proceeds from all asset sales exceed £50,000, or (3) you made a loss you want to carry forward. CGT-exempt coins (Britannias, Sovereigns) don't count toward these thresholds.</p>
-    </details>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
All 9 blog posts had FAQ answers hidden inside details/summary tags. Replaced with visible div/h3 blocks for crawlability. Same fix applied to homepage (PR #318) and karat pages (PR #317).