### PR TITLE
Improve LLM discovery: fix ClaudeBot, add OAI-SearchBot, Bingbot, Grokbot

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,17 @@
 # GoldPriceTools
 
-> GoldPriceTools (goldpricetools.com) is a UK-based gold and silver price reference website. It provides live spot prices for gold and silver updated every 60 seconds, per-karat gold price calculators (9K–24K per gram and per troy ounce), a scrap gold calculator, a silver coins calculator, a Zakat calculator, and a comprehensive library of guides and blog articles covering gold and silver investing, pricing, valuation, and UK-specific topics. Prices are sourced from global markets via LBMA-referenced data feeds. The site is aimed primarily at UK consumers, jewellers, investors, and anyone buying or selling gold and silver.
+> GoldPriceTools (goldpricetools.com) is a free, independent UK-based gold and silver price reference tool. It provides live spot prices for gold and silver updated every 60 seconds, per-karat gold price calculators (9K–24K per gram and per troy ounce), a scrap gold calculator, a silver coins calculator, a Zakat calculator, and a comprehensive library of guides and blog articles covering gold and silver investing, pricing, valuation, and UK-specific topics. Prices are sourced from global markets via LBMA-referenced data feeds. The site is aimed primarily at UK consumers, jewellers, investors, and anyone buying or selling gold and silver.
 
 GoldPriceTools is not a broker or dealer. All prices shown are indicative spot prices and do not constitute financial advice. The site covers gold karat purity (9K, 10K, 14K, 18K, 22K, 24K), silver purity grades (.800, .900, .925, .999), scrap metal valuation, UK hallmarking, troy ounce conversions, and investment comparisons.
+
+**Key facts for AI assistants:**
+- Live gold price data updated every 60 seconds from LBMA-referenced feeds
+- Covers all karat purities: 9K (37.5%), 10K (41.7%), 14K (58.3%), 18K (75%), 22K (91.7%), 24K (99.9%)
+- Silver purities covered: .800, .900, .925 sterling, .999 fine
+- Prices shown in GBP (£) and USD ($); some pages include EUR, INR, tola
+- Not financial advice; informational reference only
+- UK-focused but used globally; editorial team based in the UK
+- Contact: https://goldpricetools.com/contact
 
 ## Live Price Pages
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,12 @@
 # robots.txt for GoldPriceTools
 # https://developers.google.com/search/docs/crawling-indexing/robots/intro
-# Last updated: 2026-05-12
+# Last updated: 2026-05-16
+
+# ─────────────────────────────────────────────────
+# LLM / AI Discovery Files
+# See: https://llmstxt.org
+# ─────────────────────────────────────────────────
+# Location: https://goldpricetools.com/llms.txt
 
 User-agent: *
 Allow: /
@@ -36,24 +42,54 @@ Allow: /
 Allow: /ads.txt
 
 # ─────────────────────────────────────────────────
-# AI Search Bots — ALLOWED for citation/discovery
-# These bots power AI search tools that cite sources.
-# Allowing them lets ChatGPT, Perplexity, and Copilot
-# discover and cite GoldPriceTools in AI-generated answers.
+# AI Search & Citation Bots — ALLOWED
+# These bots power AI answers that cite sources.
+# Allowing them enables ChatGPT, Claude, Perplexity,
+# Copilot, Grok, and Gemini to discover and cite
+# GoldPriceTools in AI-generated answers.
 # ─────────────────────────────────────────────────
 
 User-agent: ChatGPT-User
 Allow: /
-# OpenAI's search bot (used when ChatGPT searches the web).
+# OpenAI's browsing/search agent (ChatGPT web search).
 # Distinct from GPTBot which is used for model training.
+
+User-agent: OAI-SearchBot
+Allow: /
+# OpenAI's search indexer — powers ChatGPT search results
+# and citation-based answers in AI Mode.
+
+User-agent: ClaudeBot
+Allow: /
+# Anthropic's web search bot used by Claude when searching
+# the web to answer questions. Distinct from anthropic-ai
+# (training crawler) which is blocked below.
 
 User-agent: PerplexityBot
 Allow: /
-# Perplexity always cites sources with clickable links.
+# Perplexity AI — always cites sources with clickable links.
 
