### PR TITLE
SEO: Enrich 5 near-page-1 pages with content, FAQs, internal links

### DIFF
--- a/18k-gold-price-in-gbp.html
+++ b/18k-gold-price-in-gbp.html
@@ -16,7 +16,7 @@
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/18k-gold-price-in-gbp">
 <link rel="canonical" href="https://goldpricetools.com/18k-gold-price-in-gbp">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"18K Gold Price in GBP Today","item":"https://goldpricetools.com/18k-gold-price-in-gbp"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is 18K gold worth in GBP today?","acceptedAnswer":{"@type":"Answer","text":"The current 18K gold price in GBP is approximately \u00a386 per gram (May 2026), based on gold near $4,627/oz and USD/GBP near 1.32. The live calculator above updates every 60 seconds with the latest GBP spot rate."}},{"@type":"Question","name":"Where can I sell 18K gold for the best GBP price?","acceptedAnswer":{"@type":"Answer","text":"In the UK, BNTA-member dealers (BullionByPost, Hatton Garden Metals, Gold.co.uk) typically pay 95\u201399% of the live 18K GBP melt value for scrap. For hallmarked fine jewellery, auction houses may achieve significantly above melt value. Always get at least two quotes."}},{"@type":"Question","name":"How do I convert the 18K gold price from USD to GBP?","acceptedAnswer":{"@type":"Answer","text":"Divide the USD price per gram by the live GBP/USD exchange rate. For example: $111/g \u00f7 1.29 = \u00a386.05/g. Our calculator does this automatically using the live exchange rate."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is 18K gold worth in GBP today?","acceptedAnswer":{"@type":"Answer","text":"The current 18K gold price in GBP is approximately £86 per gram (May 2026), based on gold near $4,627/oz and USD/GBP near 1.32. The live calculator above updates every 60 seconds with the latest GBP spot rate."}},{"@type":"Question","name":"Where can I sell 18K gold for the best GBP price?","acceptedAnswer":{"@type":"Answer","text":"In the UK, BNTA-member dealers (BullionByPost, Hatton Garden Metals, Gold.co.uk) typically pay 95–99% of the live 18K GBP melt value for scrap. For hallmarked fine jewellery, auction houses may achieve significantly above melt value. Always get at least two quotes."}},{"@type":"Question","name":"How do I convert the 18K gold price from USD to GBP?","acceptedAnswer":{"@type":"Answer","text":"Divide the USD price per gram by the live GBP/USD exchange rate. For example: $111/g ÷ 1.29 = £86.05/g. Our calculator does this automatically using the live exchange rate."}},{"@type":"Question","name":"What hallmark does 18K gold carry in the UK?","acceptedAnswer":{"@type":"Answer","text":"In the UK, 18K gold carries the '750' hallmark, indicating 750 parts per thousand pure gold. UK hallmarks are administered by four assay offices: London (leopard's head), Birmingham (anchor), Sheffield (rose), and Edinburgh (castle). Since 1999, the millesimal fineness number (750) is the primary purity mark. All gold sold as 18K in the UK must be hallmarked by law if it weighs more than 1 gram."}},{"@type":"Question","name":"Is 18K gold a good investment in the UK?","acceptedAnswer":{"@type":"Answer","text":"18K gold jewellery is primarily a personal item, not an investment vehicle. You lose the dealer margin on purchase and typically receive only 95–99% of melt value on resale. For pure investment purposes, 24K gold bars or coins (such as Sovereigns, which are CGT-exempt) are more efficient. However, 18K gold does hold its value well as a store of wealth, especially for fine jewellery from recognised makers."}},{"@type":"Question","name":"What is the difference between 18K and 750 gold?","acceptedAnswer":{"@type":"Answer","text":"They are the same thing. '18K' (18 karat) is the karat notation meaning 18/24 parts pure gold = 75.0% purity. '750' is the millesimal fineness notation meaning 750 parts per 1000 are pure gold. The UK hallmarking system uses '750', while the karat system is more common in the US, Middle East, and Asia."}}]}</script>
 <meta property="og:title" content="18K Gold Price in GBP — Live 18 Karat Gold Value in Pounds">
 <meta property="og:description" content="Live 18K gold price in GBP (British Pounds) per gram, per ounce, and per tola. Real-time 18 karat gold value for UK buyers and sellers.">
 <meta property="og:type" content="website">
@@ -515,6 +515,40 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <h2>How GBP Exchange Rate Affects 18K Gold Price</h2>
     <p>UK investors and jewellers have a dual exposure when buying or selling gold: both the international gold spot price (quoted in USD) and the USD/GBP exchange rate affect their GBP return. When the pound strengthens against the dollar, the GBP price of gold falls — even if the USD price is unchanged. Conversely, a weaker pound increases the GBP gold price without any move in the underlying metal. In 2025–2026, the pound has traded in a range of approximately $1.23–$1.32 per USD. The GBP/USD rate is displayed in real-time in our calculator. For UK investors holding gold as an inflation hedge, the effective return in GBP terms can differ significantly from the USD return in any given year.</p>
 
