### PR TITLE
Redesign: Gold Purity Guide — premium mobile-first editorial layout

### DIFF
--- a/guides/gold-purity-guide.html
+++ b/guides/gold-purity-guide.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="UTF-8">
   <script>
-(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold Purity Guide: Karats & Hallmarks | GoldPriceTools</title>
+<title>Gold Purity Guide: 9K to 24K Explained (2026) | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Gold karat purity guide: what 9K, 10K, 14K, 18K, 22K and 24K mean, how to read hallmarks, and the current live melt value for each karat today.">
+<meta name="description" content="Complete gold purity guide 2026: what 9K, 10K, 14K, 18K, 22K and 24K mean, fineness stamps (375, 585, 750, 916, 999), hallmark reading, home & XRF testing, and live value per karat.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/guides/gold-purity-guide">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/gold-purity-guide">
@@ -18,43 +18,39 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
-<meta property="og:title" content="Gold Purity Guide: Karats & Hallmarks | GoldPriceTools">
-<meta property="og:description" content="Complete guide to gold purity: what karats mean, how to read hallmarks, and the difference between 9K, 14K, 18K, 22K and 24K gold.">
+<meta property="og:title" content="Gold Purity Guide: 9K to 24K Explained (2026)">
+<meta property="og:description" content="Complete gold purity guide 2026: karats, fineness, hallmarks, home & XRF testing, value per karat, and global purity preferences.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/gold-purity-guide">
 <meta property="og:site_name" content="GoldPriceTools">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Purity Guide — Karats, Hallmarks & What They Mean","description":"Complete guide to gold purity: what karats mean, how to read hallmarks, and the difference between 9K, 14K, 18K, 22K and 24K gold.","url":"https://goldpricetools.com/guides/gold-purity-guide","datePublished":"2026-04-24","dateModified":"2026-05-17T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-purity-guide"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Purity Guide: 9K to 24K Explained (2026)","description":"Complete guide to gold purity — karat & millesimal fineness systems, every karat from 9K to 24K explained, hallmark reading, home and XRF testing, regional preferences, and value per karat.","url":"https://goldpricetools.com/guides/gold-purity-guide","datePublished":"2026-04-24","dateModified":"2026-05-17T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-purity-guide"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the highest gold purity?","acceptedAnswer":{"@type":"Answer","text":"24K (999.9 fine) is the highest purity grade for commercial gold. Investment bullion is typically 99.99% pure (four nines fine). Scientifically, gold can be refined even higher for electronic applications, but 99.99% is the practical ceiling for the bullion market."}},{"@type":"Question","name":"What does 916 mean on gold?","acceptedAnswer":{"@type":"Answer","text":"916 is the fineness stamp for 22K gold — indicating that 916 parts per thousand (91.6%) of the metal are pure gold. This is the standard for South Asian bridal gold and many world gold coins."}},{"@type":"Question","name":"Is 18K or 14K gold better?","acceptedAnswer":{"@type":"Answer","text":"Neither is objectively better — it depends on your priorities. 18K contains more gold (75% vs 58.3%), has richer colour, and is less likely to cause skin reactions. 14K is harder, more scratch-resistant, and significantly less expensive."}},{"@type":"Question","name":"How do I test gold purity at home?","acceptedAnswer":{"@type":"Answer","text":"The most reliable home methods are: (1) hallmark check with a magnifying glass, (2) magnet test with a neodymium magnet, (3) water density test, and (4) acid testing with a nitric acid kit. Using all four together gives a reliable indication. For definitive confirmation, professional XRF testing is the gold standard."}},{"@type":"Question","name":"What is the difference between karat and carat?","acceptedAnswer":{"@type":"Answer","text":"In the context of gold, karat (K) and carat (ct) mean exactly the same thing — a measurement of gold purity out of 24 parts. Carat is the spelling used in the UK, Australia, and parts of Europe; karat is used in the US and most other countries. The gem trade uses carat to mean a unit of gem weight (0.2 grams)."}},{"@type":"Question","name":"How is 22 carat gold purity percentage calculated?","acceptedAnswer":{"@type":"Answer","text":"22 ÷ 24 × 100 = 91.67%. Alternatively, the fineness figure of 916 can be read directly as 91.6%."}},{"@type":"Question","name":"What is white gold purity?","acceptedAnswer":{"@type":"Answer","text":"White gold purity is the same as its karat equivalent in yellow gold. 18K white gold is 75% pure gold — identical to 18K yellow gold. The only difference is the composition of the 25% alloy: whitening metals (palladium or platinum) replace the silver and copper used in yellow gold."}}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Gold Purity Guide"}]}</script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('consent', 'default', {'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
-<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
 <script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
 <script>
 (adsbygoogle = window.adsbygoogle || []).push({
   google_ad_client: "ca-pub-8849494330640880",
   enable_page_level_ads: true,
   overlays: {bottom: false},
-  vignette: {
-    new_triggers: false
-  }
+  vignette: { new_triggers: false }
 });
 </script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,700&display=swap" rel="stylesheet">
 <style>
-
 /* ── Guides mega panel — category links ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
@@ -64,221 +60,23 @@
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-serif:'Playfair Display','Georgia',serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
 [data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-/* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-
-
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:96px}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
-input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
-p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+:focus-visible{outline:2px solid var(--color-gold-bright);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
-@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-
-/* TICKER */
-.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
-.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
-.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
-.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
-.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
-.ticker:hover{animation-play-state:paused}
-@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
-.ticker-label{color:var(--color-text-muted)}
-.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
-.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
-@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important;scroll-behavior:auto!important}}
 
 /* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
-
-/* AD SLOTS */
-.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
-.ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
-
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
-
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
-
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
-
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
-
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
-
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
-
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
-
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
-
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
-
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
-
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
-#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-
-/* MEGA MENU */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
@@ -314,119 +112,406 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu.open{display:block;transform:translateX(0)}
 .mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
 .mobile-section{border-radius:var(--radius-md);overflow:hidden}
-.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s;min-height:44px}
 .mobile-section__toggle:hover{background:var(--color-surface-offset)}
 .mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
 .mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
 .mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
 .mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
 .mobile-section__items.open{display:flex}
-.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-sm);transition:color .12s,background .12s;min-height:40px;display:flex;align-items:center}
 .mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
 .mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
 .mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
-.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-md);min-height:44px;display:flex;align-items:center}
 .mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
 .mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