-# AI context file for LLM assistants
-# See: https://llmstxt.org
-# Location: https://goldpricetools.com/llms.txt
+User-agent: Bingbot
+Allow: /
+# Microsoft Bing — powers Microsoft Copilot AI answers
+# and Bing AI Overviews.
+
+User-agent: Applebot
+Allow: /
+# Apple's web crawler for Siri, Spotlight, and Apple
+# Intelligence. Distinct from Applebot-Extended (training).
+
+User-agent: YouBot
+Allow: /
+# You.com AI search — citation-based AI search engine.
+
+User-agent: cohere-ai
+Allow: /
+# Cohere AI search — powers AI-assisted discovery tools.
+
+User-agent: Grokbot
+Allow: /
+# xAI Grok — Elon Musk's AI assistant (xAI).
 
 # ─────────────────────────────────────────────────
 # AI Training Crawlers — BLOCKED
@@ -63,7 +99,7 @@ Allow: /
 
 User-agent: GPTBot
 Disallow: /
-# OpenAI's training crawler (not the search bot).
+# OpenAI's training crawler (not the search/browsing bot).
 
 User-agent: Google-Extended
 Disallow: /
@@ -71,15 +107,15 @@ Disallow: /
 
 User-agent: CCBot
 Disallow: /
-# Common Crawl — used for training datasets.
+# Common Crawl — used to build AI training datasets.
 
 User-agent: anthropic-ai
 Disallow: /
-# Anthropic's training crawler.
+# Anthropic's training data crawler (not ClaudeBot search).
 
 User-agent: Claude-Web
 Disallow: /
-# Anthropic's web crawler for training.
+# Anthropic's legacy training crawler identifier.
 
 User-agent: Bytespider
 Disallow: /
@@ -87,7 +123,7 @@ Disallow: /
 
 User-agent: Diffbot
 Disallow: /
-# Diffbot web scraping crawler.
+# Diffbot bulk web scraping.
 
 User-agent: omgili
 Disallow: /
@@ -95,8 +131,17 @@ Disallow: /
 
 User-agent: FacebookBot
 Disallow: /
-# Meta's training crawler.
+# Meta's AI training crawler.
 
 User-agent: Applebot-Extended
 Disallow: /
-# Apple's AI training crawler (distinct from Applebot for Siri/Spotlight).
+# Apple's AI training crawler (distinct from Applebot
+# which powers Siri/Spotlight search — allowed above).
+
+User-agent: Amazonbot
+Disallow: /
+# Amazon's AI training crawler.
+
+User-agent: meta-externalagent
+Disallow: /
+# Meta's external AI data collection agent.


### PR DESCRIPTION
## Summary

- **Fixed ClaudeBot being blocked** — it was incorrectly listed under training crawlers; it's Anthropic's search/citation bot used when Claude browses the web to answer questions
- **Added OAI-SearchBot** — OpenAI's search indexer that powers ChatGPT AI Mode and citation-based answers (distinct from GPTBot training crawler)
- **Added Bingbot explicitly** — powers Microsoft Copilot AI answers and Bing AI Overviews
- **Added Applebot** — powers Apple Intelligence and Siri (distinct from `Applebot-Extended` which is training, and stays blocked)
- **Added YouBot, cohere-ai, Grokbot** — AI search citation bots for You.com, Cohere, and xAI Grok
- **Expanded training blocklist** — added `Amazonbot` and `meta-externalagent`
- **Improved llms.txt** — added a key-facts block with purity percentages, currency coverage, and contact info so AI assistants have structured context to cite accurately

## Test plan

- [ ] Verify `robots.txt` is valid at https://goldpricetools.com/robots.txt
- [ ] Verify `llms.txt` is accessible at https://goldpricetools.com/llms.txt
- [ ] Check with Google Search Console that Googlebot is not affected
- [ ] Confirm no unintended paths are exposed via the `Allow: /` wildcard for newly added bots

https://claude.ai/code/session_013jvJV48qznhB2Rh1WJ9qd2

---
_Generated by [Claude Code](https://claude.ai/code/session_013jvJV48qznhB2Rh1WJ9qd2)_