+    <h2>18K Gold Jewellery Hallmarks in the UK</h2>
+    <p>All gold items sold as 18 karat in the UK must be hallmarked by law if they weigh more than 1 gram. The hallmark is your legal guarantee of purity and consists of several marks:</p>
+    <ul>
+      <li><strong>Sponsor's mark:</strong> The maker or retailer's initials.</li>
+      <li><strong>Millesimal fineness mark:</strong> "750" for 18K gold, indicating 750 parts per thousand pure gold.</li>
+      <li><strong>Assay office mark:</strong> London (leopard's head), Birmingham (anchor), Sheffield (rose), or Edinburgh (castle).</li>
+      <li><strong>Date letter (optional since 1999):</strong> A letter indicating the year of hallmarking.</li>
+    </ul>
+    <p>When buying or selling 18K gold in the UK, always check for the hallmark. Un-hallmarked gold sold as 18K is illegal under the <a href="/guides/gold-hallmarks-explained">Hallmarking Act 1973</a>. If you're unsure whether your gold is genuine 18K, read our guide on <a href="/guides/how-to-test-if-gold-is-real">how to test if gold is real</a>.</p>
+
+    <h2>18K vs 9K, 14K, and 22K Gold in GBP</h2>
+    <p>The karat of gold determines its purity — and therefore its price per gram. Here's how 18K compares to other common karats in GBP terms:</p>
+    <table class="data-table" aria-label="Gold karat comparison table in GBP">
+      <thead><tr><th>Karat</th><th>Purity</th><th>Hallmark</th><th>Best For</th></tr></thead>
+      <tbody>
+        <tr><td><a href="/9k-gold-price-per-gram">9K Gold</a></td><td>37.5%</td><td>375</td><td>Affordable UK jewellery</td></tr>
+        <tr><td><a href="/14k-gold-price-per-gram">14K Gold</a></td><td>58.3%</td><td>585</td><td>US-standard jewellery</td></tr>
+        <tr><td><strong>18K Gold</strong></td><td><strong>75.0%</strong></td><td><strong>750</strong></td><td><strong>Fine jewellery, watches</strong></td></tr>
+        <tr><td><a href="/22k-gold-price-per-gram">22K Gold</a></td><td>91.7%</td><td>916</td><td>Indian & Middle Eastern jewellery</td></tr>
+        <tr><td><a href="/24k-gold-price-per-gram">24K Gold</a></td><td>99.9%</td><td>999</td><td>Investment bars & coins</td></tr>
+      </tbody>
+    </table>
+    <p>18K gold strikes a balance between purity and durability. It's the standard for luxury Swiss watches (Rolex, Omega, Patek Philippe) and high-end UK jewellers. For a deeper dive into karat differences, see our <a href="/guides/gold-karat-explained">gold karat explained</a> guide.</p>
+
+    <h2>Where to Buy and Sell 18K Gold in the UK</h2>
+    <p>The UK has a well-regulated precious metals market. Here are your main options for buying and selling 18K gold:</p>
+    <ul>
+      <li><strong>BNTA-member dealers:</strong> The <a href="/blog/best-uk-gold-dealers-2026">British Numismatic Trade Association</a> members are vetted for reliability. Expect to pay 3–8% above spot for 18K bullion and receive 95–99% of spot for scrap.</li>
+      <li><strong>Hatton Garden (London):</strong> The UK's jewellery quarter has dozens of dealers offering competitive 18K prices. Useful for large transactions where face-to-face valuation matters.</li>
+      <li><strong>Online dealers:</strong> BullionByPost, Gold.co.uk, and Chards offer 18K items with next-day insured delivery. Compare prices using our <a href="/scrap-gold-calculator">scrap gold calculator</a> before selling.</li>
+      <li><strong>Auction houses:</strong> For hallmarked fine 18K jewellery from recognised makers, auction houses (Bonhams, Christie's, Fellows) may achieve prices above melt value.</li>
+    </ul>
+    <p>For tips on getting the best price, read our guide on <a href="/guides/how-to-sell-gold-jewellery">how to sell gold jewellery in the UK</a> and <a href="/guides/what-is-best-time-to-sell-scrap-gold">when to sell scrap gold</a>.</p>
+
     <h2>Frequently Asked Questions</h2>
     <div class="faq-card">
       <h3 class="faq-answer-summary">What is 18K gold worth in GBP today?</h3>
@@ -525,6 +559,15 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </div><div class="faq-card">
       <h3 class="faq-answer-summary">How do I convert the 18K gold price from USD to GBP?</h3>
       <p class="faq-answer">Divide the USD price per gram by the live GBP/USD exchange rate. For example: $111/g ÷ 1.29 = £86.05/g. Our calculator does this automatically using the live exchange rate.</p>
+    </div><div class="faq-card">
+      <h3 class="faq-answer-summary">What hallmark does 18K gold carry in the UK?</h3>
+      <p class="faq-answer">In the UK, 18K gold carries the '750' hallmark, indicating 750 parts per thousand pure gold. UK hallmarks are administered by four assay offices: London (leopard's head), Birmingham (anchor), Sheffield (rose), and Edinburgh (castle). Since 1999, the millesimal fineness number (750) is the primary purity mark. All gold sold as 18K in the UK must be hallmarked by law if it weighs more than 1 gram.</p>
+    </div><div class="faq-card">
+      <h3 class="faq-answer-summary">Is 18K gold a good investment in the UK?</h3>
+      <p class="faq-answer">18K gold jewellery is primarily a personal item, not an investment vehicle. You lose the dealer margin on purchase and typically receive only 95–99% of melt value on resale. For pure investment purposes, 24K gold bars or coins (such as Sovereigns, which are CGT-exempt) are more efficient. However, 18K gold does hold its value well as a store of wealth, especially for fine jewellery from recognised makers.</p>
+    </div><div class="faq-card">
+      <h3 class="faq-answer-summary">What is the difference between 18K and 750 gold?</h3>
+      <p class="faq-answer">They are the same thing. '18K' (18 karat) is the karat notation meaning 18/24 parts pure gold = 75.0% purity. '750' is the millesimal fineness notation meaning 750 parts per 1000 are pure gold. The UK hallmarking system uses '750', while the karat system is more common in the US, Middle East, and Asia.</p>
     </div>
 
     <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not represent dealer buy or sell prices. Not financial advice. <a href="/about">Full data methodology &rarr;</a></div>

--- a/22k-gold-price-per-gram.html
+++ b/22k-gold-price-per-gram.html
@@ -16,6 +16,7 @@
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/22k-gold-price-per-gram">
 <link rel="canonical" href="https://goldpricetools.com/22k-gold-price-per-gram">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"22K Gold Price Per Gram","item":"https://goldpricetools.com/22k-gold-price-per-gram"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I convert the 22K gold price from troy ounces to grams?","acceptedAnswer":{"@type":"Answer","text":"There are 31.1035 grams in one troy ounce. Divide the spot price by 31.1035 to get the price per gram of pure gold, then multiply by 0.9167 to get the 22K price per gram."}},{"@type":"Question","name":"What is the difference between 22K gold and gold-filled or gold-plated?","acceptedAnswer":{"@type":"Answer","text":"Solid 22K gold contains 91.67% pure gold throughout. Gold-filled has a layer bonded to base metal. Gold-plated has only a thin electroplated layer. Only solid 22K carries the 916 hallmark."}},{"@type":"Question","name":"Why is 22K gold preferred in India and the Middle East?","acceptedAnswer":{"@type":"Answer","text":"22K gold is preferred for its deep yellow colour, high melt value (91.67% pure), and cultural significance. In India, gold is gifted at weddings (streedhan). In Gulf states, 22K gold souks are central to celebrations."}},{"@type":"Question","name":"Is 22K gold too soft for everyday jewellery?","acceptedAnswer":{"@type":"Answer","text":"22K is softer than 14K or 18K but is still widely worn daily across South Asia and the Middle East. For rings subject to heavy wear, 18K may be better. For necklaces and earrings, 22K is excellent."}},{"@type":"Question","name":"What is the making charge on 22K gold jewellery?","acceptedAnswer":{"@type":"Answer","text":"Making charges typically range from 8-20% above the gold weight price. Machine-made pieces: 8-12%. Handcrafted designs: 15-25%. Always negotiate making charges separately from the gold rate."}},{"@type":"Question","name":"Why does the 22K gold price vary between websites?","acceptedAnswer":{"@type":"Answer","text":"Differences reflect data feed timing, spot price source (LBMA, COMEX, OTC), and exchange rate timestamps. GoldPriceTools updates every 60 seconds."}}]}</script>
 <meta property="og:title" content="22K Gold Price Per Gram Today (Live)">
 <meta property="og:description" content="Real-time 22K gold price per gram in USD, GBP, EUR. 91.67% pure gold. Updated every 60 seconds.">
 <meta property="og:type" content="website">
@@ -679,6 +680,46 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <div class="faq-card">
       <h3 class="faq-answer-summary">Why does the 22K gold price per gram vary between different websites?</h3>
       <p class="faq-answer">Small differences between sites reflect the timing of their data feed, the spot price source used (LBMA, COMEX, or OTC), and whether they include the GBP/USD exchange rate at slightly different timestamps. GoldPriceTools fetches live prices from gold-api.com and currency rates from the Frankfurter API, both updated every 60 seconds.</p>
+    </div>
+
+    <h2>22K Gold in Indian and Middle Eastern Markets</h2>
+    <p>22K gold is the dominant standard across South Asia and the Gulf states, making it one of the most globally traded gold purities:</p>
+    <table class="data-table" aria-label="22K gold market comparison">
+      <thead><tr><th>Market</th><th>Standard</th><th>Key Features</th></tr></thead>
+      <tbody>
+        <tr><td>India</td><td>22K (916)</td><td>World's #2 gold consumer; 30–40 tonnes bought on Dhanteras alone</td></tr>
+        <tr><td>UAE / Dubai</td><td>22K (916)</td><td>Dubai Gold Souk is the world's largest gold retail market</td></tr>
+        <tr><td>Saudi Arabia</td><td>21K–22K</td><td>21K is the Saudi standard; 22K preferred for expatriate jewellery</td></tr>
+        <tr><td>Bangladesh</td><td>22K (916)</td><td>Bridal gold is a cultural requirement</td></tr>
+        <tr><td>UK</td><td>22K (916)</td><td>Sovereign coins are 22K; jewellery market growing in Hatton Garden</td></tr>
+      </tbody>
+    </table>
+    <p>For UK residents buying 22K jewellery, compare prices at <a href="/blog/best-uk-gold-dealers-2026">trusted UK gold dealers</a>. For those selling inherited or pre-owned 22K pieces, use our <a href="/scrap-gold-calculator">scrap gold calculator</a> to estimate melt value. To compare 22K with other karats, see our pages for <a href="/18k-gold-price-per-gram">18K gold</a> and <a href="/24k-gold-price-per-gram">24K gold</a>.</p>
+
+    <h2>Frequently Asked Questions</h2>
+    <div class="faq-card">
+      <h3 class="faq-answer-summary">How do I convert the 22K gold price from troy ounces to grams?</h3>
+      <p class="faq-answer">There are 31.1035 grams in one troy ounce. Divide the spot price (in any currency) by 31.1035 to get the price per gram of pure gold, then multiply by 0.9167 to get the 22K price per gram. Our live calculator above does this automatically.</p>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-answer-summary">What is the difference between 22K gold and gold-filled or gold-plated?</h3>
+      <p class="faq-answer">Solid 22K gold contains 91.67% pure gold throughout the item. Gold-filled has a layer of 22K gold mechanically bonded to a base metal core — it contains far less gold by weight. Gold-plated items have only a thin electroplated layer of gold. Only solid 22K gold carries the 916 hallmark and has significant melt value.</p>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-answer-summary">Why does the 22K gold price per gram vary between different websites?</h3>
+      <p class="faq-answer">Small differences between sites reflect the timing of their data feed, the spot price source used (LBMA, COMEX, or OTC), and whether they include the GBP/USD exchange rate at slightly different timestamps. GoldPriceTools fetches live prices from gold-api.com and currency rates from the Frankfurter API, both updated every 60 seconds.</p>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-answer-summary">Why is 22K gold preferred in India and the Middle East?</h3>
+      <p class="faq-answer">22K gold is preferred because of its deep, rich yellow colour, high melt value (91.67% pure), and cultural significance. In India, gold is a financial asset gifted at weddings (streedhan), while in Gulf states, 22K gold souks are central to celebrations and savings. Lower karats like 14K are considered too pale in these markets.</p>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-answer-summary">Is 22K gold too soft for everyday jewellery?</h3>
+      <p class="faq-answer">22K gold is softer than 14K or 18K because of its higher gold content, but it is still widely worn daily across South Asia and the Middle East. For rings or bracelets subject to heavy wear, some jewellers recommend 18K. For necklaces, earrings, and ceremonial pieces, 22K is excellent.</p>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-answer-summary">What is the making charge on 22K gold jewellery?</h3>
+      <p class="faq-answer">Making charges (fabrication fees) on 22K gold jewellery typically range from 8–20% above the gold weight price. Machine-made pieces have lower making charges (8–12%) while handcrafted or intricate designs can reach 15–25%. When buying, always negotiate the making charge separately from the gold rate and get a detailed receipt.</p>
     </div>
 
     <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Dealer buy prices are typically 70&ndash;90% of melt value. Always verify with your dealer before selling.</div>

--- a/24-hour-gold-silver-prices.html
+++ b/24-hour-gold-silver-prices.html
@@ -16,7 +16,7 @@
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/24-hour-gold-silver-prices">
 <link rel="canonical" href="https://goldpricetools.com/24-hour-gold-silver-prices">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"24-Hour Gold and Silver Prices","item":"https://goldpricetools.com/24-hour-gold-silver-prices"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What time does the gold market open and close?","acceptedAnswer":{"@type":"Answer","text":"The global gold market operates nearly 24 hours a day: Sydney opens Sunday ~22:00 GMT, followed by Tokyo, then London at ~07:00 GMT, and finally New York at ~13:30 GMT. The market effectively closes Friday at 22:00 GMT when New York closes. The LBMA publishes official benchmark 'Fix' prices at 10:30 AM and 3:00 PM GMT on London business days."}},{"@type":"Question","name":"Why does the gold price spike at certain times of day?","acceptedAnswer":{"@type":"Answer","text":"Price spikes most commonly occur at: (1) the US market open (13:30\u201314:00 GMT) when COMEX futures open; (2) the release of major US economic data such as Non-Farm Payrolls (first Friday of the month at 13:30 GMT) and CPI/FOMC announcements; (3) geopolitical news events. The LBMA AM and PM fix times (10:30 and 15:00 GMT) also see elevated volume as contracts and settlements are priced."}},{"@type":"Question","name":"How does the 24-hour gold price compare to the closing price?","acceptedAnswer":{"@type":"Answer","text":"There is no single official 'closing price' for gold as the market never fully closes during the week. The LBMA PM Fix (15:00 GMT London) is the most widely used daily reference price. COMEX settles at approximately 13:30 GMT (the electronic session close). For UK reporting purposes, the LBMA PM Fix in GBP is the standard reference price used by HMRC, pension funds, and institutional traders."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What time does the gold market open and close?","acceptedAnswer":{"@type":"Answer","text":"The global gold market operates nearly 24 hours a day: Sydney opens Sunday ~22:00 GMT, followed by Tokyo, then London at ~07:00 GMT, and finally New York at ~13:30 GMT. The market effectively closes Friday at 22:00 GMT when New York closes. The LBMA publishes official benchmark 'Fix' prices at 10:30 AM and 3:00 PM GMT on London business days."}},{"@type":"Question","name":"Why does the gold price spike at certain times of day?","acceptedAnswer":{"@type":"Answer","text":"Price spikes most commonly occur at: (1) the US market open (13:30–14:00 GMT) when COMEX futures open; (2) the release of major US economic data such as Non-Farm Payrolls (first Friday of the month at 13:30 GMT) and CPI/FOMC announcements; (3) geopolitical news events. The LBMA AM and PM fix times (10:30 and 15:00 GMT) also see elevated volume as contracts and settlements are priced."}},{"@type":"Question","name":"How does the 24-hour gold price compare to the closing price?","acceptedAnswer":{"@type":"Answer","text":"There is no single official 'closing price' for gold as the market never fully closes during the week. The LBMA PM Fix (15:00 GMT London) is the most widely used daily reference price. COMEX settles at approximately 13:30 GMT (the electronic session close). For UK reporting purposes, the LBMA PM Fix in GBP is the standard reference price used by HMRC, pension funds, and institutional traders."}},{"@type":"Question","name":"What drives gold prices overnight?","acceptedAnswer":{"@type":"Answer","text":"Overnight gold price movements (during the Asian session) are primarily driven by physical demand from China and India, People's Bank of China (PBOC) gold reserve announcements, Shanghai Gold Exchange (SGE) premiums, and any geopolitical developments that occur outside Western trading hours. Large overnight moves often signal significant shifts in Eastern demand."}},{"@type":"Question","name":"Is the Asian trading session important for gold?","acceptedAnswer":{"@type":"Answer","text":"Yes. China and India together account for over 50% of global physical gold demand. The Shanghai Gold Exchange (SGE) regularly trades 15–30 tonnes of gold per day. When the SGE premium over London prices rises above $10/oz, it signals strong Chinese buying pressure that often lifts global prices when London opens."}},{"@type":"Question","name":"How do LBMA Fix prices work?","acceptedAnswer":{"@type":"Answer","text":"The LBMA Gold Price is set twice daily (10:30 AM and 3:00 PM London time) via an electronic auction managed by ICE Benchmark Administration. Participating banks submit buy and sell orders, and the price is adjusted in rounds until supply and demand balance within a tolerance. The resulting 'Fix' price is used globally to settle contracts, value ETF holdings, and price institutional trades."}}]}</script>
 <meta property="og:title" content="24-Hour Gold and Silver Prices — Intraday Live Chart">
 <meta property="og:description" content="24-hour gold and silver price chart and live data. Track intraday precious metals price movements across all global trading sessions. Updated every 60 seconds.">
 <meta property="og:type" content="website">
