### PR TITLE
Redesign: Gold Bar Guide — premium mobile-first editorial layout

### DIFF
--- a/guides/gold-bar-guide.html
+++ b/guides/gold-bar-guide.html
@@ -7,25 +7,28 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold Bar Guide: Sizes, Weights, and Good Delivery | GoldPriceTools</title>
+<title>Gold Bar Guide: Sizes, Weights & Valuations 2026 | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Explore different gold bar sizes from 1g to 400oz Good Delivery bars. Learn how gold bars are priced and valued.">
+<meta name="description" content="Complete gold bar guide 2026: every size from 1g to 400oz, live valuations, cast vs minted, top refineries (PAMP, Valcambi, Perth Mint), where to buy, and how to spot fakes.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/guides/gold-bar-guide.html">
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
-<meta property="og:title" content="Gold Bar Guide: Sizes, Weights, and Good Delivery">
-<meta property="og:description" content="Explore different gold bar sizes from 1g to 400oz Good Delivery bars. Learn how gold bars are priced and valued.">
+<meta property="og:title" content="Gold Bar Guide: Sizes, Weights & Valuations 2026">
+<meta property="og:description" content="Complete gold bar guide 2026: every size from 1g to 400oz, live valuations, cast vs minted, top refineries, where to buy, and how to spot fakes.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/gold-bar-guide.html">
 <meta property="og:site_name" content="GoldPriceTools">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Bar Guide: Sizes, Weights, and Good Delivery","description":"Explore different gold bar sizes from 1g to 400oz Good Delivery bars. Learn how gold bars are priced and valued.","url":"https://goldpricetools.com/guides/gold-bar-guide.html","datePublished":"2026-05-01","dateModified":"2026-05-16T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-bar-guide.html"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Question 1?","acceptedAnswer":{"@type":"Answer","text":"Answer 1."}},{"@type":"Question","name":"Question 2?","acceptedAnswer":{"@type":"Answer","text":"Answer 2."}},{"@type":"Question","name":"Question 3?","acceptedAnswer":{"@type":"Answer","text":"Answer 3."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Bar Guide: Sizes, Weights, and Valuations 2026","description":"Explore different gold bar sizes from 1g to 400oz Good Delivery bars. Learn how gold bars are priced and valued.","url":"https://goldpricetools.com/guides/gold-bar-guide.html","datePublished":"2026-05-01","dateModified":"2026-05-16T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-bar-guide.html"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How much does a gold bar weigh?","acceptedAnswer":{"@type":"Answer","text":"Gold bars come in sizes from 1 gram to 400 troy ounces (12.4 kg). The most popular retail weight is 1 troy ounce (31.1 grams). The LBMA Good Delivery bar — the standard institutional bar — weighs approximately 400 troy ounces or 12.4 kilograms."}},{"@type":"Question","name":"How much is a gold bar worth today?","acceptedAnswer":{"@type":"Answer","text":"At May 2026 spot prices (~$4,675/oz), a 1 oz gold bar retails for approximately $4,800–$4,950, a 100 gram bar for $15,200–$15,800, a 1 kg bar for $153,000–$156,000, and a 400 oz Good Delivery bar for $1.92–$2.06 million."}},{"@type":"Question","name":"What is the best gold bar to buy?","acceptedAnswer":{"@type":"Answer","text":"For most investors, a 1 oz bar from PAMP Suisse, Perth Mint, or Valcambi offers the best combination of low premium, global liquidity, strong brand recognition, and anti-counterfeiting features. For larger budgets, 100 gram and 1 kg bars offer better value per gram."}},{"@type":"Question","name":"What is a 24k gold bar?","acceptedAnswer":{"@type":"Answer","text":"A 24 karat gold bar means the bar is 99.9% or 99.99% pure gold — the same as 999 or 999.9 fine. All investment-grade gold bars are 24 karat by definition."}},{"@type":"Question","name":"Are fractional gold bars a good investment?","acceptedAnswer":{"@type":"Answer","text":"Fractional gold bars (1g, 2.5g, 5g, 10g) are useful for gifts and dollar-cost averaging but carry high premiums of 15–25% above spot. For investment purposes, 1 oz and larger bars are significantly more cost-efficient."}},{"@type":"Question","name":"How many ounces are in a gold bar?","acceptedAnswer":{"@type":"Answer","text":"It depends on the bar. The most popular retail size contains 1 troy ounce (31.1 grams). A kilogram bar contains 32.15 troy ounces. The standard institutional Good Delivery bar weighs approximately 400 troy ounces."}}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Gold Bar Guide: Sizes, Weights, and Valuations"}]}</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,800;1,700&display=swap" rel="stylesheet">
 <!-- GA and Adsense Snippets here -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
@@ -421,6 +424,336 @@ main.container article{max-width:860px}
 /* footer brand col fix */
 .footer-brand-col{min-width:180px;max-width:280px}
 .footer-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-top:var(--space-3);max-width:38ch;white-space:normal;word-break:normal}