-.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+.mobile-menu__search input{width:100%;padding:12px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm);min-height:44px}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
+/* ═══════════════════════════════════════════════
+   GOLD PURITY GUIDE — ARTICLE DESIGN SYSTEM
+   Mobile-first · Dark/light adaptive · Editorial luxury
+═══════════════════════════════════════════════ */
 
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+/* READING PROGRESS */
+#gp-progress{position:fixed;top:0;left:0;height:3px;background:linear-gradient(90deg,#b07a00,#f0c040,#b07a00);width:0%;z-index:300;transition:width .1s linear;border-radius:0 2px 2px 0}
+[data-theme="dark"] #gp-progress{background:linear-gradient(90deg,#c8960a,#f5d060,#c8960a)}
+
+/* HERO */
+.gp-hero{position:relative;overflow:hidden;background:var(--color-bg);border-bottom:1px solid var(--color-border)}
+[data-theme="dark"] .gp-hero{background:radial-gradient(ellipse at top right,#1a1408 0%,#161208 30%,#0f0e0c 70%)}
+[data-theme="light"] .gp-hero{background:radial-gradient(ellipse at top right,#faf3e0 0%,#f7f1e1 30%,#f7f6f2 70%)}
+.gp-hero__bg{position:absolute;inset:0;pointer-events:none;overflow:hidden}
+.gp-hero__orb{position:absolute;border-radius:50%;filter:blur(90px);opacity:.2}
+.gp-hero__orb--1{width:560px;height:560px;top:-160px;right:-100px;background:radial-gradient(circle,#d19900,transparent 65%)}
+.gp-hero__orb--2{width:340px;height:340px;bottom:-100px;left:5%;background:radial-gradient(circle,#b07a00,transparent 70%);opacity:.14}
+[data-theme="light"] .gp-hero__orb{opacity:.1}
+.gp-hero__grid{position:absolute;inset:0;background-image:linear-gradient(rgba(208,153,0,.04) 1px,transparent 1px),linear-gradient(90deg,rgba(208,153,0,.04) 1px,transparent 1px);background-size:40px 40px;mask-image:radial-gradient(ellipse at center,black 30%,transparent 70%)}
+.gp-hero__content{position:relative;z-index:1;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-10)}
+@media(max-width:768px){.gp-hero__content{padding:var(--space-6) var(--space-4) var(--space-8)}}
+.gp-breadcrumb{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);color:var(--color-text-muted);flex-wrap:wrap;margin-bottom:var(--space-5)}
+.gp-breadcrumb a{color:var(--color-text-muted);text-decoration:none}
+.gp-breadcrumb a:hover{color:var(--color-gold-bright)}
+.gp-breadcrumb-sep{color:var(--color-border)}
+.gp-breadcrumb-current{color:var(--color-text-muted)}
+.gp-hero__tag{display:inline-flex;align-items:center;gap:8px;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright);margin-bottom:var(--space-4)}
+.gp-hero__tag::before{content:'';width:22px;height:2px;background:linear-gradient(90deg,transparent,var(--color-gold-bright));border-radius:1px}
+.gp-hero__tag-year{color:var(--color-text-muted);font-weight:600}
+.gp-hero__title{font-family:var(--font-serif);font-size:clamp(2rem,1.1rem + 4vw,4.25rem);font-weight:700;line-height:1.05;color:var(--color-text);margin-bottom:var(--space-5);max-width:20ch;letter-spacing:-.02em}
+.gp-hero__title em{font-style:italic;color:var(--color-gold-bright);font-weight:700}
+.gp-hero__title-range{display:inline-block;position:relative;font-weight:800}
+.gp-hero__title-range::after{content:'';position:absolute;bottom:.08em;left:0;right:0;height:.18em;background:linear-gradient(90deg,transparent,rgba(208,153,0,.35),transparent);z-index:-1;border-radius:2px}
+.gp-hero__lead{font-size:clamp(1rem,.95rem + .4vw,1.2rem);color:var(--color-text-muted);line-height:1.7;max-width:62ch;margin-bottom:var(--space-6)}
+.gp-hero__lead strong{color:var(--color-text);font-weight:600}
+.gp-hero__meta{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-8)}
+.gp-hero__meta a{color:var(--color-gold-bright);text-decoration:none}
+.gp-hero__meta a:hover{text-decoration:underline}
+.gp-hero__meta .meta-sep{color:var(--color-border)}
+
+/* HERO PURITY CARDS */
+.gp-hero__cards{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);max-width:720px}
+@media(min-width:640px){.gp-hero__cards{grid-template-columns:repeat(4,1fr);max-width:none}}
+.gp-hero__card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm);position:relative;overflow:hidden;transition:transform var(--transition),border-color var(--transition)}
+[data-theme="dark"] .gp-hero__card{background:rgba(22,21,19,.85);backdrop-filter:blur(10px);border-color:#2a2820}
+.gp-hero__card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 50%,var(--color-border));transform:translateY(-2px)}
+.gp-hero__card::after{content:'';position:absolute;bottom:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,var(--color-gold-bright),transparent);opacity:.6}
+.gp-hero__card-label{font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.gp-hero__card-value{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.1;letter-spacing:-.01em}
+.gp-hero__card-sub{font-size:.7rem;color:var(--color-text-muted);margin-top:3px}
+
+/* LAYOUT */
+.gp-layout{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr;gap:var(--space-8);align-items:start}
+@media(min-width:1024px){.gp-layout{grid-template-columns:260px 1fr;padding-top:var(--space-8);gap:var(--space-10)}}
+
+/* MOBILE TOC */
+.gp-toc-mobile{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4) 0}
+@media(min-width:1024px){.gp-toc-mobile{display:none}}
+.gp-toc-toggle{display:flex;align-items:center;gap:var(--space-2);width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);font-size:var(--text-sm);font-weight:600;color:var(--color-text);cursor:pointer;min-height:48px;transition:border-color var(--transition),background var(--transition)}
+.gp-toc-toggle:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset)}
+.gp-toc-toggle__icon{color:var(--color-gold-bright);flex-shrink:0}
+.gp-toc-chevron{margin-left:auto;transition:transform var(--transition);color:var(--color-text-muted)}
+.gp-toc-toggle[aria-expanded="true"] .gp-toc-chevron{transform:rotate(180deg);color:var(--color-gold-bright)}
+.gp-toc-nav--mobile{margin-top:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-3);box-shadow:var(--shadow-sm)}
+.gp-toc-nav--mobile ol{list-style:none;display:flex;flex-direction:column;gap:1px}
+.gp-toc-nav--mobile a{display:block;padding:10px 12px;font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);min-height:40px;transition:color var(--transition),background var(--transition)}
+.gp-toc-nav--mobile a:hover{color:var(--color-gold-bright);background:var(--color-surface-offset)}
+
+/* SIDEBAR TOC */
+.gp-sidebar{display:none}
+@media(min-width:1024px){.gp-sidebar{display:block}}
+.gp-toc{position:sticky;top:80px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);box-shadow:var(--shadow-sm);max-height:calc(100vh - 100px);overflow-y:auto}
+[data-theme="dark"] .gp-toc{background:rgba(22,21,19,.92);backdrop-filter:blur(14px)}
+.gp-toc__header{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-text-muted);margin-bottom:var(--space-4);padding-bottom:var(--space-3);border-bottom:1px solid var(--color-divider)}
+.gp-toc__header svg{color:var(--color-gold-bright)}
+.gp-toc__list{list-style:none;display:flex;flex-direction:column;gap:1px}
+.gp-toc__link{display:block;padding:8px 12px;font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);border-left:2px solid transparent;transition:color var(--transition),background var(--transition),border-color var(--transition);line-height:1.4}
+.gp-toc__link:hover{color:var(--color-gold-bright);background:var(--color-surface-offset);border-left-color:var(--color-gold-bright)}
+.gp-toc__link.active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 8%,transparent);font-weight:600}
+.gp-toc__spot{margin-top:var(--space-5);padding-top:var(--space-4);border-top:1px solid var(--color-divider);display:grid;grid-template-columns:1fr;gap:var(--space-2)}
+.gp-toc__spot-row{display:flex;justify-content:space-between;align-items:baseline;font-size:var(--text-xs);padding:6px 10px;background:var(--color-surface-offset);border-radius:var(--radius-md)}
+.gp-toc__spot-label{color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em;font-size:.65rem}
+.gp-toc__spot-value{font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;font-size:var(--text-sm)}
+
+/* ARTICLE */
+.gp-article{min-width:0}
+.gp-prose{display:flex;flex-direction:column;gap:var(--space-8)}
+.gp-prose h2{font-family:var(--font-serif);font-size:clamp(1.5rem,1.1rem + 1.5vw,2.25rem);font-weight:700;color:var(--color-text);margin-top:var(--space-2);padding-top:var(--space-6);border-top:1px solid var(--color-border);line-height:1.2;letter-spacing:-.01em;scroll-margin-top:80px}
+.gp-prose h2:first-of-type{border-top:none;margin-top:0;padding-top:0}
+.gp-prose h3{font-family:var(--font-serif);font-size:clamp(1.2rem,1rem + .7vw,1.5rem);font-weight:700;color:var(--color-text);margin-top:var(--space-2);line-height:1.3;letter-spacing:-.01em}
+.gp-prose p{font-size:var(--text-base);color:var(--color-text);line-height:1.78;max-width:72ch}
+.gp-prose strong{color:var(--color-text);font-weight:700}
+.gp-prose em{font-style:italic;color:var(--color-text)}
+.gp-prose ul,.gp-prose ol{padding-left:var(--space-5);display:flex;flex-direction:column;gap:var(--space-2)}
+.gp-prose li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;max-width:68ch}
+.gp-prose li::marker{color:var(--color-gold-bright)}
+.gp-prose a{color:var(--color-primary);text-decoration:underline;text-decoration-color:color-mix(in oklch,var(--color-primary) 40%,transparent);text-underline-offset:3px}
+.gp-prose a:hover{color:var(--color-primary-hover);text-decoration-color:var(--color-primary-hover)}
+
+/* DROP CAP for first paragraph */
+.gp-dropcap::first-letter{font-family:var(--font-serif);font-size:4.2em;line-height:.82;float:left;font-weight:700;color:var(--color-gold-bright);padding-right:var(--space-3);padding-top:var(--space-1);font-style:italic}
+
+/* PULL QUOTE */
+.gp-pullquote{border-left:3px solid var(--color-gold-bright);padding:var(--space-5) var(--space-6);background:color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface));border-radius:0 var(--radius-lg) var(--radius-lg) 0;position:relative}
+.gp-pullquote::before{content:'\201C';position:absolute;top:-8px;left:14px;font-family:var(--font-serif);font-size:3.5rem;color:var(--color-gold-bright);opacity:.4;line-height:1;font-style:italic}
+.gp-pullquote p{font-family:var(--font-serif);font-size:clamp(1.1rem,1rem + .5vw,1.35rem);color:var(--color-text);line-height:1.55;font-style:italic;max-width:60ch;margin:0}
+.gp-pullquote strong{color:var(--color-gold-bright);font-style:normal;font-weight:700}
+
+/* NOTE BOX */
+.gp-note{display:flex;gap:var(--space-3);align-items:flex-start;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5)}
+.gp-note__icon{flex-shrink:0;width:28px;height:28px;border-radius:50%;background:color-mix(in oklch,var(--color-primary) 15%,transparent);color:var(--color-primary);display:flex;align-items:center;justify-content:center;margin-top:1px}
+.gp-note p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+.gp-note strong{color:var(--color-text)}
+
+/* SYSTEM CARDS - Karat & Millesimal */
+.gp-systems{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:640px){.gp-systems{grid-template-columns:repeat(2,1fr)}}
+.gp-system{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);position:relative;overflow:hidden}
+.gp-system--karat{background:linear-gradient(155deg,color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface)),var(--color-surface));border-color:color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border))}
+.gp-system::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--color-gold-bright),transparent)}
+.gp-system__badge{display:inline-flex;align-items:center;gap:6px;font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-3);padding:3px 10px;background:color-mix(in oklch,var(--color-gold-bright) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,transparent);border-radius:var(--radius-full)}
+.gp-system__title{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.gp-system__body{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-4)}
+.gp-system__list{list-style:none;display:flex;flex-direction:column;gap:var(--space-2);padding:0}
+.gp-system__list li{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:10px 14px;background:var(--color-surface-offset);border-radius:var(--radius-md);font-size:var(--text-sm);max-width:none}
+.gp-system__list li::marker{content:''}
+.gp-system__list-key{font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.gp-system__list-val{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;font-size:var(--text-xs)}
+
+/* PURITY CHART TABLE */
+.gp-table-wrap{overflow-x:auto;border:1px solid var(--color-border);border-radius:var(--radius-xl);background:var(--color-surface);box-shadow:var(--shadow-sm);-webkit-overflow-scrolling:touch}
+.gp-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:600px}
+.gp-table thead tr{background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-offset))}
+.gp-table th{padding:var(--space-3) var(--space-4);text-align:left;font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);border-bottom:2px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));white-space:nowrap}
+.gp-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-border);color:var(--color-text);vertical-align:middle;font-variant-numeric:tabular-nums}
+.gp-table tbody tr{transition:background var(--transition)}
+.gp-table tbody tr:hover{background:var(--color-surface-offset)}
+.gp-table tbody tr:last-child td{border-bottom:none}
+.gp-table__row--featured{background:color-mix(in oklch,var(--color-gold-bright) 7%,var(--color-surface))!important}
+.gp-table__row--featured:hover{background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface))!important}
+.gp-table__karat{font-weight:700;color:var(--color-gold-bright);font-size:var(--text-base)}
+.gp-table__stamp{display:inline-block;font-family:var(--font-display);font-weight:700;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:2px 8px;font-size:var(--text-xs);color:var(--color-text)}
+.gp-table__pct{font-weight:600;color:var(--color-text);font-size:var(--text-sm)}
+.gp-table__bar{display:inline-block;height:6px;background:linear-gradient(90deg,#b07a00,#f0c040);border-radius:3px;margin-top:4px;min-width:6px;max-width:100%}
+.gp-table-note{font-size:var(--text-xs);color:var(--color-text-muted);font-style:italic;margin-top:var(--space-3);max-width:none}
+
+/* KARAT DEEP-DIVE CARDS */
+.gp-karat-detail{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;display:grid;grid-template-columns:1fr;transition:border-color var(--transition),box-shadow var(--transition)}
+.gp-karat-detail:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));box-shadow:var(--shadow-md)}
+@media(min-width:768px){.gp-karat-detail{grid-template-columns:240px 1fr}}
+.gp-karat-detail__visual{background:linear-gradient(135deg,var(--color-surface-offset),var(--color-surface-offset-2));padding:var(--space-5);display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;position:relative;overflow:hidden;border-bottom:1px solid var(--color-border)}
+@media(min-width:768px){.gp-karat-detail__visual{border-bottom:none;border-right:1px solid var(--color-border)}}
+.gp-karat-detail__visual::before{content:'';position:absolute;inset:0;background:radial-gradient(circle at 30% 30%,rgba(208,153,0,.15),transparent 60%);pointer-events:none}
+.gp-karat-disc{position:relative;width:120px;height:120px;border-radius:50%;display:flex;align-items:center;justify-content:center;margin-bottom:var(--space-3);box-shadow:0 8px 24px rgba(0,0,0,.15),inset 0 2px 8px rgba(255,255,255,.2)}
+.gp-karat-disc--24{background:radial-gradient(circle at 35% 35%,#fce181,#e8af34 50%,#a87800 100%)}
+.gp-karat-disc--22{background:radial-gradient(circle at 35% 35%,#fcdd72,#d8a020 50%,#a07000 100%)}
+.gp-karat-disc--18{background:radial-gradient(circle at 35% 35%,#f9d35a,#c8960a 50%,#8c6800 100%)}
+.gp-karat-disc--14{background:radial-gradient(circle at 35% 35%,#f5cd5a,#b88010 50%,#7c5800 100%)}
+.gp-karat-disc--10{background:radial-gradient(circle at 35% 35%,#e8c878,#a87a30 50%,#6c5418 100%)}
+.gp-karat-disc--9{background:radial-gradient(circle at 35% 35%,#dcbe85,#9c7338 50%,#604c1c 100%)}
+.gp-karat-disc__inner{position:absolute;inset:6px;border-radius:50%;background:inherit;display:flex;flex-direction:column;align-items:center;justify-content:center;box-shadow:inset 0 -2px 6px rgba(0,0,0,.2)}
+.gp-karat-disc__k{font-family:var(--font-serif);font-size:1.8rem;font-weight:800;color:rgba(0,0,0,.7);line-height:1;letter-spacing:-.02em;text-shadow:0 1px 0 rgba(255,255,255,.3)}
+.gp-karat-disc__lbl{font-size:.6rem;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:rgba(0,0,0,.55);margin-top:2px}
+.gp-karat-detail__pct{font-family:var(--font-serif);font-size:1.6rem;font-weight:700;color:var(--color-text);line-height:1;margin-top:var(--space-2)}
+.gp-karat-detail__pct-lbl{font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-top:4px}
+.gp-karat-detail__body{padding:var(--space-5) var(--space-6)}
+.gp-karat-detail__meta{display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-3)}
+.gp-karat-detail__chip{display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted)}
+.gp-karat-detail__chip--stamp{background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));color:var(--color-gold-bright)}
+.gp-karat-detail__title{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3);line-height:1.3}
+.gp-karat-detail__body p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-3);max-width:none}
+.gp-karat-detail__body strong{color:var(--color-text)}
+.gp-karat-detail__best{margin-top:var(--space-3);padding:var(--space-3) var(--space-4);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text);line-height:1.6}
+.gp-karat-detail__best strong{color:var(--color-gold-bright);font-weight:700;display:block;text-transform:uppercase;letter-spacing:.06em;font-size:var(--text-xs);margin-bottom:2px}
+
+/* GOLD COLOUR CARDS */
+.gp-colours{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:640px){.gp-colours{grid-template-columns:repeat(3,1fr)}}
+.gp-colour-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.gp-colour-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-2px)}
+.gp-colour-card__swatch{height:100px;position:relative;overflow:hidden}
+.gp-colour-card__swatch::after{content:'';position:absolute;inset:0;background:radial-gradient(ellipse at 30% 30%,rgba(255,255,255,.35),transparent 50%),radial-gradient(ellipse at 70% 70%,rgba(0,0,0,.15),transparent 50%)}
+.gp-colour-card__swatch--yellow{background:linear-gradient(135deg,#f5d060,#d19900 60%,#a87800)}
+.gp-colour-card__swatch--white{background:linear-gradient(135deg,#f8f7f3,#dcdad3 60%,#a8a69e)}
+.gp-colour-card__swatch--rose{background:linear-gradient(135deg,#f5cab1,#d99c7e 60%,#a87156)}
+.gp-colour-card__content{padding:var(--space-5)}
+.gp-colour-card__title{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
+.gp-colour-card__alloy{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.gp-colour-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+.gp-colour-card strong{color:var(--color-text)}
+
+/* REGION CARDS */
+.gp-regions{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:640px){.gp-regions{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:1024px){.gp-regions{grid-template-columns:repeat(3,1fr)}}
+.gp-region{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-3);transition:border-color var(--transition),box-shadow var(--transition)}
+.gp-region:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));box-shadow:var(--shadow-md)}
+.gp-region__header{display:flex;align-items:center;gap:var(--space-3);padding-bottom:var(--space-3);border-bottom:1px solid var(--color-divider)}
+.gp-region__flag{width:36px;height:36px;border-radius:50%;background:var(--color-surface-offset);border:1px solid var(--color-border);display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:1rem;color:var(--color-gold-bright)}
+.gp-region__name{font-weight:700;font-size:var(--text-base);color:var(--color-text);line-height:1.3}
+.gp-region__sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:2px}
+.gp-region__standard{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-md);font-weight:700;color:var(--color-gold-bright);font-size:var(--text-sm);align-self:flex-start}
+.gp-region p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none;flex:1}
+
+/* TEST STEPS */
+.gp-steps{display:flex;flex-direction:column;gap:var(--space-4)}
+.gp-step{display:flex;gap:var(--space-4);align-items:flex-start;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);position:relative;overflow:hidden;transition:border-color var(--transition)}
+.gp-step:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border))}
+.gp-step::before{content:'';position:absolute;top:0;left:0;bottom:0;width:3px;background:linear-gradient(to bottom,var(--color-gold-bright),transparent)}
+.gp-step__num{flex-shrink:0;width:44px;height:44px;border-radius:50%;background:linear-gradient(135deg,var(--color-gold-bright),#b07a00);color:#1a1207;font-weight:700;font-size:var(--text-base);font-family:var(--font-serif);display:flex;align-items:center;justify-content:center;margin-top:2px;box-shadow:0 4px 12px rgba(208,153,0,.25),inset 0 1px 0 rgba(255,255,255,.3)}
+.gp-step__content{flex:1;min-width:0;display:flex;flex-direction:column;gap:var(--space-2)}
+.gp-step__title{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-text);line-height:1.3;margin:0}
+.gp-step__needs{font-size:var(--text-xs);color:var(--color-text-muted);padding:6px 12px;background:var(--color-surface-offset);border-radius:var(--radius-md);font-weight:500;align-self:flex-start;border:1px solid var(--color-border)}
+.gp-step__needs strong{color:var(--color-text);font-weight:700}
+.gp-step__content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0;max-width:none}
+.gp-step__content strong{color:var(--color-text)}
+.gp-step__limitation{font-size:var(--text-xs);color:var(--color-text-muted);font-style:italic;padding:var(--space-3);background:color-mix(in oklch,#f87171 5%,var(--color-surface-offset));border-left:2px solid color-mix(in oklch,#f87171 50%,transparent);border-radius:0 var(--radius-md) var(--radius-md) 0;line-height:1.6}
+.gp-step__limitation strong{color:var(--color-text);font-style:normal}
+.gp-step__stamps{display:flex;flex-wrap:wrap;gap:6px;margin-top:var(--space-1)}
+.gp-step__stamp{display:inline-flex;align-items:center;padding:4px 10px;background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);font-family:var(--font-display)}
+
+/* HOUSEHOLD TESTS GRID */
+.gp-household{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:640px){.gp-household{grid-template-columns:repeat(2,1fr)}}
+.gp-household__item{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4)}
+.gp-household__title{display:flex;align-items:center;gap:var(--space-2);font-weight:700;color:var(--color-text);font-size:var(--text-sm);margin-bottom:var(--space-2)}
+.gp-household__rating{display:inline-flex;align-items:center;padding:2px 8px;border-radius:var(--radius-full);font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;margin-left:auto}
+.gp-household__rating--ok{background:color-mix(in oklch,#facc15 12%,transparent);color:#8a6d00;border:1px solid color-mix(in oklch,#facc15 25%,transparent)}
+[data-theme="dark"] .gp-household__rating--ok{color:#facc15}
+.gp-household__rating--bad{background:color-mix(in oklch,#f87171 12%,transparent);color:#c8534e;border:1px solid color-mix(in oklch,#f87171 25%,transparent)}
+[data-theme="dark"] .gp-household__rating--bad{color:#f87171}
+.gp-household__item p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+
+/* PROFESSIONAL METHOD CARDS */
+.gp-method{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;display:grid;grid-template-columns:1fr;transition:border-color var(--transition),box-shadow var(--transition)}
+.gp-method:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));box-shadow:var(--shadow-md)}
+@media(min-width:768px){.gp-method{grid-template-columns:200px 1fr}}
+.gp-method--featured{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));background:color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface))}
+.gp-method__visual{background:linear-gradient(135deg,var(--color-surface-offset),var(--color-surface-offset-2));padding:var(--space-5);display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:var(--space-2);border-bottom:1px solid var(--color-border)}
+@media(min-width:768px){.gp-method__visual{border-bottom:none;border-right:1px solid var(--color-border)}}
+.gp-method--featured .gp-method__visual{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset)),var(--color-surface-offset-2))}
+.gp-method__icon{width:64px;height:64px;border-radius:50%;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));display:flex;align-items:center;justify-content:center;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.gp-method__abbr{font-family:var(--font-serif);font-size:1.5rem;font-weight:700;color:var(--color-text);line-height:1}
+.gp-method__type{font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright)}
+.gp-method__body{padding:var(--space-5) var(--space-6)}
+.gp-method__title{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3);line-height:1.3}
+.gp-method__body p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-3);max-width:none}
+.gp-method__body strong{color:var(--color-text)}
+.gp-method__advantages{margin-top:var(--space-3);padding:var(--space-3) var(--space-4);background:color-mix(in oklch,#4ade80 5%,var(--color-surface-offset));border:1px solid color-mix(in oklch,#4ade80 15%,var(--color-border));border-radius:var(--radius-md)}
+.gp-method__advantages-title{display:flex;align-items:center;gap:6px;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:#1d7a47;margin-bottom:var(--space-2)}
+[data-theme="dark"] .gp-method__advantages-title{color:#4ade80}
+.gp-method__advantages ul{list-style:none;padding:0;display:flex;flex-direction:column;gap:4px}
+.gp-method__advantages li{font-size:var(--text-xs);color:var(--color-text);line-height:1.6;padding-left:18px;position:relative;max-width:none}
+.gp-method__advantages li::before{content:'';position:absolute;left:0;top:7px;width:10px;height:10px;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2322c55e' stroke-width='3'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");background-size:contain;background-repeat:no-repeat}
+
+/* DECISION MATRIX */
+.gp-decision{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:640px){.gp-decision{grid-template-columns:repeat(2,1fr)}}
+.gp-decision__card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-3);position:relative;overflow:hidden;transition:border-color var(--transition),box-shadow var(--transition)}
+.gp-decision__card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));box-shadow:var(--shadow-md)}
+.gp-decision__card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px}
+.gp-decision__card:nth-child(1)::before{background:linear-gradient(90deg,#fce181,#d19900)}
+.gp-decision__card:nth-child(2)::before{background:linear-gradient(90deg,#c8960a,#8c6800)}
+.gp-decision__card:nth-child(3)::before{background:linear-gradient(90deg,#a87a30,#604c1c)}
+.gp-decision__card:nth-child(4)::before{background:linear-gradient(90deg,#60a5fa,#3b82f6)}
+.gp-decision__card:nth-child(5)::before{background:linear-gradient(90deg,#a78bfa,#8b5cf6)}
+.gp-decision__card:nth-child(6)::before{background:linear-gradient(90deg,#22d3ee,#06b6d4)}
+.gp-decision__purpose{font-size:.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted)}
+.gp-decision__rec{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-text);line-height:1.3}
+.gp-decision__rec strong{color:var(--color-gold-bright)}
+.gp-decision__card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+
+/* COINS GRID */
+.gp-coins{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:640px){.gp-coins{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:1024px){.gp-coins{grid-template-columns:repeat(2,1fr)}}
+.gp-coin{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4) var(--space-5);display:grid;grid-template-columns:auto 1fr auto;gap:var(--space-3);align-items:center;transition:border-color var(--transition)}
+.gp-coin:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border))}
+.gp-coin__icon{width:48px;height:48px;border-radius:50%;flex-shrink:0;box-shadow:inset 0 -2px 4px rgba(0,0,0,.15),inset 0 1px 2px rgba(255,255,255,.3),0 2px 6px rgba(0,0,0,.1);position:relative;overflow:hidden;display:flex;align-items:center;justify-content:center}
+.gp-coin__icon--24{background:radial-gradient(circle at 35% 30%,#fce181,#e8af34 55%,#a87800)}
+.gp-coin__icon--22{background:radial-gradient(circle at 35% 30%,#f5cd5a,#c8960a 55%,#8c6800)}
+.gp-coin__icon::after{content:'';position:absolute;inset:6px;border-radius:50%;border:1px solid rgba(0,0,0,.15)}
+.gp-coin__icon-text{font-family:var(--font-serif);font-size:.7rem;font-weight:800;color:rgba(0,0,0,.7);letter-spacing:-.02em;text-shadow:0 1px 0 rgba(255,255,255,.3);z-index:1;position:relative}
+.gp-coin__info{min-width:0}
+.gp-coin__name{font-weight:700;color:var(--color-text);font-size:var(--text-sm);line-height:1.3;margin-bottom:2px}
+.gp-coin__country{font-size:var(--text-xs);color:var(--color-text-muted)}
+.gp-coin__purity{font-family:var(--font-display);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;font-size:var(--text-sm);background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-md);padding:4px 10px;text-align:center;line-height:1.2;display:flex;flex-direction:column;gap:1px;min-width:50px}
+.gp-coin__karat{font-size:.65rem;color:var(--color-text-muted);font-weight:600}
+
+/* CALCULATION CALLOUT */
+.gp-calc{background:linear-gradient(155deg,color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface)),var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-5) var(--space-6);position:relative;overflow:hidden}
+.gp-calc::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--color-gold-bright),transparent)}
+.gp-calc__title{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.gp-calc__formula{font-family:var(--font-display);font-size:var(--text-base);color:var(--color-text);background:var(--color-surface-offset);padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-align:center;line-height:1.6;margin-bottom:var(--space-3);overflow-x:auto;white-space:nowrap}
+.gp-calc__formula strong{color:var(--color-gold-bright);font-weight:700}
+.gp-calc__example{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0;max-width:none}
+.gp-calc__example strong{color:var(--color-text);font-weight:700}
+.gp-calc__result{display:inline-block;font-weight:700;color:var(--color-gold-bright);font-size:var(--text-base);background:color-mix(in oklch,var(--color-gold-bright) 8%,transparent);padding:2px 10px;border-radius:var(--radius-md);font-variant-numeric:tabular-nums}
+
+/* CTA BOX */
+.gp-cta{background:linear-gradient(155deg,color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface)),var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-6) var(--space-6) var(--space-6);position:relative;overflow:hidden;display:grid;grid-template-columns:1fr;gap:var(--space-4);align-items:center}
+@media(min-width:640px){.gp-cta{grid-template-columns:1fr auto;padding:var(--space-6) var(--space-8)}}
+.gp-cta::after{content:'';position:absolute;top:-50px;right:-50px;width:200px;height:200px;background:radial-gradient(circle,rgba(208,153,0,.18),transparent 70%);border-radius:50%;pointer-events:none}
+.gp-cta__content{position:relative;z-index:1}
+.gp-cta__title{font-family:var(--font-serif);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2);line-height:1.25}
+.gp-cta__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:60ch}
+.gp-cta__btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-3) var(--space-5);background:var(--color-gold-bright);color:#1a1207;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;text-decoration:none;white-space:nowrap;transition:transform var(--transition),box-shadow var(--transition);min-height:44px;justify-content:center;position:relative;z-index:1;box-shadow:0 4px 14px rgba(208,153,0,.25)}
+.gp-cta__btn:hover{transform:translateY(-1px);box-shadow:0 6px 20px rgba(208,153,0,.35);color:#1a1207;text-decoration:none}
+
+/* FAQ ACCORDION */
+.gp-faq{display:flex;flex-direction:column;border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;background:var(--color-surface)}
+.gp-faq__item{border-bottom:1px solid var(--color-border)}
+.gp-faq__item:last-child{border-bottom:none}
+.gp-faq__question{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);width:100%;padding:var(--space-4) var(--space-5);text-align:left;font-size:var(--text-base);font-weight:600;color:var(--color-text);background:none;cursor:pointer;transition:background var(--transition),color var(--transition);min-height:60px;font-family:var(--font-body);border:none}
+.gp-faq__question:hover{background:var(--color-surface-offset)}
+.gp-faq__question[aria-expanded="true"]{color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface))}
+.gp-faq__chevron{flex-shrink:0;transition:transform var(--transition);color:var(--color-text-muted)}
+.gp-faq__question[aria-expanded="true"] .gp-faq__chevron{transform:rotate(180deg);color:var(--color-gold-bright)}
+.gp-faq__answer{padding:0 var(--space-5) var(--space-5)}
+.gp-faq__answer p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.75;max-width:none;margin:0}
+.gp-faq__answer strong{color:var(--color-text);font-weight:700}
+
+/* VALUE TABLE - PROGRESS BAR STYLE */
+.gp-value-table{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.gp-value-row{display:grid;grid-template-columns:60px 1fr 90px;gap:var(--space-3);align-items:center;padding:var(--space-2) 0;font-size:var(--text-sm)}
+@media(max-width:480px){.gp-value-row{grid-template-columns:50px 1fr 80px;gap:var(--space-2)}}
+.gp-value-row__karat{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);line-height:1}
+.gp-value-row__bar-wrap{height:14px;background:var(--color-surface-offset);border-radius:var(--radius-full);overflow:hidden;border:1px solid var(--color-border);position:relative}
+.gp-value-row__bar{height:100%;background:linear-gradient(90deg,#b07a00,#d19900,#f0c040);border-radius:var(--radius-full);position:relative;display:flex;align-items:center;padding-left:10px;color:#1a1207;font-size:.7rem;font-weight:700;transition:width .6s cubic-bezier(.16,1,.3,1)}
+.gp-value-row__bar-pct{position:absolute;left:10px;color:#1a1207;font-weight:700;font-size:.7rem;line-height:14px;letter-spacing:.02em;white-space:nowrap}
+.gp-value-row__price{font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;font-size:var(--text-sm);text-align:right}
+.gp-value-table__caption{display:flex;justify-content:space-between;align-items:center;padding:6px 0 var(--space-3);margin-bottom:var(--space-1);border-bottom:1px solid var(--color-divider);font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted)}
+.gp-value-table__live{color:var(--color-gold-bright);font-weight:700}
+.gp-value-table__live::before{content:'';display:inline-block;width:6px;height:6px;border-radius:50%;background:#4ade80;margin-right:6px;animation:gp-pulse 2s ease-in-out infinite;vertical-align:1px}
+@keyframes gp-pulse{0%,100%{opacity:1}50%{opacity:.4}}
+
+/* DISCLAIMER */
+.gp-disclaimer{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-2);font-style:italic}
+.gp-disclaimer strong{color:var(--color-text);font-style:normal}
+
+/* SHARE */
+.gp-share{border-top:1px solid var(--color-border);padding-top:var(--space-5);margin-top:var(--space-2)}
+.gp-share__label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-3)}
+.gp-share__buttons{display:flex;flex-wrap:wrap;gap:var(--space-2)}
+.gp-share__btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);border:1px solid var(--color-border);border-radius:var(--radius-full);background:var(--color-surface);color:var(--color-text-muted);font-size:var(--text-sm);font-weight:500;text-decoration:none;min-height:40px;transition:border-color var(--transition),color var(--transition)}
+.gp-share__btn:hover{border-color:var(--color-primary);color:var(--color-primary);text-decoration:none}
+
+/* RELATED */
+.gp-related{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4)}
+.gp-related__header{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:var(--space-6);flex-wrap:wrap;gap:var(--space-3)}
+.gp-related__title{font-family:var(--font-serif);font-size:clamp(1.5rem,1.2rem + 1.2vw,2rem);font-weight:700;color:var(--color-text);letter-spacing:-.01em}
+.gp-related__all{font-size:var(--text-sm);color:var(--color-gold-bright);font-weight:600;text-decoration:none}
+.gp-related__all:hover{text-decoration:underline}
+.gp-related__grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:var(--space-4)}
+.gp-related__card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.gp-related__card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-md);text-decoration:none}
+.gp-related__card-tag{display:inline-block;font-size:.65rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.gp-related__card-title{font-family:var(--font-serif);font-weight:700;font-size:var(--text-base);color:var(--color-text);margin-bottom:var(--space-2);line-height:1.3}
+.gp-related__card-desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
 /* FOOTER */
-.footer-brand-col{max-width:260px}
+.gp-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0 var(--space-4)}
+.gp-footer__inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:grid;grid-template-columns:1fr;gap:var(--space-6)}
+@media(min-width:768px){.gp-footer__inner{grid-template-columns:1.4fr repeat(3,1fr);gap:var(--space-6)}}
+@media(min-width:1024px){.gp-footer__inner{grid-template-columns:1.4fr repeat(5,1fr)}}
+.gp-footer__brand-col{min-width:0;max-width:320px}
+.gp-footer__brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-top:var(--space-3);max-width:40ch}
+.gp-footer__brand-note{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)}
+.gp-footer__col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.gp-footer__col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.gp-footer__col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color var(--transition)}
+.gp-footer__col a:hover{color:var(--color-gold-bright)}
+.gp-footer__bottom{max-width:1200px;margin:var(--space-6) auto 0;padding:var(--space-4) var(--space-4) 0;border-top:1px solid var(--color-divider);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2);font-size:var(--text-xs);color:var(--color-text-faint)}
 