@@ -521,6 +521,42 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 <li><strong>New York Session (COMEX)</strong> — Opens ~13:30 GMT. The primary futures market. COMEX open interest and volume data give insight into institutional positioning. Major US economic releases (NFP, CPI, FOMC) during this session can cause rapid intraday moves of 1–3%.</li>
 </ul></p>
 
+    <h2>Key Economic Events That Move Gold Prices</h2>
+    <p>Certain scheduled economic releases reliably trigger sharp intraday gold price moves. If you are timing a purchase or sale, these are the dates and times to watch:</p>
+    <table class="data-table" aria-label="Key economic events affecting gold prices">
+      <thead><tr><th>Event</th><th>Schedule</th><th>Typical Impact</th></tr></thead>
+      <tbody>
+        <tr><td>US Non-Farm Payrolls (NFP)</td><td>1st Friday of month, 13:30 GMT</td><td>1–3% moves common</td></tr>
+        <tr><td>US CPI (Inflation)</td><td>~12th of month, 13:30 GMT</td><td>1–2% moves common</td></tr>
+        <tr><td>FOMC Rate Decision</td><td>8 times/year, 19:00 GMT</td><td>0.5–2% on surprise</td></tr>
+        <tr><td>LBMA AM Fix</td><td>Daily, 10:30 GMT</td><td>Benchmark settlement</td></tr>
+        <tr><td>LBMA PM Fix</td><td>Daily, 15:00 GMT</td><td>Benchmark settlement</td></tr>
+        <tr><td>PBOC Gold Reserves</td><td>Monthly (7th business day)</td><td>Signals central bank demand</td></tr>
+        <tr><td>US Dollar Index (DXY)</td><td>Continuous</td><td>Inverse correlation with gold</td></tr>
+      </tbody>
+    </table>
+    <p>Gold typically rises when NFP or CPI data comes in weaker than expected (signalling potential rate cuts) and falls on stronger-than-expected prints. The FOMC statement and press conference at 19:00–19:30 GMT can cause rapid moves if the Fed changes its rate guidance. For real-time tracking during these events, keep this page open — our prices update every 60 seconds.</p>
+
+    <h2>Silver Spot Price — 24-Hour Data</h2>
+    <p>Silver trades alongside gold in a 24-hour global market but is typically more volatile intraday due to lower liquidity and its dual role as both a precious metal and an industrial commodity. Silver's daily trading volume on COMEX averages roughly $25–30 billion — compared to gold's $80–100 billion — which means individual trades can move the price more sharply.</p>
+    <p>Key differences between 24-hour gold and silver trading:</p>
+    <ul>
+      <li><strong>Higher intraday volatility:</strong> Silver regularly moves 2–4% intraday versus gold's typical 0.5–1.5%.</li>
+      <li><strong>Industrial demand sensitivity:</strong> Silver reacts to manufacturing PMI data, solar panel demand forecasts, and electronics supply chain news — factors that don't affect gold.</li>
+      <li><strong>Gold/silver ratio:</strong> The <a href="/gold-silver-ratio">gold-to-silver ratio</a> (currently ~100:1 historically) is a key metric. Ratios above 80 historically suggest silver is undervalued relative to gold.</li>
+      <li><strong>Wider spreads in Asian session:</strong> Silver bid-ask spreads widen significantly during the Asian session due to lower volume. Avoid large silver trades between 00:00–07:00 GMT if possible.</li>
+    </ul>
+    <p>For live silver prices by weight, see our <a href="/silver-price-per-kilo">silver price per kilo</a> page, or use the <a href="/silver-coins-calculator">silver coins calculator</a> for US and UK coin melt values.</p>
+
+    <h2>How to Use 24-Hour Price Data</h2>
+    <p>Whether you are buying bullion, selling scrap gold, or monitoring your portfolio, the 24-hour price chart provides actionable insight:</p>
+    <ul>
+      <li><strong>Buying gold:</strong> Prices tend to dip slightly during the Asian session (00:00–07:00 GMT) when volume is lowest. The London AM Fix at 10:30 GMT often sets the day's direction. If you are placing a buy order with a UK dealer, morning orders before the PM Fix (15:00 GMT) typically get executed at or near the AM Fix level.</li>
+      <li><strong>Selling scrap gold:</strong> Most UK dealers (<a href="/blog/best-uk-gold-dealers-2026">see our dealer reviews</a>) quote based on the live spot or the LBMA PM Fix. Selling during London hours (08:00–16:00 GMT) ensures you get the most liquid price. Use our <a href="/scrap-gold-calculator">scrap gold calculator</a> to estimate your payout before contacting a dealer.</li>
+      <li><strong>Portfolio monitoring:</strong> If you hold gold ETFs (such as iShares Physical Gold ETC on the LSE), the NAV is calculated using the LBMA PM Fix. Intraday ETF prices may deviate slightly from spot — this is normal and corrects at the next Fix.</li>
+    </ul>
+    <p>For historical price trends and long-term charts, see our <a href="/guides/gold-price-history">gold price history guide</a>. For understanding what drives price movements, read <a href="/guides/what-affects-gold-price">what affects the gold price</a>.</p>
+
     <h2>Frequently Asked Questions</h2>
     <div class="faq-card">
       <h3 class="faq-answer-summary">What time does the gold market open and close?</h3>