+
+/* ═══════════════════════════════════════════════
+   GOLD BAR GUIDE — ARTICLE DESIGN SYSTEM
+   Mobile-first · Dark/light adaptive · Gold luxury
+═══════════════════════════════════════════════ */
+
+/* READING PROGRESS */
+#gb-progress{position:fixed;top:0;left:0;height:3px;background:linear-gradient(90deg,#b07a00,#f0c040,#b07a00);width:0%;z-index:200;transition:width .1s linear}
+[data-theme="dark"] #gb-progress{background:linear-gradient(90deg,#c8960a,#f5d060,#c8960a)}
+
+/* HERO */
+.gb-hero{position:relative;overflow:hidden;background:var(--color-bg);border-bottom:1px solid var(--color-border);margin-bottom:0}
+[data-theme="dark"] .gb-hero{background:linear-gradient(160deg,#0f0e0c 0%,#161208 40%,#1a1505 70%,#0f0e0c 100%)}
+[data-theme="light"] .gb-hero{background:linear-gradient(160deg,#f7f6f2 0%,#f5f0e0 50%,#f7f6f2 100%)}
+.gb-hero__bg{position:absolute;inset:0;pointer-events:none;overflow:hidden}
+.gb-hero__orb{position:absolute;border-radius:50%;filter:blur(80px);opacity:.18}
+.gb-hero__orb--1{width:500px;height:500px;top:-100px;right:-50px;background:radial-gradient(circle,#c8960a,transparent 70%)}
+.gb-hero__orb--2{width:300px;height:300px;bottom:-80px;left:10%;background:radial-gradient(circle,#b07a00,transparent 70%);opacity:.12}
+[data-theme="light"] .gb-hero__orb{opacity:.08}
+.gb-hero__content{position:relative;z-index:1;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-10)}
+@media(max-width:768px){.gb-hero__content{padding:var(--space-6) var(--space-4) var(--space-8)}}
+.gb-hero__tag{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-4)}
+.gb-hero__tag::before{content:'';width:20px;height:2px;background:var(--color-gold-bright);border-radius:1px}
+.gb-hero__title{font-family:'Playfair Display','Georgia',serif;font-size:clamp(2rem,1.2rem + 3.5vw,4rem);font-weight:800;line-height:1.1;color:var(--color-text);margin-bottom:var(--space-4);max-width:18ch}
+.gb-hero__title em{font-style:italic;color:var(--color-gold-bright)}
+.gb-hero__lead{font-size:clamp(1rem,.95rem + .4vw,1.2rem);color:var(--color-text-muted);line-height:1.7;max-width:58ch;margin-bottom:var(--space-5)}
+.gb-hero__meta{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-8)}
+.gb-hero__meta .meta-sep{color:var(--color-border)}
+.gb-hero__meta a{color:var(--color-gold-bright);text-decoration:none}
+.gb-hero__meta a:hover{text-decoration:underline}
+
+/* HERO SPOT CARDS */
+.gb-spot-row{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);max-width:640px}
+@media(min-width:640px){.gb-spot-row{grid-template-columns:repeat(4,1fr);max-width:none}}
+.gb-spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-4) var(--space-3);box-shadow:var(--shadow-sm);position:relative;overflow:hidden}
+[data-theme="dark"] .gb-spot-card{background:rgba(22,21,19,.85);border-color:#2a2820;backdrop-filter:blur(8px)}
+.gb-spot-card::after{content:'';position:absolute;bottom:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,var(--color-gold-bright),transparent);opacity:.5}
+.gb-spot-card__label{font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.gb-spot-card__value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.2}
+.gb-spot-card__sub{font-size:.65rem;color:var(--color-text-muted);margin-top:2px}
+
+/* LAYOUT */
+.gb-layout{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr;gap:var(--space-8);align-items:start}
+@media(min-width:1024px){.gb-layout{grid-template-columns:240px 1fr;padding-top:var(--space-8)}}
+
+/* MOBILE TOC */
+.gb-toc-mobile{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4) 0}
+@media(min-width:1024px){.gb-toc-mobile{display:none}}
+.gb-toc-toggle{display:flex;align-items:center;gap:var(--space-2);width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);font-size:var(--text-sm);font-weight:600;color:var(--color-text);cursor:pointer;transition:border-color var(--transition),background var(--transition)}
+.gb-toc-toggle:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset)}
+.toc-chevron{margin-left:auto;transition:transform var(--transition)}
+.gb-toc-toggle[aria-expanded="true"] .toc-chevron{transform:rotate(180deg)}
+.gb-toc-nav--mobile{margin-top:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4)}
+.gb-toc-nav--mobile ol{list-style:none;display:flex;flex-direction:column;gap:2px}
+.gb-toc-nav--mobile a{display:block;padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);transition:color var(--transition),background var(--transition)}
+.gb-toc-nav--mobile a:hover{color:var(--color-gold-bright);background:var(--color-surface-offset)}
+
+/* SIDEBAR TOC */
+.gb-sidebar{display:none}
+@media(min-width:1024px){.gb-sidebar{display:block}}
+.gb-toc{position:sticky;top:72px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+[data-theme="dark"] .gb-toc{background:rgba(22,21,19,.9);backdrop-filter:blur(12px)}
+.gb-toc__header{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-4)}
+.gb-toc__list{list-style:none;display:flex;flex-direction:column;gap:1px}
+.gb-toc__link{display:block;padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);border-left:2px solid transparent;transition:color var(--transition),background var(--transition),border-color var(--transition)}
+.gb-toc__link:hover{color:var(--color-gold-bright);background:var(--color-surface-offset);border-left-color:var(--color-gold-bright)}
+.gb-toc__link.active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 8%,transparent)}
+.gb-toc__spot{margin-top:var(--space-5);padding-top:var(--space-4);border-top:1px solid var(--color-border);text-align:center}
+.gb-toc__spot-label{font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.gb-toc__spot-value{font-size:var(--text-base);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* ARTICLE PROSE */
+.gb-article{min-width:0}
+.gb-prose{display:flex;flex-direction:column;gap:var(--space-6)}
+.gb-prose h2{font-family:'Playfair Display','Georgia',serif;font-size:clamp(1.4rem,1.1rem + 1.4vw,2rem);font-weight:700;color:var(--color-text);margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-border);line-height:1.2}
+.gb-prose h2:first-of-type{border-top:none;margin-top:0;padding-top:0}
+.gb-prose p{font-size:var(--text-base);color:var(--color-text);line-height:1.75;max-width:72ch}
+.gb-prose strong{color:var(--color-text);font-weight:700}
+.gb-prose em{font-style:italic}
+.gb-note{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;font-style:italic}
+
+/* PULL QUOTE */
+.gb-pullquote{border-left:3px solid var(--color-gold-bright);padding:var(--space-4) var(--space-6);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface));border-radius:0 var(--radius-lg) var(--radius-lg) 0;margin:var(--space-2) 0}
+.gb-pullquote p{font-family:'Playfair Display','Georgia',serif;font-size:clamp(1.05rem,1rem + .3vw,1.2rem);color:var(--color-text);line-height:1.65;font-style:italic;max-width:60ch}
+.gb-pullquote strong{color:var(--color-gold-bright);font-style:normal}
+
+/* CALLOUT / CONVERSIONS */
+.gb-callout{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-6);position:relative;overflow:hidden}
+.gb-callout::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--color-gold-bright),transparent)}
+.gb-callout__title{font-size:var(--text-sm);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-4)}
+.gb-conversions{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3)}
+@media(min-width:640px){.gb-conversions{grid-template-columns:repeat(4,1fr)}}
+.gb-conversion-item{display:flex;flex-direction:column;gap:2px;padding:var(--space-3);background:var(--color-surface-offset);border-radius:var(--radius-md);border:1px solid var(--color-border)}
+.gb-conversion-value{font-size:var(--text-base);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+.gb-conversion-label{font-size:var(--text-xs);color:var(--color-text-muted)}
+
+/* PURITY CARDS */
+.gb-purity-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:640px){.gb-purity-grid{grid-template-columns:repeat(3,1fr)}}
+.gb-purity-card{padding:var(--space-5);border-radius:var(--radius-xl);border:1px solid var(--color-border);text-align:center;position:relative;overflow:hidden}
+.gb-purity-card--gold{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface));border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border))}
+.gb-purity-card--silver{background:var(--color-surface);border-color:var(--color-border)}
+.gb-purity-card--muted{background:var(--color-surface-offset);border-color:var(--color-border);opacity:.8}
+.gb-purity-card__badge{font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.gb-purity-card--muted .gb-purity-card__badge{color:var(--color-text-muted)}
+.gb-purity-card__value{font-family:'Playfair Display','Georgia',serif;font-size:clamp(1.8rem,1rem + 2vw,2.5rem);font-weight:700;color:var(--color-text);line-height:1;margin-bottom:var(--space-2)}
+.gb-purity-card--gold .gb-purity-card__value{color:var(--color-gold-bright)}
+.gb-purity-card__label{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.gb-purity-card__note{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.5}
+
+/* TABLE */
+.gb-table-wrap{overflow-x:auto;border:1px solid var(--color-border);border-radius:var(--radius-xl);background:var(--color-surface);box-shadow:var(--shadow-sm)}
+.gb-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:520px}
+.gb-table thead tr{background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-offset))}
+.gb-table th{padding:var(--space-3) var(--space-4);text-align:left;font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);border-bottom:2px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));white-space:nowrap}
+.gb-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-border);color:var(--color-text);vertical-align:middle;font-variant-numeric:tabular-nums}
+.gb-table tbody tr:hover{background:var(--color-surface-offset)}
+.gb-table tbody tr:last-child td{border-bottom:none}
+.gb-table__row--featured{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface))!important}
+.gb-table__row--featured:hover{background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface))!important}
+.gb-bar-pill{display:inline-flex;align-items:center;padding:2px var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;background:var(--color-surface-offset);border:1px solid var(--color-border);white-space:nowrap}
+.gb-bar-pill--gold{background:color-mix(in oklch,var(--color-gold-bright) 15%,var(--color-surface));border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));color:var(--color-gold-bright)}
+.gb-premium{display:inline-flex;padding:2px var(--space-2);border-radius:var(--radius-sm);font-size:.65rem;font-weight:700;white-space:nowrap}
+.gb-premium--high{background:color-mix(in oklch,#f87171 12%,transparent);color:#c8534e;border:1px solid color-mix(in oklch,#f87171 25%,transparent)}
+[data-theme="dark"] .gb-premium--high{color:#f87171}
+.gb-premium--med{background:color-mix(in oklch,#fb923c 12%,transparent);color:#b8641a;border:1px solid color-mix(in oklch,#fb923c 25%,transparent)}
+[data-theme="dark"] .gb-premium--med{color:#fb923c}
+.gb-premium--low{background:color-mix(in oklch,#facc15 12%,transparent);color:#8a6d00;border:1px solid color-mix(in oklch,#facc15 25%,transparent)}
+[data-theme="dark"] .gb-premium--low{color:#facc15}
+.gb-premium--vlow{background:color-mix(in oklch,#4ade80 10%,transparent);color:#1d7a47;border:1px solid color-mix(in oklch,#4ade80 25%,transparent)}
+[data-theme="dark"] .gb-premium--vlow{color:#4ade80}
+.gb-premium--best{background:color-mix(in oklch,#22d3ee 10%,transparent);color:#0e6e8a;border:1px solid color-mix(in oklch,#22d3ee 25%,transparent)}
+[data-theme="dark"] .gb-premium--best{color:#22d3ee}
+.gb-table-note{font-size:var(--text-xs);color:var(--color-text-muted);font-style:italic;max-width:none}
+
+/* INSIGHT CARD */
+.gb-insight-card{display:flex;gap:var(--space-4);align-items:flex-start;background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-4) var(--space-5)}
+.gb-insight-card__icon{flex-shrink:0;width:36px;height:36px;background:color-mix(in oklch,var(--color-gold-bright) 15%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));border-radius:var(--radius-md);display:flex;align-items:center;justify-content:center;color:var(--color-gold-bright);margin-top:2px}
+.gb-insight-card p{margin:0;max-width:none}
+
+/* SIZE CARDS */
+.gb-size-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:640px){.gb-size-grid{grid-template-columns:repeat(2,1fr)}}
+.gb-size-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;display:flex;flex-direction:column;transition:border-color var(--transition),box-shadow var(--transition);cursor:default}
+.gb-size-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 50%,var(--color-border));box-shadow:var(--shadow-md)}
+.gb-size-card--vault{border-color:color-mix(in oklch,var(--color-text-muted) 30%,var(--color-border));opacity:.9}
+.gb-size-card__visual{height:80px;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,var(--color-surface-offset),var(--color-surface-offset-2));position:relative;overflow:hidden}
+.gb-size-card__visual::before{content:'';position:absolute;inset:0;background:linear-gradient(120deg,transparent 40%,rgba(255,255,255,.04) 50%,transparent 60%)}
+.gb-bar-visual{border-radius:3px;background:linear-gradient(135deg,#8b6914 0%,#c8960a 30%,#f5d060 50%,#c8960a 70%,#8b6914 100%);box-shadow:0 3px 12px rgba(184,120,0,.4),inset 0 1px 0 rgba(255,255,255,.25)}
+.gb-bar-visual--xs{width:60px;height:36px}
+.gb-bar-visual--sm{width:72px;height:44px}
+.gb-bar-visual--md{width:96px;height:56px}
+.gb-bar-visual--xl{width:120px;height:64px}
+.gb-size-card__content{padding:var(--space-4) var(--space-5);flex:1;display:flex;flex-direction:column;gap:var(--space-2)}
+.gb-size-card__weight{font-family:'Playfair Display','Georgia',serif;font-size:var(--text-lg);font-weight:700;color:var(--color-text)}
+.gb-size-card__grams{font-size:var(--text-sm);color:var(--color-text-muted)}
+.gb-size-card__price{font-size:var(--text-base);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+.gb-size-card__dims{font-size:var(--text-xs);color:var(--color-text-muted);font-family:monospace}
+.gb-size-card__premium{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted)}
+.gb-size-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;flex:1;max-width:none}
+.gb-size-card__tag{display:inline-flex;align-self:flex-start;padding:3px var(--space-3);border-radius:var(--radius-full);font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;margin-top:auto}
+.gb-size-card__tag--best{background:color-mix(in oklch,var(--color-gold-bright) 15%,transparent);color:var(--color-gold-bright);border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,transparent)}
+.gb-size-card__tag--value{background:color-mix(in oklch,#4ade80 12%,transparent);color:#1d7a47;border:1px solid color-mix(in oklch,#4ade80 25%,transparent)}
+[data-theme="dark"] .gb-size-card__tag--value{color:#4ade80}
+.gb-size-card__tag--efficiency{background:color-mix(in oklch,#22d3ee 10%,transparent);color:#0e6e8a;border:1px solid color-mix(in oklch,#22d3ee 25%,transparent)}
+[data-theme="dark"] .gb-size-card__tag--efficiency{color:#22d3ee}
+.gb-size-card__tag--vault{background:color-mix(in oklch,var(--color-text-muted) 12%,transparent);color:var(--color-text-muted);border:1px solid var(--color-border)}
+
+/* SPEC BOX */
+.gb-spec-box{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-6)}
+.gb-spec-box__title{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-4)}
+.gb-spec-list{list-style:none;display:flex;flex-direction:column;gap:var(--space-2)}
+.gb-spec-list li{display:flex;align-items:baseline;gap:var(--space-2);font-size:var(--text-sm);color:var(--color-text-muted);padding:var(--space-2) var(--space-3);border-radius:var(--radius-md);background:var(--color-surface-offset)}
+.gb-spec-list li::before{content:'';display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);flex-shrink:0;margin-top:6px}
+.gb-spec-list strong{color:var(--color-text)}
+
+/* CAST VS MINTED */
+.gb-compare{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:768px){.gb-compare{grid-template-columns:1fr auto 1fr;align-items:center}}
+.gb-compare__card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden}
+.gb-compare__header{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-weight:700;font-size:var(--text-base)}
+.gb-compare__header--cast{background:color-mix(in oklch,var(--color-text-muted) 10%,var(--color-surface-offset));color:var(--color-text)}
+.gb-compare__header--minted{background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-offset));color:var(--color-text)}
+.gb-compare__body{padding:var(--space-4) var(--space-5) var(--space-5)}
+.gb-compare__method{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:.08em;font-weight:700;color:var(--color-text-muted);margin-bottom:var(--space-3)}
+.gb-compare__list{list-style:none;display:flex;flex-direction:column;gap:var(--space-2);margin-bottom:var(--space-4)}
+.gb-compare__list li{font-size:var(--text-sm);color:var(--color-text-muted);padding-left:var(--space-4);position:relative;line-height:1.5;max-width:none}
+.gb-compare__list li::before{content:'•';position:absolute;left:0;color:var(--color-border)}
+.gb-compare__list strong{color:var(--color-text)}
+.gb-compare__best{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);padding:var(--space-2) var(--space-3);background:color-mix(in oklch,var(--color-gold-bright) 8%,transparent);border-radius:var(--radius-md);border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,transparent)}
+.gb-compare__vs{font-family:'Playfair Display','Georgia',serif;font-size:var(--text-xl);font-weight:700;color:var(--color-border);text-align:center;padding:var(--space-2);display:none}
+@media(min-width:768px){.gb-compare__vs{display:block}}
+
+/* VALUATION STEPS */
+.gb-valuation-steps{display:flex;flex-direction:column;gap:var(--space-4)}
+.gb-step{display:flex;gap:var(--space-4);align-items:flex-start;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5)}
+.gb-step__num{flex-shrink:0;width:36px;height:36px;border-radius:50%;background:var(--color-gold-bright);color:var(--color-text-inverse);font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;margin-top:2px}
+[data-theme="light"] .gb-step__num{color:#fff}
+.gb-step__content{flex:1;display:flex;flex-direction:column;gap:var(--space-2)}
+.gb-step__content strong{color:var(--color-text);font-size:var(--text-base)}
+.gb-step__content p{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.65;max-width:none;margin:0}
+.gb-calc-list{display:flex;flex-direction:column;gap:var(--space-2);margin-top:var(--space-2)}
+.gb-calc-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) var(--space-3);background:var(--color-surface-offset);border-radius:var(--radius-md);font-size:var(--text-sm);gap:var(--space-4)}
+.gb-calc-row span:first-child{color:var(--color-text-muted)}
+.gb-calc-row span:last-child{font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;white-space:nowrap}
+
+/* REFINERY CARDS */
+.gb-refinery-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:640px){.gb-refinery-grid{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:1024px){.gb-refinery-grid{grid-template-columns:repeat(3,1fr)}}
+.gb-refinery-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-3);transition:border-color var(--transition),box-shadow var(--transition);cursor:default}
+.gb-refinery-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));box-shadow:var(--shadow-md)}
+.gb-refinery-card__header{display:flex;align-items:center;gap:var(--space-3)}
+.gb-refinery-flag{font-size:1.5rem;line-height:1;flex-shrink:0}
+.gb-refinery-card__name{font-weight:700;font-size:var(--text-base);color:var(--color-text)}
+.gb-refinery-card__country{font-size:var(--text-xs);color:var(--color-text-muted)}
+.gb-refinery-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;flex:1;max-width:none;margin:0}
+.gb-refinery-card__stats{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+.gb-refinery-card__stats span{font-size:.65rem;font-weight:600;padding:2px var(--space-2);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);color:var(--color-text-muted)}
+.gb-refinery-badge{margin-left:auto;font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;padding:2px var(--space-2);border-radius:var(--radius-full);white-space:nowrap;flex-shrink:0}
+.gb-refinery-badge--premium{background:color-mix(in oklch,var(--color-gold-bright) 15%,transparent);color:var(--color-gold-bright);border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,transparent)}
+.gb-refinery-badge--value{background:color-mix(in oklch,#4ade80 12%,transparent);color:#1d7a47;border:1px solid color-mix(in oklch,#4ade80 25%,transparent)}
+[data-theme="dark"] .gb-refinery-badge--value{color:#4ade80}
+.gb-refinery-badge--new{background:color-mix(in oklch,#60a5fa 12%,transparent);color:#1a5fa8;border:1px solid color-mix(in oklch,#60a5fa 25%,transparent)}
+[data-theme="dark"] .gb-refinery-badge--new{color:#60a5fa}
+.gb-refinery-badge--security{background:color-mix(in oklch,#a78bfa 12%,transparent);color:#5b3da8;border:1px solid color-mix(in oklch,#a78bfa 25%,transparent)}
+[data-theme="dark"] .gb-refinery-badge--security{color:#a78bfa}
+
+/* DEALER LIST */
+.gb-dealer-list{display:flex;flex-direction:column;gap:var(--space-3)}
+.gb-dealer{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5)}
+.gb-dealer__name{font-weight:700;font-size:var(--text-base);color:var(--color-text);margin-bottom:2px}
+.gb-dealer__region{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.gb-dealer p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;max-width:none;margin:0}
+
+/* CHECKLIST */
+.gb-checklist-box{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-6)}
+.gb-checklist-box__title{font-weight:700;font-size:var(--text-sm);color:var(--color-text);margin-bottom:var(--space-4)}
+.gb-checklist{list-style:none;display:flex;flex-direction:column;gap:var(--space-2)}
+.gb-checklist li{display:flex;align-items:flex-start;gap:var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;max-width:none}
+.gb-checklist li::before{content:'';width:16px;height:16px;flex-shrink:0;border-radius:50%;background:color-mix(in oklch,var(--color-gold-bright) 15%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 40%,transparent);margin-top:2px;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23c8960a' stroke-width='3'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:center;background-size:10px}
+
+/* SCAM CARDS */
+.gb-scam-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:640px){.gb-scam-grid{grid-template-columns:repeat(3,1fr)}}
+.gb-scam-card{background:color-mix(in oklch,#f87171 6%,var(--color-surface));border:1px solid color-mix(in oklch,#f87171 20%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-4) var(--space-5)}
+.gb-scam-card__icon{color:#e85555;margin-bottom:var(--space-3)}
+[data-theme="dark"] .gb-scam-card__icon{color:#f87171}
+.gb-scam-card__title{font-weight:700;font-size:var(--text-sm);color:var(--color-text);margin-bottom:var(--space-2)}
+.gb-scam-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;max-width:none;margin:0}
+
+/* VERIFY STEPS */
+.gb-verify-steps{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-6);display:flex;flex-direction:column;gap:var(--space-3)}
+.gb-verify-steps__title{font-weight:700;font-size:var(--text-sm);color:var(--color-text);margin-bottom:var(--space-1);text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.gb-verify-step{display:flex;align-items:flex-start;gap:var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.gb-verify-step__num{flex-shrink:0;width:24px;height:24px;border-radius:50%;background:var(--color-surface-offset);border:1px solid var(--color-border);display:flex;align-items:center;justify-content:center;font-size:.65rem;font-weight:700;color:var(--color-gold-bright);margin-top:2px}
+.gb-verify-step strong{color:var(--color-text)}
+
+/* VERSUS */
+.gb-versus{display:grid;grid-template-columns:1fr;gap:0;border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden}
+@media(min-width:640px){.gb-versus{grid-template-columns:1fr auto 1fr}}
+.gb-versus__side{padding:var(--space-5) var(--space-6)}
+.gb-versus__side--bars{background:color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface))}
+.gb-versus__side--coins{background:var(--color-surface)}
+.gb-versus__title{font-family:'Playfair Display','Georgia',serif;font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-4)}
+.gb-versus__pros{display:flex;flex-direction:column;gap:var(--space-2);margin-bottom:var(--space-4)}
+.gb-versus__pro{display:flex;align-items:flex-start;gap:var(--space-2);font-size:var(--text-sm);color:var(--color-text)}
+.gb-versus__pro::before{content:'';width:16px;height:16px;flex-shrink:0;background:color-mix(in oklch,#4ade80 12%,transparent);border:1px solid color-mix(in oklch,#4ade80 30%,transparent);border-radius:50%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%2322c55e' stroke-width='3'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:center;background-size:10px;margin-top:3px}
+.gb-versus__cons{display:flex;flex-direction:column;gap:var(--space-2)}
+.gb-versus__con{display:flex;align-items:flex-start;gap:var(--space-2);font-size:var(--text-sm);color:var(--color-text-muted)}
+.gb-versus__con::before{content:'';width:16px;height:16px;flex-shrink:0;background:color-mix(in oklch,#f87171 10%,transparent);border:1px solid color-mix(in oklch,#f87171 25%,transparent);border-radius:50%;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23ef4444' stroke-width='3'%3E%3Cline x1='18' y1='6' x2='6' y2='18'/%3E%3Cline x1='6' y1='6' x2='18' y2='18'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:center;background-size:10px;margin-top:3px}
+.gb-versus__divider{display:none;align-items:center;justify-content:center;background:var(--color-surface-offset);padding:0 var(--space-4);border-left:1px solid var(--color-border);border-right:1px solid var(--color-border)}
+@media(min-width:640px){.gb-versus__divider{display:flex}}
+.gb-versus__divider span{font-family:'Playfair Display','Georgia',serif;font-weight:700;color:var(--color-border);writing-mode:vertical-rl}
+
+/* BUDGET GRID */
+.gb-budget-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:640px){.gb-budget-grid{grid-template-columns:repeat(2,1fr)}}
+.gb-budget-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-6);display:flex;flex-direction:column;gap:var(--space-3);position:relative;overflow:hidden}
+.gb-budget-card--premium{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface));border-color:color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border))}
+.gb-budget-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px}
+.gb-budget-card:nth-child(1)::before{background:color-mix(in oklch,#60a5fa 70%,transparent)}
+.gb-budget-card:nth-child(2)::before{background:color-mix(in oklch,var(--color-gold-bright) 70%,transparent)}
+.gb-budget-card:nth-child(3)::before{background:color-mix(in oklch,#a78bfa 70%,transparent)}
+.gb-budget-card:nth-child(4)::before{background:linear-gradient(90deg,var(--color-gold-bright),#f5d060)}
+.gb-budget-card__range{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.gb-budget-card__rec{font-family:'Playfair Display','Georgia',serif;font-size:var(--text-lg);font-weight:700;color:var(--color-text)}
+.gb-budget-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none;margin:0}
+.gb-budget-card strong{color:var(--color-text)}
+
+/* STORAGE */
+.gb-storage-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:640px){.gb-storage-grid{grid-template-columns:repeat(3,1fr)}}
+.gb-storage-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-3);position:relative}
+.gb-storage-card--recommended{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));background:color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface))}
+.gb-storage-card__badge{position:absolute;top:-1px;left:var(--space-4);font-size:.6rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;background:var(--color-gold-bright);color:var(--color-text-inverse);padding:2px var(--space-3);border-radius:0 0 var(--radius-md) var(--radius-md)}
+[data-theme="light"] .gb-storage-card__badge{color:#fff}
+.gb-storage-card__icon{color:var(--color-gold-bright);margin-top:var(--space-2)}
+.gb-storage-card--recommended .gb-storage-card__icon{margin-top:var(--space-6)}
+.gb-storage-card__title{font-weight:700;font-size:var(--text-base);color:var(--color-text)}
+.gb-storage-card__limit{font-size:var(--text-xs);font-weight:600;color:var(--color-primary)}
+.gb-storage-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;flex:1;max-width:none;margin:0}
+.gb-storage-card__cost{font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);padding:var(--space-2) var(--space-3);background:color-mix(in oklch,var(--color-gold-bright) 8%,transparent);border-radius:var(--radius-md);align-self:flex-start}
+
+/* FAQ ACCORDION */
+.gb-faq{display:flex;flex-direction:column;border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;background:var(--color-surface)}
+.gb-faq__item{border-bottom:1px solid var(--color-border)}
+.gb-faq__item:last-child{border-bottom:none}
+.gb-faq__question{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);width:100%;padding:var(--space-4) var(--space-5);text-align:left;font-size:var(--text-base);font-weight:600;color:var(--color-text);background:none;cursor:pointer;transition:background var(--transition);min-height:44px}
+.gb-faq__question:hover{background:var(--color-surface-offset)}
+.gb-faq__question[aria-expanded="true"]{color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface))}
+.gb-faq__chevron{flex-shrink:0;transition:transform var(--transition);color:var(--color-text-muted)}
+.gb-faq__question[aria-expanded="true"] .gb-faq__chevron{transform:rotate(180deg);color:var(--color-gold-bright)}
+.gb-faq__answer{padding:0 var(--space-5) var(--space-5)}
+.gb-faq__answer p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;max-width:none;margin:0}
+.gb-faq__answer strong{color:var(--color-text)}
+
+/* BREADCRUMB */
+.gb-breadcrumb{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);color:var(--color-text-muted);flex-wrap:wrap;margin-bottom:var(--space-5)}
+.gb-breadcrumb a{color:var(--color-text-muted);text-decoration:none}
+.gb-breadcrumb a:hover{color:var(--color-gold-bright)}
+.gb-breadcrumb-sep{color:var(--color-border)}
+.gb-breadcrumb-current{color:var(--color-text-muted)}
+
+/* SHARE SECTION */
+.share-section{border-top:1px solid var(--color-border);padding-top:var(--space-5);margin-top:var(--space-4)}
+.share-section-label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-3)}
+.share-buttons{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+.share-btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);border:1px solid var(--color-border);border-radius:var(--radius-full);background:var(--color-surface);color:var(--color-text-muted);font-size:var(--text-sm);font-weight:500;text-decoration:none;transition:border-color var(--transition),color var(--transition);white-space:nowrap;cursor:pointer;min-height:36px}
+.share-btn:hover{border-color:var(--color-primary);color:var(--color-primary)}
 </style>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