-
-
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
-.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
-
-
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
-
-
-/* ── ARTICLE LAYOUT FIX (batch applied) ── */
-.breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
-.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
-.breadcrumb a:hover{color:var(--color-primary)}
-.breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.article-wrap{max-width:1200px;margin:0 auto;padding:var(--space-6) var(--space-4) var(--space-16)}
-.article-tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-article.article-wrap .article-title,h1.article-title{font-family:var(--font-display)!important;font-size:clamp(1.75rem,3.5vw,2.75rem)!important;font-weight:700!important;line-height:1.15!important;margin:var(--space-2) 0 var(--space-5)!important;color:var(--color-text)!important}
-.article-byline{font-size:var(--text-sm);color:var(--color-text-muted);display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin-bottom:var(--space-6);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
-.article-byline a{color:var(--color-primary);text-decoration:none;font-weight:500}
-.article-byline a:hover{text-decoration:underline}
-.prose{max-width:860px}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose em{font-style:italic}
-.prose table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
-.prose table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-3) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.prose table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.prose table tr:last-child td{border-bottom:none}
-.prose table td:first-child,.prose table th:first-child{padding-left:0;color:var(--color-text)}
-.ad-slot{min-height:0!important;margin:var(--space-2) 0}
-.ad-slot:not(:has(ins[data-ad-status])){border:none!important;background:none!important;padding:0!important;min-height:0!important;margin:0!important}
-.cta-box{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-8) 0}
-.cta-box h3{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:0 0 var(--space-2)}
-.cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-4)}
-.cta-btn{display:inline-flex;align-items:center;gap:var(--space-1);padding:var(--space-2) var(--space-5);background:var(--color-primary);color:#fff;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none;transition:background .15s}
-.cta-btn:hover{background:var(--color-primary-hover);color:#fff}
-.disclaimer-box{background:var(--color-surface-alt,#f4f3ef);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
-.disclaimer-box strong{color:var(--color-text);font-weight:700}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin-top:var(--space-4)}
-
-/* Share buttons */
-.share-buttons{display:flex;flex-wrap:wrap;gap:var(--space-2);margin:var(--space-6) 0}
-.share-btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);border:1px solid var(--color-border);border-radius:var(--radius-full);background:var(--color-surface);color:var(--color-text-muted);font-size:var(--text-sm);font-weight:500;text-decoration:none;transition:border-color .15s,color .15s;white-space:nowrap}
-.share-btn:hover{border-color:var(--color-primary);color:var(--color-primary)}
-/* Related Guides */
-.related-guides-section{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4)}
-.related-guides-section>h2{font-family:var(--font-display);font-size:var(--text-xl);margin-bottom:var(--space-6)}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:var(--space-4)}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,transform .15s}
-.related-card:hover{border-color:var(--color-primary);transform:translateY(-2px)}
-.related-card__tag{display:inline-block;font-size:.65rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-primary);margin-bottom:var(--space-2)}
-.related-card__title{font-weight:700;font-size:var(--text-base);color:var(--color-text);margin-bottom:var(--space-2)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.5}
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 </style>
-
 <link rel="stylesheet" href="/assets/site.css">
-<!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
 </head>
 <body>
+<div id="gp-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Reading progress"></div>
+
 <nav class="site-nav" role="navigation" aria-label="Main navigation">
   <div class="nav-inner">
     <a href="/" class="nav-logo" aria-label="GoldPriceTools Home">
@@ -435,7 +520,7 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
     </a>
     <ul class="mega-nav" role="menubar">
       <li class="mega-nav__item" role="none">
-        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Gold Prices <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
+        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Gold Prices <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Gold Prices">
           <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/gold-silver-ratio">Gold / Silver Ratio</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">By Karat</span><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></div>
@@ -443,21 +528,21 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
         </div>
       </li>
       <li class="mega-nav__item" role="none">
-        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Calculators <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
+        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Calculators <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Calculators">
           <div class="mega-panel__col"><span class="mega-panel__heading">Gold Tools</span><a href="/scrap-gold-calculator">Scrap Gold Calculator</a><a href="/gold-bar-value">Gold Bar Value</a><a href="/gold-coins-vs-bars">Gold Coins vs Bars</a><a href="/guides/how-much-is-a-gold-ring-worth">Gold Ring Worth</a><a href="/gold-silver-test-kit-reviews">Testing Kit Reviews</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Special Tools</span><a href="/zakat-gold-silver-calculator">Zakat Calculator</a><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a><a href="/best-gold-ira-companies">Best Gold IRA Companies</a><a href="/where-to-sell-gold-silver">Where to Sell Gold</a></div>
         </div>
       </li>
       <li class="mega-nav__item" role="none">
-        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
+        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Silver <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Silver">
           <div class="mega-panel__col"><span class="mega-panel__heading">Live Prices</span><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Calculators &amp; Guides</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/what-is-925-sterling-silver">925 Sterling Silver</a><a href="/guides/silver-price-guide">Silver Price Guide</a><a href="/guides/silver-price-per-gram-explained">Silver Per Gram Explained</a></div>
         </div>
       </li>
       <li class="mega-nav__item mega-nav__item--wide" role="none">
-        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Guides <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
+        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Guides <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel mega-panel--wide" role="menu" aria-label="Guides">
           <div class="mega-panel__col"><a href="/guides/buying-investing/" class="mega-panel__category-link"><span class="mega-panel__cat-title">Buying &amp; Investing</span><span class="mega-panel__cat-desc">Bullion, ETFs, IRA &amp; more</span></a></div>
           <div class="mega-panel__col"><a href="/guides/selling-testing/" class="mega-panel__category-link"><span class="mega-panel__cat-title">Selling &amp; Testing</span><span class="mega-panel__cat-desc">Value, sell &amp; test your gold</span></a></div>
@@ -468,7 +553,7 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
         </div>
       </li>
       <li class="mega-nav__item" role="none">
-        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Blog <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
+        <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Blog <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel mega-panel--blog" role="menu" aria-label="Blog">
           <div class="mega-panel__col mega-panel__col--blog"><span class="mega-panel__heading">Latest Articles</span><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers 2026</a><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026?</a><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a><a href="/blog/" class="mega-panel__view-all">View All Articles &rarr;</a></div>
         </div>
@@ -478,176 +563,1002 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
       </li>
     </ul>
     <div class="nav-actions">
-      <button class="theme-toggle" data-theme-toggle aria-label="Toggle dark mode"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
+      <button class="theme-toggle" data-theme-toggle aria-label="Toggle dark mode"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
       <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false"><span></span><span></span><span></span></button>
     </div>
   </div>
   <div class="mobile-menu" id="mobileMenu" role="dialog" aria-label="Mobile navigation" aria-modal="true">
     <div class="mobile-menu__inner">
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Gold Prices</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/gold-silver-ratio">Gold / Silver Ratio</a><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></div></div>
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Calculators</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/scrap-gold-calculator">Scrap Gold Calculator</a><a href="/gold-bar-value">Gold Bar Value</a><a href="/gold-coins-vs-bars">Gold Coins vs Bars</a><a href="/zakat-gold-silver-calculator">Zakat Calculator</a><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a><a href="/where-to-sell-gold-silver">Where to Sell Gold</a><a href="/best-gold-ira-companies">Best Gold IRA Companies</a></div></div>
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Silver</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/silver-price-guide">Silver Price Guide</a></div></div>
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Guides</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/guides/buying-investing/">Buying &amp; Investing</a><a href="/guides/selling-testing/">Selling &amp; Testing</a><a href="/guides/market-prices/">Market &amp; Prices</a><a href="/guides/silver-guides/">Silver Guides</a><a href="/guides/deep-dives/">Deep Dives</a><a href="/guides/">Browse All Guides</a></div></div>
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Blog</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers 2026</a><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026?</a><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a><a href="/blog/" class="mobile-view-all">All Articles &rarr;</a></div></div>
+      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Gold Prices</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/gold-silver-ratio">Gold / Silver Ratio</a><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></div></div>
+      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Calculators</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/scrap-gold-calculator">Scrap Gold Calculator</a><a href="/gold-bar-value">Gold Bar Value</a><a href="/gold-coins-vs-bars">Gold Coins vs Bars</a><a href="/zakat-gold-silver-calculator">Zakat Calculator</a><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a><a href="/where-to-sell-gold-silver">Where to Sell Gold</a><a href="/best-gold-ira-companies">Best Gold IRA Companies</a></div></div>
+      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Silver</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/silver-price-guide">Silver Price Guide</a></div></div>
+      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Guides</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/guides/buying-investing/">Buying &amp; Investing</a><a href="/guides/selling-testing/">Selling &amp; Testing</a><a href="/guides/market-prices/">Market &amp; Prices</a><a href="/guides/silver-guides/">Silver Guides</a><a href="/guides/deep-dives/">Deep Dives</a><a href="/guides/">Browse All Guides</a></div></div>
+      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Blog</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers 2026</a><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026?</a><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a><a href="/blog/" class="mobile-view-all">All Articles &rarr;</a></div></div>
       <div class="mobile-section mobile-section--flat"><a href="/about">About</a><a href="/contact">Contact</a><a href="/editorial-standards/">Editorial Standards</a></div>
       <div class="mobile-menu__search"><form action="/" method="GET"><input type="search" name="q" placeholder="Search GoldPriceTools..." aria-label="Search site"></form></div>
     </div>
   </div>
 </nav>
 
