### PR TITLE
fix: upgrade GitHub Actions to Node 24 (v6)

### DIFF
--- a/.github/workflows/api-health.yml
+++ b/.github/workflows/api-health.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check API Health
         id: check

--- a/.github/workflows/generate-sitemap.yml
+++ b/.github/workflows/generate-sitemap.yml
@@ -20,15 +20,15 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Generate sitemap
         run: node scripts/generate-sitemap.js

--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2  # Need previous commit for diff
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Submit changed URLs to IndexNow
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'changed')

--- a/.github/workflows/scope-guard.yml
+++ b/.github/workflows/scope-guard.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history so we can diff against the PR base ref exactly.
           fetch-depth: 0

--- a/.github/workflows/seo-audit-reminder.yml
+++ b/.github/workflows/seo-audit-reminder.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create Issue
         uses: peter-evans/create-issue-from-file@v5

--- a/.github/workflows/update-chart-data.yml
+++ b/.github/workflows/update-chart-data.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_PAT }}
       - name: Fetch and write chart JSON

--- a/.github/workflows/update-datemodified-in-jsonld.yml
+++ b/.github/workflows/update-datemodified-in-jsonld.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Update dateModified in all HTML files
         run: |

--- a/.github/workflows/validate-jsonld.yml
+++ b/.github/workflows/validate-jsonld.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run JSON-LD Validator
         id: validate


### PR DESCRIPTION
Fixes Node.js 20 deprecation warning. All 8 workflows updated:
- actions/checkout@v4 → @v6
- actions/setup-node@v4 → @v6
- node-version: 20 → 24

Node 20 stops working Jun 2, 2026.