@@ -494,116 +827,726 @@ main.container article{max-width:860px}
     </div>
   </div>
 </nav>
-<main class="container">
-  <nav class="breadcrumb-wrap" aria-label="Breadcrumb">
-    <ol class="breadcrumb">
-      <li><a href="/">Home</a></li>
-      <li><a href="/guides/">Guides</a></li>
-      <li aria-current="page">Gold Bar Guide</li>
+<main>
+<div id="gb-progress" role="progressbar" aria-label="Reading progress" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+
+<!-- ═══ HERO ═══ -->
+<section class="gb-hero">
+  <div class="gb-hero__bg" aria-hidden="true">
+    <div class="gb-hero__orb gb-hero__orb--1"></div>
+    <div class="gb-hero__orb gb-hero__orb--2"></div>
+  </div>
+  <div class="gb-hero__content">
+    <nav class="gb-breadcrumb" aria-label="Breadcrumb">
+      <a href="/">Home</a>
+      <span class="gb-breadcrumb-sep" aria-hidden="true">/</span>
+      <a href="/guides/">Guides</a>
+      <span class="gb-breadcrumb-sep" aria-hidden="true">/</span>
+      <span class="gb-breadcrumb-current" aria-current="page">Gold Bar Guide</span>
+    </nav>
+    <div class="gb-hero__tag">Complete Guide &middot; 2026</div>
+    <h1 class="gb-hero__title">Gold Bar Guide:<br><em>Sizes, Weights &amp; Valuations</em></h1>
+    <p class="gb-hero__lead">From a 1 gram gift bar to the 400 oz Good Delivery vault brick &mdash; every size, every premium, every refinery. Everything you need to buy, verify, and value physical gold in 2026.</p>
+    <div class="gb-hero__meta">
+      <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
+      <span class="meta-sep" aria-hidden="true">&middot;</span>
+      <span>Published 3 May 2026</span>
+      <span class="meta-sep" aria-hidden="true">&middot;</span>
+      <span>Updated 16 May 2026</span>
+    </div>
+    <div class="gb-spot-row" role="region" aria-label="Live gold prices">
+      <div class="gb-spot-card">
+        <div class="gb-spot-card__label">Gold Spot (XAU/oz)</div>
+        <div class="gb-spot-card__value" id="spotGoldOz">—</div>
+        <div class="gb-spot-card__sub">Live price</div>
+      </div>
+      <div class="gb-spot-card">
+        <div class="gb-spot-card__label">1 oz Bar (retail)</div>
+        <div class="gb-spot-card__value" id="bar1ozValue">—</div>
+        <div class="gb-spot-card__sub">incl. ~4% premium</div>
+      </div>
+      <div class="gb-spot-card">
+        <div class="gb-spot-card__label">100g Bar (retail)</div>
+        <div class="gb-spot-card__value" id="bar100gValue">—</div>
+        <div class="gb-spot-card__sub">incl. ~3% premium</div>
+      </div>
+      <div class="gb-spot-card">
+        <div class="gb-spot-card__label">Silver Spot (XAG/oz)</div>
+        <div class="gb-spot-card__value" id="spotSilverOz">—</div>
+        <div class="gb-spot-card__sub">Live price</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ MOBILE TOC ═══ -->
+<div class="gb-toc-mobile">
+  <button class="gb-toc-toggle" id="tocToggle" aria-expanded="false" aria-controls="tocMobile">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+    Table of Contents
+    <svg class="toc-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+  </button>
+  <nav id="tocMobile" class="gb-toc-nav--mobile" aria-label="Article sections" hidden>
+    <ol>
+      <li><a href="#weight-measurement">How Weight Is Measured</a></li>
+      <li><a href="#purity">Gold Bar Purity</a></li>
+      <li><a href="#all-sizes">All Gold Bar Sizes</a></li>
+      <li><a href="#popular-sizes">Popular Sizes Explained</a></li>
+      <li><a href="#cast-vs-minted">Cast vs Minted</a></li>
+      <li><a href="#valuation">How Much Is a Bar Worth?</a></li>
+      <li><a href="#top-brands">Top Brands &amp; Refineries</a></li>
+      <li><a href="#where-to-buy">Where to Buy</a></li>
+      <li><a href="#scams">Spotting Fakes</a></li>
+      <li><a href="#bars-vs-coins">Bars vs Coins</a></li>
+      <li><a href="#investment-strategy">Investment Strategy</a></li>
+      <li><a href="#storage">Safe Storage</a></li>
+      <li><a href="#faq">FAQ</a></li>
     </ol>
   </nav>