-<div class="breadcrumb-wrap">
-  <ol class="breadcrumb" aria-label="Breadcrumb">
-    <li><a href="/">Home</a></li>
-    <li><a href="/guides/">Guides</a></li>
-    <li aria-current="page">Gold Purity Guide</li>
-  </ol>
-</div>
-
-<article class="article-wrap" itemscope itemtype="https://schema.org/Article">
-  <div class="article-tag">Buyer's Guide</div>
-  <h1 class="article-title" itemprop="headline">Gold Purity Guide: 9K to 24K Explained</h1>
-  <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
-    <span>&middot;</span>
-    <span>Published <time datetime="2026-05-17" itemprop="datePublished">24 April 2026</time></span>
-    <span>&middot;</span>
-    <span>Updated <time datetime="2026-05-17" itemprop="dateModified">25 April 2026</time></span>
+<!-- ═══ HERO ═══ -->
+<section class="gp-hero">
+  <div class="gp-hero__bg" aria-hidden="true">
+    <div class="gp-hero__grid"></div>
+    <div class="gp-hero__orb gp-hero__orb--1"></div>
+    <div class="gp-hero__orb gp-hero__orb--2"></div>
   </div>
-
-  <div class="prose">
-    <p>Gold is rarely found in its pure form in everyday jewellery and products. Instead, pure gold is combined with other metals to create alloys with varying purity levels, hardness, and colour. The purity of gold is expressed in <strong>karats (K)</strong>, a scale from 0 to 24, where 24K represents pure gold. This guide explains every karat you are likely to encounter.</p>
-
-    <h2>How the Karat System Works</h2>
-    <p>The karat number tells you how many parts out of 24 are pure gold. For example, 18K gold contains 18 parts gold and 6 parts other metals (such as copper, silver, or zinc), giving it a purity of 75%. This ratio directly affects both the gold&rsquo;s colour, hardness, and its melt value when selling as scrap.</p>
-
-    <table class="data-table" aria-label="Gold purity by karat">
-      <thead>
-        <tr><th>Karat</th><th>Purity %</th><th>Hallmark (UK)</th><th>Common Use</th></tr>
-      </thead>
-      <tbody>
-        <tr><td>24K</td><td>99.9%</td><td>999</td><td>Bullion bars &amp; coins</td></tr>
-        <tr><td>22K</td><td>91.7%</td><td>916</td><td>Indian jewellery, coins</td></tr>
-        <tr><td>18K</td><td>75.0%</td><td>750</td><td>Fine European jewellery</td></tr>
-        <tr><td>14K</td><td>58.3%</td><td>585</td><td>US &amp; European jewellery</td></tr>
-        <tr><td>10K</td><td>41.7%</td><td>417</td><td>US budget jewellery</td></tr>
-        <tr><td>9K</td><td>37.5%</td><td>375</td><td>UK budget jewellery</td></tr>
-      </tbody>
-    </table>
-
-    <h2>Reading UK Hallmarks</h2>
-    <p>In the United Kingdom, gold items must be hallmarked by an Assay Office if they are to be sold as gold. The hallmark contains four elements: a maker&rsquo;s mark, a fineness mark (the three-digit number indicating purity), an Assay Office mark, and a date letter. You may also see a crown symbol on pre-2000 items.</p>
-    <p>The fineness mark is the most important number for scrap value purposes. Look for <strong>375</strong> (9K), <strong>585</strong> (14K), <strong>750</strong> (18K), or <strong>916</strong> (22K) stamped into the metal.</p>
-
-    <h2>24K Gold &mdash; Pure Gold</h2>
-    <p>24K gold is 99.9% pure gold. It has a distinctive deep yellow colour and is extremely soft, making it unsuitable for most jewellery that will be worn regularly. It is primarily used for investment bullion (bars and coins) and some high-end Asian jewellery markets where purity is culturally important. Marked as <strong>999</strong>.</p>
-
-    <h2>22K Gold &mdash; Coin and Indian Jewellery Standard</h2>
-    <p>22K gold (91.67% pure) is the standard for Indian fine jewellery and many sovereign gold coins (including the UK Sovereign). The small percentage of alloy makes it marginally harder than 24K while retaining its rich deep yellow colour. Marked as <strong>916</strong>.</p>
-
-    <h2>18K Gold &mdash; European Fine Jewellery Standard</h2>
-    <p>18K gold (75% pure) is the most widely used karat in European fine jewellery. It offers an excellent balance of gold content, rich colour, and durability. Engagement rings and luxury watches frequently use 18K. Marked as <strong>750</strong>.</p>
-
-    <h2>14K Gold &mdash; US and Export Standard</h2>
-    <p>14K gold (58.33% pure) is the most popular karat in the United States and is widely used in mass-market jewellery globally. It is significantly more durable than 18K and more affordable, though its colour is slightly paler. Marked as <strong>585</strong>.</p>
-
-    <h2>10K Gold &mdash; US Minimum Legal Standard</h2>
-    <p>10K gold (41.67% pure) is the minimum purity that can legally be sold as &ldquo;gold&rdquo; in the United States under Federal Trade Commission guidelines. It is the most affordable gold alloy, highly durable, but noticeably less rich in colour than higher karats. Marked as <strong>417</strong>.</p>
-
-    <h2>9K Gold &mdash; UK and EU Minimum</h2>
-    <p>9K gold (37.5% pure) is the minimum legal standard in the United Kingdom and is widely used in affordable British jewellery. It contains more alloy than gold, giving it a paler yellow colour. It is, however, extremely durable and affordable. Marked as <strong>375</strong>.</p>
-
-    <div class="callout">
-      <p><strong>Note on &ldquo;Gold-Plated&rdquo;:</strong> Gold-plated items have a very thin layer of gold over a base metal. They are not gold alloys and carry negligible gold value for scrap purposes. Look for a &ldquo;GP&rdquo;, &ldquo;GF&rdquo; (gold-filled), or &ldquo;RGP&rdquo; (rolled gold plate) stamp to identify plated items.</p>
+  <div class="gp-hero__content">
+    <nav class="gp-breadcrumb" aria-label="Breadcrumb">
+      <a href="/">Home</a>
+      <span class="gp-breadcrumb-sep" aria-hidden="true">/</span>
+      <a href="/guides/">Guides</a>
+      <span class="gp-breadcrumb-sep" aria-hidden="true">/</span>
+      <span class="gp-breadcrumb-current" aria-current="page">Gold Purity Guide</span>
+    </nav>
+    <div class="gp-hero__tag">Buyer&rsquo;s Guide &middot; <span class="gp-hero__tag-year">2026 Edition</span></div>
+    <h1 class="gp-hero__title">Gold Purity Guide: <span class="gp-hero__title-range">9K to 24K</span> <em>Explained</em></h1>
+    <p class="gp-hero__lead">Pick up a piece of gold jewellery and the first question is deceptively simple: <strong>how much gold is actually in this?</strong> The answer lives inside a small stamped number &mdash; a hallmark that tells you everything about composition, value, durability, and even colour.</p>
+    <div class="gp-hero__meta">
+      <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
+      <span class="meta-sep" aria-hidden="true">&middot;</span>
+      <span>Published <time datetime="2026-04-24">24 April 2026</time></span>
+      <span class="meta-sep" aria-hidden="true">&middot;</span>
+      <span>Updated <time datetime="2026-05-17">17 May 2026</time></span>
+      <span class="meta-sep" aria-hidden="true">&middot;</span>
+      <span>15 min read</span>
     </div>
-
-    <h2>Which Karat Is Right for You?</h2>
-    <ul>
-      <li><strong>Investment / maximum value:</strong> 24K bullion bars or coins</li>
-      <li><strong>Fine jewellery / European standard:</strong> 18K</li>
-      <li><strong>Everyday US jewellery / durability:</strong> 14K</li>
-      <li><strong>Budget jewellery / maximum hardness:</strong> 10K (US) or 9K (UK)</li>
-    </ul>
-  </div><!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
-      <a class="share-btn" href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/gold-purity-guide&text=Gold+Purity+Guide+%E2%80%94+Karats%2C+Hallmarks+%26+What+They+Mean" target="_blank" rel="noopener noreferrer">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.737-8.835L1.254 2.25H8.08l4.259 5.631 5.905-5.631zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-        X
-      </a>
-      <a class="share-btn" href="https://www.reddit.com/submit?url=https://goldpricetools.com/guides/gold-purity-guide&title=Gold+Purity+Guide+%E2%80%94+Karats%2C+Hallmarks+%26+What+They+Mean" target="_blank" rel="noopener noreferrer">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
-        Reddit
-      </a>
-      <a class="share-btn" href="https://wa.me/?text=Gold+Purity+Guide+%E2%80%94+Karats%2C+Hallmarks+%26+What+They+Mean+https://goldpricetools.com/guides/gold-purity-guide" target="_blank" rel="noopener noreferrer">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg>
-        WhatsApp
-      </a>
+    <div class="gp-hero__cards" role="region" aria-label="Quick purity reference">
+      <div class="gp-hero__card">
+        <div class="gp-hero__card-label">24K &middot; Fineness 999</div>
+        <div class="gp-hero__card-value">99.9% Pure</div>
+        <div class="gp-hero__card-sub">Bullion &amp; investment</div>
+      </div>
+      <div class="gp-hero__card">
+        <div class="gp-hero__card-label">22K &middot; Fineness 916</div>
+        <div class="gp-hero__card-value">91.7% Pure</div>
+        <div class="gp-hero__card-sub">South Asian bridal</div>
+      </div>
+      <div class="gp-hero__card">
+        <div class="gp-hero__card-label">18K &middot; Fineness 750</div>
+        <div class="gp-hero__card-value">75.0% Pure</div>
+        <div class="gp-hero__card-sub">Fine jewellery</div>
+      </div>
+      <div class="gp-hero__card">
+        <div class="gp-hero__card-label">14K &middot; Fineness 585</div>
+        <div class="gp-hero__card-value">58.3% Pure</div>
+        <div class="gp-hero__card-sub">Everyday US standard</div>
+      </div>
     </div>
-  <script>
-  document.querySelectorAll('.share-buttons a').forEach(btn => {
-    btn.addEventListener('click', () => {
-      if (typeof gtag === 'function') {
-        gtag('event', 'share', { method: btn.dataset.platform, content_type: 'article', item_id: window.location.pathname });
-      }
-    });
-  });
-  </script>
-
-  <div class="cta-box">
-    <h3>Check Live Gold Value by Karat</h3>
-    <p>Use our live calculator to see current prices for every karat from 9K to 24K, updated every 60 seconds.</p>
-    <a href="/" class="cta-btn">Open Gold Calculator &rarr;</a>
   </div>
-</article>
+</section>
 
-
-<div style="max-width:860px;margin:0 auto var(--space-10);padding:0 var(--space-4)">
-  <div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
-  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
+<!-- ═══ MOBILE TOC ═══ -->
+<div class="gp-toc-mobile">
+  <button class="gp-toc-toggle" id="tocToggle" aria-expanded="false" aria-controls="tocMobile">
+    <svg class="gp-toc-toggle__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+    In this guide
+    <svg class="gp-toc-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+  </button>
+  <nav id="tocMobile" class="gp-toc-nav--mobile" aria-label="Article sections" hidden>
+    <ol>
+      <li><a href="#what-is-purity">What Is Gold Purity?</a></li>
+      <li><a href="#purity-chart">Complete Purity Chart</a></li>
+      <li><a href="#every-karat">Every Karat Explained</a></li>
+      <li><a href="#colours">Gold Colours: Yellow, White, Rose</a></li>
+      <li><a href="#regions">Purity by Country</a></li>
+      <li><a href="#how-to-test">How to Check Purity</a></li>
+      <li><a href="#pro-testing">Professional Testing</a></li>
+      <li><a href="#value">Karat &amp; Value</a></li>
+      <li><a href="#which-karat">Which Karat to Choose</a></li>
+      <li><a href="#coins">Gold Coin Purity</a></li>
+      <li><a href="#faq">FAQ</a></li>
+    </ol>
+  </nav>
 </div>
-</div>
 
+<!-- ═══ MAIN LAYOUT ═══ -->
+<div class="gp-layout">
 