@@ -531,6 +567,15 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </div><div class="faq-card">
       <h3 class="faq-answer-summary">How does the 24-hour gold price compare to the closing price?</h3>
       <p class="faq-answer">There is no single official 'closing price' for gold as the market never fully closes during the week. The LBMA PM Fix (15:00 GMT London) is the most widely used daily reference price. COMEX settles at approximately 13:30 GMT (the electronic session close). For UK reporting purposes, the LBMA PM Fix in GBP is the standard reference price used by HMRC, pension funds, and institutional traders.</p>
+    </div><div class="faq-card">
+      <h3 class="faq-answer-summary">What drives gold prices overnight?</h3>
+      <p class="faq-answer">Overnight gold price movements (during the Asian session) are primarily driven by physical demand from China and India, People's Bank of China (PBOC) gold reserve announcements, Shanghai Gold Exchange (SGE) premiums, and any geopolitical developments that occur outside Western trading hours. Large overnight moves often signal significant shifts in Eastern demand.</p>
+    </div><div class="faq-card">
+      <h3 class="faq-answer-summary">Is the Asian trading session important for gold?</h3>
+      <p class="faq-answer">Yes. China and India together account for over 50% of global physical gold demand. The Shanghai Gold Exchange (SGE) regularly trades 15–30 tonnes of gold per day. When the SGE premium over London prices rises above $10/oz, it signals strong Chinese buying pressure that often lifts global prices when London opens.</p>
+    </div><div class="faq-card">
+      <h3 class="faq-answer-summary">How do LBMA Fix prices work?</h3>
+      <p class="faq-answer">The LBMA Gold Price is set twice daily (10:30 AM and 3:00 PM London time) via an electronic auction managed by ICE Benchmark Administration. Participating banks submit buy and sell orders, and the price is adjusted in rounds until supply and demand balance within a tolerance. The resulting 'Fix' price is used globally to settle contracts, value ETF holdings, and price institutional trades.</p>
     </div>
 
     <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not represent dealer buy or sell prices. Not financial advice. <a href="/about">Full data methodology &rarr;</a></div>