-
-  <div class="article-tag">Guide</div>
-  <h1>Gold Bar Guide: Sizes, Weights, and Valuations</h1>
-  <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/" class="byline-author">GoldPriceTools Editorial Team</a></span>
-    <span class="byline-sep">·</span>
-    <span>Published 3 May 2026</span>
-    <span class="byline-sep">·</span>
-    <span>Updated 3 May 2026</span>
-  </div>
-  <hr class="byline-rule" aria-hidden="true">
-
-  <!-- Live Price Widget (Reusing existing logic later) -->
-  <div class="spot-cards">
-    <div class="spot-card">
-      <div>Gold Spot (XAU)</div>
-      <div class="spot-card-value" id="spotGoldOz">—</div>
-    </div>
-    <div class="spot-card">
-      <div>Silver Spot (XAG)</div>
-      <div class="spot-card-value" id="spotSilverOz">—</div>
-    </div>
-  </div>
-
-  <article>
-  
-<div class="prose">
-  <p>Gold bars are one of the most cost-effective ways to own physical gold. Unlike jewellery or coins, gold bars carry minimal fabrication premiums, meaning more of your money goes into actual gold. This guide covers everything you need to know — from the smallest 1g retail bar to the 400 troy ounce Good Delivery bar traded by central banks.</p>
-
-  <h2>Gold Bar Sizes &amp; Weights</h2>
-  <p>Gold bars are produced in a standardised range of sizes to suit investors at every level. Here are the most common investment bar sizes:</p>
-  <table>
-    <thead><tr><th>Bar Size</th><th>Weight (grams)</th><th>Weight (troy oz)</th><th>Typical Buyer</th></tr></thead>
-    <tbody>
-      <tr><td>1 g</td><td>1.000</td><td>0.032</td><td>Gift buyers, beginners</td></tr>
-      <tr><td>5 g</td><td>5.000</td><td>0.161</td><td>Retail investors</td></tr>
-      <tr><td>10 g</td><td>10.000</td><td>0.322</td><td>Retail investors</td></tr>
-      <tr><td>1 troy oz</td><td>31.103</td><td>1.000</td><td>Retail &amp; investors</td></tr>
-      <tr><td>100 g</td><td>100.000</td><td>3.215</td><td>Serious investors</td></tr>
-      <tr><td>250 g</td><td>250.000</td><td>8.038</td><td>Investors</td></tr>
-      <tr><td>1 kg</td><td>1,000.000</td><td>32.151</td><td>Investors &amp; dealers</td></tr>
-      <tr><td>100 troy oz</td><td>3,110.348</td><td>100.000</td><td>Professional / COMEX</td></tr>
-      <tr><td>400 troy oz (Good Delivery)</td><td>12,441.393</td><td>400.000</td><td>Central banks / LBMA</td></tr>
-    </tbody>
-  </table>
-
-  <h2>How Gold Bars Are Valued</h2>
-  <p>A gold bar's value is calculated directly from the current spot price of gold. The formula is straightforward:</p>
-  <p><strong>Bar Value = Weight (troy oz) × Current Spot Price per troy oz</strong></p>
-  <p>For example, a 100g bar weighs 3.215 troy ounces. At a spot price of $3,200/oz, its melt value would be approximately $10,288. Dealer buy prices are typically 0.5–2% below spot, while retail prices carry a 1–5% premium above spot depending on bar size.</p>
-
-  <h2>Premiums: Smaller Bars Cost More Per Gram</h2>
-  <p>One of the most important concepts for gold bar investors is the premium over spot. Smaller bars cost significantly more per gram than larger bars because the manufacturing cost is spread over less gold. A 1g bar might carry a 10–15% premium, while a 1kg bar from a major refiner carries just 0.5–1%.</p>
-  <p>For this reason, investors who plan to hold gold long-term typically prefer 1 troy ounce or 100g bars as the optimum balance between premium and liquidity.</p>
-
-  <h2>What Is the LBMA Good Delivery Standard?</h2>
-  <p>The London Bullion Market Association (LBMA) sets the global standard for wholesale gold bars. A Good Delivery bar must weigh between 350 and 430 troy ounces (approximately 10.9–13.4 kg) and must be at least 99.5% pure gold. These are the bars held in central bank vaults and traded between institutional investors.</p>
-  <p>For retail investors, the key benefit of LBMA-accredited bars is authenticity and resale value. Bars from LBMA-approved refiners (such as Valcambi, PAMP, The Royal Mint, Argor-Heraeus) are accepted worldwide without additional authentication.</p>
-
-  <h2>UK-Specific Tax Considerations</h2>
-  <p>Investment gold bars in the UK are <strong>exempt from VAT</strong> provided they are at least 99.5% pure and weigh more than 1 gram. This VAT exemption applies under HMRC's investment gold provisions and is one of the key advantages of owning gold bars versus gold jewellery.</p>
-  <p>However, gold bars are subject to <strong>Capital Gains Tax (CGT)</strong> when sold at a profit. UK residents have an annual CGT allowance (£3,000 in 2024/25). Profits above this threshold are taxed at 18% (basic rate) or 24% (higher rate) for most assets. Unlike British Gold Sovereigns or Britannia coins, gold bars do not benefit from CGT exemption.</p>
-
-  <h2>Where to Buy Gold Bars in the UK</h2>
-  <p>Reputable UK gold bar dealers include The Royal Mint, Bullion Vault, Gold Investments, BullionByPost, and Atkinsons Bullion. Always compare premiums before purchasing and buy from LBMA-accredited or BNTA-member dealers to ensure authenticity and resale value.</p>
-  <p>When storing gold bars at home, consider a high-quality safe bolted to the floor or wall. For larger holdings, professional vault storage (offered by BullionVault and The Royal Mint) provides insurance-backed security at low annual costs.</p>
-
-  <h2>Frequently Asked Questions</h2>
-  <h3>Are gold bars a good investment?</h3>
-  <p>Gold bars offer one of the most cost-effective ways to hold physical gold. They carry low premiums over spot price and are universally recognised. Over the long term, gold has historically preserved purchasing power, making bars a popular choice for wealth preservation rather than speculative gain.</p>
-  <h3>Can I buy gold bars from a bank?</h3>
-  <p>Most UK high street banks no longer sell gold bars directly to retail customers. You are better served by specialist bullion dealers such as The Royal Mint, BullionByPost, or Atkinsons, who offer competitive premiums and secure delivery.</p>
-  <h3>What is the most popular gold bar size for investors?</h3>
-  <p>The 1 troy ounce (31.1g) and 100g bar are the most popular retail investment sizes. Both offer a reasonable premium-to-liquidity balance. The 1oz bar is the global benchmark and extremely easy to buy, sell, and store.</p>
 </div>
 
+<!-- ═══ MAIN LAYOUT ═══ -->
+<div class="gb-layout">
 
-
-  <section class="share-section">
-    <div class="share-section-label">Share this guide</div>
-    <div class="share-buttons">
-      <a class="share-btn" href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/gold-bar-guide&text=Gold+Bar+Guide%3A+Sizes%2C+Weights%2C+and+Valuations" target="_blank" rel="noopener">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.737-8.835L1.254 2.25H8.08l4.259 5.631 5.905-5.631zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-        Share on X
-      </a>
-      <a class="share-btn" href="https://www.reddit.com/submit?url=https://goldpricetools.com/guides/gold-bar-guide&title=Gold+Bar+Guide" target="_blank" rel="noopener">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
-        Reddit
-      </a>
-      <a class="share-btn" href="https://api.whatsapp.com/send?text=Gold+Bar+Guide%20https%3A%2F%2Fgoldpricetools.com%2Fguides%2Fgold-bar-guide" target="_blank" rel="noopener">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg>
-        WhatsApp
-      </a>
+  <!-- SIDEBAR TOC (desktop only) -->
+  <aside class="gb-sidebar" aria-label="Article navigation">
+    <div class="gb-toc" id="desktopToc">
+      <div class="gb-toc__header">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/></svg>
+        Contents
+      </div>
+      <nav aria-label="Table of contents">
+        <ol class="gb-toc__list">
+          <li><a href="#weight-measurement" class="gb-toc__link">How Weight Is Measured</a></li>
+          <li><a href="#purity" class="gb-toc__link">Gold Bar Purity</a></li>
+          <li><a href="#all-sizes" class="gb-toc__link">All Gold Bar Sizes</a></li>
+          <li><a href="#popular-sizes" class="gb-toc__link">Popular Sizes Explained</a></li>
+          <li><a href="#cast-vs-minted" class="gb-toc__link">Cast vs Minted</a></li>
+          <li><a href="#valuation" class="gb-toc__link">Live Valuation</a></li>
+          <li><a href="#top-brands" class="gb-toc__link">Top Brands</a></li>
+          <li><a href="#where-to-buy" class="gb-toc__link">Where to Buy</a></li>
+          <li><a href="#scams" class="gb-toc__link">Spotting Fakes</a></li>
+          <li><a href="#bars-vs-coins" class="gb-toc__link">Bars vs Coins</a></li>
+          <li><a href="#investment-strategy" class="gb-toc__link">Investment Strategy</a></li>
+          <li><a href="#storage" class="gb-toc__link">Safe Storage</a></li>
+          <li><a href="#faq" class="gb-toc__link">FAQ</a></li>
+        </ol>
+      </nav>
+      <div class="gb-toc__spot" aria-live="polite">
+        <div class="gb-toc__spot-label">Gold / troy oz</div>
+        <div class="gb-toc__spot-value" id="sidebarGoldPrice">—</div>
+      </div>
     </div>
-  </section>
+  </aside>
 
-</article>
+  <!-- ARTICLE -->
+  <article class="gb-article" id="article-content">
+    <div class="gb-prose">
 
+      <div class="gb-pullquote">
+        <p>Pick up a 1 oz gold bar and it feels deceptively small &mdash; a slab roughly the size of a credit card, two millimetres thin, that fits easily in the palm of your hand. Yet at May 2026 prices, that modest rectangle of metal is worth close to <strong>$5,000</strong>.</p>
+      </div>
 