-<section class="related-guides-section">
-  <h2>Related Guides</h2>
-  <div class="related-guides-grid">
-    <a class="related-card" href="/guides/gold-karat-explained">
-      <span class="related-card__tag">GUIDE</span>
-      <div class="related-card__title">Gold Karat Explained</div>
-      <div class="related-card__desc">What does 14K, 18K, and 10K mean? A deep dive into karat purity.</div>
+  <!-- SIDEBAR TOC (desktop only) -->
+  <aside class="gp-sidebar" aria-label="Article navigation">
+    <div class="gp-toc">
+      <div class="gp-toc__header">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/></svg>
+        Contents
+      </div>
+      <nav aria-label="Table of contents">
+        <ol class="gp-toc__list">
+          <li><a href="#what-is-purity" class="gp-toc__link">What Is Gold Purity?</a></li>
+          <li><a href="#purity-chart" class="gp-toc__link">Complete Purity Chart</a></li>
+          <li><a href="#every-karat" class="gp-toc__link">Every Karat Explained</a></li>
+          <li><a href="#colours" class="gp-toc__link">Yellow, White &amp; Rose</a></li>
+          <li><a href="#regions" class="gp-toc__link">Purity by Country</a></li>
+          <li><a href="#how-to-test" class="gp-toc__link">How to Check Purity</a></li>
+          <li><a href="#pro-testing" class="gp-toc__link">Professional Testing</a></li>
+          <li><a href="#value" class="gp-toc__link">Karat &amp; Value</a></li>
+          <li><a href="#which-karat" class="gp-toc__link">Which Karat to Choose</a></li>
+          <li><a href="#coins" class="gp-toc__link">Gold Coin Purity</a></li>
+          <li><a href="#faq" class="gp-toc__link">FAQ</a></li>
+        </ol>
+      </nav>
+      <div class="gp-toc__spot" aria-live="polite">
+        <div class="gp-toc__spot-row"><span class="gp-toc__spot-label">24K / oz</span><span class="gp-toc__spot-value" id="spotGoldOz">&mdash;</span></div>
+        <div class="gp-toc__spot-row"><span class="gp-toc__spot-label">24K / gram</span><span class="gp-toc__spot-value" id="spotGold24g">&mdash;</span></div>
+        <div class="gp-toc__spot-row"><span class="gp-toc__spot-label">18K / gram</span><span class="gp-toc__spot-value" id="spotGold18g">&mdash;</span></div>
+      </div>
+    </div>
+  </aside>
+
+  <!-- ARTICLE -->
+  <article class="gp-article" id="article-content">
+    <div class="gp-prose">
+
+      <p class="gp-dropcap">Pick up a piece of gold jewellery and the first question most people have is deceptively simple: <em>how much gold is actually in this?</em> The answer lives inside a small stamped number &mdash; a hallmark that tells you everything about the metal&rsquo;s composition, value, durability, and even colour. Understanding gold purity is not just for jewellers or investors. Whether you are buying an engagement ring, selling inherited jewellery, or choosing a gold bar for your portfolio, knowing what 9K, 14K, 18K, 22K, and 24K actually mean puts you firmly in control.</p>
+
+      <p>This guide explains the entire gold purity scale &mdash; what every karat means in plain terms, how purity affects price and performance, how to test gold purity at home, and which karat is right for which purpose.</p>
+
+      <!-- ── WHAT IS PURITY ── -->
+      <h2 id="what-is-purity">What Is Gold Purity and How Is It Measured?</h2>
+      <p>Pure gold, as it comes out of the ground and is refined to its highest form, is a remarkably soft, deeply yellow, completely non-reactive metal. It does not tarnish, corrode, or rust. But that softness &mdash; the same quality that made early civilisations able to hammer it into intricate shapes &mdash; is also a practical problem for everyday objects. A ring made of pure gold would bend and scratch with ordinary wear within days.</p>
+      <p>To solve this, gold is almost always mixed with other metals to form an <strong>alloy</strong> &mdash; a blend that preserves gold&rsquo;s beauty while adding the durability needed for jewellery, coins, and industrial use. <strong>Gold purity</strong> simply describes how much actual gold is present in that alloy. There are two major systems for expressing gold purity used around the world today.</p>
+
+      <div class="gp-systems">
+        <div class="gp-system gp-system--karat">
+          <div class="gp-system__badge">System One</div>
+          <div class="gp-system__title">The Karat (K) System</div>
+          <p class="gp-system__body">The karat system divides any piece of metal into <strong style="color:var(--color-text)">24 equal parts</strong> and counts how many of those parts are pure gold. Each karat represents one twenty-fourth &mdash; or approximately 4.17% &mdash; of the total. Standard in North America, the UK, and English-speaking markets.</p>
+          <ul class="gp-system__list">
+            <li><span class="gp-system__list-key">24K</span><span class="gp-system__list-val">24 / 24 &middot; 100%</span></li>
+            <li><span class="gp-system__list-key">18K</span><span class="gp-system__list-val">18 / 24 &middot; 75%</span></li>
+            <li><span class="gp-system__list-key">14K</span><span class="gp-system__list-val">14 / 24 &middot; 58.3%</span></li>
+            <li><span class="gp-system__list-key">9K</span><span class="gp-system__list-val">9 / 24 &middot; 37.5%</span></li>
+          </ul>
+        </div>
+        <div class="gp-system">
+          <div class="gp-system__badge">System Two</div>
+          <div class="gp-system__title">The Millesimal Fineness System</div>
+          <p class="gp-system__body">Millesimal fineness expresses purity in <strong style="color:var(--color-text)">parts per thousand</strong>. It is the standard used across continental Europe, in international trade, and on most internationally hallmarked pieces. A ring stamped &ldquo;585&rdquo; and a ring stamped &ldquo;14K&rdquo; contain identical gold &mdash; just different notation.</p>
+          <ul class="gp-system__list">
+            <li><span class="gp-system__list-key">999</span><span class="gp-system__list-val">24K &middot; 99.9% pure</span></li>
+            <li><span class="gp-system__list-key">750</span><span class="gp-system__list-val">18K &middot; 75.0% pure</span></li>
+            <li><span class="gp-system__list-key">585</span><span class="gp-system__list-val">14K &middot; 58.5% pure</span></li>
+            <li><span class="gp-system__list-key">375</span><span class="gp-system__list-val">9K &middot; 37.5% pure</span></li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="gp-note">
+        <div class="gp-note__icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+        </div>
+        <p>The spelling <strong>&ldquo;karat&rdquo; (K)</strong> is used for gold purity in most countries; <strong>&ldquo;carat&rdquo; (ct)</strong> is used for the same measurement in the UK, Australia, and parts of Europe. In the diamond trade, <em>carat</em> means something entirely different &mdash; a unit of gemstone weight equal to 0.2 grams. Context matters.</p>
+      </div>
+
+      <!-- ── PURITY CHART ── -->
+      <h2 id="purity-chart">The Complete Gold Purity Chart</h2>
+      <p>Here is a comprehensive reference covering every common karat level, from the lowest to the highest gold purity. The gold content percentage is calculated by dividing the karat number by 24 and multiplying by 100. So for 18K: (18 &divide; 24) &times; 100 = 75%.</p>
+
+      <div class="gp-table-wrap">
+        <table class="gp-table" aria-label="Complete gold purity chart">
+          <thead>
+            <tr>
+              <th>Karat</th>
+              <th>Stamp</th>
+              <th>Gold %</th>
+              <th>Alloy %</th>
+              <th>Visual</th>
+              <th>Common Use</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="gp-table__karat">8K</span></td>
+              <td><span class="gp-table__stamp">333</span></td>
+              <td><span class="gp-table__pct">33.3%</span></td>
+              <td>66.7%</td>
+              <td><span class="gp-table__bar" style="width:33%"></span></td>
+              <td>Germany, parts of Eastern Europe</td>
+            </tr>
+            <tr>
+              <td><span class="gp-table__karat">9K</span></td>
+              <td><span class="gp-table__stamp">375</span></td>
+              <td><span class="gp-table__pct">37.5%</span></td>
+              <td>62.5%</td>
+              <td><span class="gp-table__bar" style="width:38%"></span></td>
+              <td>Budget jewellery, UK &amp; Australia</td>
+            </tr>
+            <tr>
+              <td><span class="gp-table__karat">10K</span></td>
+              <td><span class="gp-table__stamp">417</span></td>
+              <td><span class="gp-table__pct">41.7%</span></td>
+              <td>58.3%</td>
+              <td><span class="gp-table__bar" style="width:42%"></span></td>
+              <td>Entry-level jewellery, US market</td>
+            </tr>
+            <tr>
+              <td><span class="gp-table__karat">12K</span></td>
+              <td><span class="gp-table__stamp">500</span></td>
+              <td><span class="gp-table__pct">50.0%</span></td>
+              <td>50.0%</td>
+              <td><span class="gp-table__bar" style="width:50%"></span></td>
+              <td>Uncommon; some vintage pieces</td>
+            </tr>
+            <tr class="gp-table__row--featured">
+              <td><span class="gp-table__karat">14K</span></td>
+              <td><span class="gp-table__stamp">585</span></td>
+              <td><span class="gp-table__pct">58.3%</span></td>
+              <td>41.7%</td>
+              <td><span class="gp-table__bar" style="width:58%"></span></td>
+              <td>Most popular grade in US &amp; Central Europe</td>
+            </tr>
+            <tr class="gp-table__row--featured">
+              <td><span class="gp-table__karat">18K</span></td>
+              <td><span class="gp-table__stamp">750</span></td>
+              <td><span class="gp-table__pct">75.0%</span></td>
+              <td>25.0%</td>
+              <td><span class="gp-table__bar" style="width:75%"></span></td>
+              <td>Fine jewellery, luxury watches</td>
+            </tr>
+            <tr>
+              <td><span class="gp-table__karat">20K</span></td>
+              <td><span class="gp-table__stamp">834</span></td>
+              <td><span class="gp-table__pct">83.4%</span></td>
+              <td>16.6%</td>
+              <td><span class="gp-table__bar" style="width:83%"></span></td>
+              <td>Rare; some Middle Eastern markets</td>
+            </tr>
+            <tr>
+              <td><span class="gp-table__karat">21K</span></td>
+              <td><span class="gp-table__stamp">875</span></td>
+              <td><span class="gp-table__pct">87.5%</span></td>
+              <td>12.5%</td>
+              <td><span class="gp-table__bar" style="width:88%"></span></td>
+              <td>Gulf region jewellery</td>
+            </tr>
+            <tr class="gp-table__row--featured">
+              <td><span class="gp-table__karat">22K</span></td>
+              <td><span class="gp-table__stamp">916</span></td>
+              <td><span class="gp-table__pct">91.7%</span></td>
+              <td>8.3%</td>
+              <td><span class="gp-table__bar" style="width:92%"></span></td>
+              <td>South Asian bridal, gold coins</td>
+            </tr>
+            <tr>
+              <td><span class="gp-table__karat">23K</span></td>
+              <td><span class="gp-table__stamp">958</span></td>
+              <td><span class="gp-table__pct">95.8%</span></td>
+              <td>4.2%</td>
+              <td><span class="gp-table__bar" style="width:96%"></span></td>
+              <td>Rare; some East Asian markets</td>
+            </tr>
+            <tr class="gp-table__row--featured">
+              <td><span class="gp-table__karat">24K</span></td>
+              <td><span class="gp-table__stamp">999</span></td>
+              <td><span class="gp-table__pct">99.9%</span></td>
+              <td>&lt;0.1%</td>
+              <td><span class="gp-table__bar" style="width:100%"></span></td>
+              <td>Bullion, coins, electronics</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="gp-table-note">Sources: World Gold Council, BullionByPost, millesimal fineness data. Highlighted rows indicate the most commercially significant karat grades worldwide.</p>
+
+      <!-- ── EVERY KARAT EXPLAINED ── -->
+      <h2 id="every-karat">Every Karat Level Explained in Detail</h2>
+      <p>Each karat sits at a different point on the purity scale &mdash; and serves a different practical purpose. Here is what each level actually means for colour, durability, price, and use.</p>
+
+      <div style="display:flex;flex-direction:column;gap:var(--space-5)">
+
+        <!-- 9K -->
+        <article class="gp-karat-detail" aria-labelledby="karat-9k">
+          <div class="gp-karat-detail__visual">
+            <div class="gp-karat-disc gp-karat-disc--9" aria-hidden="true"><div class="gp-karat-disc__inner"><div class="gp-karat-disc__k">9K</div><div class="gp-karat-disc__lbl">Karat</div></div></div>
+            <div class="gp-karat-detail__pct">37.5%</div>
+            <div class="gp-karat-detail__pct-lbl">Gold Content</div>
+          </div>
+          <div class="gp-karat-detail__body">
+            <div class="gp-karat-detail__meta">
+              <span class="gp-karat-detail__chip gp-karat-detail__chip--stamp">Stamp 375</span>
+              <span class="gp-karat-detail__chip">Hardness: High</span>
+              <span class="gp-karat-detail__chip">Colour: Pale yellow</span>
+            </div>
+            <h3 class="gp-karat-detail__title" id="karat-9k">9K Gold &mdash; 37.5% Pure</h3>
+            <p>Nine karat gold sits at the bottom of the mainstream purity scale, containing just 37.5% pure gold &mdash; the remaining 62.5% is silver, copper, and zinc. Despite the modest gold content, 9K is widely used in markets where durability and affordability take priority over maximum gold content.</p>
+            <p>Because of its high alloy content, 9K gold is <strong>significantly harder</strong> than higher-karat grades and resists scratching well &mdash; making it practical for daily wear. It also carries the lowest material cost of any &ldquo;true&rdquo; gold alloy. The trade-offs are real: a paler, more washed-out yellow tone, and the higher copper content can trigger skin reactions in people with metal sensitivities.</p>
+            <div class="gp-karat-detail__best">
+              <strong>Best for</strong>
+              Budget-conscious buyers, fashion jewellery, pieces that see heavy daily wear. Not recommended for investors &mdash; gold content is too low to hold meaningful intrinsic value.
+            </div>
+          </div>
+        </article>
+
+        <!-- 10K -->
+        <article class="gp-karat-detail" aria-labelledby="karat-10k">
+          <div class="gp-karat-detail__visual">
+            <div class="gp-karat-disc gp-karat-disc--10" aria-hidden="true"><div class="gp-karat-disc__inner"><div class="gp-karat-disc__k">10K</div><div class="gp-karat-disc__lbl">Karat</div></div></div>
+            <div class="gp-karat-detail__pct">41.7%</div>
+            <div class="gp-karat-detail__pct-lbl">Gold Content</div>
+          </div>
+          <div class="gp-karat-detail__body">
+            <div class="gp-karat-detail__meta">
+              <span class="gp-karat-detail__chip gp-karat-detail__chip--stamp">Stamp 417</span>
+              <span class="gp-karat-detail__chip">US legal minimum</span>
+              <span class="gp-karat-detail__chip">Colour: Pale yellow</span>
+            </div>
+            <h3 class="gp-karat-detail__title" id="karat-10k">10K Gold &mdash; 41.7% Pure</h3>
+            <p>Ten karat gold contains 10 parts gold to 14 parts alloy. It is primarily a <strong>North American convention</strong> &mdash; the minimum legal standard for items sold as &ldquo;gold&rdquo; in the United States &mdash; and common for budget and mid-range jewellery.</p>
+            <p>At this purity level, 10K is the most scratch-resistant of all standard gold alloys &mdash; harder even than platinum in many conditions &mdash; because the base metal components dominate the relatively soft gold.</p>
+            <div class="gp-karat-detail__best">
+              <strong>Best for</strong>
+              US buyers seeking affordable gold jewellery, pieces requiring maximum durability (children&rsquo;s jewellery, sports accessories), budget engagement rings.
+            </div>
+          </div>
+        </article>
+
+        <!-- 14K -->
+        <article class="gp-karat-detail" aria-labelledby="karat-14k">
+          <div class="gp-karat-detail__visual">
+            <div class="gp-karat-disc gp-karat-disc--14" aria-hidden="true"><div class="gp-karat-disc__inner"><div class="gp-karat-disc__k">14K</div><div class="gp-karat-disc__lbl">Karat</div></div></div>
+            <div class="gp-karat-detail__pct">58.3%</div>
+            <div class="gp-karat-detail__pct-lbl">Gold Content</div>
+          </div>
+          <div class="gp-karat-detail__body">
+            <div class="gp-karat-detail__meta">
+              <span class="gp-karat-detail__chip gp-karat-detail__chip--stamp">Stamp 585</span>
+              <span class="gp-karat-detail__chip">US bestseller</span>
+              <span class="gp-karat-detail__chip">Colour: Warm yellow</span>
+            </div>
+            <h3 class="gp-karat-detail__title" id="karat-14k">14K Gold &mdash; 58.3% Pure</h3>
+            <p>At 58.3% gold content, 14K is the <strong>most popular jewellery karat in the United States</strong> and widely used across Central and Eastern Europe. It strikes a practical balance: high enough gold content for a distinctly warm yellow colour, with enough alloy (41.7%) to provide excellent durability for everyday wear.</p>
+            <p>14K white gold &mdash; widely used for engagement rings in North American markets &mdash; uses palladium (9.5%) and silver (32.2%) as whitening agents. At May 2026 prices, 14K gold is worth approximately <strong>$85&ndash;$86 per gram</strong> in pure gold content.</p>
+            <div class="gp-karat-detail__best">
+              <strong>Best for</strong>
+              Engagement rings, wedding bands, everyday jewellery, US and Central European markets. The sweet spot for buyers who want the gold aesthetic without the premium cost of 18K.
+            </div>
+          </div>
+        </article>
+
+        <!-- 18K -->
+        <article class="gp-karat-detail" aria-labelledby="karat-18k">
+          <div class="gp-karat-detail__visual">
+            <div class="gp-karat-disc gp-karat-disc--18" aria-hidden="true"><div class="gp-karat-disc__inner"><div class="gp-karat-disc__k">18K</div><div class="gp-karat-disc__lbl">Karat</div></div></div>
+            <div class="gp-karat-detail__pct">75.0%</div>
+            <div class="gp-karat-detail__pct-lbl">Gold Content</div>
+          </div>
+          <div class="gp-karat-detail__body">
+            <div class="gp-karat-detail__meta">
+              <span class="gp-karat-detail__chip gp-karat-detail__chip--stamp">Stamp 750</span>
+              <span class="gp-karat-detail__chip">Global luxury standard</span>
+              <span class="gp-karat-detail__chip">Colour: Rich yellow</span>
+            </div>
+            <h3 class="gp-karat-detail__title" id="karat-18k">18K Gold &mdash; 75% Pure</h3>
+            <p>Eighteen karat gold is the <strong>global standard for fine jewellery</strong>. With three-quarters of the metal pure gold, it produces the rich, deep yellow most people associate with quality gold, while the 25% alloy provides the structural strength needed for complex stone-set pieces.</p>
+            <p>This is the standard inside luxury watches by Patek Philippe, Rolex, and Cartier, and across the world&rsquo;s top maisons. White 18K uses platinum or palladium (25%) for its silver tone; rose 18K uses approximately 22.25% copper plus 2.75% silver. All retain identical 75% gold value. Approximately <strong>$109&ndash;$110 per gram</strong> in pure gold content at current prices.</p>
+            <div class="gp-karat-detail__best">
+              <strong>Best for</strong>
+              Fine jewellery, luxury watches, European engagement rings, pieces where rich gold colour matters, people sensitive to base metal allergies (lower nickel content).
+            </div>
+          </div>
+        </article>
+
+        <!-- 22K -->
+        <article class="gp-karat-detail" aria-labelledby="karat-22k">
+          <div class="gp-karat-detail__visual">
+            <div class="gp-karat-disc gp-karat-disc--22" aria-hidden="true"><div class="gp-karat-disc__inner"><div class="gp-karat-disc__k">22K</div><div class="gp-karat-disc__lbl">Karat</div></div></div>
+            <div class="gp-karat-detail__pct">91.7%</div>
+            <div class="gp-karat-detail__pct-lbl">Gold Content</div>
+          </div>
+          <div class="gp-karat-detail__body">
+            <div class="gp-karat-detail__meta">
+              <span class="gp-karat-detail__chip gp-karat-detail__chip--stamp">Stamp 916</span>
+              <span class="gp-karat-detail__chip">Bridal &amp; coin standard</span>
+              <span class="gp-karat-detail__chip">Colour: Deep yellow</span>
+            </div>
+            <h3 class="gp-karat-detail__title" id="karat-22k">22K Gold &mdash; 91.7% Pure</h3>
+            <p>22K represents the <strong>highest purity level commonly used in wearable jewellery</strong>. The deep, intensely yellow colour is unmistakable and culturally significant in many markets. South Asian weddings &mdash; particularly in India &mdash; are the defining market: bridal sets, temple jewellery, and heirlooms are almost exclusively 22K or higher.</p>
+            <p>22K is unsuitable for stones and complex prong settings because the metal remains relatively soft. Its use is largely restricted to plain chains, bangles, and coin manufacture. Many famous investment coins &mdash; including the South African Krugerrand and British Sovereign &mdash; are struck in 22K gold.</p>
+            <div class="gp-karat-detail__best">
+              <strong>Best for</strong>
+              South Asian bridal jewellery, traditional and cultural gold pieces, plain gold chains and bangles, investment coins.
+            </div>
+          </div>
+        </article>
+
+        <!-- 24K -->
+        <article class="gp-karat-detail" aria-labelledby="karat-24k">
+          <div class="gp-karat-detail__visual">
+            <div class="gp-karat-disc gp-karat-disc--24" aria-hidden="true"><div class="gp-karat-disc__inner"><div class="gp-karat-disc__k">24K</div><div class="gp-karat-disc__lbl">Karat</div></div></div>
+            <div class="gp-karat-detail__pct">99.9%</div>
+            <div class="gp-karat-detail__pct-lbl">Gold Content</div>
+          </div>
+          <div class="gp-karat-detail__body">
+            <div class="gp-karat-detail__meta">
+              <span class="gp-karat-detail__chip gp-karat-detail__chip--stamp">Stamp 999</span>
+              <span class="gp-karat-detail__chip">Investment grade</span>
+              <span class="gp-karat-detail__chip">Colour: Vivid yellow</span>
+            </div>
+            <h3 class="gp-karat-detail__title" id="karat-24k">24K Gold &mdash; 99.9% Pure</h3>
+            <p>24 karat gold is the <strong>purest commercially available form</strong>: 99.9% pure (often 999.9 for highest-grade bullion, indicating 99.99% purity). There is no higher karat &mdash; you cannot go above 24K. This is the gold of investment bars, world-class minted coins (Canadian Maple Leaf, Chinese Gold Panda), central bank reserves, and industrial electronics.</p>
+            <p>24K has a vivid, saturated yellow more intense than any lower karat, and produces no allergic reactions associated with base metal alloys. However it is extremely soft &mdash; it scratches with a fingernail, bends easily, and cannot hold gemstones &mdash; making it impractical for most wearable jewellery.</p>
+            <div class="gp-karat-detail__best">
+              <strong>Best for</strong>
+              Investment bars and bullion coins, electronics and aerospace applications, people who want maximum gold content regardless of durability, collectors.
+            </div>
+          </div>
+        </article>
+
+      </div>
+
+      <!-- ── COLOURS ── -->
+      <h2 id="colours">Gold Colours: Yellow, White and Rose Gold Purity</h2>
+      <p>Gold&rsquo;s natural colour is the warm yellow most people picture &mdash; but the same gold can be transformed into white, rose, or even green through alloying. The <em>purity at any given karat is identical regardless of colour</em>; what changes is the composition of the non-gold portion. A white 18K ring and a yellow 18K ring contain the same 75% gold and carry the same intrinsic metal value.</p>
+
+      <div class="gp-colours">
+        <article class="gp-colour-card">
+          <div class="gp-colour-card__swatch gp-colour-card__swatch--yellow" aria-hidden="true"></div>
+          <div class="gp-colour-card__content">
+            <div class="gp-colour-card__alloy">Yellow Gold &middot; Default</div>
+            <h3 class="gp-colour-card__title">Yellow Gold</h3>
+            <p>The &ldquo;default&rdquo; &mdash; gold alloyed primarily with <strong>silver and copper</strong> in proportions that preserve the characteristic warm hue. At higher karats (22K, 24K), the deep saturation of pure gold dominates. At lower karats (9K, 10K), more alloy dilutes the colour toward a paler, slightly greenish tone.</p>
+          </div>
+        </article>
+
+        <article class="gp-colour-card">
+          <div class="gp-colour-card__swatch gp-colour-card__swatch--white" aria-hidden="true"></div>
+          <div class="gp-colour-card__content">
+            <div class="gp-colour-card__alloy">White Gold &middot; Pd/Pt alloy</div>
+            <h3 class="gp-colour-card__title">White Gold</h3>
+            <p>Created by alloying gold with whitening metals &mdash; primarily <strong>palladium or platinum</strong>, sometimes nickel and zinc. At 18K, a white gold alloy is 75% gold with 25% palladium/platinum. Almost always finished with a rhodium plating for the bright, silver-like appearance customers expect.</p>
+          </div>
+        </article>
+
+        <article class="gp-colour-card">
+          <div class="gp-colour-card__swatch gp-colour-card__swatch--rose" aria-hidden="true"></div>
+          <div class="gp-colour-card__content">
+            <div class="gp-colour-card__alloy">Rose Gold &middot; Cu-heavy alloy</div>
+            <h3 class="gp-colour-card__title">Rose Gold</h3>
+            <p>Gets its characteristic pink-to-red tone from a higher <strong>copper content</strong>. A typical 18K rose gold alloy contains 75% gold, 22.25% copper, and 2.75% silver. Copper content can be adjusted to produce shades from pale champagne pink through to deep reddish &ldquo;red gold&rdquo;.</p>
+          </div>
+        </article>
+      </div>
+
+      <!-- ── REGIONS ── -->
+      <h2 id="regions">Gold Purity by Country: Regional Preferences</h2>
+      <p>Gold purity preferences vary significantly around the world, shaped by cultural tradition, market convention, and regulatory standards. What is considered &ldquo;real gold&rdquo; in one country may be regarded as low-grade in another &mdash; understanding regional norms is essential when buying or selling internationally.</p>
+
+      <div class="gp-regions">
+        <div class="gp-region">
+          <div class="gp-region__header">
+            <div class="gp-region__flag" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+            </div>
+            <div><div class="gp-region__name">South Asia</div><div class="gp-region__sub">India, Bangladesh, Sri Lanka</div></div>
+          </div>
+          <div class="gp-region__standard">22K (916) Standard</div>
+          <p>22K gold dominates jewellery, particularly bridal and traditional pieces. Gold is deeply embedded in wedding traditions and festivals including Diwali and Dhanteras &mdash; purity treated as a direct expression of value. 24K coins and bars are also popular for investment.</p>
+        </div>
+
+        <div class="gp-region">
+          <div class="gp-region__header">
+            <div class="gp-region__flag" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15 15 0 0 1 0 20"/></svg>
+            </div>
+            <div><div class="gp-region__name">East Asia</div><div class="gp-region__sub">China, Japan, Hong Kong, Taiwan</div></div>
+          </div>
+          <div class="gp-region__standard">24K (999) Preferred</div>
+          <p>China has historically preferred 24K (&ldquo;pure gold&rdquo;) jewellery, especially heavy chains and investment pieces. Japan favours 18K for fashion but has a strong 24K tradition for heavy chains (<em>kihei</em>). Hong Kong is a major global trading hub carrying all karat levels.</p>
+        </div>
+
+        <div class="gp-region">
+          <div class="gp-region__header">
+            <div class="gp-region__flag" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+            </div>
+            <div><div class="gp-region__name">Middle East</div><div class="gp-region__sub">UAE, Saudi Arabia, Turkey</div></div>
+          </div>
+          <div class="gp-region__standard">21K &amp; 22K Dominant</div>
+          <p>21K (875) and 22K (916) are dominant standards for jewellery, reflecting regional preference for high-purity gold. Gold souqs in Dubai carry vast selections of 21K and 22K pieces alongside 18K options for international buyers.</p>
+        </div>
+
+        <div class="gp-region">
+          <div class="gp-region__header">
+            <div class="gp-region__flag" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>
+            </div>
+            <div><div class="gp-region__name">Europe</div><div class="gp-region__sub">Western Europe, UK, Germany</div></div>
+          </div>
+          <div class="gp-region__standard">18K (750) Fine Standard</div>
+          <p>18K is the predominant standard for fine jewellery across Western Europe. 9K (375) is common in the UK, Ireland, and some Nordic countries for everyday and budget pieces. 14K is more common in Germany and Central Europe.</p>
+        </div>
+
+        <div class="gp-region">
+          <div class="gp-region__header">
+            <div class="gp-region__flag" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12h20"/><path d="M2 6h20"/><path d="M2 18h20"/></svg>
+            </div>
+            <div><div class="gp-region__name">North America</div><div class="gp-region__sub">United States &amp; Canada</div></div>
+          </div>
+          <div class="gp-region__standard">14K (585) Most Popular</div>
+          <p>14K is the most popular jewellery karat in the US and Canada. 10K (417) represents the legal minimum for gold sale. 18K is positioned as &ldquo;luxury&rdquo; and commands a premium. 24K bullion bars and coins are the standard for investment.</p>
+        </div>
+
+        <div class="gp-region">
+          <div class="gp-region__header">
+            <div class="gp-region__flag" aria-hidden="true">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+            </div>
+            <div><div class="gp-region__name">Latin America</div><div class="gp-region__sub">Brazil, Mexico, Argentina</div></div>
+          </div>
+          <div class="gp-region__standard">18K with 14K &amp; 10K</div>
+          <p>18K dominates as the fine jewellery standard across South and Central America, with 14K and 10K used for fashion pieces. Investment-grade bullion follows the global 999.9 fine convention.</p>
+        </div>
+      </div>
+
+      <!-- ── HOW TO TEST ── -->
+      <h2 id="how-to-test">How to Check Gold Purity: A Practical Guide</h2>
+      <p>Knowing the theory is one thing &mdash; being able to verify gold purity in your hands is another. Here are all the methods available, from quick home tests to professional laboratory analysis. Used together, these methods give a reliable indication of authenticity; used alone, each has limitations.</p>
+
+      <div class="gp-steps">
+
+        <article class="gp-step">
+          <div class="gp-step__num" aria-hidden="true">1</div>
+          <div class="gp-step__content">
+            <h3 class="gp-step__title">Look for Hallmarks</h3>
+            <p>The single fastest and most reliable starting point. Use a jeweller&rsquo;s loupe (10&times; magnification) or a magnifying glass. On rings, the stamp is typically on the inside of the band. On chains, near the clasp. On larger pieces, check less visible areas like the back or underside.</p>
+            <div class="gp-step__stamps">
+              <span class="gp-step__stamp">999</span>
+              <span class="gp-step__stamp">916</span>
+              <span class="gp-step__stamp">750</span>
+              <span class="gp-step__stamp">585</span>
+              <span class="gp-step__stamp">417</span>
+              <span class="gp-step__stamp">375</span>
+              <span class="gp-step__stamp">14K</span>
+              <span class="gp-step__stamp">18K</span>
+            </div>
+            <p>A hallmark from a recognised assay office or known maker is strong evidence of authenticity. However, hallmarks <strong>can be forged</strong> &mdash; particularly on cheaper mass-produced pieces from unregulated markets &mdash; so additional verification is sometimes warranted.</p>
+          </div>
+        </article>
+
+        <article class="gp-step">
+          <div class="gp-step__num" aria-hidden="true">2</div>
+          <div class="gp-step__content">
+            <h3 class="gp-step__title">The Magnet Test</h3>
+            <div class="gp-step__needs"><strong>You need:</strong> A strong neodymium (rare-earth) magnet &mdash; available at hardware stores for a few dollars.</div>
+            <p><strong>What it tells you:</strong> Gold is non-magnetic. A strong neodymium magnet should produce <em>absolutely zero attraction</em> to genuine gold, regardless of karat. If a piece is attracted to the magnet, it contains iron or steel &mdash; either fake or gold-plated over a base metal core.</p>
+            <div class="gp-step__limitation"><strong>Limitation:</strong> The magnet test only screens for iron/steel cores. It does not detect brass, copper, or aluminium cores &mdash; all non-magnetic but not gold. Passing this test eliminates one category of fakes but does not confirm authenticity.</div>
+          </div>
+        </article>
+
+        <article class="gp-step">
+          <div class="gp-step__num" aria-hidden="true">3</div>
+          <div class="gp-step__content">
+            <h3 class="gp-step__title">The Float / Water Density Test</h3>
+            <div class="gp-step__needs"><strong>You need:</strong> A glass of water and (optional) a scale accurate to 0.01 grams for the advanced version.</div>
+            <p><strong>Basic float test:</strong> Real gold sinks immediately and completely. Gold has a density of 19.32 g/cm&sup3; &mdash; much denser than most common base metals. Any piece that floats or hangs suspended rather than sinking straight to the bottom is almost certainly not gold.</p>
+            <p><strong>Density calculation (advanced):</strong> By weighing in air and again submerged, you can calculate approximate density. Reference values: 24K yellow gold ~19.3 g/cm&sup3;; 18K yellow gold ~15.2&ndash;15.9 g/cm&sup3;; 14K yellow gold ~12.9&ndash;14.6 g/cm&sup3;; 18K white gold ~14.7&ndash;16.9 g/cm&sup3;.</p>
+            <div class="gp-step__limitation"><strong>Limitation:</strong> This is a rough screening method. Composite fakes (gold-plated over heavy base metal) can mimic the density of certain alloys.</div>
+          </div>
+        </article>
+
+        <article class="gp-step">
+          <div class="gp-step__num" aria-hidden="true">4</div>
+          <div class="gp-step__content">
+            <h3 class="gp-step__title">The Acid Test (Nitric Acid)</h3>
+            <div class="gp-step__needs"><strong>You need:</strong> A gold testing acid kit (jewellery supply stores, $20&ndash;$60) with nitric acid solutions matched to karat levels, a touchstone, plus protective gloves and eyewear.</div>
+            <p>A small scratch is made on a touchstone using the piece. A drop of karat-specific acid is applied. The acid&rsquo;s reaction indicates gold content: <strong>24K reacts minimally</strong> to all standard gold acids; lower karats show progressively stronger reactions; fake gold (copper, brass, base metal) dissolves or discolours immediately.</p>
+            <p>This is the most definitive home-accessible test and is widely used by second-hand jewellers, pawn shops, and precious metal buyers worldwide.</p>
+            <div class="gp-step__limitation"><strong>Limitation:</strong> Slightly destructive (leaves a small scratch mark). Provides approximate karat identification rather than a precise purity reading. Requires careful handling of corrosive acids.</div>
+          </div>
+        </article>
+
+        <article class="gp-step">
+          <div class="gp-step__num" aria-hidden="true">5</div>
+          <div class="gp-step__content">
+            <h3 class="gp-step__title">Household Item Tests (Use With Caution)</h3>
+            <p>Several informal tests circulate online. Here is an honest assessment &mdash; these are quick preliminary filters, not conclusive tests:</p>
+            <div class="gp-household">
+              <div class="gp-household__item">
+                <div class="gp-household__title">Vinegar<span class="gp-household__rating gp-household__rating--ok">Mildly useful</span></div>
+                <p>Real gold doesn&rsquo;t react; base metals may darken or corrode. Vinegar is too weak to discriminate karats reliably and can cause minor surface damage on some alloys.</p>
+              </div>
+              <div class="gp-household__item">
+                <div class="gp-household__title">Toothpaste<span class="gp-household__rating gp-household__rating--ok">Rough indicator</span></div>
+                <p>Genuine gold should emerge clean and bright. Base metals or plating may leave a dark mark. Extremely rough indicator only.</p>
+              </div>
+              <div class="gp-household__item">
+                <div class="gp-household__title">Bleach<span class="gp-household__rating gp-household__rating--bad">Not recommended</span></div>
+                <p>Genuine gold doesn&rsquo;t react. Bleach can permanently damage jewellery &mdash; even genuine pieces &mdash; and provides no karat information. Avoid this test.</p>
+              </div>
+              <div class="gp-household__item">
+                <div class="gp-household__title">Skin Marks<span class="gp-household__rating gp-household__rating--bad">Unreliable</span></div>
+                <p>Fake or heavily alloyed gold can leave green/black marks from copper oxidation. Many genuine low-karat alloys also temporarily mark skin. Not a standalone test.</p>
+              </div>
+            </div>
+          </div>
+        </article>
+
+      </div>
+
+      <!-- ── PROFESSIONAL TESTING ── -->
+      <h2 id="pro-testing">Professional Gold Purity Testing Methods</h2>
+      <p>For definitive, precise gold purity measurement &mdash; needed when buying or selling significant quantities &mdash; professional testing is the only reliable standard. These methods are used by assay offices, refineries, and precious metal dealers worldwide.</p>
+
+      <div style="display:flex;flex-direction:column;gap:var(--space-4)">
+
+        <article class="gp-method gp-method--featured">
+          <div class="gp-method__visual">
+            <div class="gp-method__icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg>
+            </div>
+            <div class="gp-method__abbr">XRF</div>
+            <div class="gp-method__type">Industry Standard</div>
+          </div>
+          <div class="gp-method__body">
+            <h3 class="gp-method__title">XRF (X-Ray Fluorescence) Testing</h3>
+            <p><strong>XRF gold purity testing</strong> is the most widely used professional method and has largely replaced traditional fire assay in commercial buying and selling. An XRF machine fires high-energy X-rays at a sample, causing the metal&rsquo;s atoms to emit characteristic fluorescent X-rays that identify each element and its concentration.</p>
+            <p>Results appear on screen within seconds with accuracy typically within <strong>0.1% of true purity</strong>. Modern handheld XRF analyzers cost $15,000&ndash;$30,000, making them standard equipment for professional dealers and assay offices rather than home buyers.</p>
+            <div class="gp-method__advantages">
+              <div class="gp-method__advantages-title">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+                Key advantages
+              </div>
+              <ul>
+                <li>Non-destructive &mdash; no scratching or damage</li>
+                <li>Fast &mdash; results in seconds</li>
+                <li>Accurate &mdash; identifies exact karat to within 0.1%</li>
+                <li>Multi-element &mdash; reveals full alloy composition</li>
+                <li>Can distinguish surface plating from core metal</li>
+              </ul>
+            </div>
+          </div>
+        </article>
+
+        <article class="gp-method">
+          <div class="gp-method__visual">
+            <div class="gp-method__icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="6" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+            </div>
+            <div class="gp-method__abbr">SIGMA</div>
+            <div class="gp-method__type">Electromagnetic</div>
+          </div>
+          <div class="gp-method__body">
+            <h3 class="gp-method__title">Sigma Metalytics Precious Metal Verifier</h3>
+            <p>Uses <strong>electromagnetic fields at multiple frequencies</strong> to measure the electrical conductivity and magnetic permeability of a metal. Because each metal and alloy has a unique electrical signature, the device can identify gold purity without surface contact &mdash; even through a coin flip or sealed packaging.</p>
+            <p>Particularly useful for <strong>testing gold coins quickly</strong>. The verifier doesn&rsquo;t reveal exact percentage composition but excels at confirming whether a coin matches its declared purity profile.</p>
+          </div>
+        </article>
+
+        <article class="gp-method">
+          <div class="gp-method__visual">
+            <div class="gp-method__icon" aria-hidden="true">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 8h1a4 4 0 0 1 0 8h-1"/><path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z"/><line x1="6" y1="1" x2="6" y2="4"/><line x1="10" y1="1" x2="10" y2="4"/><line x1="14" y1="1" x2="14" y2="4"/></svg>
+            </div>
+            <div class="gp-method__abbr">FIRE</div>
+            <div class="gp-method__type">Legal Standard</div>
+          </div>
+          <div class="gp-method__body">
+            <h3 class="gp-method__title">Fire Assay</h3>
+            <p>The <strong>oldest and most accurate method</strong> for gold purity determination &mdash; and the legal standard for trade disputes and official certification. A small sample is dissolved in flux and melted, precious metals are separated chemically, and the gold is weighed against the original sample.</p>
+            <p>Fire assay is <strong>destructive and slow</strong>, requiring laboratory conditions and skilled technicians. Used by national assay offices, mints, and refineries for official certification rather than everyday testing.</p>
+          </div>
+        </article>
+
+      </div>
+
+      <div class="gp-calc">
+        <div class="gp-calc__title">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="8" y1="6" x2="16" y2="6"/><line x1="16" y1="14" x2="16" y2="18"/><line x1="12" y1="14" x2="12" y2="18"/><line x1="8" y1="14" x2="8" y2="18"/><line x1="8" y1="10" x2="16" y2="10"/></svg>
+          Gold Purity Calculator Formula
+        </div>
+        <div class="gp-calc__formula">Pure Gold Value = Weight (g) &times; <strong>Purity Fraction</strong> &times; Spot Price (per gram)</div>
+        <p class="gp-calc__example"><strong>Example:</strong> A 10-gram 18K gold ring &nbsp;&middot;&nbsp; 10 &times; 0.75 &times; $145.98 = <span class="gp-calc__result">$1,094.85</span> pure gold value</p>
+        <p class="gp-calc__example" style="margin-top:var(--space-3);font-size:var(--text-xs)">This figure represents the metal&rsquo;s intrinsic value only. Buyback rates from dealers will typically be 85&ndash;95% of this figure depending on the seller and market conditions.</p>
+      </div>
+
+      <!-- ── VALUE ── -->
+      <h2 id="value">Gold Purity and Value: How Karat Affects Price</h2>
+      <p>The relationship between karat and value is direct and mathematical: higher karat means more gold per gram, which means higher value per gram. At May 2026 spot prices of approximately <strong>$145.98/gram for 24K gold</strong>, the price per gram for each karat scales linearly.</p>
+
+      <div class="gp-value-table" aria-label="Price per gram by karat">
+        <div class="gp-value-table__caption">
+          <span>Spot value per gram &middot; May 2026</span>
+          <span class="gp-value-table__live">Live data above</span>
+        </div>
+        <div class="gp-value-row">
+          <div class="gp-value-row__karat">24K</div>
+          <div class="gp-value-row__bar-wrap"><div class="gp-value-row__bar" style="width:100%"><span class="gp-value-row__bar-pct">99.9% Gold</span></div></div>
+          <div class="gp-value-row__price" id="val-24k">$145.98</div>
+        </div>
+        <div class="gp-value-row">
+          <div class="gp-value-row__karat">22K</div>
+          <div class="gp-value-row__bar-wrap"><div class="gp-value-row__bar" style="width:91.7%"><span class="gp-value-row__bar-pct">91.7% Gold</span></div></div>
+          <div class="gp-value-row__price" id="val-22k">$133.81</div>
+        </div>
+        <div class="gp-value-row">
+          <div class="gp-value-row__karat">18K</div>
+          <div class="gp-value-row__bar-wrap"><div class="gp-value-row__bar" style="width:75%"><span class="gp-value-row__bar-pct">75% Gold</span></div></div>
+          <div class="gp-value-row__price" id="val-18k">$109.48</div>
+        </div>
+        <div class="gp-value-row">
+          <div class="gp-value-row__karat">14K</div>
+          <div class="gp-value-row__bar-wrap"><div class="gp-value-row__bar" style="width:58.3%"><span class="gp-value-row__bar-pct">58.3% Gold</span></div></div>
+          <div class="gp-value-row__price" id="val-14k">$85.15</div>
+        </div>
+        <div class="gp-value-row">
+          <div class="gp-value-row__karat">10K</div>
+          <div class="gp-value-row__bar-wrap"><div class="gp-value-row__bar" style="width:41.7%"><span class="gp-value-row__bar-pct">41.7%</span></div></div>
+          <div class="gp-value-row__price" id="val-10k">$60.82</div>
+        </div>
+        <div class="gp-value-row">
+          <div class="gp-value-row__karat">9K</div>
+          <div class="gp-value-row__bar-wrap"><div class="gp-value-row__bar" style="width:37.5%"><span class="gp-value-row__bar-pct">37.5%</span></div></div>
+          <div class="gp-value-row__price" id="val-9k">$54.74</div>
+        </div>
+      </div>
+      <p class="gp-table-note">Based on LBMA spot price, 16 May 2026. This is the <strong>spot value per gram</strong> &mdash; the intrinsic metal content before retail markup. Retail jewellery prices include craftsmanship, brand, design complexity, and retailer margins that often far exceed the raw gold content.</p>
+
+      <!-- ── WHICH KARAT ── -->
+      <h2 id="which-karat">Which Gold Purity Should You Choose?</h2>
+      <p>The right karat depends entirely on the purpose. Use this decision matrix to match your priorities &mdash; investment value, durability, cultural fit, or skin compatibility &mdash; to the appropriate purity level.</p>
+
+      <div class="gp-decision">
+        <article class="gp-decision__card">
+          <div class="gp-decision__purpose">Investment &middot; Bullion</div>
+          <div class="gp-decision__rec">Choose <strong>24K</strong> (or 22K coins)</div>
+          <p>Always 24K (999.9 fine) for bars, or 22K for recognised investment coins (Krugerrand, Sovereign). Maximum gold content equals maximum intrinsic value and the tightest possible spread over spot price.</p>
+        </article>
+        <article class="gp-decision__card">
+          <div class="gp-decision__purpose">Fine Jewellery &middot; Everyday Wear</div>
+          <div class="gp-decision__rec">Choose <strong>18K</strong> (750)</div>
+          <p>The optimal balance &mdash; rich gold colour, high purity, and sufficient alloy strength for daily rings, chains, and earrings. The global standard used by the world&rsquo;s finest jewellery makers.</p>
+        </article>
+        <article class="gp-decision__card">
+          <div class="gp-decision__purpose">Engagement Rings &middot; Durability Focus</div>
+          <div class="gp-decision__rec">Choose <strong>14K</strong> or 18K</div>
+          <p>14K (585) in North American markets; 18K in European and South American markets. Both offer excellent durability for daily wear. 14K is harder; 18K is richer in colour.</p>
+        </article>
+        <article class="gp-decision__card">
+          <div class="gp-decision__purpose">Budget &middot; Fashion Pieces</div>
+          <div class="gp-decision__rec">Choose <strong>9K</strong> or 10K</div>
+          <p>9K (375) or 10K (417) provide the most durability at the lowest cost. Understand that you are buying mostly alloy with a gold content of less than 42%.</p>
+        </article>
+        <article class="gp-decision__card">
+          <div class="gp-decision__purpose">South Asian &middot; Bridal &amp; Ceremonial</div>
+          <div class="gp-decision__rec">Choose <strong>22K</strong> (916)</div>
+          <p>22K is the cultural and commercial standard. Pieces below this purity are often viewed with suspicion in these markets regardless of their actual gold content.</p>
+        </article>
+        <article class="gp-decision__card">
+          <div class="gp-decision__purpose">Metal Sensitivities &middot; Allergies</div>
+          <div class="gp-decision__rec">Choose <strong>18K+</strong> (palladium)</div>
+          <p>Higher karat gold (18K and above with palladium-based alloys). For white gold, ensure it uses palladium rather than nickel &mdash; nickel is the primary culprit in gold-related allergic reactions.</p>
+        </article>
+      </div>
+
+      <!-- CTA -->
+      <div class="gp-cta">
+        <div class="gp-cta__content">
+          <div class="gp-cta__title">Check Live Gold Value by Karat</div>
+          <p class="gp-cta__desc">See current prices for every karat from 9K to 24K, updated every 60 seconds. Compare 14K, 18K, 22K and 24K spot value per gram with our live calculator.</p>
+        </div>
+        <a href="/" class="gp-cta__btn">
+          Open Gold Calculator
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+        </a>
+      </div>
+
+      <!-- ── COINS ── -->
+      <h2 id="coins">Understanding Gold Coin Purity</h2>
+      <p>Gold coins span the full range of the purity scale. Here are the most widely held investment coins worldwide and their karat equivalents:</p>
+
+      <div class="gp-coins">
+        <div class="gp-coin">
+          <div class="gp-coin__icon gp-coin__icon--24" aria-hidden="true"><span class="gp-coin__icon-text">CA</span></div>
+          <div class="gp-coin__info"><div class="gp-coin__name">Canadian Maple Leaf</div><div class="gp-coin__country">Royal Canadian Mint</div></div>
+          <div class="gp-coin__purity">999.9<span class="gp-coin__karat">24K</span></div>
+        </div>
+        <div class="gp-coin">
+          <div class="gp-coin__icon gp-coin__icon--24" aria-hidden="true"><span class="gp-coin__icon-text">CN</span></div>
+          <div class="gp-coin__info"><div class="gp-coin__name">Chinese Gold Panda</div><div class="gp-coin__country">People&rsquo;s Bank of China</div></div>
+          <div class="gp-coin__purity">999.9<span class="gp-coin__karat">24K</span></div>
+        </div>
+        <div class="gp-coin">
+          <div class="gp-coin__icon gp-coin__icon--24" aria-hidden="true"><span class="gp-coin__icon-text">US</span></div>
+          <div class="gp-coin__info"><div class="gp-coin__name">American Buffalo</div><div class="gp-coin__country">United States Mint</div></div>
+          <div class="gp-coin__purity">9999<span class="gp-coin__karat">24K</span></div>
+        </div>
+        <div class="gp-coin">
+          <div class="gp-coin__icon gp-coin__icon--24" aria-hidden="true"><span class="gp-coin__icon-text">AU</span></div>
+          <div class="gp-coin__info"><div class="gp-coin__name">Australian Kangaroo</div><div class="gp-coin__country">Perth Mint</div></div>
+          <div class="gp-coin__purity">9999<span class="gp-coin__karat">24K</span></div>
+        </div>
+        <div class="gp-coin">
+          <div class="gp-coin__icon gp-coin__icon--22" aria-hidden="true"><span class="gp-coin__icon-text">US</span></div>
+          <div class="gp-coin__info"><div class="gp-coin__name">American Gold Eagle</div><div class="gp-coin__country">US Mint &middot; 3% Ag, 5.33% Cu</div></div>
+          <div class="gp-coin__purity">916.7<span class="gp-coin__karat">22K</span></div>
+        </div>
+        <div class="gp-coin">
+          <div class="gp-coin__icon gp-coin__icon--22" aria-hidden="true"><span class="gp-coin__icon-text">ZA</span></div>
+          <div class="gp-coin__info"><div class="gp-coin__name">South African Krugerrand</div><div class="gp-coin__country">South African Mint</div></div>
+          <div class="gp-coin__purity">916.7<span class="gp-coin__karat">22K</span></div>
+        </div>
+        <div class="gp-coin">
+          <div class="gp-coin__icon gp-coin__icon--22" aria-hidden="true"><span class="gp-coin__icon-text">UK</span></div>
+          <div class="gp-coin__info"><div class="gp-coin__name">British Sovereign</div><div class="gp-coin__country">The Royal Mint</div></div>
+          <div class="gp-coin__purity">916.7<span class="gp-coin__karat">22K</span></div>
+        </div>
+        <div class="gp-coin">
+          <div class="gp-coin__icon gp-coin__icon--24" aria-hidden="true"><span class="gp-coin__icon-text">UK</span></div>
+          <div class="gp-coin__info"><div class="gp-coin__name">British Britannia</div><div class="gp-coin__country">The Royal Mint &middot; post-2013</div></div>
+          <div class="gp-coin__purity">999.9<span class="gp-coin__karat">24K</span></div>
+        </div>
+      </div>
+
+      <div class="gp-note" style="margin-top:var(--space-4)">
+        <div class="gp-note__icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+        </div>
+        <p>The <strong>American Gold Eagle</strong> is an interesting case: despite being only 91.67% pure gold, its gold content is guaranteed by the US government to be exactly <strong>1 troy ounce of fine gold</strong> &mdash; the coin is simply heavier to account for the copper and silver alloy. For investment purposes, it contains exactly as much gold as a 1 oz Maple Leaf, but weighs slightly more.</p>
+      </div>
+
+      <!-- ── FAQ ── -->
+      <h2 id="faq">Frequently Asked Questions on Gold Purity</h2>
+
+      <div class="gp-faq">
+        <div class="gp-faq__item">
+          <button class="gp-faq__question" aria-expanded="false">
+            What is the highest gold purity?
+            <svg class="gp-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gp-faq__answer" hidden>
+            <p><strong>24K (999.9 fine)</strong> is the highest purity grade for commercial gold. Investment bullion is typically 99.99% pure (&ldquo;four nines fine&rdquo;). Scientifically, gold can be refined to even higher purities for electronic applications, but 99.99% is the practical ceiling for the bullion market.</p>
+          </div>
+        </div>
+        <div class="gp-faq__item">
+          <button class="gp-faq__question" aria-expanded="false">
+            What does 916 mean on gold?
+            <svg class="gp-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gp-faq__answer" hidden>
+            <p><strong>916</strong> is the fineness stamp for 22K gold &mdash; indicating that 916 parts per thousand (91.6%) of the metal are pure gold. This is the standard for South Asian bridal gold and many world gold coins including the Krugerrand and British Sovereign.</p>
+          </div>
+        </div>
+        <div class="gp-faq__item">
+          <button class="gp-faq__question" aria-expanded="false">
+            Is 18K or 14K gold better?
+            <svg class="gp-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gp-faq__answer" hidden>
+            <p>Neither is objectively &ldquo;better&rdquo; &mdash; it depends on your priorities. <strong>18K</strong> contains more gold (75% vs 58.3%), has richer colour, and is less likely to cause skin reactions. <strong>14K</strong> is harder, more scratch-resistant, and significantly less expensive. For investment value, 18K wins. For durability and budget, 14K wins.</p>
+          </div>
+        </div>
+        <div class="gp-faq__item">
+          <button class="gp-faq__question" aria-expanded="false">
+            How do I test gold purity at home?
+            <svg class="gp-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gp-faq__answer" hidden>
+            <p>The most reliable home methods are: (1) <strong>hallmark check</strong> with a magnifying glass, (2) <strong>magnet test</strong> with a neodymium magnet, (3) <strong>water density test</strong>, and (4) <strong>acid testing</strong> with a nitric acid kit. Using all four together gives a reliable indication. For definitive confirmation, professional XRF testing is the gold standard.</p>
+          </div>
+        </div>
+        <div class="gp-faq__item">
+          <button class="gp-faq__question" aria-expanded="false">
+            What is the difference between karat and carat?
+            <svg class="gp-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gp-faq__answer" hidden>
+            <p>In the context of gold, <strong>&ldquo;karat&rdquo; (K)</strong> and <strong>&ldquo;carat&rdquo; (ct)</strong> mean exactly the same thing &mdash; a measurement of gold purity out of 24 parts. &ldquo;Carat&rdquo; is the spelling used in the UK, Australia, and parts of Europe; &ldquo;karat&rdquo; is used in the US and most other countries. The gem trade uses &ldquo;carat&rdquo; to mean something different (a unit of gem weight, 0.2 grams), so context matters.</p>
+          </div>
+        </div>
+        <div class="gp-faq__item">
+          <button class="gp-faq__question" aria-expanded="false">
+            How is 22 carat gold purity percentage calculated?
+            <svg class="gp-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gp-faq__answer" hidden>
+            <p><strong>22 &divide; 24 &times; 100 = 91.67%</strong>. Alternatively, the fineness figure of 916 can be read directly as 91.6%.</p>
+          </div>
+        </div>
+        <div class="gp-faq__item">
+          <button class="gp-faq__question" aria-expanded="false">
+            What is white gold purity?
+            <svg class="gp-faq__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+          <div class="gp-faq__answer" hidden>
+            <p><strong>White gold purity is the same as its karat equivalent in yellow gold.</strong> 18K white gold is 75% pure gold &mdash; identical to 18K yellow gold. The only difference is the composition of the 25% alloy: whitening metals (palladium or platinum) replace the silver and copper used in yellow gold.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- SHARE -->
+      <section class="gp-share" aria-label="Share this guide">
+        <div class="gp-share__label">Share this guide</div>
+        <div class="gp-share__buttons">
+          <a class="gp-share__btn" href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/gold-purity-guide&text=Gold+Purity+Guide%3A+9K+to+24K+Explained+%282026%29" target="_blank" rel="noopener noreferrer">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.737-8.835L1.254 2.25H8.08l4.259 5.631 5.905-5.631zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            Share on X
+          </a>
+          <a class="gp-share__btn" href="https://www.reddit.com/submit?url=https://goldpricetools.com/guides/gold-purity-guide&title=Gold+Purity+Guide+2026" target="_blank" rel="noopener noreferrer">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
+            Reddit
+          </a>
+          <a class="gp-share__btn" href="https://api.whatsapp.com/send?text=Gold+Purity+Guide+9K+to+24K+%282026%29%20https%3A%2F%2Fgoldpricetools.com%2Fguides%2Fgold-purity-guide" target="_blank" rel="noopener noreferrer">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg>
+            WhatsApp
+          </a>
+        </div>
+      </section>
+
+      <div class="gp-disclaimer" role="note" aria-label="Editorial disclaimer">
+        <strong>Disclaimer:</strong> This article is for informational and educational purposes only and does not constitute financial or investment advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always seek independent professional guidance before making significant purchases or investment decisions involving precious metals. Prices shown are indicative only and may differ from those offered by any specific dealer.
+      </div>
+
+    </div><!-- /gp-prose -->
+  </article><!-- /gp-article -->
+</div><!-- /gp-layout -->
+
+<!-- ═══ RELATED GUIDES ═══ -->
+<section class="gp-related">
+  <div class="gp-related__header">
+    <h2 class="gp-related__title">Related Guides</h2>
+    <a href="/guides/" class="gp-related__all">View all guides &rarr;</a>
+  </div>
+  <div class="gp-related__grid">
+    <a class="gp-related__card" href="/guides/gold-karat-explained">
+      <span class="gp-related__card-tag">Guide</span>
+      <div class="gp-related__card-title">Gold Karat Explained</div>
+      <div class="gp-related__card-desc">A deeper look at the karat system &mdash; how the 24-part scale works and why it exists.</div>
     </a>