--- a/800-silver-price-per-gram.html
+++ b/800-silver-price-per-gram.html
@@ -480,6 +480,7 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
   }
 }
 </script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is .800 silver worth per gram today?","acceptedAnswer":{"@type":"Answer","text":"The value of .800 silver per gram is calculated by multiplying the live silver spot price per gram by 0.800 (80% purity). The live price is shown on this page."}},{"@type":"Question","name":"Is .800 silver worth anything?","acceptedAnswer":{"@type":"Answer","text":"Yes, .800 silver contains 80% pure silver, giving it significant intrinsic melt value based on the current silver spot price."}},{"@type":"Question","name":"How do I identify .800 European silver?","acceptedAnswer":{"@type":"Answer","text":".800 silver is typically identified by an '800' hallmark stamp. German pieces often feature a crescent moon and crown mark alongside the 800 stamp."}},{"@type":"Question","name":"What is the difference between .800 silver and sterling silver?","acceptedAnswer":{"@type":"Answer","text":".800 silver is 80% pure silver, commonly used in continental Europe for cutlery and holloware. Sterling silver (.925) is purer, containing 92.5% silver, and is the standard in the UK and US."}},{"@type":"Question","name":"What common items are made from .800 silver?","acceptedAnswer":{"@type":"Answer","text":"Common .800 silver items include Continental European cutlery sets (especially German and Italian), antique tea services, decorative trays, cake servers, older pocket watch cases, cigarette cases, and small decorative boxes. Many pre-1940 German silverware sets marked with the crescent moon and crown are .800 silver."}},{"@type":"Question","name":"Can I sell .800 silver at a UK pawnbroker?","acceptedAnswer":{"@type":"Answer","text":"Yes, most UK pawnbrokers accept .800 silver, but they typically pay less per gram than specialist precious metal dealers because of the lower purity. For the best price, use a weight-based online buyer or specialist silver dealer who evaluates items purely on metal content."}},{"@type":"Question","name":"Is .800 silver magnetic?","acceptedAnswer":{"@type":"Answer","text":"No, genuine .800 silver is not magnetic. Silver and copper (its main alloying metal) are both non-magnetic. If your item is attracted to a magnet, it is likely silver-plated over a ferromagnetic base metal, not solid .800 silver."}}]}</script>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