-<div style="max-width:860px;margin:0 auto var(--space-10);padding:0 var(--space-4)">
+      <p>Understanding how gold bars are sized, weighed, priced, and valued is the foundation of any serious gold investment plan. Whether you are researching a 1 gram bar as a first purchase, comparing 100 gram vs 1 kg options, or simply want to understand how much a gold bar is worth at today&rsquo;s prices &mdash; everything you need is here.</p>
+
+      <!-- ── WEIGHT ── -->
+      <h2 id="weight-measurement">How Gold Bar Weight Is Measured</h2>
+      <p>Before comparing gold bar sizes, it helps to understand the weight system used across the global bullion trade. Gold is not measured in regular ounces &mdash; it uses the <strong>troy ounce</strong> system, a unit that dates back to medieval Troyes, France, and remains the global standard for precious metals today.</p>
+      <div class="gb-callout">
+        <div class="gb-callout__title">Key Troy Ounce Conversions</div>
+        <div class="gb-conversions">
+          <div class="gb-conversion-item">
+            <span class="gb-conversion-value">31.1035 g</span>
+            <span class="gb-conversion-label">= 1 troy ounce</span>
+          </div>
+          <div class="gb-conversion-item">
+            <span class="gb-conversion-value">32.1507 oz</span>
+            <span class="gb-conversion-label">= 1 kilogram</span>
+          </div>
+          <div class="gb-conversion-item">
+            <span class="gb-conversion-value">12 troy oz</span>
+            <span class="gb-conversion-label">= 1 troy pound</span>
+          </div>
+          <div class="gb-conversion-item">
+            <span class="gb-conversion-value">14.58 oz</span>
+            <span class="gb-conversion-label">&asymp; 1 regular pound</span>
+          </div>
+        </div>
+      </div>
+      <p>This distinction matters practically: a bar described as &ldquo;1 oz&rdquo; in the bullion market always means one <em>troy</em> ounce, or 31.1 grams &mdash; not the 28.35 grams a regular ounce would represent. Every major refinery, exchange, and dealer uses troy ounces.</p>
+
+      <!-- ── PURITY ── -->
+      <h2 id="purity">What Purity Does a Gold Bar Need to Be?</h2>
+      <p>Investment-grade gold bars carry a purity of <strong>999.9 fine</strong> (also written as 24 karat, 0.9999, or 99.99% pure gold). This is the global standard for retail bullion bars produced by accredited refineries.</p>
+      <div class="gb-purity-grid">
+        <div class="gb-purity-card gb-purity-card--gold">
+          <div class="gb-purity-card__badge">Investment Grade</div>
+          <div class="gb-purity-card__value">999.9</div>
+          <div class="gb-purity-card__label">99.99% Pure Gold</div>
+          <div class="gb-purity-card__note">Standard for all retail bullion bars from accredited refineries</div>
+        </div>
+        <div class="gb-purity-card gb-purity-card--silver">
+          <div class="gb-purity-card__badge">LBMA Minimum</div>
+          <div class="gb-purity-card__value">995.0</div>
+          <div class="gb-purity-card__label">99.5% Pure Gold</div>
+          <div class="gb-purity-card__note">Floor for Good Delivery institutional bars &mdash; most are 999.9</div>
+        </div>
+        <div class="gb-purity-card gb-purity-card--muted">
+          <div class="gb-purity-card__badge">Not Investment Grade</div>
+          <div class="gb-purity-card__value">916</div>
+          <div class="gb-purity-card__label">22 Karat (91.67%)</div>
+          <div class="gb-purity-card__note">Alloy &mdash; not bullion grade, different pricing and resale terms</div>
+        </div>
+      </div>
+
+      <!-- ── ALL SIZES TABLE ── -->
+      <h2 id="all-sizes">All Gold Bar Sizes: Complete Weight &amp; Value Reference</h2>
+      <p>Gold bars are manufactured across an enormous range of sizes, from tiny 1 gram wafers to the iconic 400 troy ounce institutional bar. Prices below are based on approximately <strong>$4,675/oz</strong> spot (May 2026 LBMA PM fix).</p>
+      <div class="gb-table-wrap">
+        <table class="gb-table">
+          <thead>
+            <tr>
+              <th>Bar Weight</th>
+              <th>Grams</th>
+              <th>Troy Oz</th>
+              <th>Premium</th>
+              <th>Retail Price (USD)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td><span class="gb-bar-pill">1 gram</span></td><td>1.00</td><td>0.0322</td><td><span class="gb-premium gb-premium--high">15&ndash;25%</span></td><td>$180&ndash;$195</td></tr>
+            <tr><td><span class="gb-bar-pill">2.5 gram</span></td><td>2.50</td><td>0.0804</td><td><span class="gb-premium gb-premium--high">12&ndash;20%</span></td><td>$430&ndash;$490</td></tr>
+            <tr><td><span class="gb-bar-pill">5 gram</span></td><td>5.00</td><td>0.1607</td><td><span class="gb-premium gb-premium--med">8&ndash;15%</span></td><td>$860&ndash;$960</td></tr>
+            <tr><td><span class="gb-bar-pill">10 gram</span></td><td>10.00</td><td>0.3215</td><td><span class="gb-premium gb-premium--med">5&ndash;10%</span></td><td>$1,560&ndash;$1,650</td></tr>
+            <tr><td><span class="gb-bar-pill">20 gram</span></td><td>20.00</td><td>0.6430</td><td><span class="gb-premium gb-premium--low">4&ndash;7%</span></td><td>$3,000&ndash;$3,200</td></tr>
+            <tr class="gb-table__row--featured"><td><span class="gb-bar-pill gb-bar-pill--gold">1 troy oz &#9733;</span></td><td>31.10</td><td>1.0000</td><td><span class="gb-premium gb-premium--low">3&ndash;5%</span></td><td>$4,800&ndash;$4,950</td></tr>
+            <tr><td><span class="gb-bar-pill">50 gram</span></td><td>50.00</td><td>1.6075</td><td><span class="gb-premium gb-premium--low">3&ndash;5%</span></td><td>$7,700&ndash;$8,000</td></tr>
+            <tr class="gb-table__row--featured"><td><span class="gb-bar-pill gb-bar-pill--gold">100 gram &#9733;</span></td><td>100.00</td><td>3.2150</td><td><span class="gb-premium gb-premium--vlow">2&ndash;4%</span></td><td>$15,200&ndash;$15,800</td></tr>
+            <tr><td><span class="gb-bar-pill">250 gram</span></td><td>250.00</td><td>8.0376</td><td><span class="gb-premium gb-premium--vlow">2&ndash;3%</span></td><td>$38,000&ndash;$39,500</td></tr>
+            <tr><td><span class="gb-bar-pill">10 troy oz</span></td><td>311.04</td><td>10.000</td><td><span class="gb-premium gb-premium--vlow">2&ndash;3%</span></td><td>$47,800&ndash;$49,500</td></tr>
+            <tr><td><span class="gb-bar-pill">500 gram</span></td><td>500.00</td><td>16.075</td><td><span class="gb-premium gb-premium--vlow">1.5&ndash;2.5%</span></td><td>$76,000&ndash;$78,000</td></tr>
+            <tr class="gb-table__row--featured"><td><span class="gb-bar-pill gb-bar-pill--gold">1 kilogram &#9733;</span></td><td>1,000.00</td><td>32.150</td><td><span class="gb-premium gb-premium--best">1&ndash;2%</span></td><td>$153,000&ndash;$156,000</td></tr>
+            <tr><td><span class="gb-bar-pill">100 troy oz</span></td><td>3,110.35</td><td>100.000</td><td><span class="gb-premium gb-premium--best">~0.5&ndash;1%</span></td><td>~$478,000</td></tr>
+            <tr><td><span class="gb-bar-pill">400 troy oz</span></td><td>~12,400</td><td>~400</td><td><span class="gb-premium gb-premium--best">~0.5%</span></td><td>$1.92M&ndash;$2.06M</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="gb-table-note">&#9733; Most popular investor sizes. Prices based on ~$4,675/oz spot; actual retail prices vary by dealer, payment method, and quantity.</p>
+      <div class="gb-insight-card">
+        <div class="gb-insight-card__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+        </div>
+        <div><strong>The Premium Rule:</strong> The larger the bar, the lower the premium above spot. A 1 gram bar costs ~20% over spot due to manufacturing and packaging costs; a 1 kg bar from the same refiner might carry just 1.5%.</div>
+      </div>
+
+      <!-- ── POPULAR SIZES ── -->
+      <h2 id="popular-sizes">The Most Popular Gold Bar Sizes Explained</h2>
+      <div class="gb-size-grid">
+        <div class="gb-size-card">
+          <div class="gb-size-card__visual" aria-hidden="true"><div class="gb-bar-visual gb-bar-visual--xs"></div></div>
+          <div class="gb-size-card__content">
+            <div class="gb-size-card__weight">1 troy oz</div>
+            <div class="gb-size-card__grams">31.1 grams</div>
+            <div class="gb-size-card__price" id="sz1oz">~$4,875</div>
+            <div class="gb-size-card__dims">42 &times; 24 &times; 2 mm</div>
+            <div class="gb-size-card__premium">3&ndash;5% premium</div>
+            <p class="gb-size-card__desc">The most widely traded retail size globally. Best combination of affordability, liquidity, and cost efficiency. Instantly recognisable to dealers worldwide &mdash; the natural entry point for most investors.</p>
+            <div class="gb-size-card__tag gb-size-card__tag--best">Most Popular</div>
+          </div>
+        </div>
+        <div class="gb-size-card">
+          <div class="gb-size-card__visual" aria-hidden="true"><div class="gb-bar-visual gb-bar-visual--sm"></div></div>
+          <div class="gb-size-card__content">
+            <div class="gb-size-card__weight">100 gram</div>
+            <div class="gb-size-card__grams">3.215 troy oz</div>
+            <div class="gb-size-card__price" id="sz100g">~$15,500</div>
+            <div class="gb-size-card__dims">45 &times; 25 &times; 5 mm</div>
+            <div class="gb-size-card__premium">2&ndash;4% premium</div>
+            <p class="gb-size-card__desc">The sweet spot for mid-level investors. Better value per gram than 1 oz while remaining accessible. Standard dimensions include hallmarks, serial numbers, and assay certificates.</p>
+            <div class="gb-size-card__tag gb-size-card__tag--value">Best Value</div>
+          </div>
+        </div>
+        <div class="gb-size-card">
+          <div class="gb-size-card__visual" aria-hidden="true"><div class="gb-bar-visual gb-bar-visual--md"></div></div>
+          <div class="gb-size-card__content">
+            <div class="gb-size-card__weight">1 kilogram</div>
+            <div class="gb-size-card__grams">32.15 troy oz</div>
+            <div class="gb-size-card__price" id="sz1kg">~$154,500</div>
+            <div class="gb-size-card__dims">118 &times; 53 &times; 8 mm</div>
+            <div class="gb-size-card__premium">1&ndash;2% premium</div>
+            <p class="gb-size-card__desc">The largest size most private investors purchase outright. Best spot-price efficiency available to non-institutional buyers. Weighs the same as a standard bag of sugar &mdash; 2.2 lbs.</p>
+            <div class="gb-size-card__tag gb-size-card__tag--efficiency">Lowest Premium</div>
+          </div>
+        </div>
+        <div class="gb-size-card gb-size-card--vault">
+          <div class="gb-size-card__visual" aria-hidden="true"><div class="gb-bar-visual gb-bar-visual--xl"></div></div>
+          <div class="gb-size-card__content">
+            <div class="gb-size-card__weight">400 troy oz</div>
+            <div class="gb-size-card__grams">~12.4 kg &middot; ~27.4 lbs</div>
+            <div class="gb-size-card__price">$1.92M&ndash;$2.06M</div>
+            <div class="gb-size-card__dims">210&ndash;290 &times; 55&ndash;85 &times; 25&ndash;45 mm</div>
+            <div class="gb-size-card__premium">~0.5% premium</div>
+            <p class="gb-size-card__desc">The LBMA Good Delivery bar &mdash; the standard instrument of the global interbank gold market. Traded between central banks and bullion banks, not practically available to most private investors directly.</p>
+            <div class="gb-size-card__tag gb-size-card__tag--vault">Central Bank Bar</div>
+          </div>
+        </div>
+      </div>
+      <div class="gb-spec-box">
+        <div class="gb-spec-box__title">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          LBMA Good Delivery Requirements
+        </div>
+        <ul class="gb-spec-list">
+          <li>Weight range: <strong>350&ndash;430 fine troy ounces</strong> (roughly 10.9&ndash;13.4 kg)</li>
+          <li>Minimum fineness: <strong>995.0 parts per thousand</strong> (99.5% pure gold)</li>
+          <li>Must originate from an <strong>LBMA-approved refinery</strong></li>
+          <li>Stamped with: serial number, refinery hallmark, assay stamp, fineness, and year of manufacture</li>
+          <li>Dimensions: Length 210&ndash;290 mm, Width 55&ndash;85 mm, Height 25&ndash;45 mm</li>
+        </ul>
+      </div>
+
+      <!-- ── CAST VS MINTED ── -->
+      <h2 id="cast-vs-minted">Cast vs Minted Gold Bars: What Is the Difference?</h2>
+      <p>Not all gold bars are made the same way. There are two fundamental manufacturing methods, and understanding the difference helps buyers choose more intelligently.</p>
+      <div class="gb-compare">
+        <div class="gb-compare__card">
+          <div class="gb-compare__header gb-compare__header--cast">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 20h20M4 20V8l8-4 8 4v12"/></svg>
+            Cast Gold Bars
+          </div>
+          <div class="gb-compare__body">
+            <div class="gb-compare__method">Molten gold poured into mould</div>
+            <ul class="gb-compare__list">
+              <li>Rough texture, natural surface variations</li>
+              <li>Traditional &ldquo;authentic&rdquo; appearance</li>
+              <li><strong>Lower premium</strong> above spot</li>
+              <li>Mainly 100g, 250g, 500g, 1kg, 400oz</li>
+              <li>Usually without sealed assay card</li>
+              <li>Hallmark + serial number markings</li>
+            </ul>
+            <div class="gb-compare__best">Best for: Large-scale investment &mdash; lowest cost per gram</div>
+          </div>
+        </div>
+        <div class="gb-compare__vs" aria-hidden="true">VS</div>
+        <div class="gb-compare__card">
+          <div class="gb-compare__header gb-compare__header--minted">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            Minted Gold Bars
+          </div>
+          <div class="gb-compare__body">
+            <div class="gb-compare__method">Pressed from rolled gold strips</div>
+            <ul class="gb-compare__list">
+              <li>Polished finish, sharp precise edges</li>
+              <li>Intricate design on the reverse</li>
+              <li><strong>Slightly higher premium</strong> above spot</li>
+              <li>Mainly 1g to 100g, up to 10oz</li>
+              <li>Often in tamper-proof sealed assay card</li>
+              <li>Serial + assay certificate + anti-counterfeiting</li>
+            </ul>
+            <div class="gb-compare__best">Best for: Gifts, new investors &mdash; maximum security</div>
+          </div>
+        </div>
+      </div>
+      <p class="gb-note">Both types are 999.9 pure &mdash; purity is identical. The choice between cast and minted is primarily about premium cost, aesthetics, and intended use.</p>
+
+      <!-- ── VALUATION ── -->
+      <h2 id="valuation">How Much Is a Gold Bar Worth? Live Valuation</h2>
+      <p>The question &ldquo;how much is a gold bar worth?&rdquo; has two parts: the <strong>spot value</strong> (intrinsic metal content at current market prices) and the <strong>retail price</strong> (spot plus dealer premium).</p>
+      <div class="gb-valuation-steps">
+        <div class="gb-step">
+          <div class="gb-step__num" aria-hidden="true">1</div>
+          <div class="gb-step__content">
+            <strong>Find the current gold spot price</strong>
+            <p>The price at which one troy ounce of 99.99% fine gold trades right now on global markets. As of mid-May 2026, the LBMA PM fix was approximately <strong id="valSpot">$4,675.70</strong> per troy ounce.</p>
+          </div>
+        </div>
+        <div class="gb-step">
+          <div class="gb-step__num" aria-hidden="true">2</div>
+          <div class="gb-step__content">
+            <strong>Calculate the spot value of your bar</strong>
+            <p>Multiply the weight in troy ounces by the current spot price:</p>
+            <div class="gb-calc-list" aria-label="Bar spot value calculations">
+              <div class="gb-calc-row"><span>1 gram bar (0.0322 oz)</span><span id="val1g">$150.55</span></div>
+              <div class="gb-calc-row"><span>1 oz bar (1.000 oz)</span><span id="val1oz">$4,675</span></div>
+              <div class="gb-calc-row"><span>100 gram bar (3.215 oz)</span><span id="val100g">$15,031</span></div>
+              <div class="gb-calc-row"><span>1 kg bar (32.15 oz)</span><span id="val1kg">$150,341</span></div>
+              <div class="gb-calc-row"><span>400 oz Good Delivery</span><span>~$1.87M</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="gb-step">
+          <div class="gb-step__num" aria-hidden="true">3</div>
+          <div class="gb-step__content">
+            <strong>Add the retail premium</strong>
+            <p>What you pay at a dealer is always spot <em>plus</em> a premium. What you receive when selling is always spot <em>minus</em> the dealer&rsquo;s buyback margin. Understanding this <strong>spread</strong> is essential before purchasing.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── TOP BRANDS ── -->
+      <h2 id="top-brands">Best Gold Bars to Buy: Top Brands &amp; Refineries</h2>
+      <p>When buying gold bars, <strong>the refinery behind the bar matters as much as the weight</strong>. A bar from an LBMA-accredited refiner is accepted worldwide, easy to resell to any dealer, and verifiable through its markings.</p>
+      <div class="gb-refinery-grid">
+        <div class="gb-refinery-card">
+          <div class="gb-refinery-card__header">
+            <span class="gb-refinery-flag" aria-label="Switzerland" role="img">&#x1F1E8;&#x1F1ED;</span>
+            <div><div class="gb-refinery-card__name">PAMP Suisse</div><div class="gb-refinery-card__country">Switzerland &middot; Est. 1979</div></div>
+            <div class="gb-refinery-badge gb-refinery-badge--premium">Prestige</div>
+          </div>
+          <p>World&rsquo;s most prestigious gold bar brand. Iconic Fortuna design. Proprietary <strong>Veriscan technology</strong> authenticates each bar via smartphone app against a global database of unique surface scans.</p>
+          <div class="gb-refinery-card__stats"><span>4&ndash;6% premium</span><span>LBMA Accredited</span><span>Assay Card</span></div>
+        </div>
+        <div class="gb-refinery-card">
+          <div class="gb-refinery-card__header">
+            <span class="gb-refinery-flag" aria-label="Switzerland" role="img">&#x1F1E8;&#x1F1ED;</span>
+            <div><div class="gb-refinery-card__name">Valcambi Suisse</div><div class="gb-refinery-card__country">Switzerland</div></div>
+            <div class="gb-refinery-badge gb-refinery-badge--value">Best Value</div>
+          </div>
+          <p>One of the world&rsquo;s highest-volume refineries. Globally recognised. Famous for the <strong>CombiBar</strong> &mdash; a 50g or 100g bar pre-scored into 1g detachable pieces for maximum divisibility.</p>
+          <div class="gb-refinery-card__stats"><span>3&ndash;5% premium</span><span>LBMA Accredited</span><span>Assay Card</span></div>
+        </div>
+        <div class="gb-refinery-card">
+          <div class="gb-refinery-card__header">
+            <span class="gb-refinery-flag" aria-label="Australia" role="img">&#x1F1E6;&#x1F1FA;</span>
+            <div><div class="gb-refinery-card__name">Perth Mint</div><div class="gb-refinery-card__country">Australia &middot; Govt. Backed</div></div>
+            <div class="gb-refinery-badge gb-refinery-badge--new">New Investors</div>
+          </div>
+          <p>Backed by the Government of Western Australia. Government-backed certificate of authenticity. Frequently highlighted as the best 1 oz bar for new investors &mdash; low premium, high liquidity.</p>
+          <div class="gb-refinery-card__stats"><span>3&ndash;4% premium</span><span>LBMA Accredited</span><span>Govt. Backed</span></div>
+        </div>
+        <div class="gb-refinery-card">
+          <div class="gb-refinery-card__header">
+            <span class="gb-refinery-flag" aria-label="Canada" role="img">&#x1F1E8;&#x1F1E6;</span>
+            <div><div class="gb-refinery-card__name">Royal Canadian Mint</div><div class="gb-refinery-card__country">Canada</div></div>
+            <div class="gb-refinery-badge gb-refinery-badge--security">Best Security</div>
+          </div>
+          <p>Advanced security features: micro-engraved maple leaf patterns and radial lines. Among the best counterfeit-proofing in the industry. Widely preferred for IRA eligibility and institutional credibility.</p>
+          <div class="gb-refinery-card__stats"><span>4&ndash;6% premium</span><span>LBMA Accredited</span><span>IRA Eligible</span></div>
+        </div>
+        <div class="gb-refinery-card">
+          <div class="gb-refinery-card__header">
+            <span class="gb-refinery-flag" aria-label="Switzerland" role="img">&#x1F1E8;&#x1F1ED;</span>
+            <div><div class="gb-refinery-card__name">Argor-Heraeus</div><div class="gb-refinery-card__country">Switzerland</div></div>
+          </div>
+          <p>Major LBMA-accredited refiner producing institutional-grade bars recognised across global markets. Particularly popular in European and Asian markets. Competitive pricing on larger bars.</p>
+          <div class="gb-refinery-card__stats"><span>3&ndash;5% premium</span><span>LBMA Accredited</span><span>European markets</span></div>
+        </div>
+        <div class="gb-refinery-card">
+          <div class="gb-refinery-card__header">
+            <span class="gb-refinery-flag" aria-label="Switzerland" role="img">&#x1F1E8;&#x1F1ED;</span>
+            <div><div class="gb-refinery-card__name">Metalor</div><div class="gb-refinery-card__country">Switzerland</div></div>
+          </div>
+          <p>Swiss refinery with global reach, particularly recognised in Asian and European markets. Consistently competitive pricing with the quality assurance of Swiss manufacturing standards.</p>
+          <div class="gb-refinery-card__stats"><span>3&ndash;5% premium</span><span>LBMA Accredited</span><span>Asian/European</span></div>
+        </div>
+      </div>
+
+      <!-- ── WHERE TO BUY ── -->
+      <h2 id="where-to-buy">Where to Buy Gold Bars: Trusted Bullion Dealers</h2>
+      <p>The safest and most cost-effective way to purchase gold bars for most investors is through an established, accredited <strong>online bullion dealer</strong>. Reputable platforms consistently offer lower premiums than banks or jewellers.</p>
+      <div class="gb-dealer-list">
+        <div class="gb-dealer">
+          <div class="gb-dealer__name">APMEX (American Precious Metals Exchange)</div>
+          <div class="gb-dealer__region">North America</div>
+          <p>One of the largest and most respected bullion dealers globally. Vast inventory from every major refinery. Has handled billions of dollars of transactions. Particularly strong in North America.</p>
+        </div>
+        <div class="gb-dealer">
+          <div class="gb-dealer__name">JM Bullion</div>
+          <div class="gb-dealer__region">North America</div>
+          <p>Known for transparent pricing, frequent low-premium promotions on 1 oz bars, and a clean buying experience with free shipping above certain order values.</p>
+        </div>
+        <div class="gb-dealer">
+          <div class="gb-dealer__name">Kitco</div>
+          <div class="gb-dealer__region">North America &middot; Montreal</div>
+          <p>Long-established precious metals dealer and information platform. Kitco&rsquo;s prices are widely referenced as a market benchmark. Offers storage solutions alongside physical purchases.</p>
+        </div>
+        <div class="gb-dealer">
+          <div class="gb-dealer__name">BullionByPost</div>
+          <div class="gb-dealer__region">United Kingdom</div>
+          <p>UK&rsquo;s largest online bullion dealer by volume. Highly competitive pricing on Royal Mint, PAMP, and Valcambi bars. Free insured delivery standard. Among the most transparent buyback programmes in the UK.</p>
+        </div>
+        <div class="gb-dealer">
+          <div class="gb-dealer__name">BullionVault</div>
+          <div class="gb-dealer__region">Global &middot; Online</div>
+          <p>Near-wholesale pricing via fractional access to institutional bars stored in allocated vaults in London, New York, Zurich, Singapore, and Toronto. Ideal for cost-sensitive investors who want physical exposure without taking delivery.</p>
+        </div>
+      </div>
+      <div class="gb-checklist-box">
+        <div class="gb-checklist-box__title">What to look for when choosing a bullion dealer</div>
+        <ul class="gb-checklist">
+          <li>Membership in an accredited industry body (LBMA, BNTA, PNG, or national equivalent)</li>
+          <li>Transparent pricing showing the exact premium over spot</li>
+          <li>A published buyback programme with clear, pre-stated pricing</li>
+          <li>Independent customer reviews on Trustpilot or the Better Business Bureau</li>
+          <li>Secure, tracked, fully insured delivery for physical orders</li>
+          <li>Audited vault storage options if you are not taking delivery</li>
+        </ul>
+      </div>
+
+      <!-- ── SCAMS ── -->
+      <h2 id="scams">Gold Bar Scams: How to Spot Fakes and Protect Yourself</h2>
+      <p>The gold market attracts a small but persistent number of fraudsters. Understanding how to verify authenticity is not paranoia &mdash; it is prudent due diligence for any significant purchase.</p>
+      <div class="gb-scam-grid">
+        <div class="gb-scam-card">
+          <div class="gb-scam-card__icon" aria-hidden="true">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+          </div>
+          <div class="gb-scam-card__title">Tungsten-Core Bars</div>
+          <p>Tungsten is nearly identical in density to gold (19.25 vs 19.32 g/cm&sup3;). Sophisticated fakes can pass visual and weight checks. Only ultrasonic testing reliably detects density inconsistencies.</p>
+        </div>
+        <div class="gb-scam-card">
+          <div class="gb-scam-card__icon" aria-hidden="true">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+          </div>
+          <div class="gb-scam-card__title">Gold-Plated Base Metal</div>
+          <p>Cheaper fakes use copper, lead, or iron with a thin gold electroplate. These fail a magnet test immediately &mdash; genuine gold has zero magnetic response. Any attraction is an instant red flag.</p>
+        </div>
+        <div class="gb-scam-card">
+          <div class="gb-scam-card__icon" aria-hidden="true">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+          </div>
+          <div class="gb-scam-card__title">Fake Assay Certificates</div>
+          <p>Convincing certificates with no legitimate digital verification. PAMP Suisse&rsquo;s Veriscan app authenticates each bar against a global database of unique surface scans captured at manufacture.</p>
+        </div>
+      </div>
+      <div class="gb-verify-steps">
+        <div class="gb-verify-steps__title">How to Verify a Gold Bar &mdash; 6 Steps</div>
+        <div class="gb-verify-step">
+          <div class="gb-verify-step__num" aria-hidden="true">1</div>
+          <div><strong>Buy from an accredited dealer only</strong> &mdash; this single step eliminates the vast majority of counterfeit risk</div>
+        </div>
+        <div class="gb-verify-step">
+          <div class="gb-verify-step__num" aria-hidden="true">2</div>
+          <div><strong>Magnet test</strong> &mdash; genuine gold has zero magnetic response; any attraction is an immediate red flag</div>
+        </div>
+        <div class="gb-verify-step">
+          <div class="gb-verify-step__num" aria-hidden="true">3</div>
+          <div><strong>Weight and dimensions</strong> &mdash; use a digital scale accurate to 0.01g; even a 0.1g discrepancy on a 1 oz bar warrants investigation</div>
+        </div>
+        <div class="gb-verify-step">
+          <div class="gb-verify-step__num" aria-hidden="true">4</div>
+          <div><strong>Hallmarks and serial number</strong> &mdash; every investment-grade bar carries a refiner&rsquo;s hallmark, purity stamp, weight, and unique serial number</div>
+        </div>
+        <div class="gb-verify-step">
+          <div class="gb-verify-step__num" aria-hidden="true">5</div>
+          <div><strong>Assay packaging integrity</strong> &mdash; opened or re-sealed assay card is a serious red flag; do not accept it</div>
+        </div>
+        <div class="gb-verify-step">
+          <div class="gb-verify-step__num" aria-hidden="true">6</div>
+          <div><strong>Professional assay</strong> &mdash; XRF (X-ray fluorescence) or fire assay provides definitive purity confirmation for any significant purchase from an unfamiliar source</div>
+        </div>
+      </div>
+
+      <!-- ── BARS VS COINS ── -->
+      <h2 id="bars-vs-coins">Gold Bars vs Gold Coins: Which Is the Better Investment?</h2>
+      <p>This is one of the most common questions for new gold investors. The honest answer is that it depends on your priorities.</p>
+      <div class="gb-versus">
+        <div class="gb-versus__side gb-versus__side--bars">
+          <div class="gb-versus__title">Gold Bars</div>
+          <div class="gb-versus__pros">
+            <div class="gb-versus__pro">Lower premiums at 100g and above</div>
+            <div class="gb-versus__pro">Better grams-for-dollar at large sizes</div>
+            <div class="gb-versus__pro">1kg bars: just 1&ndash;2% over spot</div>
+          </div>
+          <div class="gb-versus__cons">
+            <div class="gb-versus__con">Large bars are less divisible to sell</div>
+            <div class="gb-versus__con">No CGT exemption in most jurisdictions</div>
+          </div>
+        </div>
+        <div class="gb-versus__divider" aria-hidden="true"><span>VS</span></div>
+        <div class="gb-versus__side gb-versus__side--coins">
+          <div class="gb-versus__title">Gold Coins</div>
+          <div class="gb-versus__pros">
+            <div class="gb-versus__pro">Greater liquidity &mdash; sell one coin at a time</div>
+            <div class="gb-versus__pro">Potential CGT exemptions (varies by country)</div>
+            <div class="gb-versus__pro">Widely recognised and universally trusted</div>
+          </div>
+          <div class="gb-versus__cons">
+            <div class="gb-versus__con">Higher per-gram premium (4&ndash;8%)</div>
+            <div class="gb-versus__con">Takes longer to build a large position</div>
+          </div>
+        </div>
+      </div>
+      <div class="gb-insight-card">
+        <div class="gb-insight-card__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        </div>
+        <div><strong>For most first-time investors:</strong> A 1 oz gold bar or a mix of 1 oz gold coins provides the best starting point &mdash; combining moderate premiums, global liquidity, recognisability, and accessibility into a practical entry-level position.</div>
+      </div>
+
+      <!-- ── INVESTMENT STRATEGY ── -->
+      <h2 id="investment-strategy">Gold Bar Investment Strategy by Budget</h2>
+      <p>Physical gold bar investment works best when approached systematically. Here is a practical framework for different investment levels.</p>
+      <div class="gb-budget-grid">
+        <div class="gb-budget-card">
+          <div class="gb-budget-card__range">Under $5,000</div>
+          <div class="gb-budget-card__rec">1 oz gold bar</div>
+          <p>Start with a <strong>1 oz bar</strong> from PAMP Suisse, Perth Mint, or Valcambi in a sealed assay card. Alternatively, two to three 10 gram bars for slightly more flexibility. Avoid 1 gram bars at this level &mdash; the premium-to-content ratio is poor for investment purposes.</p>
+        </div>
+        <div class="gb-budget-card">
+          <div class="gb-budget-card__range">$5,000 &ndash; $25,000</div>
+          <div class="gb-budget-card__rec">1 oz + 100 gram bars</div>
+          <p>A combination of <strong>1 oz and 100g bars</strong> balances premium efficiency with resale flexibility. A 100g bar at ~$15,400 carries a lower premium per gram than a 1 oz bar, and is still easy to sell to any major dealer.</p>
+        </div>
+        <div class="gb-budget-card">
+          <div class="gb-budget-card__range">$25,000 &ndash; $150,000</div>
+          <div class="gb-budget-card__rec">100g, 250g, or 1kg bars</div>
+          <p><strong>100g and 250g bars</strong> offer solid cost efficiency, or a <strong>1kg bar</strong> if you do not anticipate needing to sell in portions. The 1kg gold bar carries the best premium-to-value ratio available to private investors.</p>
+        </div>
+        <div class="gb-budget-card gb-budget-card--premium">
+          <div class="gb-budget-card__range">Above $150,000</div>
+          <div class="gb-budget-card__rec">1kg bars + vault storage</div>
+          <p>Mix of <strong>1kg bars</strong> for cost efficiency plus a smaller allocation to 1 oz bars for liquidity. At very large allocations, allocated professional vault storage becomes important &mdash; insuring $500,000+ of gold at home is both expensive and practically difficult to arrange.</p>
+        </div>
+      </div>
+
+      <!-- ── SWISS LEGACY ── -->
+      <h2 id="swiss-gold">The Swiss Gold Bar Legacy</h2>
+      <p>Switzerland occupies a singular place in the global gold bar market. Three of the world&rsquo;s most trusted brands &mdash; PAMP Suisse, Valcambi, and Argor-Heraeus &mdash; are all Swiss-based refineries, reinforced by the country&rsquo;s political neutrality, robust financial law, and deep ties to the LBMA-governed global bullion market.</p>
+      <div class="gb-insight-card">
+        <div class="gb-insight-card__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
+        </div>
+        <div><strong>PAMP vs Valcambi:</strong> PAMP commands a slightly higher premium due to its design reputation and Veriscan technology. Valcambi offers comparable purity and global recognition at marginally lower cost. Both are excellent investment-grade choices.</div>
+      </div>
+
+      <!-- ── STORAGE ── -->
+      <h2 id="storage">Storing Your Gold Bars Safely</h2>
+      <p>Owning gold bars creates a storage and security obligation that is just as important as the purchase decision itself.</p>
+      <div class="gb-storage-grid">
+        <div class="gb-storage-card">
+          <div class="gb-storage-card__icon" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+          </div>
+          <div class="gb-storage-card__title">Home Storage</div>
+          <div class="gb-storage-card__limit">Up to ~$20,000&ndash;$30,000</div>
+          <p>Quality in-wall or floor-mounted safe, anchored and concealed. Ensure home insurance explicitly covers bullion &mdash; standard contents policies usually do not, or impose very low sub-limits.</p>
+          <div class="gb-storage-card__cost">Cost: safe price + bullion insurance premium</div>
+        </div>
+        <div class="gb-storage-card">
+          <div class="gb-storage-card__icon" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+          </div>
+          <div class="gb-storage-card__title">Bank Safety Deposit</div>
+          <div class="gb-storage-card__limit">Any size holding</div>
+          <p>Institutional-grade physical security at very low cost. Limitation: access only during bank hours. Some countries have restricted box contents to non-financial instruments in recent years.</p>
+          <div class="gb-storage-card__cost">Cost: ~$50&ndash;$200 per year</div>
+        </div>
+        <div class="gb-storage-card gb-storage-card--recommended">
+          <div class="gb-storage-card__badge">Recommended for large holdings</div>
+          <div class="gb-storage-card__icon" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          </div>
+          <div class="gb-storage-card__title">Professional Vault</div>
+          <div class="gb-storage-card__limit">Any size &middot; fully insured &middot; allocated</div>
+          <p>Allocated, insured, independently audited storage. BullionVault, Sharps Pixley, and GoldCore offer vaults across London, Zurich, New York, Singapore, and Toronto.</p>
+          <div class="gb-storage-card__cost">Cost: ~0.12% of metal value per year</div>
+        </div>
+      </div>
+
+      <!-- ── FAQ ── -->
+      <h2 id="faq">Frequently Asked Questions About Gold Bars</h2>
+      <div class="gb-faq">
+        <div class="gb-faq__item">
+          <button class="gb-faq__question" aria-expanded="false">
+            How much does a gold bar weigh?
+            <svg class="gb-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gb-faq__answer" hidden>
+            <p>Gold bars come in sizes from 1 gram to 400 troy ounces (12.4 kg). The most popular retail weight is 1 troy ounce (31.1 grams). The standard institutional bar &mdash; the LBMA Good Delivery bar &mdash; weighs approximately 400 troy ounces or 12.4 kilograms.</p>
+          </div>
+        </div>
+        <div class="gb-faq__item">
+          <button class="gb-faq__question" aria-expanded="false">
+            How much is a gold bar worth today?
+            <svg class="gb-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gb-faq__answer" hidden>
+            <p>At May 2026 spot prices (~$4,675/oz): a 1 oz bar retails for approximately $4,800&ndash;$4,950; a 100 gram bar for $15,200&ndash;$15,800; a 1 kg bar for $153,000&ndash;$156,000; and a 400 oz Good Delivery bar for $1.92&ndash;$2.06 million. Use the live prices at the top of this page for the most current valuations.</p>
+          </div>
+        </div>
+        <div class="gb-faq__item">
+          <button class="gb-faq__question" aria-expanded="false">
+            What is the best gold bar to buy?
+            <svg class="gb-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gb-faq__answer" hidden>
+            <p>For most investors, a <strong>1 oz bar from PAMP Suisse, Perth Mint, or Valcambi</strong> offers the best combination of low premium, global liquidity, strong brand recognition, and anti-counterfeiting features. For larger budgets, 100 gram and 1 kg bars offer better value per gram.</p>
+          </div>
+        </div>
+        <div class="gb-faq__item">
+          <button class="gb-faq__question" aria-expanded="false">
+            What is a 24k gold bar?
+            <svg class="gb-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gb-faq__answer" hidden>
+            <p>A 24 karat gold bar means the bar is 99.9% or 99.99% pure gold &mdash; the same as 999 or 999.9 fine. All investment-grade gold bars are 24 karat (24K) by definition. Lower karats indicate an alloy and are not used in bullion bar production.</p>
+          </div>
+        </div>
+        <div class="gb-faq__item">
+          <button class="gb-faq__question" aria-expanded="false">
+            How many ounces are in a gold bar?
+            <svg class="gb-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gb-faq__answer" hidden>
+            <p>It depends on the bar. The most popular retail size contains 1 troy ounce (31.1 grams). A kilogram bar contains 32.15 troy ounces. The standard Good Delivery bar weighs approximately 400 troy ounces. Bars are also produced in 1g, 2.5g, 5g, 10g, 20g, 50g, 100g, 250g, 500g, and 10 troy oz sizes.</p>
+          </div>
+        </div>
+        <div class="gb-faq__item">
+          <button class="gb-faq__question" aria-expanded="false">
+            Can I buy gold bars from Costco or Walmart?
+            <svg class="gb-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gb-faq__answer" hidden>
+            <p>Costco has sold 1 oz gold bars (typically PAMP Suisse) in limited quantities. Walmart lists gold bars through third-party marketplace sellers. While not inherently fraudulent, you should verify the seller&rsquo;s credentials carefully and compare pricing against specialist bullion dealers, who typically offer wider selection, clearer provenance, and dedicated buyback programmes.</p>
+          </div>
+        </div>
+        <div class="gb-faq__item">
+          <button class="gb-faq__question" aria-expanded="false">
+            Are fractional gold bars a good investment?
+            <svg class="gb-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gb-faq__answer" hidden>
+            <p>Fractional gold bars (1g, 2.5g, 5g, 10g) are useful for gifts, building a small starting position, or dollar-cost averaging in small increments. As pure investments, their higher per-gram premiums (15&ndash;25%) mean you need meaningful price appreciation before breaking even. For investment purposes, 1 oz and larger bars are significantly more cost-efficient.</p>
+          </div>
+        </div>
+        <div class="gb-faq__item">
+          <button class="gb-faq__question" aria-expanded="false">
+            Is it better to buy gold bars online or locally?
+            <svg class="gb-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gb-faq__answer" hidden>
+            <p>Online bullion dealers almost always offer better pricing &mdash; lower overheads mean lower premiums. The trade-off is that you cannot inspect the bar before purchasing. Buying from an LBMA-accredited dealer online with insured tracked delivery carries minimal additional risk compared to a physical shop, and you are protected by established return and authenticity policies.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- SHARE -->
+      <section class="share-section" aria-label="Share this guide">
+        <div class="share-section-label">Share this guide</div>
+        <div class="share-buttons">
+          <a class="share-btn" href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/gold-bar-guide&text=Gold+Bar+Guide%3A+Sizes%2C+Weights%2C+and+Valuations+2026" target="_blank" rel="noopener noreferrer">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.737-8.835L1.254 2.25H8.08l4.259 5.631 5.905-5.631zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            Share on X
+          </a>
+          <a class="share-btn" href="https://www.reddit.com/submit?url=https://goldpricetools.com/guides/gold-bar-guide&title=Gold+Bar+Guide+2026" target="_blank" rel="noopener noreferrer">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
+            Reddit
+          </a>
+          <a class="share-btn" href="https://api.whatsapp.com/send?text=Gold+Bar+Guide+2026%20https%3A%2F%2Fgoldpricetools.com%2Fguides%2Fgold-bar-guide" target="_blank" rel="noopener noreferrer">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg>
+            WhatsApp
+          </a>
+        </div>
+      </section>
+
+    </div><!-- /gb-prose -->
+  </article><!-- /gb-article -->
+</div><!-- /gb-layout -->
+
+<div style="max-width:900px;margin:0 auto var(--space-10);padding:0 var(--space-4)">
   <div class="disclaimer-box">