-    <a class="related-card" href="/guides/how-to-sell-gold-jewellery">
-      <span class="related-card__tag">GUIDE</span>
-      <div class="related-card__title">How to Sell Gold Jewellery</div>
-      <div class="related-card__desc">Get the best price for your gold — which buyers pay more and what to expect.</div>
+    <a class="gp-related__card" href="/guides/gold-hallmarks-explained">
+      <span class="gp-related__card-tag">Guide</span>
+      <div class="gp-related__card-title">Gold Hallmarks Explained</div>
+      <div class="gp-related__card-desc">How to read maker&rsquo;s marks, assay office stamps, fineness numbers, and date letters.</div>
     </a>
-    <a class="related-card" href="/24k-gold-price-per-gram">
-      <span class="related-card__tag">LIVE PRICE</span>
-      <div class="related-card__title">24K Gold Price Per Gram</div>
-      <div class="related-card__desc">Today's pure gold price per gram — the benchmark for bullion investments.</div>
+    <a class="gp-related__card" href="/guides/how-to-test-if-gold-is-real">
+      <span class="gp-related__card-tag">Guide</span>
+      <div class="gp-related__card-title">How to Test if Gold Is Real</div>
+      <div class="gp-related__card-desc">Step-by-step home tests for verifying gold authenticity before you buy or sell.</div>
     </a>