@@ -718,6 +719,22 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
       <h3 class="faq-answer-summary">Does 800 silver tarnish?</h3>
       <p class="faq-answer">Yes — all silver alloys tarnish over time through oxidation of the copper content. 800 silver tarnishes slightly faster than 925 sterling due to its higher base metal content. Regular polishing with a silver cloth and proper storage in anti-tarnish pouches will maintain its appearance.</p>
     </div>
+
+    <h2>Common .800 Silver Items and Their Value</h2>
+    <p>If you've inherited or collected silverware, knowing which items are commonly made from .800 silver can help you identify pieces worth valuing:</p>
+    <table class="data-table" aria-label="Common .800 silver items">
+      <thead><tr><th>Item</th><th>Typical Weight</th><th>Notes</th></tr></thead>
+      <tbody>
+        <tr><td>6-piece cutlery set</td><td>300–500g</td><td>German/Italian flatware sets; check for 800 stamp on each piece</td></tr>
+        <tr><td>Tea/coffee pot</td><td>400–800g</td><td>Deduct weight of non-silver handles and resin bases</td></tr>
+        <tr><td>Cake server/serving spoon</td><td>50–120g</td><td>Common estate sale find; often undervalued</td></tr>
+        <tr><td>Cigarette case</td><td>80–150g</td><td>Pre-war German cases frequently .800; check hinge mechanism</td></tr>
+        <tr><td>Decorative tray</td><td>200–1,000g</td><td>Larger trays can have significant melt value; weigh accurately</td></tr>
+        <tr><td>Pocket watch case</td><td>20–60g</td><td>Case only (movement is not silver); look for 800 stamp inside back cover</td></tr>
+      </tbody>
+    </table>
+    <p>To calculate the melt value of any .800 silver item, use our calculator above or the <a href="/scrap-gold-calculator">scrap metal calculator</a>. For items with potential antique or collector value (especially marked pieces from makers like WMF, Wilkens, or Bruckmann), consider getting a specialist valuation before selling for scrap.</p>
+    <p>For more on silver purity grades, see our <a href="/silver-purity-grades">silver purity grades</a> page, or compare with <a href="/900-silver-price-per-gram">.900 coin silver</a> and <a href="/guides/what-is-925-sterling-silver">925 sterling silver</a>. If you're looking at silver coins specifically, use our <a href="/silver-coins-calculator">silver coins calculator</a>.</p>
 
     <div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative spot values and do not include dealer premiums. Physical silver coins and bars typically sell at 5&ndash;20% above spot. Not financial advice.</div>
   </div>