-    <strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.
+    <strong>Disclaimer:</strong> This guide is for educational and informational purposes only and does not constitute investment, tax, or financial advice. The value of gold investments can go down as well as up. Always consult a qualified financial adviser before making significant investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.
   </div>
 </div>
 
@@ -613,27 +1556,27 @@ main.container article{max-width:860px}
     <a class="related-card" href="/gold-coins-vs-bars">
       <span class="related-card__tag">GUIDE</span>
       <div class="related-card__title">Gold Coins vs Bars</div>
-      <div class="related-card__desc">Which is the better investment — coins or bars? A full cost and liquidity comparison.</div>
+      <div class="related-card__desc">Which is the better investment &mdash; coins or bars? A full cost and liquidity comparison.</div>
     </a>
     <a class="related-card" href="/guides/how-to-sell-gold-jewellery">
       <span class="related-card__tag">GUIDE</span>
       <div class="related-card__title">How to Sell Gold Jewellery</div>
-      <div class="related-card__desc">Get the best price for your gold bars and jewellery — which buyers pay more.</div>
+      <div class="related-card__desc">Get the best price for your gold &mdash; which buyers pay more and how to compare offers.</div>
     </a>
     <a class="related-card" href="/24k-gold-price-per-gram">
       <span class="related-card__tag">LIVE PRICE</span>
       <div class="related-card__title">24K Gold Price Per Gram</div>