-    <a class="related-card" href="/guides/gold-bar-guide">
-      <span class="related-card__tag">GUIDE</span>
-      <div class="related-card__title">Gold Bar Guide</div>
-      <div class="related-card__desc">From 1g to 400oz Good Delivery bars, learn about gold bar sizes.</div>
+    <a class="gp-related__card" href="/24k-gold-price-per-gram">
+      <span class="gp-related__card-tag">Live Price</span>
+      <div class="gp-related__card-title">24K Gold Price Per Gram</div>
+      <div class="gp-related__card-desc">Today&rsquo;s pure gold price per gram &mdash; the benchmark for all karat calculations.</div>
     </a>
-    <a class="related-card" href="/guides/how-to-invest-in-gold">
-      <span class="related-card__tag">GUIDE</span>
-      <div class="related-card__title">How to Invest in Gold</div>
-      <div class="related-card__desc">Beginner's guide covering ETFs, coins, bars, and digital gold accounts.</div>
+    <a class="gp-related__card" href="/guides/how-to-sell-gold-jewellery">
+      <span class="gp-related__card-tag">Guide</span>
+      <div class="gp-related__card-title">How to Sell Gold Jewellery</div>
+      <div class="gp-related__card-desc">Get the best price for your gold &mdash; which buyers pay more and what to expect.</div>
+    </a>
+    <a class="gp-related__card" href="/guides/gold-bar-guide">
+      <span class="gp-related__card-tag">Guide</span>
+      <div class="gp-related__card-title">Gold Bar Guide</div>
+      <div class="gp-related__card-desc">From 1g to 400oz Good Delivery bars &mdash; sizes, weights, and valuations explained.</div>
+    </a>
+    <a class="gp-related__card" href="/scrap-gold-calculator">
+      <span class="gp-related__card-tag">Calculator</span>
+      <div class="gp-related__card-title">Scrap Gold Calculator</div>
+      <div class="gp-related__card-desc">Calculate the live melt value of scrap gold by karat and weight in seconds.</div>
+    </a>
+    <a class="gp-related__card" href="/guides/how-to-invest-in-gold">
+      <span class="gp-related__card-tag">Guide</span>
+      <div class="gp-related__card-title">How to Invest in Gold</div>
+      <div class="gp-related__card-desc">Beginner&rsquo;s guide covering ETFs, coins, bars, and digital gold accounts.</div>
     </a>
   </div>
 </section>