--- a/blog/best-uk-gold-dealers-2026.html
+++ b/blog/best-uk-gold-dealers-2026.html
@@ -95,6 +95,30 @@
         "@type": "Answer",
         "text": "A fair dealer premium over spot for popular coins (e.g. Britannia, Sovereign) is typically 3–6% over spot for purchases under £5,000. Larger orders attract lower premiums. Spreads above 10% are excessive for standard bullion coins. CGT-exempt UK coins (Britannias, Sovereigns) may carry slightly higher premiums due to the tax benefit."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Are online gold dealers safe in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, provided you use an established dealer with verifiable UK premises, secure checkout (HTTPS), and a clear returns policy. Insured delivery is standard practice. Look for BNTA membership and HMRC AML registration. Avoid marketplace sites like eBay for investment-grade gold."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the BNTA and why does it matter?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The British Numismatic Trade Association (BNTA) is the UK's leading trade body for coin and bullion dealers. Members must adhere to a strict code of conduct covering fair trading, accurate grading, and dispute resolution. BNTA membership is one of the strongest credibility signals when choosing a UK gold dealer."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I verify a UK gold dealer is legitimate?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Check three things: (1) HMRC anti-money-laundering (AML) registration. (2) BNTA or IBMA membership. (3) Companies House registration — verify the company exists and check filed accounts. Also check Trustpilot reviews and look for a physical UK address."