-      <div class="related-card__desc">Today's pure gold price per gram — the benchmark for bullion investments.</div>
+      <div class="related-card__desc">Today&rsquo;s pure gold price per gram &mdash; the benchmark for bullion investments.</div>
     </a>
     <a class="related-card" href="/guides/gold-purity-guide">
       <span class="related-card__tag">GUIDE</span>
       <div class="related-card__title">Gold Purity Guide</div>
-      <div class="related-card__desc">What 999, 995, and 916 hallmarks mean for gold bar purity and value.</div>
+      <div class="related-card__desc">What 999, 995, and 916 hallmarks mean for gold bar purity and resale value.</div>
     </a>
     <a class="related-card" href="/guides/how-to-invest-in-gold">
       <span class="related-card__tag">GUIDE</span>
       <div class="related-card__title">How to Invest in Gold</div>
-      <div class="related-card__desc">Beginner's guide covering ETFs, coins, bars, and digital gold accounts.</div>
+      <div class="related-card__desc">Beginner&rsquo;s guide covering ETFs, coins, bars, and digital gold accounts.</div>
     </a>
   </div>
 </section>
@@ -718,43 +1661,143 @@ main.container article{max-width:860px}
 </footer>
 
 <script>
-// Price Widget Logic
+// ── Price fetching & live valuations ──────────────────────────────
+const TROY_OZ_PER_GRAM = 1 / 31.1034768;
 const TROY_OZ_TO_GRAM = 31.1034768;