-<footer>
-  <div class="footer-inner">
-    <div class="footer-brand-col">
+
+<!-- ═══ FOOTER ═══ -->
+<footer class="gp-footer">
+  <div class="gp-footer__inner">
+    <div class="gp-footer__brand-col">
       <div class="nav-logo" style="margin-bottom:var(--space-3)">
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
-      <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
+      <p class="gp-footer__brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p class="gp-footer__brand-note">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
-    <div class="footer-col">
+    <div class="gp-footer__col">
       <h4>Gold Prices</h4>
       <ul>
         <li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li>
@@ -657,10 +1568,9 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
-    <div class="footer-col">
+    <div class="gp-footer__col">
       <h4>Calculators</h4>
       <ul>
         <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
@@ -673,7 +1583,7 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
         <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
       </ul>
     </div>
-    <div class="footer-col">
+    <div class="gp-footer__col">
       <h4>Guides</h4>
       <ul>
         <li><a href="/guides/how-to-invest-in-gold">How to Invest in Gold</a></li>
@@ -686,7 +1596,7 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
         <li><a href="/guides/">All Guides</a></li>
       </ul>
     </div>
-    <div class="footer-col">
+    <div class="gp-footer__col">
       <h4>Blog</h4>
       <ul>
         <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
@@ -697,7 +1607,7 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
         <li><a href="/blog/">All Articles</a></li>
       </ul>
     </div>
-    <div class="footer-col">
+    <div class="gp-footer__col">
       <h4>Info</h4>
       <ul>
         <li><a href="/about">About</a></li>
@@ -708,35 +1618,182 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
       </ul>
     </div>
   </div>
-  <div class="footer-bottom">
+  <div class="gp-footer__bottom">
     <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
     <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
+
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+
 <script>
-let _deepReadFired = false;
-window.addEventListener('scroll', () => {
-  if (_deepReadFired) return;
-  const scrollTop = window.scrollY || document.documentElement.scrollTop;
-  const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-  if (scrollHeight > 0 && (scrollTop / scrollHeight) > 0.75) {
-    gtag('event', 'guide_deep_read');
-    _deepReadFired = true;
+// ── Gold Purity Guide :: price fetching, TOC, FAQ, reading progress ──
+const GP_TROY_OZ_TO_GRAM = 31.1034768;
+const GP_PURITIES = {
+  '24k': 0.999,
+  '22k': 0.917,
+  '18k': 0.750,
+  '14k': 0.583,
+  '10k': 0.417,
+  '9k': 0.375
+};
+
+function gpFmtUSD(val, decimals) {
+  if (val === null || val === undefined || isNaN(val)) return '—';
+  const opts = {minimumFractionDigits: decimals ?? 2, maximumFractionDigits: decimals ?? 2};
+  return '$' + val.toLocaleString('en-US', opts);
+}
+
+function gpUpdateValuations(spotOz) {
+  const set = (id, val) => { const e = document.getElementById(id); if (e) e.textContent = val; };
+  const perGram24 = spotOz / GP_TROY_OZ_TO_GRAM;
+
+  // Sidebar live spot
+  set('spotGoldOz', gpFmtUSD(spotOz));
+  set('spotGold24g', gpFmtUSD(perGram24));
+  set('spotGold18g', gpFmtUSD(perGram24 * GP_PURITIES['18k']));
+
+  // Value table
+  Object.entries(GP_PURITIES).forEach(([k, frac]) => {
+    set('val-' + k, gpFmtUSD(perGram24 * frac));
+  });
+}
+
+async function gpFetchPrices() {
+  try {
+    const res = await fetch('https://api.gold-api.com/price/XAU');
+    const data = await res.json();
+    if (data && data.price) gpUpdateValuations(data.price);
+  } catch (e) {
+    console.warn('Gold price fetch failed', e);
   }
-}, { passive: true });
+}
+
+// Reading progress bar
+function gpInitProgress() {
+  const bar = document.getElementById('gp-progress');
+  if (!bar) return;
+  const update = () => {
+    const scrollTop = window.scrollY;
+    const docH = document.documentElement.scrollHeight - window.innerHeight;
+    const pct = docH > 0 ? Math.min(100, (scrollTop / docH) * 100) : 0;
+    bar.style.width = pct + '%';
+    bar.setAttribute('aria-valuenow', Math.round(pct));
+  };
+  window.addEventListener('scroll', update, {passive: true});
+  update();
+}
+
+// TOC active section highlighting
+function gpInitTocHighlight() {
+  const links = document.querySelectorAll('.gp-toc__link');
+  if (!links.length) return;
+  const sections = Array.from(links).map(l => {
+    const id = l.getAttribute('href').slice(1);
+    return {link: l, section: document.getElementById(id)};
+  }).filter(x => x.section);
+  if (!sections.length) return;
+
+  const obs = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        links.forEach(l => l.classList.remove('active'));
+        const active = sections.find(s => s.section === entry.target);
+        if (active) active.link.classList.add('active');
+      }
+    });
+  }, {rootMargin: '-80px 0px -60% 0px', threshold: 0});
+
+  sections.forEach(s => obs.observe(s.section));
+}
+
+// Mobile TOC toggle
+function gpInitMobileToc() {
+  const btn = document.getElementById('tocToggle');
+  const nav = document.getElementById('tocMobile');
+  if (!btn || !nav) return;
+  btn.addEventListener('click', () => {
+    const expanded = btn.getAttribute('aria-expanded') === 'true';
+    btn.setAttribute('aria-expanded', !expanded);
+    nav.hidden = expanded;
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      btn.setAttribute('aria-expanded', 'false');
+      nav.hidden = true;
+    });
+  });
+}
+
+// FAQ accordion
+function gpInitFaq() {
+  document.querySelectorAll('.gp-faq__question').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const answer = btn.nextElementSibling;
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      document.querySelectorAll('.gp-faq__question').forEach(b => {
+        b.setAttribute('aria-expanded', 'false');
+        const a = b.nextElementSibling;
+        if (a) a.hidden = true;
+      });
+      if (!expanded) {
+        btn.setAttribute('aria-expanded', 'true');
+        if (answer) answer.hidden = false;
+      }
+    });
+  });
+}
+
+// Deep read analytics
+function gpInitDeepRead() {
+  let fired = false;
+  window.addEventListener('scroll', () => {
+    if (fired) return;
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+    if (scrollHeight > 0 && (scrollTop / scrollHeight) > 0.75) {
+      if (typeof gtag === 'function') gtag('event', 'guide_deep_read', {guide: 'gold-purity-guide'});
+      fired = true;
+    }
+  }, {passive: true});
+}
+
+// Share tracking
+function gpInitShare() {
+  document.querySelectorAll('.gp-share__btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (typeof gtag === 'function') {
+        gtag('event', 'share', {content_type: 'article', item_id: window.location.pathname});
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  gpFetchPrices();
+  gpInitProgress();
+  gpInitTocHighlight();
+  gpInitMobileToc();
+  gpInitFaq();
+  gpInitDeepRead();
+  gpInitShare();
+  setInterval(gpFetchPrices, 60000);
+});
 </script>
+
 <script>(function(){
   const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
   let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
   root.setAttribute('data-theme',theme);
-  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  function setIcon(){if(!themeBtn)return;themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');}
+  setIcon();
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);try{localStorage.setItem('gpt-theme',theme);}catch(e){}setIcon();});}
   const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
   if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
   document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
   document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
-  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
 })();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Full editorial redesign of `/guides/gold-purity-guide`, matching the visual quality of the existing Gold Bar Guide while introducing original components tailored to the purity topic.

The page was rebuilt mobile-first, scales cleanly from 375px → 1440px+, and supports both light and dark themes.

## What changed

**Layout & navigation**
- Reading-progress bar fixed to viewport top
- Radial-gradient hero with subtle grid + orb backdrop, breadcrumb, byline, read-time
- Four hero quick-reference cards (24K / 22K / 18K / 14K) with frosted glass treatment in dark mode
- Sticky desktop sidebar TOC with active-section IntersectionObserver highlighting and live spot rows (24K oz, 24K g, 18K g)
- Collapsible mobile TOC with 44px+ tap targets

**Content components**
- Two-card explainer for the Karat (K) vs Millesimal Fineness systems
- 11-row comprehensive purity chart with inline gold-gradient content bars (8K → 24K)
- Per-karat deep-dive cards (9K, 10K, 14K, 18K, 22K, 24K) — each with a radial-gradient metallic disc whose colour matches the actual purity tint, chips for fineness/hardness/colour, and a "Best for" footer
- Yellow / White / Rose gold colour swatches with alloy breakdown
- Six regional preference cards (South Asia, East Asia, Middle East, Europe, North America, Latin America)
- Five-step home-testing guide (hallmark, magnet, water density, acid, household) with neon stamp chips and limitation callouts
- Household-test sub-grid with reliability ratings (Mildly useful / Rough indicator / Not recommended / Unreliable)
- Three professional testing method cards (XRF featured, Sigma Metalytics, Fire Assay) with green-tinted advantages list for XRF
- Animated value-per-karat progress-bar table, wired to live LBMA spot price (refreshes every 60s)
- Six-card "Which karat to choose" decision matrix
- Gold-coin grid (Maple Leaf, Panda, Buffalo, Kangaroo, Eagle, Krugerrand, Sovereign, Britannia) with metallic icons tinted to coin purity
- Calculator-formula callout with worked example
- Accordion FAQ wired to FAQPage JSON-LD
- Gold CTA, share buttons (X / Reddit / WhatsApp), disclaimer, related-guides grid

**Design system**
- Typography: IBM Plex Sans + Inter + Playfair Display (display + serif accents)
- Brand tokens (gold, teal, surface, border) preserved across light/dark
- All touch targets ≥ 44px, focus rings on every interactive element
- `prefers-reduced-motion` respected (transitions/animations disabled)
- SVG-only icons (no emoji), `cursor-pointer` on every clickable surface
- Mobile-first breakpoints at 480 / 640 / 768 / 1024px
- HTML validated — zero unbalanced tags, zero parser errors

**SEO / structured data**
- Article, FAQPage (7 questions), BreadcrumbList JSON-LD
- Canonical + hreflang preserved
- 60s LBMA spot refresh feeds value table

## Test plan

- [ ] Visual: hero renders correctly at 375px, 640px, 1024px, 1440px
- [ ] Visual: light/dark theme toggle preserves readability and gradient orbs
- [ ] Behaviour: sticky TOC highlights the section currently in view
- [ ] Behaviour: mobile TOC opens, scrolls to anchors, then closes
- [ ] Behaviour: FAQ accordion opens one item at a time
- [ ] Behaviour: reading-progress bar tracks scroll 0→100%
- [ ] Behaviour: value table prices update from live `api.gold-api.com` feed
- [ ] Behaviour: theme toggle, hamburger menu, mega-nav still work
- [ ] A11y: keyboard tab order, focus-visible rings, screen-reader landmarks
- [ ] A11y: `prefers-reduced-motion` disables transitions
- [ ] SEO: structured data validates (FAQ + Article + Breadcrumb)

https://claude.ai/code/session_01LVj5mMgDoK7NtC1VYJ8pjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVj5mMgDoK7NtC1VYJ8pjb)_