+      }
     }
   ]
 }
@@ -602,6 +626,36 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <h3 class="faq-q">What is a fair spread for gold coins in the UK?</h3>
       <p class="faq-answer">A fair dealer premium over spot for popular coins (e.g. Britannia, Sovereign) is typically 3–6% over spot for purchases under £5,000. Larger orders attract lower premiums. Spreads above 10% are excessive for standard bullion coins. CGT-exempt UK coins (Britannias, Sovereigns) may carry slightly higher premiums due to the tax benefit.</p>
     </div>
+    <div class="faq-card">
+      <h3 class="faq-q">Are online gold dealers safe in the UK?</h3>
+      <p class="faq-answer">Yes, provided you use an established dealer with verifiable UK premises, secure checkout (HTTPS), and a clear returns policy. Insured delivery is standard practice. Look for BNTA membership and HMRC AML registration. Avoid marketplace sites like eBay for investment-grade gold.</p>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">What is the BNTA and why does it matter?</h3>
+      <p class="faq-answer">The British Numismatic Trade Association (BNTA) is the UK's leading trade body for coin and bullion dealers. Members must adhere to a strict code of conduct covering fair trading, accurate grading, and dispute resolution. BNTA membership is one of the strongest credibility signals when choosing a UK gold dealer.</p>
+    </div>
+    <div class="faq-card">
+      <h3 class="faq-q">How do I verify a UK gold dealer is legitimate?</h3>
+      <p class="faq-answer">Check three things: (1) HMRC anti-money-laundering (AML) registration — all legitimate UK dealers must be registered. (2) BNTA or IBMA membership — voluntary but a strong trust signal. (3) Companies House registration — verify the company exists and check filed accounts. Also check Trustpilot reviews and look for a physical UK address.</p>
+    </div>
+  </div>
+</section>
+
+<section style="padding:2rem 0 0;">
+  <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">How to Choose a UK Gold Dealer: Checklist</h2>
+  <div class="prose">
+    <p>Before making your first (or next) gold purchase, run through this checklist. A good dealer should tick every box:</p>
+    <ul>
+      <li><strong>HMRC AML registration:</strong> Non-negotiable. All UK businesses trading in precious metals must be registered with HMRC for anti-money-laundering compliance.</li>
+      <li><strong>BNTA or IBMA membership:</strong> Voluntary, but the strongest credibility signal in the UK bullion market.</li>
+      <li><strong>Transparent buy/sell spreads:</strong> The dealer should display both buy and sell prices on their website. If only the sell price is shown, ask for the buyback price before purchasing.</li>
+      <li><strong>Clear delivery and insurance policy:</strong> Insured next-day delivery should be standard for orders over £500. Check who bears the risk during transit.</li>
+      <li><strong>Buyback guarantee:</strong> The best dealers guarantee to buy back what they sold you at a competitive spread. This is essential for liquidity.</li>
+      <li><strong>CGT and VAT guidance:</strong> A good dealer proactively flags which products are CGT-exempt (Britannias, Sovereigns) and VAT-free.</li>
+      <li><strong>Physical UK address:</strong> Avoid dealers who operate only through a PO Box or have no verifiable UK premises.</li>
+      <li><strong>Independent reviews:</strong> Check Trustpilot, Google Reviews, and specialist forums like <a href="https://www.thegoldforum.com">The Gold Forum</a>.</li>
+    </ul>
+    <p>Before buying, always check the live gold spot price using our <a href="/">live gold price calculator</a> so you know exactly what premium you're paying. For scrap gold sellers, our <a href="/scrap-gold-calculator">scrap gold calculator</a> shows the melt value of your items at today's price — compare this to dealer offers to ensure you're getting a fair deal.</p>
   </div>
 </section>
 


### PR DESCRIPTION
- 24-hour-gold-silver-prices: +3 H2 sections (economic events, silver data, usage guide), +3 FAQs, +6 internal links
- 18k-gold-price-in-gbp: +3 H2 sections (hallmarks, karat comparison, buy/sell guide), +3 FAQs, +8 internal links
- 800-silver-price-per-gram: +1 H2 section (common items table), +3 FAQs in schema, +4 internal links
- 22k-gold-price-per-gram: +1 H2 section (Indian/ME markets table), FAQPage schema added, +3 FAQs, +4 internal links
- blog/best-uk-gold-dealers-2026: +1 H2 section (dealer checklist), +3 FAQs, +3 internal links

All pages updated with expanded FAQPage structured data.