-function fmtUSD(val) { return '$' + val.toLocaleString('en-US', {minimumFractionDigits:2, maximumFractionDigits:2}); }
 
-async function fetchPrices() {
-    try {
-        const [gRes, sRes] = await Promise.all([
-            fetch('https://api.gold-api.com/price/XAU'),
-            fetch('https://api.gold-api.com/price/XAG')
-        ]);
-        const gData = await gRes.json();
-        const sData = await sRes.json();
-
-        document.getElementById('spotGoldOz').textContent = fmtUSD(gData.price);
-        document.getElementById('spotSilverOz').textContent = fmtUSD(sData.price);
-    } catch (e) {
-        console.error("Price fetch failed", e);
-    }
+function fmtUSD(val, decimals) {
+  if (val === null || val === undefined || isNaN(val)) return '—';
+  if (val >= 1e6) return '$' + (val / 1e6).toFixed(2) + 'M';
+  return '$' + val.toLocaleString('en-US', {minimumFractionDigits: decimals ?? 2, maximumFractionDigits: decimals ?? 2});
 }
 
-document.addEventListener('DOMContentLoaded', fetchPrices);
+function updateValuations(spot) {
+  const el = (id) => document.getElementById(id);
+  const set = (id, val) => { const e = el(id); if (e) e.textContent = val; };
+
+  set('spotGoldOz', fmtUSD(spot));
+  set('sidebarGoldPrice', fmtUSD(spot));
+  set('valSpot', fmtUSD(spot));
+
+  // Spot values
+  set('val1g',  fmtUSD(spot * 0.0322));
+  set('val1oz', fmtUSD(spot * 1));
+  set('val100g', fmtUSD(spot * 3.215));
+  set('val1kg',  fmtUSD(spot * 32.15));
+
+  // Retail estimates (spot × troy oz × premium multiplier)
+  set('bar1ozValue',  fmtUSD(spot * 1 * 1.04));
+  set('bar100gValue', fmtUSD(spot * 3.215 * 1.03));
+  set('sz1oz',  fmtUSD(spot * 1 * 1.04));
+  set('sz100g', fmtUSD(spot * 3.215 * 1.03));
+  set('sz1kg',  fmtUSD(spot * 32.15 * 1.015));
+}
+
+async function fetchPrices() {
+  try {
+    const [gRes, sRes] = await Promise.all([
+      fetch('https://api.gold-api.com/price/XAU'),
+      fetch('https://api.gold-api.com/price/XAG')
+    ]);
+    const gData = await gRes.json();
+    const sData = await sRes.json();
+
+    const goldSpot = gData.price;
+    const silverSpot = sData.price;
+
+    updateValuations(goldSpot);
+    const silEl = document.getElementById('spotSilverOz');
+    if (silEl) silEl.textContent = fmtUSD(silverSpot);
+  } catch (e) {
+    console.error('Price fetch failed', e);
+  }
+}
+
+// ── Reading progress bar ─────────────────────────────────────────
+function initReadingProgress() {
+  const bar = document.getElementById('gb-progress');
+  if (!bar) return;
+  const updateProgress = () => {
+    const scrollTop = window.scrollY;
+    const docH = document.documentElement.scrollHeight - window.innerHeight;
+    const pct = docH > 0 ? Math.min(100, (scrollTop / docH) * 100) : 0;
+    bar.style.width = pct + '%';
+    bar.setAttribute('aria-valuenow', Math.round(pct));
+  };
+  window.addEventListener('scroll', updateProgress, {passive: true});
+}
+
+// ── Table of Contents: active section highlighting ───────────────
+function initTocHighlight() {
+  const links = document.querySelectorAll('.gb-toc__link');
+  if (!links.length) return;
+  const sections = Array.from(links).map(l => {
+    const id = l.getAttribute('href').slice(1);
+    return {link: l, section: document.getElementById(id)};
+  }).filter(x => x.section);
+
+  const obs = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        links.forEach(l => l.classList.remove('active'));
+        const active = sections.find(s => s.section === entry.target);
+        if (active) active.link.classList.add('active');
+      }
+    });
+  }, {rootMargin: '-72px 0px -60% 0px', threshold: 0});
+
+  sections.forEach(s => obs.observe(s.section));
+}
+
+// ── Mobile TOC toggle ────────────────────────────────────────────
+function initMobileToc() {
+  const btn = document.getElementById('tocToggle');
+  const nav = document.getElementById('tocMobile');
+  if (!btn || !nav) return;
+  btn.addEventListener('click', () => {
+    const expanded = btn.getAttribute('aria-expanded') === 'true';
+    btn.setAttribute('aria-expanded', !expanded);
+    nav.hidden = expanded;
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      btn.setAttribute('aria-expanded', 'false');
+      nav.hidden = true;
+    });
+  });
+}
+
+// ── FAQ accordion ────────────────────────────────────────────────
+function initFaq() {
+  document.querySelectorAll('.gb-faq__question').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const answer = btn.nextElementSibling;
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      // Close all others
+      document.querySelectorAll('.gb-faq__question').forEach(b => {
+        b.setAttribute('aria-expanded', 'false');
+        const a = b.nextElementSibling;
+        if (a) a.hidden = true;
+      });
+      // Toggle clicked
+      if (!expanded) {
+        btn.setAttribute('aria-expanded', 'true');
+        if (answer) answer.hidden = false;
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchPrices();
+  initReadingProgress();
+  initTocHighlight();
+  initMobileToc();
+  initFaq();
+  // Refresh prices every 60s
+  setInterval(fetchPrices, 60000);
+});
 </script>
-
-<script>(function(){
-  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
-  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
-  root.setAttribute('data-theme',theme);
-  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
-  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
-  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
-  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
-  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
-  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
-  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
-})();</script>
-
-
 
 
 


### PR DESCRIPTION
## Summary

Complete redesign of `/guides/gold-bar-guide.html` with the full 2026 article content and a premium mobile-first editorial layout built on the existing design token system.

- **Hero section** — dark gold-gradient background with Playfair Display editorial headline, live price cards (gold spot, 1oz retail, 100g retail, silver), and animated gold orb glows
- **Reading progress bar** — thin gold gradient line pinned to viewport top, updates on scroll
- **Sticky sidebar ToC** (desktop) + **collapsible mobile ToC** — both with IntersectionObserver active section highlighting
- **Full article content** — all sections from the 2026 article: troy weight system, purity standards, sizes table, popular sizes, cast vs minted, valuation, refineries, dealers, scams, bars vs coins, budget strategy, Swiss gold legacy, storage, FAQ
- **Complete 14-row size & price table** — gold-accented headers, colour-coded premium badges (red → cyan scale), featured rows for 1oz / 100g / 1kg
- **Visual gold bar size cards** — CSS-rendered gold bar graphics for 1oz, 100g, 1kg, 400oz with hover animations
- **Cast vs Minted comparison** — two-column layout, side by side on desktop, stacked on mobile
- **3-step valuation guide** — numbered steps with live-updated spot calculations (auto-refreshes every 60s)
- **6 refinery cards** — PAMP, Valcambi, Perth Mint, Royal Canadian Mint, Argor-Heraeus, Metalor with country flags, badges, and stat chips
- **Scam warning cards** + **6-step verification checklist** — red-tinted alert styling
- **Bars vs Coins** — pros/cons comparison with green/red tick/cross indicators
- **4-tier budget strategy cards** — colour-coded top accent bars per tier
- **3-column storage options** — home / bank / vault with "Recommended" badge
- **8-question FAQ accordion** — ARIA-compliant expand/collapse, closes others on open
- **Updated JSON-LD FAQ schema** — real questions and answers from the article
- **Dark/light mode** — fully adaptive, all `gb-*` components use existing CSS variable tokens

## Test plan

- [ ] View on mobile (375px) — hero, ToC toggle, size cards, table horizontal scroll, FAQ
- [ ] View on tablet (768px) — cast vs minted side-by-side, refinery 2-col grid
- [ ] View on desktop (1024px+) — sidebar ToC sticky, 3-col refinery grid, storage grid
- [ ] Toggle dark/light mode — verify all `gb-*` components adapt correctly
- [ ] Live price cards load values from API within a few seconds
- [ ] FAQ accordion opens/closes correctly with keyboard and mouse
- [ ] Reading progress bar fills as you scroll to the bottom
- [ ] ToC active link updates as sections scroll into view
- [ ] All anchor links (#weight-measurement, #purity, etc.) scroll to correct sections

https://claude.ai/code/session_01NzwJfvJkH712cz92e5z6Eq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzwJfvJkH712cz92e5z6Eq)_