### PR TITLE
Redesign Where-to-Sell article with premium editorial UX

### DIFF
--- a/where-to-sell-gold-silver.html
+++ b/where-to-sell-gold-silver.html
@@ -9,7 +9,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Where to Sell Gold & Silver in 2026 | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Compare the best places to sell gold and silver. Find out which pays closest to spot price and how to avoid getting ripped off.">
+<meta name="description" content="Where to sell gold and silver in 2026: online bullion dealers (95–99% of spot), specialist dealers, pawn shops, jewellers, auctions and more. Compare payouts, speed and scams to avoid.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/where-to-sell-gold-silver">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/where-to-sell-gold-silver">
@@ -28,7 +28,7 @@
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Where to Sell Gold and Silver in 2026 — Best Options Compared","description":"Compare the best places to sell gold and silver. Find out which pays closest to spot price and how to avoid getting ripped off.","url":"https://goldpricetools.com/where-to-sell-gold-silver","datePublished":"2026-04-30","dateModified":"2026-05-17T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/where-to-sell-gold-silver"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"Where to Sell Gold and Silver"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Where is the best place to sell gold?","acceptedAnswer":{"@type":"Answer","text":"Online bullion dealers generally offer the best payouts for coins and bars (90-97% of spot), while refineries pay the most for scrap gold (90-95%). For small amounts of jewellery, a local coin shop or independent jeweller will typically pay 80-92%."}},{"@type":"Question","name":"How much should I expect to get when selling silver?","acceptedAnswer":{"@type":"Answer","text":"Expect to receive around 90-95% of the spot price for sovereign silver coins (like Silver Eagles or Maples) from online dealers. Generic silver rounds or bars usually fetch 85-90%, while scrap silver or flatware often only yields 70-80% of melt value."}},{"@type":"Question","name":"Do pawn shops pay good money for gold?","acceptedAnswer":{"@type":"Answer","text":"Pawn shops should be a last resort. They typically offer the lowest payouts, ranging from 50% to 70% of the actual gold spot value, because they have high overhead costs and act as intermediaries."}},{"@type":"Question","name":"How do I know I'm getting a fair price for scrap gold?","acceptedAnswer":{"@type":"Answer","text":"Always calculate your gold's melt value first using a scrap gold calculator. Get quotes from at least three different buyers, and expect a fair offer to be between 80% and 92% of the total melt value."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Where is the best place to sell gold?","acceptedAnswer":{"@type":"Answer","text":"For investment-grade bullion coins and bars, online bullion dealers (APMEX, JM Bullion, BullionByPost, SD Bullion) consistently offer the best rates — 95–99% of spot. For jewellery and scrap, specialist precious metal dealers offer the best combination of fair pricing, speed, and professional testing (70–90% of melt value)."}},{"@type":"Question","name":"How do I find gold buyers near me?","acceptedAnswer":{"@type":"Answer","text":"Search for precious metal dealers or coin dealers with strong Trustpilot and Google reviews in your area, or ask for recommendations from local collector communities. Avoid anonymous cash for gold kiosks and pop-up buyers. National trade association directories (BNTA in the UK, ICTA in the US) list vetted, reputable dealers by location."}},{"@type":"Question","name":"What is scrap gold and how do I sell it?","acceptedAnswer":{"@type":"Answer","text":"Scrap gold includes any gold jewellery, broken or unwearable pieces, dental gold, or gold items being sold for metal content only. Scrap gold is bought at a percentage of its melt value by dealers and refiners. The higher the purity and the more gold content, the more you receive per gram."}},{"@type":"Question","name":"How do I sell gold coins near me?","acceptedAnswer":{"@type":"Answer","text":"Local coin dealers (LCS) offer same-day assessment and payment for most bullion and numismatic coins. For bullion, online dealers typically offer better rates than local shops for common coins; for rare or collectible coins, a local specialist who knows the numismatic market may provide a better result."}},{"@type":"Question","name":"Can I sell silver for cash?","acceptedAnswer":{"@type":"Answer","text":"Yes — specialist dealers, bullion buyback services, and local coin dealers all buy silver coins, bars, and jewellery. For sterling silver (925) jewellery and silverware, specialist online buyers often offer better rates than local dealers. Silver-plated items (EPNS) have almost no silver value and cannot be sold as silver."}},{"@type":"Question","name":"How do I sell gold and silver tax-free?","acceptedAnswer":{"@type":"Answer","text":"Tax rules vary by jurisdiction. In the UK, selling CGT-exempt coins (Gold and Silver Britannias, Gold Sovereigns from the Royal Mint) generates no CGT regardless of profit. In the US, using a Roth IRA or similar tax-advantaged account structure can eliminate capital gains tax. Always consult a tax professional for advice specific to your situation."}},{"@type":"Question","name":"How do I sell gold online safely?","acceptedAnswer":{"@type":"Answer","text":"Use only established, reviewed dealers with transparent pricing and clear return policies. Check Trustpilot and Google reviews. Always use tracked, insured shipping with declared value. Keep proof of postage. Lock your price before shipping and confirm the dealer's process for returns if you decline the final offer."}},{"@type":"Question","name":"Where can I sell gold bars?","acceptedAnswer":{"@type":"Answer","text":"Gold bars — particularly LBMA-accredited bars from refiners like PAMP, Valcambi, and Perth Mint — are best sold to specialist bullion dealers who recognise their provenance and can offer rates close to spot. Banks rarely buy gold bars directly from private sellers; specialist dealers and online bullion buyback services are the primary route."}},{"@type":"Question","name":"Do pawn shops pay good money for gold?","acceptedAnswer":{"@type":"Answer","text":"Pawn shops typically pay only 25–60% of melt value for gold jewellery — among the lowest rates in the market. The same 14K ring weighing 5 grams could net $118 at a pawn shop versus $400+ at a specialist dealer. Pawn shops offer speed and immediate cash, but at a steep cost. Only use them when you need cash in your hands within the hour."}}]}</script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
@@ -472,6 +472,273 @@ article > a,article > ul li a,article > ol li a{color:var(--color-primary);text-
 .comparison-table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
 .comparison-table tr:last-child td{border-bottom:none}
 .comparison-table td:first-child,.comparison-table th:first-child{color:var(--color-text);font-weight:600;padding-left:0}
+
+/* ============================================================ */
+/* EDITORIAL ARTICLE — Where to Sell Gold & Silver 2026          */
+/* Mobile-first, scales to all viewports. Premium publication.   */
+/* ============================================================ */
+
+/* Reading progress bar */
+.reading-progress{position:fixed;top:0;left:0;right:0;height:3px;z-index:201;pointer-events:none;background:transparent}
+.reading-progress__bar{height:100%;width:0;background:linear-gradient(90deg,var(--color-gold),var(--color-gold-bright));transition:width .12s linear;box-shadow:0 0 12px color-mix(in oklch,var(--color-gold-bright) 50%,transparent)}
+
+/* Article container */
+.editorial{max-width:none!important;margin:0!important;padding:0!important}
+.editorial *{max-width:none}
+
+/* ─── HERO ─────────────────────────────────────────────────── */
+.ed-hero{position:relative;overflow:hidden;background:radial-gradient(ellipse at top right,color-mix(in oklch,var(--color-gold) 18%,transparent),transparent 60%),radial-gradient(ellipse at bottom left,color-mix(in oklch,var(--color-primary) 12%,transparent),transparent 50%),var(--color-surface);border-bottom:1px solid var(--color-border)}
+.ed-hero::before{content:"";position:absolute;inset:0;background-image:radial-gradient(circle at 1px 1px,var(--color-border) 1px,transparent 0);background-size:32px 32px;opacity:.25;pointer-events:none;mask:radial-gradient(ellipse at center,black 30%,transparent 70%)}
+.ed-hero__inner{position:relative;max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-8)}
+.ed-hero__badge{display:inline-flex;align-items:center;gap:var(--space-2);padding:6px 12px;background:color-mix(in oklch,var(--color-gold) 15%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-gold-bright);margin-bottom:var(--space-5)}
+.ed-hero__badge::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);box-shadow:0 0 8px var(--color-gold-bright)}
+.ed-hero h1{font-family:var(--font-display);font-size:clamp(1.75rem,3vw + .5rem,3.25rem)!important;font-weight:700;line-height:1.08;letter-spacing:-.02em;color:var(--color-text);margin:0 0 var(--space-4);max-width:18ch;text-wrap:balance}
+.ed-hero h1 .accent{background:linear-gradient(120deg,var(--color-gold) 0%,var(--color-gold-bright) 50%,#f9d76e 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.ed-byline{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-5)}
+.ed-byline a{color:var(--color-primary);font-weight:500;text-decoration:none}
+.ed-byline a:hover{text-decoration:underline}
+.ed-byline__dot{width:3px;height:3px;border-radius:50%;background:var(--color-text-faint)}
+.ed-byline__chip{display:inline-flex;align-items:center;gap:6px;padding:3px 10px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);color:var(--color-text-muted)}
+.ed-deck{font-size:clamp(1rem,.5vw + .95rem,1.25rem);line-height:1.6;color:var(--color-text-muted);max-width:62ch;margin:0 0 var(--space-8);text-wrap:pretty}
+.ed-deck strong{color:var(--color-text)}
+
+/* Hero stat row */
+.ed-stat-row{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-6)}
+@media(min-width:560px){.ed-stat-row{grid-template-columns:repeat(3,1fr);gap:var(--space-4)}}
+.ed-stat{background:color-mix(in oklch,var(--color-surface) 80%,transparent);backdrop-filter:blur(10px);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);position:relative;overflow:hidden}
+.ed-stat::after{content:"";position:absolute;top:0;left:0;width:3px;height:100%;background:linear-gradient(180deg,var(--color-gold-bright),transparent);opacity:.7}
+.ed-stat__value{font-family:var(--font-display);font-size:clamp(1.5rem,1vw + 1.25rem,2.25rem);font-weight:700;color:var(--color-gold-bright);line-height:1;letter-spacing:-.02em;font-variant-numeric:tabular-nums;margin-bottom:6px}
+.ed-stat__label{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4;font-weight:500}
+.ed-stat__source{font-size:10px;color:var(--color-text-faint);margin-top:6px;text-transform:uppercase;letter-spacing:.06em}
+
+/* ─── TL;DR / Featured Answer ─────────────────────────────── */
+.ed-tldr{max-width:1200px;margin:calc(var(--space-8) * -1) auto var(--space-8);padding:0 var(--space-4);position:relative;z-index:2}
+.ed-tldr__inner{background:var(--color-surface);border:1px solid var(--color-border);border-left:4px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);box-shadow:var(--shadow-md)}
+.ed-tldr__label{display:inline-flex;align-items:center;gap:6px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.ed-tldr__label svg{width:14px;height:14px}
+.ed-tldr p{font-size:var(--text-base);color:var(--color-text);line-height:1.65;margin:0;max-width:none}
+.ed-tldr strong{color:var(--color-gold-bright);font-weight:600}
+
+/* ─── LAYOUT: Sidebar TOC + Content ──────────────────────── */
+.ed-layout{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-12);display:block}
+@media(min-width:1024px){.ed-layout{display:grid;grid-template-columns:240px minmax(0,1fr);gap:var(--space-10);align-items:start}}
+
+/* Sticky TOC (desktop) */
+.ed-toc{display:none}
+@media(min-width:1024px){
+  .ed-toc{display:block;position:sticky;top:80px;padding-top:var(--space-4)}
+  .ed-toc__title{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-faint);margin-bottom:var(--space-3);padding-left:var(--space-3)}
+  .ed-toc__list{display:flex;flex-direction:column;gap:2px;list-style:none;padding:0;margin:0;border-left:1px solid var(--color-divider)}
+  .ed-toc__list a{display:block;padding:8px var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;border-left:2px solid transparent;margin-left:-1px;transition:color .15s,border-color .15s;line-height:1.35}
+  .ed-toc__list a:hover{color:var(--color-text);border-left-color:var(--color-text-muted)}
+  .ed-toc__list a.is-active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);font-weight:600}
+}
+
+/* Floating TOC button (mobile) */
+.ed-toc-fab{position:fixed;right:var(--space-4);bottom:var(--space-4);z-index:150;width:52px;height:52px;border-radius:50%;background:var(--color-gold-bright);color:#0f0e0c;border:none;box-shadow:0 8px 24px oklch(0 0 0/.3);display:flex;align-items:center;justify-content:center;cursor:pointer;transition:transform .2s,box-shadow .2s}
+.ed-toc-fab:hover{transform:scale(1.05);box-shadow:0 12px 32px oklch(0 0 0/.4)}
+@media(min-width:1024px){.ed-toc-fab{display:none}}
+.ed-toc-drawer{display:none;position:fixed;inset:0;z-index:200;background:oklch(0 0 0/.6);backdrop-filter:blur(4px);align-items:flex-end;justify-content:center}
+.ed-toc-drawer.is-open{display:flex}
+.ed-toc-drawer__panel{width:100%;max-width:480px;max-height:75vh;background:var(--color-surface);border-top-left-radius:var(--radius-xl);border-top-right-radius:var(--radius-xl);padding:var(--space-6) var(--space-5) var(--space-8);overflow-y:auto;animation:slideUp .25s cubic-bezier(.16,1,.3,1)}
+@keyframes slideUp{from{transform:translateY(100%)}to{transform:translateY(0)}}
+.ed-toc-drawer__handle{width:36px;height:4px;background:var(--color-text-faint);border-radius:99px;margin:0 auto var(--space-4)}
+.ed-toc-drawer__title{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.ed-toc-drawer a{display:block;padding:var(--space-3) var(--space-2);font-size:var(--text-sm);color:var(--color-text);text-decoration:none;border-bottom:1px solid var(--color-divider)}
+.ed-toc-drawer a:last-child{border-bottom:none}
+.ed-toc-drawer a:hover{color:var(--color-gold-bright)}
+
+/* ─── CONTENT ─────────────────────────────────────────────── */
+.ed-content{min-width:0}
+.ed-content > section{margin-bottom:var(--space-12);scroll-margin-top:80px}
+.ed-content > section:last-child{margin-bottom:0}
+.ed-content h2{font-family:var(--font-display);font-size:clamp(1.5rem,1.5vw + 1rem,2.125rem)!important;font-weight:700;line-height:1.15;letter-spacing:-.015em;color:var(--color-text);margin:0 0 var(--space-3)!important;max-width:24ch;text-wrap:balance;position:relative;padding-top:var(--space-2)}
+.ed-content h2::before{content:"";display:block;width:32px;height:3px;background:linear-gradient(90deg,var(--color-gold-bright),var(--color-gold));border-radius:99px;margin-bottom:var(--space-4)}
+.ed-content h3{font-family:var(--font-display);font-size:clamp(1.125rem,.5vw + 1rem,1.375rem)!important;font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)!important;line-height:1.3;letter-spacing:-.01em;max-width:none}
+.ed-content p{font-size:clamp(.9375rem,.15vw + .9rem,1.0625rem);line-height:1.75;color:var(--color-text);margin:0 0 var(--space-4)!important;max-width:65ch}
+.ed-content p strong{color:var(--color-text);font-weight:600}
+.ed-content a{color:var(--color-primary);text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;transition:color .15s}
+.ed-content a:hover{color:var(--color-primary-hover)}
+.ed-content ul,.ed-content ol{padding-left:0;list-style:none;margin:0 0 var(--space-5);max-width:65ch}
+.ed-content ul li,.ed-content ol li{position:relative;padding-left:var(--space-6);font-size:clamp(.9375rem,.15vw + .9rem,1.0625rem);line-height:1.7;color:var(--color-text);margin-bottom:var(--space-2)}
+.ed-content ul > li::before{content:"";position:absolute;left:0;top:.6em;width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright)}
+.ed-content ol{counter-reset:ol-counter}
+.ed-content ol > li{counter-increment:ol-counter}
+.ed-content ol > li::before{content:counter(ol-counter,decimal-leading-zero);position:absolute;left:0;top:0;font-family:var(--font-display);font-weight:700;color:var(--color-gold-bright);font-size:var(--text-sm);font-variant-numeric:tabular-nums}
+
+/* Highlighted bullet item start */
+.ed-content ul li strong:first-child,.ed-content ol li strong:first-child{color:var(--color-text)}
+
+/* Section divider */
+.ed-divider{border:0;height:1px;background:linear-gradient(90deg,transparent,var(--color-border),transparent);margin:var(--space-12) 0}
+
+/* ─── CALLOUTS ───────────────────────────────────────────── */
+.ed-callout{display:flex;gap:var(--space-3);padding:var(--space-4) var(--space-5);margin:var(--space-5) 0;border-radius:var(--radius-lg);border:1px solid var(--color-border);background:var(--color-surface-offset);font-size:var(--text-sm);line-height:1.65;color:var(--color-text)}
+.ed-callout__icon{flex-shrink:0;width:24px;height:24px;display:flex;align-items:center;justify-content:center;border-radius:50%;font-weight:700;font-size:13px;margin-top:2px}
+.ed-callout p{margin:0!important;font-size:inherit!important;color:inherit!important;line-height:inherit!important;max-width:none!important}
+.ed-callout p + p{margin-top:var(--space-2)!important}
+.ed-callout strong{color:var(--color-text);font-weight:700}
+.ed-callout--info{border-left:3px solid var(--color-primary);background:color-mix(in oklch,var(--color-primary) 8%,var(--color-surface-offset))}
+.ed-callout--info .ed-callout__icon{background:var(--color-primary);color:#fff}
+.ed-callout--tip{border-left:3px solid var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset))}
+.ed-callout--tip .ed-callout__icon{background:var(--color-gold-bright);color:#0f0e0c}
+.ed-callout--warning{border-left:3px solid #f59e0b;background:color-mix(in oklch,#f59e0b 8%,var(--color-surface-offset))}
+.ed-callout--warning .ed-callout__icon{background:#f59e0b;color:#0f0e0c}
+.ed-callout--danger{border-left:3px solid #ef4444;background:color-mix(in oklch,#ef4444 8%,var(--color-surface-offset))}
+.ed-callout--danger .ed-callout__icon{background:#ef4444;color:#fff}
+
+/* ─── STEPS / METHODOLOGY ─────────────────────────────────── */
+.ed-steps{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0}
+@media(min-width:768px){.ed-steps{grid-template-columns:repeat(3,1fr)}}
+.ed-step{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);transition:border-color .2s,transform .2s}
+.ed-step:hover{border-color:var(--color-gold-bright);transform:translateY(-2px)}
+.ed-step__num{font-family:var(--font-display);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);letter-spacing:.1em;margin-bottom:var(--space-2)}
+.ed-step h3{font-size:var(--text-base)!important;margin:0 0 var(--space-2)!important;color:var(--color-text)}
+.ed-step p{font-size:var(--text-sm)!important;color:var(--color-text-muted)!important;line-height:1.6!important;margin:0!important;max-width:none!important}
+
+/* Formula highlight */
+.ed-formula{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold) 8%,var(--color-surface)),var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-5) 0}
+.ed-formula__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.ed-formula__expr{font-family:var(--font-display);font-size:clamp(1rem,1vw + .85rem,1.375rem);font-weight:600;color:var(--color-text);line-height:1.4;letter-spacing:-.01em;margin-bottom:var(--space-3);text-align:center;padding:var(--space-4) var(--space-3);background:var(--color-bg);border-radius:var(--radius-md);border:1px dashed color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border))}
+.ed-formula__example{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;font-variant-numeric:tabular-nums}
+.ed-formula__example strong{color:var(--color-gold-bright);font-size:var(--text-base);font-weight:700}
+
+/* ─── CHANNEL CARDS ──────────────────────────────────────── */
+.ed-channels{display:flex;flex-direction:column;gap:var(--space-4);margin:var(--space-6) 0}
+.ed-channel{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;transition:border-color .2s,box-shadow .2s}
+@media(min-width:640px){.ed-channel{padding:var(--space-6)}}
+.ed-channel:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));box-shadow:var(--shadow-md)}
+.ed-channel--best{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold) 5%,var(--color-surface)),var(--color-surface))}
+.ed-channel--best::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--color-gold),var(--color-gold-bright),var(--color-gold));z-index:1}
+.ed-channel--worst{opacity:.92}
+.ed-channel__head{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin-bottom:var(--space-3)}
+.ed-channel__rank{font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text-faint);letter-spacing:.05em}
+.ed-channel__badge{display:inline-flex;align-items:center;gap:4px;padding:3px 10px;border-radius:var(--radius-full);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em}
+.ed-channel__badge--best{background:color-mix(in oklch,var(--color-gold-bright) 18%,transparent);color:var(--color-gold-bright);border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,transparent)}
+.ed-channel__badge--good{background:color-mix(in oklch,var(--color-primary) 15%,transparent);color:var(--color-primary);border:1px solid color-mix(in oklch,var(--color-primary) 30%,transparent)}
+.ed-channel__badge--caution{background:color-mix(in oklch,#f59e0b 15%,transparent);color:#f59e0b;border:1px solid color-mix(in oklch,#f59e0b 30%,transparent)}
+.ed-channel__badge--avoid{background:color-mix(in oklch,#ef4444 15%,transparent);color:#ef4444;border:1px solid color-mix(in oklch,#ef4444 30%,transparent)}
+.ed-channel h3{font-family:var(--font-display);font-size:clamp(1.125rem,.5vw + 1rem,1.5rem)!important;font-weight:700;color:var(--color-text);margin:0 0 var(--space-1)!important;letter-spacing:-.015em}
+.ed-channel__sub{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4)}
+.ed-channel__body p{font-size:var(--text-sm)!important;line-height:1.65!important;color:var(--color-text-muted)!important;margin:0 0 var(--space-3)!important;max-width:none!important}
+.ed-channel__body p strong{color:var(--color-text)}
+
+/* Payout bar visualization */
+.ed-payout{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-4) 0;padding:var(--space-4);background:var(--color-bg);border-radius:var(--radius-md);border:1px solid var(--color-divider)}
+@media(min-width:480px){.ed-payout{grid-template-columns:1fr auto;align-items:center;gap:var(--space-5)}}
+.ed-payout__bar{flex:1;min-width:0}
+.ed-payout__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:6px}
+.ed-payout__track{position:relative;height:10px;background:var(--color-surface-offset);border-radius:99px;overflow:hidden;border:1px solid var(--color-divider)}
+.ed-payout__fill{height:100%;border-radius:99px;background:linear-gradient(90deg,var(--color-gold),var(--color-gold-bright));position:relative;transition:width .4s cubic-bezier(.16,1,.3,1)}
+.ed-payout__fill--high{background:linear-gradient(90deg,#10b981,#34d399)}
+.ed-payout__fill--mid{background:linear-gradient(90deg,var(--color-gold),var(--color-gold-bright))}
+.ed-payout__fill--low{background:linear-gradient(90deg,#f59e0b,#fbbf24)}
+.ed-payout__fill--bad{background:linear-gradient(90deg,#ef4444,#f87171)}
+.ed-payout__scale{display:flex;justify-content:space-between;font-size:10px;color:var(--color-text-faint);margin-top:4px;font-variant-numeric:tabular-nums}
+.ed-payout__value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;white-space:nowrap;letter-spacing:-.01em}
+.ed-channel--best .ed-payout__fill{box-shadow:0 0 12px color-mix(in oklch,var(--color-gold-bright) 60%,transparent)}
+
+.ed-channel__meta{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);padding:var(--space-3);background:var(--color-surface-offset);border-radius:var(--radius-md);margin:var(--space-4) 0;font-size:var(--text-xs)}
+@media(min-width:480px){.ed-channel__meta{grid-template-columns:repeat(3,1fr)}}
+.ed-channel__meta-item{display:flex;flex-direction:column;gap:2px}
+.ed-channel__meta-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint)}
+.ed-channel__meta-value{font-size:var(--text-sm);font-weight:600;color:var(--color-text)}
+
+.ed-channel__pros{display:grid;grid-template-columns:1fr;gap:var(--space-1) var(--space-4);margin:var(--space-3) 0 0!important;list-style:none;padding:0!important;max-width:none!important}
+@media(min-width:520px){.ed-channel__pros{grid-template-columns:1fr 1fr}}
+.ed-channel__pros li{position:relative;padding-left:22px!important;font-size:var(--text-sm)!important;line-height:1.5!important;color:var(--color-text)!important;margin-bottom:0!important}
+.ed-channel__pros li::before{content:""!important;position:absolute;left:0;top:.45em;width:14px;height:14px;background:none!important;border-radius:0;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2310b981' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6L9 17l-5-5'/%3E%3C/svg%3E")!important;background-size:contain;background-repeat:no-repeat}
+
+/* ─── INFO GRID (Coins, Silver categories) ─────────────────── */
+.ed-info-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-5) 0}
+@media(min-width:640px){.ed-info-grid{grid-template-columns:1fr 1fr}}
+.ed-info-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);transition:border-color .2s}
+.ed-info-card:hover{border-color:var(--color-primary)}
+.ed-info-card__tag{display:inline-block;padding:3px 10px;border-radius:var(--radius-full);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,transparent);margin-bottom:var(--space-2)}
+.ed-info-card h3{font-size:var(--text-base)!important;margin:0 0 var(--space-2)!important}
+.ed-info-card p{font-size:var(--text-sm)!important;line-height:1.65!important;color:var(--color-text-muted)!important;margin:0!important;max-width:none!important}
+
+/* ─── TIMELINE / STEPS ────────────────────────────────────── */
+.ed-timeline{margin:var(--space-6) 0;padding:0!important;list-style:none}
+.ed-timeline li{position:relative;padding:0 0 var(--space-5) var(--space-8)!important;border-left:2px solid var(--color-divider);margin:0 0 0 var(--space-3)!important;font-size:clamp(.9375rem,.15vw + .9rem,1.0625rem);line-height:1.7;color:var(--color-text)}
+.ed-timeline li:last-child{border-left-color:transparent;padding-bottom:0!important}
+.ed-timeline li::before{content:counter(timeline-counter)!important;counter-increment:timeline-counter;position:absolute;left:-19px!important;top:-2px!important;width:36px;height:36px;border-radius:50%;background:var(--color-bg);border:2px solid var(--color-gold-bright);color:var(--color-gold-bright);font-family:var(--font-display);font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-variant-numeric:tabular-nums}
+.ed-timeline{counter-reset:timeline-counter}
+.ed-timeline li strong{display:block;color:var(--color-text);font-size:var(--text-base);margin-bottom:4px;font-weight:600}
+
+/* ─── PREMIUM COMPARISON TABLE ─────────────────────────────── */
+.ed-table-wrap{margin:var(--space-5) 0;overflow:hidden;border-radius:var(--radius-lg);border:1px solid var(--color-border);background:var(--color-surface)}
+.ed-table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.ed-table{width:100%;min-width:640px;border-collapse:collapse;font-size:var(--text-sm)}
+.ed-table thead th{position:sticky;top:0;background:var(--color-surface-offset);text-align:left;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-border);white-space:nowrap}
+.ed-table tbody td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text);vertical-align:middle;line-height:1.5}
+.ed-table tbody tr:last-child td{border-bottom:none}
+.ed-table tbody tr:hover td{background:color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface))}
+.ed-table td.ed-td-name{font-weight:600;color:var(--color-text);min-width:200px}
+.ed-table td.ed-td-payout{font-family:var(--font-display);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;white-space:nowrap}
+.ed-table .ed-row-best td.ed-td-payout{color:#10b981}
+.ed-table .ed-row-avoid td.ed-td-payout{color:#ef4444}
+.ed-table-scroll-hint{display:flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);background:var(--color-surface-offset);font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);border-top:1px solid var(--color-divider)}
+@media(min-width:640px){.ed-table-scroll-hint{display:none}}
+
+/* ─── WARNING / SCAM CARDS ─────────────────────────────────── */
+.ed-warnings{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:640px){.ed-warnings{grid-template-columns:1fr 1fr}}
+.ed-warning{display:flex;gap:var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid #ef4444;border-radius:var(--radius-md);padding:var(--space-4) var(--space-5)}
+.ed-warning__icon{flex-shrink:0;width:32px;height:32px;border-radius:50%;background:color-mix(in oklch,#ef4444 15%,transparent);color:#ef4444;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:var(--text-base)}
+.ed-warning__body{flex:1;min-width:0}
+.ed-warning__body h3{font-size:var(--text-sm)!important;font-weight:700;color:var(--color-text);margin:0 0 4px!important;line-height:1.3}
+.ed-warning__body p{font-size:var(--text-xs)!important;line-height:1.55!important;color:var(--color-text-muted)!important;margin:0!important;max-width:none!important}
+
+/* ─── FAQ ACCORDION ────────────────────────────────────────── */
+.ed-faq{display:flex;flex-direction:column;gap:var(--space-2);margin:var(--space-5) 0}
+.ed-faq details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color .2s}
+.ed-faq details:hover{border-color:var(--color-primary)}
+.ed-faq details[open]{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));background:color-mix(in oklch,var(--color-gold) 3%,var(--color-surface))}
+.ed-faq summary{list-style:none;cursor:pointer;padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);display:flex;justify-content:space-between;align-items:center;gap:var(--space-3);line-height:1.4;transition:background .15s}
+.ed-faq summary::-webkit-details-marker{display:none}
+.ed-faq summary::after{content:"";flex-shrink:0;width:22px;height:22px;border-radius:50%;border:1.5px solid var(--color-text-muted);background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2.5' stroke-linecap='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");background-size:14px 14px;background-position:center;background-repeat:no-repeat;color:var(--color-text-muted);transition:transform .25s,border-color .25s,color .25s}
+.ed-faq details[open] summary::after{transform:rotate(180deg);border-color:var(--color-gold-bright);color:var(--color-gold-bright)}
+.ed-faq summary:hover{background:var(--color-surface-offset)}
+.ed-faq details[open] summary{background:transparent}
+.ed-faq__body{padding:0 var(--space-5) var(--space-5);border-top:1px solid var(--color-divider);padding-top:var(--space-4);margin-top:0}
+.ed-faq__body p{font-size:var(--text-sm)!important;line-height:1.7!important;color:var(--color-text-muted)!important;margin:0!important;max-width:none!important}
+.ed-faq__body p + p{margin-top:var(--space-3)!important}
+
+/* ─── PULL QUOTE ───────────────────────────────────────────── */
+.ed-pullquote{margin:var(--space-6) 0;padding:var(--space-5) var(--space-6);border-left:3px solid var(--color-gold-bright);background:var(--color-surface-offset);border-radius:0 var(--radius-md) var(--radius-md) 0;font-family:var(--font-display);font-size:clamp(1.0625rem,.8vw + .9rem,1.375rem);font-weight:500;line-height:1.5;color:var(--color-text);font-style:italic;letter-spacing:-.01em}
+.ed-pullquote::before{content:"\201C";display:block;font-family:Georgia,serif;font-size:3rem;color:var(--color-gold-bright);line-height:1;margin-bottom:-1.5rem;font-style:normal}
+
+/* ─── DISCLAIMER ───────────────────────────────────────────── */
+.ed-disclaimer{max-width:1200px;margin:var(--space-10) auto 0;padding:var(--space-5) var(--space-4);font-size:var(--text-xs);color:var(--color-text-faint);line-height:1.7;text-align:center;border-top:1px solid var(--color-divider);font-style:italic}
+
+/* ─── RELATED SECTION (override default) ───────────────────── */
+.ed-related{max-width:1200px;margin:var(--space-10) auto 0;padding:0 var(--space-4)}
+.ed-related h2{font-family:var(--font-display);font-size:clamp(1.25rem,1vw + 1rem,1.75rem);font-weight:700;color:var(--color-text);margin-bottom:var(--space-5);letter-spacing:-.015em}
+.ed-related .related-guides-grid{margin-top:0}
+
+/* ─── HERO mobile spacing fix ──────────────────────────────── */
+@media(max-width:640px){
+  .ed-hero__inner{padding:var(--space-8) var(--space-4) var(--space-10)}
+  .ed-tldr{margin-top:calc(var(--space-6) * -1)}
+  .ed-tldr__inner{padding:var(--space-4) var(--space-5)}
+  .ed-channel__head{gap:6px}
+  .ed-content > section{margin-bottom:var(--space-10)}
+}
+
+/* Reduce motion */
+@media(prefers-reduced-motion:reduce){
+  .ed-step:hover,.ed-channel:hover,.ed-info-card:hover{transform:none}
+  .ed-payout__fill{transition:none}
+  .ed-toc-drawer__panel{animation:none}
+}
+
+/* Print-friendly */
+@media print{
+  .reading-progress,.ed-toc,.ed-toc-fab,.share-buttons,nav,footer{display:none!important}
+  .ed-hero{background:none}
+  .ed-content > section{break-inside:avoid}
+}
 </style>
 
 <link rel="stylesheet" href="/assets/site.css">
@@ -551,134 +818,853 @@ article > a,article > ul li a,article > ol li a{color:var(--color-primary);text-
   <li><a href="/guides/">Guides</a></li>
   <li aria-current="page">Where to Sell Gold and Silver</li>
 </ul>
-<article>
-  <header class="article-header">
-    <h1>Where to Sell Gold and Silver in 2026 — Best Options Compared</h1>
-    <div class="author-meta">
-      <div>
-        By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> &middot; Updated <time datetime="2026-05-17">April 30, 2026</time>
+
+<!-- Reading progress bar -->
+<div class="reading-progress" aria-hidden="true"><div class="reading-progress__bar" id="readingProgressBar"></div></div>
+
+<article class="editorial">
+  <!-- ═══ HERO ═══════════════════════════════════════════════ -->
+  <header class="ed-hero">
+    <div class="ed-hero__inner">
+      <div class="ed-hero__badge">2026 Selling Guide</div>
+      <h1>Where to Sell <span class="accent">Gold &amp; Silver</span> in 2026 — Best Options Compared</h1>
+      <div class="ed-byline">
+        <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
+        <span class="ed-byline__dot"></span>
+        <span>Updated <time datetime="2026-05-17">17 May 2026</time></span>
+        <span class="ed-byline__dot"></span>
+        <span class="ed-byline__chip">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+          18 min read
+        </span>
+      </div>
+      <p class="ed-deck">With gold at <strong>historic highs</strong> and silver tracking close behind, 2026 is one of the most favourable selling windows in a generation. But how much ends up in your pocket depends almost entirely on <strong>where</strong> you sell. The same 14K chain can net $940 at a pawn shop — or $1,600+ at a specialist dealer.</p>
+
+      <div class="ed-stat-row">
+        <div class="ed-stat">
+          <div class="ed-stat__value">$5,055</div>
+          <div class="ed-stat__label">Q4 2026 gold forecast per troy oz</div>
+          <div class="ed-stat__source">Source: J.P. Morgan</div>
+        </div>
+        <div class="ed-stat">
+          <div class="ed-stat__value">70%</div>
+          <div class="ed-stat__label">Price gap between pawn shop and specialist dealer</div>
+          <div class="ed-stat__source">Same 14K piece</div>
+        </div>
+        <div class="ed-stat">
+          <div class="ed-stat__value">99%</div>
+          <div class="ed-stat__label">Top bullion dealer buyback rate vs spot price</div>
+          <div class="ed-stat__source">Best-in-class</div>
+        </div>
       </div>
     </div>
-    <p class="featured-snippet">You can sell gold and silver through online bullion dealers, local coin shops, pawn shops, jewellers, or refineries. Online dealers typically offer the best prices (closest to spot), while pawn shops offer convenience but pay 20–40% below spot. The best option depends on the form of your metal (jewellery, coins, bars, or scrap).</p>
   </header>
-  <div class="content">
-    <h2>Quick Comparison Table</h2>
-    <table class="comparison-table">
-      <thead>
-        <tr>
-          <th>Option</th>
-          <th>Best for</th>
-          <th>Typical payout vs spot</th>
-          <th>Speed</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Online bullion dealer</td>
-          <td>Coins &amp; bars</td>
-          <td>90–97%</td>
-          <td>3–7 days</td>
-        </tr>
-        <tr>
-          <td>Local coin shop</td>
-          <td>Coins, small bars</td>
-          <td>80–92%</td>
-          <td>Same day</td>
-        </tr>
-        <tr>
-          <td>Pawn shop</td>
-          <td>Any form (last resort)</td>
-          <td>50–70%</td>
-          <td>Same day</td>
-        </tr>
-        <tr>
-          <td>Jeweller/goldsmith</td>
-          <td>Gold jewellery</td>
-          <td>60–80%</td>
-          <td>Same day</td>
-        </tr>
-        <tr>
-          <td>Refinery (direct)</td>
-          <td>Scrap, bulk</td>
-          <td>90–95%</td>
-          <td>5–14 days</td>
-        </tr>
-        <tr>
-          <td>Online marketplace (eBay)</td>
-          <td>Rare/collectible coins</td>
-          <td>Varies</td>
-          <td>Variable</td>
-        </tr>
-      </tbody>
-    </table>
 
-    <h2>Selling Online</h2>
-    <p>Selling your precious metals online is often the best way to secure a payout closest to the spot price. Major online bullion dealers such as JM Bullion, APMEX, GoldSilver.com, and Kitco have dedicated buyback programmes. These companies handle high volumes, allowing them to operate on narrower margins and offer better prices than local shops.</p>
-    <p>The process typically involves locking in a price over the phone or online, shipping your metals via insured mail, and receiving payment via bank transfer or cheque within 3 to 7 days.</p>
-
-    <h2>Selling Locally</h2>
-    <p>If you need cash immediately or prefer face-to-face transactions, selling locally is your best option. Local coin shops are generally the most reputable and offer competitive prices for bullion coins and small bars (typically 80–92% of spot).</p>
-    <p>Jewellers and goldsmiths are better suited for selling jewellery, offering 60–80% of the melt value. Pawn shops should be considered a last resort; while they offer ultimate convenience, they usually pay the lowest rates (50–70% of spot) due to their high overheads and need for higher profit margins.</p>
-
-    <h2>Selling Scrap Gold</h2>
-    <p>When selling broken jewellery, dental gold, or unhallmarked items, you are selling "scrap." The value is based entirely on the metal content, not aesthetics or craftsmanship. To ensure you don't get ripped off, it is critical to get at least 3 quotes from different buyers (such as local jewellers and online refineries).</p>
-    <p>Before soliciting quotes, always use a <a href="/scrap-gold-calculator">scrap gold calculator</a> to determine the true melt value of your items. If you are selling items of varying purities, you should also check the current <a href="/14k-gold-price-per-gram">14K gold price per gram</a> and other specific karat values.</p>
-
-    <h2>Selling Silver Coins</h2>
-    <p>Silver coins can be sold to online dealers or local coin shops. The payout depends heavily on whether the coins are sovereign bullion (like American Silver Eagles), which command a premium, or generic silver rounds. Numismatic (collectible) coins should be appraised by a specialist, as their value can far exceed their silver content. You can calculate the silver melt value of coins to have a baseline understanding.</p>
-
-    <h2>Frequently Asked Questions</h2>
-    <div class="faq-item">
-      <h3>Where is the best place to sell gold?</h3>
-      <p>Online bullion dealers generally offer the best payouts for coins and bars (90-97% of spot), while refineries pay the most for scrap gold (90-95%). For small amounts of jewellery, a local coin shop or independent jeweller will typically pay 80-92%.</p>
+  <!-- ═══ TL;DR ═════════════════════════════════════════════ -->
+  <aside class="ed-tldr">
+    <div class="ed-tldr__inner">
+      <div class="ed-tldr__label">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+        The Quick Answer
+      </div>
+      <p>For <strong>coins &amp; bars</strong>, sell to online bullion dealers (APMEX, JM Bullion, BullionByPost) — expect <strong>95–99% of spot</strong>. For <strong>jewellery &amp; scrap</strong>, use specialist precious metal dealers (70–90% of melt). For <strong>antiques and designer pieces</strong>, auction houses or specialist resellers beat melt by multiples. <strong>Avoid pawn shops and mall kiosks</strong> — they typically pay 25–60% of melt value.</p>
     </div>
-    <div class="faq-item">
-      <h3>How much should I expect to get when selling silver?</h3>
-      <p>Expect to receive around 90-95% of the spot price for sovereign silver coins (like Silver Eagles or Maples) from online dealers. Generic silver rounds or bars usually fetch 85-90%, while scrap silver or flatware often only yields 70-80% of melt value.</p>
-    </div>
-    <div class="faq-item">
-      <h3>Do pawn shops pay good money for gold?</h3>
-      <p>Pawn shops should be a last resort. They typically offer the lowest payouts, ranging from 50% to 70% of the actual gold spot value, because they have high overhead costs and act as intermediaries.</p>
-    </div>
-    <div class="faq-item">
-      <h3>How do I know I'm getting a fair price for scrap gold?</h3>
-      <p>Always calculate your gold's melt value first using a scrap gold calculator. Get quotes from at least three different buyers, and expect a fair offer to be between 80% and 92% of the total melt value.</p>
-    </div>
+  </aside>
+
+  <!-- ═══ LAYOUT (TOC + CONTENT) ═════════════════════════════ -->
+  <div class="ed-layout">
+
+    <!-- Sticky desktop TOC -->
+    <aside class="ed-toc" aria-label="Table of contents">
+      <div class="ed-toc__title">On this page</div>
+      <ul class="ed-toc__list">
+        <li><a href="#good-time">Is it a good time to sell?</a></li>
+        <li><a href="#know-value">Know your metal's value</a></li>
+        <li><a href="#channels">All selling channels</a></li>
+        <li><a href="#coins">Selling gold coins</a></li>
+        <li><a href="#silver">Selling silver</a></li>
+        <li><a href="#how-online">How to sell online</a></li>
+        <li><a href="#comparison">Comparison at a glance</a></li>
+        <li><a href="#tax">Tax considerations</a></li>
+        <li><a href="#scams">Red flags &amp; scams</a></li>
+        <li><a href="#tips">Tips to maximise</a></li>
+        <li><a href="#faq">FAQ</a></li>
+      </ul>
+    </aside>
+
+    <!-- Main content -->
+    <main class="ed-content">
+
+      <!-- ─── SECTION 1: Good time to sell? ─── -->
+      <section id="good-time">
+        <h2>Is It a Good Time to Sell Gold and Silver in 2026?</h2>
+        <p><strong>Short answer: yes, by almost any metric.</strong> Gold hit its highest-ever recorded price in March 2026 — and while prices have softened slightly from that peak as markets consolidate, the underlying demand picture remains strongly supportive. The World Gold Council noted that gold had achieved over 50 all-time highs in 2025 alone before carrying that momentum into 2026. Silver has tracked gold with even sharper moves in percentage terms.</p>
+        <p>The structural case for high precious metal prices — central bank accumulation, de-dollarisation, persistent geopolitical uncertainty, and elevated inflation expectations — has not materially changed. Even if prices dip modestly from current levels, anyone who acquired gold or silver before 2023 is sitting on significant gains.</p>
+
+        <div class="ed-pullquote">A piece of 18K jewellery worth $90/g in melt value two years ago might now be worth $130–$140/g — without you doing a thing.</div>
+
+        <p>For sellers, the implication is straightforward: <strong>the higher the spot price, the more every gram is worth</strong>. If you have inherited jewellery you will never wear, duplicate coins, or scrap metal collecting dust, converting it at today's prices is rational financial decision-making.</p>
+
+        <div class="ed-callout ed-callout--info">
+          <div class="ed-callout__icon">i</div>
+          <p><strong>That said, &quot;should I sell?&quot; is personal.</strong> If you hold gold as a long-term inflation hedge or portfolio anchor, the case for keeping it remains strong. This guide focuses on getting maximum value from the metal you've already decided to part with.</p>
+        </div>
+      </section>
+
+      <!-- ─── SECTION 2: Know your value ─── -->
+      <section id="know-value">
+        <h2>Know Your Metal's Value Before You Sell</h2>
+        <p>The single most important thing you can do before approaching any buyer is to understand what your metal is actually worth. This removes any information asymmetry between you and the person making an offer — and makes it immediately obvious when you are being lowballed.</p>
+
+        <div class="ed-steps">
+          <div class="ed-step">
+            <div class="ed-step__num">STEP 01</div>
+            <h3>Check the live spot price</h3>
+            <p>The gold spot price is the global benchmark — the price at which one troy ounce of pure gold trades right now. Use <a href="/gold-per-gram-today">live tools</a> updated every 60 seconds.</p>
+          </div>
+          <div class="ed-step">
+            <div class="ed-step__num">STEP 02</div>
+            <h3>Calculate your melt value</h3>
+            <p>This is the intrinsic gold (or silver) content converted to dollars. Use weight, purity, and the current spot price per gram.</p>
+          </div>
+          <div class="ed-step">
+            <div class="ed-step__num">STEP 03</div>
+            <h3>Understand &quot;% of spot&quot;</h3>
+            <p>No buyer pays 100% of melt. The question is how big the margin is — 95–98% for top bullion dealers, 25–40% for pawn shops.</p>
+          </div>
+        </div>
+
+        <div class="ed-formula">
+          <div class="ed-formula__label">★ Melt Value Formula</div>
+          <div class="ed-formula__expr">Weight (g) × Purity × Spot Price / g</div>
+          <div class="ed-formula__example">Example: a 20-gram, 18K gold bracelet at $150/g for pure 24K gold →<br>20 × 0.75 × $150 = <strong>$2,250 melt value</strong></div>
+        </div>
+
+        <p>Online calculators on sites like <a href="/scrap-gold-calculator">GoldPriceTools' scrap gold calculator</a> allow you to input the karat (9K, 10K, 14K, 18K, 22K, 24K) and weight directly for an instant figure. Knowing your melt value before any conversation gives you the power to evaluate every offer on its merits and walk away when it falls short.</p>
+      </section>
+
+      <!-- ─── SECTION 3: Channels ─── -->
+      <section id="channels">
+        <h2>All the Places You Can Sell Gold and Silver</h2>
+        <p>Seven main channels exist for selling precious metals — each with a different combination of payout, speed, and required effort. Match the channel to your asset type and your priorities.</p>
+
+        <div class="ed-channels">
+
+          <!-- Channel 1 -->
+          <article class="ed-channel ed-channel--best">
+            <div class="ed-channel__head">
+              <span class="ed-channel__rank">01</span>
+              <span class="ed-channel__badge ed-channel__badge--best">★ Best Price</span>
+            </div>
+            <h3>Online Bullion Dealers</h3>
+            <div class="ed-channel__sub">For investment coins &amp; bars</div>
+
+            <div class="ed-payout">
+              <div class="ed-payout__bar">
+                <div class="ed-payout__label">Typical payout vs spot</div>
+                <div class="ed-payout__track"><div class="ed-payout__fill ed-payout__fill--high" style="width:97%"></div></div>
+                <div class="ed-payout__scale"><span>0%</span><span>50%</span><span>100%</span></div>
+              </div>
+              <div class="ed-payout__value">95–99%</div>
+            </div>
+
+            <div class="ed-channel__meta">
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Speed</div><div class="ed-channel__meta-value">3–5 days</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Minimum</div><div class="ed-channel__meta-value">$500–$1,000</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Effort</div><div class="ed-channel__meta-value">Low</div></div>
+            </div>
+
+            <div class="ed-channel__body">
+              <p>For investment-grade gold and silver — bullion bars, recognisable mint coins (American Eagles, Maple Leafs, Britannias, Krugerrands, Kangaroos), and rounds — <strong>specialist online bullion dealers offer the most competitive buyback rates anywhere</strong>. Volume + scale = thin margins, consistently closest-to-spot offers.</p>
+              <p><strong>Leading dealers:</strong> APMEX, JM Bullion, SD Bullion, BullionByPost. BullionByPost publishes live buyback at 96% (gold) and 100.1% (silver coins) directly on their site. JM Bullion lets you lock prices online 24/7.</p>
+              <ul class="ed-channel__pros">
+                <li>Closest to spot price available</li>
+                <li>24/7 online price locking</li>
+                <li>Industry-trusted brands</li>
+                <li>Fast bank transfer payment</li>
+              </ul>
+            </div>
+          </article>
+
+          <!-- Channel 2 -->
+          <article class="ed-channel">
+            <div class="ed-channel__head">
+              <span class="ed-channel__rank">02</span>
+              <span class="ed-channel__badge ed-channel__badge--best">★ Best for Scrap</span>
+            </div>
+            <h3>Specialist Precious Metal Dealers</h3>
+            <div class="ed-channel__sub">For jewellery, scrap &amp; mixed lots</div>
+
+            <div class="ed-payout">
+              <div class="ed-payout__bar">
+                <div class="ed-payout__label">Typical payout vs melt</div>
+                <div class="ed-payout__track"><div class="ed-payout__fill ed-payout__fill--mid" style="width:80%"></div></div>
+                <div class="ed-payout__scale"><span>0%</span><span>50%</span><span>100%</span></div>
+              </div>
+              <div class="ed-payout__value">70–90%</div>
+            </div>
+
+            <div class="ed-channel__meta">
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Speed</div><div class="ed-channel__meta-value">Same day – 3 days</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Minimum</div><div class="ed-channel__meta-value">None</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Effort</div><div class="ed-channel__meta-value">Low</div></div>
+            </div>
+
+            <div class="ed-channel__body">
+              <p>For metal that <em>isn't</em> investment-grade bullion — jewellery, scrap, broken pieces, mixed-karat items — specialist dealers are the best channel. They have XRF machines and acid test kits for mixed lots, operate at higher margins than bullion dealers but far lower than pawn shops.</p>
+              <p><strong>Reputable names:</strong> Hatton Garden Metals (London), Gold Traders, Gold Bank, plus strong regional operators. Always check Trustpilot, look for Trading Standards approval or national trade association membership.</p>
+              <ul class="ed-channel__pros">
+                <li>Professional XRF / acid testing</li>
+                <li>Handles mixed-karat lots fairly</li>
+                <li>Mail-in or in-person options</li>
+                <li>Same-day payment available</li>
+              </ul>
+            </div>
+          </article>
+
+          <!-- Channel 3 -->
+          <article class="ed-channel">
+            <div class="ed-channel__head">
+              <span class="ed-channel__rank">03</span>
+              <span class="ed-channel__badge ed-channel__badge--good">Good — Same-Day</span>
+            </div>
+            <h3>Local Coin Dealers (LCS)</h3>
+            <div class="ed-channel__sub">For bullion &amp; numismatic coins</div>
+
+            <div class="ed-payout">
+              <div class="ed-payout__bar">
+                <div class="ed-payout__label">Typical payout vs spot</div>
+                <div class="ed-payout__track"><div class="ed-payout__fill ed-payout__fill--mid" style="width:86%"></div></div>
+                <div class="ed-payout__scale"><span>0%</span><span>50%</span><span>100%</span></div>
+              </div>
+              <div class="ed-payout__value">80–93%</div>
+            </div>
+
+            <div class="ed-channel__meta">
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Speed</div><div class="ed-channel__meta-value">Same day</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Minimum</div><div class="ed-channel__meta-value">None</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Effort</div><div class="ed-channel__meta-value">Low</div></div>
+            </div>
+
+            <div class="ed-channel__body">
+              <p>Local coin shops — often called <strong>LCS</strong> in North American collector parlance — offer same-day cash for bullion and numismatic coins. Particularly valuable if you have rare coins where a specialist's numismatic knowledge unlocks premium pricing above melt.</p>
+              <ul class="ed-channel__pros">
+                <li>Same-day cash in hand</li>
+                <li>Numismatic expertise on staff</li>
+                <li>Face-to-face transparency</li>
+                <li>Builds long-term relationships</li>
+              </ul>
+            </div>
+          </article>
+
+          <!-- Channel 4 -->
+          <article class="ed-channel">
+            <div class="ed-channel__head">
+              <span class="ed-channel__rank">04</span>
+              <span class="ed-channel__badge ed-channel__badge--good">Variable</span>
+            </div>
+            <h3>High Street Jewellers</h3>
+            <div class="ed-channel__sub">For designer &amp; branded pieces</div>
+
+            <div class="ed-payout">
+              <div class="ed-payout__bar">
+                <div class="ed-payout__label">Typical payout vs melt (plain)</div>
+                <div class="ed-payout__track"><div class="ed-payout__fill ed-payout__fill--mid" style="width:77%"></div></div>
+                <div class="ed-payout__scale"><span>0%</span><span>50%</span><span>100%</span></div>
+              </div>
+              <div class="ed-payout__value">70–85%</div>
+            </div>
+
+            <div class="ed-channel__meta">
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Speed</div><div class="ed-channel__meta-value">Same day</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Minimum</div><div class="ed-channel__meta-value">None</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Effort</div><div class="ed-channel__meta-value">Low</div></div>
+            </div>
+
+            <div class="ed-channel__body">
+              <p>Most jewellers are retailers, not metal buyers — payouts reflect that. But for <strong>Cartier, Tiffany, Bulgari and other designer pieces</strong>, jewellers and estate buyers understand brand premium and pay accordingly. A scrap dealer only pays for metal; a jeweller pays for craftsmanship + brand.</p>
+              <ul class="ed-channel__pros">
+                <li>Recognises brand &amp; design value</li>
+                <li>Estate jewellery specialists</li>
+                <li>Same-day evaluation</li>
+                <li>Consignment options sometimes available</li>
+              </ul>
+            </div>
+          </article>
+
+          <!-- Channel 5 -->
+          <article class="ed-channel">
+            <div class="ed-channel__head">
+              <span class="ed-channel__rank">05</span>
+              <span class="ed-channel__badge ed-channel__badge--good">Highest Upside</span>
+            </div>
+            <h3>Online Marketplaces (eBay, Etsy)</h3>
+            <div class="ed-channel__sub">For unique &amp; collectible pieces</div>
+
+            <div class="ed-payout">
+              <div class="ed-payout__bar">
+                <div class="ed-payout__label">Typical realised price</div>
+                <div class="ed-payout__track"><div class="ed-payout__fill ed-payout__fill--high" style="width:95%"></div></div>
+                <div class="ed-payout__scale"><span>0%</span><span>50%</span><span>100%+</span></div>
+              </div>
+              <div class="ed-payout__value">85–105%+</div>
+            </div>
+
+            <div class="ed-channel__meta">
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Speed</div><div class="ed-channel__meta-value">Days–weeks</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Fees</div><div class="ed-channel__meta-value">~13–14% eBay</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Effort</div><div class="ed-channel__meta-value">High</div></div>
+            </div>
+
+            <div class="ed-channel__body">
+              <p>Direct sales to buyers can beat <em>any</em> dealer — collectors will pay retail for design, maker, or rarity. Sellers report moving PAMP Fortuna bars at <strong>$15–$20 above spot</strong> on marketplaces. The catch: photography, listings, buyer comms, insured shipping all fall on you.</p>
+              <p><strong>When it makes sense:</strong> designer or branded jewellery, rare numismatic coins, unusual bullion with collector demand. <strong>When it doesn't:</strong> plain scrap, when you need cash quickly, large quantities of standard bullion.</p>
+              <ul class="ed-channel__pros">
+                <li>Highest potential payout</li>
+                <li>Reach collectors directly</li>
+                <li>Numismatic premium captured</li>
+                <li>Brand premium captured</li>
+              </ul>
+            </div>
+          </article>
+
+          <!-- Channel 6 -->
+          <article class="ed-channel">
+            <div class="ed-channel__head">
+              <span class="ed-channel__rank">06</span>
+              <span class="ed-channel__badge ed-channel__badge--good">For Rare Pieces</span>
+            </div>
+            <h3>Auction Houses</h3>
+            <div class="ed-channel__sub">For antique, rare &amp; high-value items</div>
+
+            <div class="ed-payout">
+              <div class="ed-payout__bar">
+                <div class="ed-payout__label">Realised hammer (less commission)</div>
+                <div class="ed-payout__track"><div class="ed-payout__fill ed-payout__fill--high" style="width:90%;background:linear-gradient(90deg,var(--color-primary),#34d399)"></div></div>
+                <div class="ed-payout__scale"><span>0%</span><span>Melt</span><span>Multiples</span></div>
+              </div>
+              <div class="ed-payout__value">Variable</div>
+            </div>
+
+            <div class="ed-channel__meta">
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Speed</div><div class="ed-channel__meta-value">Weeks–months</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Commission</div><div class="ed-channel__meta-value">10–25%</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Effort</div><div class="ed-channel__meta-value">Medium</div></div>
+            </div>
+
+            <div class="ed-channel__body">
+              <p>For antique gold jewellery, vintage silverware, rare coins, or pieces with historical significance, auction houses can achieve prices no other channel matches. Competitive bidding can push results <strong>multiples above melt value</strong>. Christie's, Sotheby's, Bonhams handle high-end ($1,000+ estimates); regional specialists cover mid-range estate jewellery and silver services.</p>
+              <ul class="ed-channel__pros">
+                <li>Captures collector competition</li>
+                <li>Free valuations available</li>
+                <li>Best for marked / hallmarked items</li>
+                <li>Specialist authentication included</li>
+              </ul>
+            </div>
+          </article>
+
+          <!-- Channel 7 -->
+          <article class="ed-channel">
+            <div class="ed-channel__head">
+              <span class="ed-channel__rank">07</span>
+              <span class="ed-channel__badge ed-channel__badge--good">For Bulk</span>
+            </div>
+            <h3>Refineries (Direct)</h3>
+            <div class="ed-channel__sub">For large quantities of scrap</div>
+
+            <div class="ed-payout">
+              <div class="ed-payout__bar">
+                <div class="ed-payout__label">Typical payout vs melt</div>
+                <div class="ed-payout__track"><div class="ed-payout__fill ed-payout__fill--high" style="width:85%"></div></div>
+                <div class="ed-payout__scale"><span>0%</span><span>50%</span><span>100%</span></div>
+              </div>
+              <div class="ed-payout__value">75–95%</div>
+            </div>
+
+            <div class="ed-channel__meta">
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Speed</div><div class="ed-channel__meta-value">1–2 weeks</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Minimum</div><div class="ed-channel__meta-value">$2,000+</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Effort</div><div class="ed-channel__meta-value">Medium</div></div>
+            </div>
+
+            <div class="ed-channel__body">
+              <p>For substantial scrap lots — mixed-karat jewellery, dental gold, industrial scrap — going direct to a refinery cuts out middlemen entirely. Best for jewellers, estate liquidators, or investors with large inherited collections. Most consumers will find a specialist dealer simpler with similar results.</p>
+              <ul class="ed-channel__pros">
+                <li>Highest % for large lots</li>
+                <li>No middleman markup</li>
+                <li>Industrial-grade testing</li>
+                <li>Trusted for jeweller / trade</li>
+              </ul>
+            </div>
+          </article>
+
+          <!-- Channel 8 (negative) -->
+          <article class="ed-channel ed-channel--worst">
+            <div class="ed-channel__head">
+              <span class="ed-channel__rank">08</span>
+              <span class="ed-channel__badge ed-channel__badge--avoid">⚠ Avoid for Value</span>
+            </div>
+            <h3>Pawn Shops &amp; Cash-for-Gold Kiosks</h3>
+            <div class="ed-channel__sub">Fastest cash, lowest payout</div>
+
+            <div class="ed-payout">
+              <div class="ed-payout__bar">
+                <div class="ed-payout__label">Typical payout vs melt</div>
+                <div class="ed-payout__track"><div class="ed-payout__fill ed-payout__fill--bad" style="width:40%"></div></div>
+                <div class="ed-payout__scale"><span>0%</span><span>50%</span><span>100%</span></div>
+              </div>
+              <div class="ed-payout__value">25–60%</div>
+            </div>
+
+            <div class="ed-channel__meta">
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Speed</div><div class="ed-channel__meta-value">Within the hour</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Minimum</div><div class="ed-channel__meta-value">None</div></div>
+              <div class="ed-channel__meta-item"><div class="ed-channel__meta-label">Effort</div><div class="ed-channel__meta-value">Minimal</div></div>
+            </div>
+
+            <div class="ed-channel__body">
+              <p>The most widely recognised gold-buying venues — and <strong>consistently the worst-paying</strong>. The business model is high volume, rapid turnover, wide margins. A 5g 14K ring nets ~$118 at a pawn shop versus $400+ at a specialist dealer — a <strong>200%+ difference</strong>. Mall and event &quot;cash-for-gold&quot; kiosks pay even less (30–50%).</p>
+              <p>The <strong>pawn loan option</strong> advances 25–60% with interest rates up to 20–25% per month, plus the risk of losing the item if you can't repay. Almost always more expensive than selling outright.</p>
+              <div class="ed-callout ed-callout--warning" style="margin:var(--space-3) 0 0;font-size:var(--text-xs);padding:var(--space-3) var(--space-4)">
+                <div class="ed-callout__icon">!</div>
+                <p><strong>When it makes sense:</strong> only if you need cash in your hand within the hour and have no other option. Go in knowing exactly what you're giving up.</p>
+              </div>
+            </div>
+          </article>
+
+        </div>
+      </section>
+
+      <!-- ─── SECTION 4: Coins ─── -->
+      <section id="coins">
+        <h2>Selling Gold Coins: A Special Consideration</h2>
+        <p>Gold coins have two potential sources of value: <strong>bullion value</strong> (gold content at spot) and <strong>numismatic value</strong> (collector premium from rarity, condition, history). Knowing which you hold determines where you should sell.</p>
+
+        <div class="ed-info-grid">
+          <div class="ed-info-card">
+            <div class="ed-info-card__tag">Bullion</div>
+            <h3>Standard Bullion Coins</h3>
+            <p>American Eagles, Canadian Maples, Krugerrands, Kangaroos, Philharmonics. Best sold to specialist <strong>bullion dealers</strong> who recognise their global liquidity. Most pay <strong>95–99% of spot</strong> in good condition.</p>
+          </div>
+          <div class="ed-info-card">
+            <div class="ed-info-card__tag">Numismatic</div>
+            <h3>Rare &amp; Graded Coins</h3>
+            <p>1933 Gold Eagles, key-date Victorian sovereigns, graded slabs. Sell to <strong>numismatic specialists or auction houses</strong>. Selling a rare key-date to a scrap buyer could cost you hundreds or thousands in unrealised value.</p>
+          </div>
+        </div>
+
+        <div class="ed-callout ed-callout--tip">
+          <div class="ed-callout__icon">✓</div>
+          <p><strong>Tip for selling gold coins near you:</strong> Local coin dealers (LCS) offer same-day assessment and payment. Offers vary considerably — compare two or three quotes before committing.</p>
+        </div>
+      </section>
+
+      <!-- ─── SECTION 5: Silver ─── -->
+      <section id="silver">
+        <h2>Selling Silver: Coins, Bullion, and Silverware</h2>
+        <p>The silver-selling process mirrors gold, with a few important distinctions. Spot value per gram is lower than gold, so processing costs represent a larger percentage — payouts as a % of melt are typically lower for silver scrap than gold scrap.</p>
+
+        <div class="ed-info-grid">
+          <div class="ed-info-card">
+            <div class="ed-info-card__tag">Bullion</div>
+            <h3>Silver Bullion Coins</h3>
+            <p>Silver Eagles, Britannias, Maples, Philharmonics — sell to bullion dealers. BullionByPost quotes <strong>100.1% of spot</strong> for recognised silver coins; most online buyers pay 95–100%.</p>
+          </div>
+          <div class="ed-info-card">
+            <div class="ed-info-card__tag">Scrap</div>
+            <h3>Sterling Silver (925)</h3>
+            <p>Sterling jewellery and silverware. Specialist scrap buyers and online silver buying services typically pay <strong>70–85% of melt value</strong>. Always check <a href="/silver-purity-grades">hallmarks</a> first.</p>
+          </div>
+          <div class="ed-info-card">
+            <div class="ed-info-card__tag">Antique</div>
+            <h3>Silver Flatware &amp; Hollowware</h3>
+            <p>Sets with good hallmarks, maker's marks, and complete service condition command <strong>significant premiums at auction</strong> over melt. Check hallmarks before assuming it's plate.</p>
+          </div>
+          <div class="ed-info-card">
+            <div class="ed-info-card__tag">Plated</div>
+            <h3>Silver-Plated (EPNS)</h3>
+            <p>Almost no silver value. Sell as decorative objects, not for metal. Items without &quot;925&quot;, &quot;Sterling&quot;, or a lion passant hallmark are <strong>almost certainly silver-plated</strong>.</p>
+          </div>
+        </div>
+
+        <div class="ed-callout ed-callout--warning">
+          <div class="ed-callout__icon">!</div>
+          <p><strong>Sterling silver vs silver plate:</strong> Sterling silver is always hallmarked with &quot;925,&quot; &quot;Sterling,&quot; or in the UK, a lion passant and date letter. Items without these marks are almost certainly silver-plated and contain negligible silver value. Do not confuse the two before approaching a buyer.</p>
+        </div>
+      </section>
+
+      <!-- ─── SECTION 6: How to sell online ─── -->
+      <section id="how-online">
+        <h2>How to Sell Gold and Silver Online: Step-by-Step</h2>
+        <p>For those choosing an online dealer or mail-in service (the route that typically maximises payout), the process is consistent across reputable providers.</p>
+
+        <ol class="ed-timeline">
+          <li>
+            <strong>Research and select a dealer</strong>
+            Check Trustpilot, Google Reviews, and the BBB. Look for BNTA (British Numismatic Trade Association), PNG (Professional Numismatists Guild), or equivalent national trade association membership as a baseline credential check.
+          </li>
+          <li>
+            <strong>Get an online quote</strong>
+            Most reputable dealers have online calculators or quote forms. Enter the karat/purity, weight, and item type for an indicative price.
+          </li>
+          <li>
+            <strong>Lock in your price</strong>
+            When you are ready to proceed, call or complete the online checkout to lock a live price. Prices are typically locked for 24–48 hours to account for shipping time. JM Bullion allows live price locks online 24/7.
+          </li>
+          <li>
+            <strong>Package and ship securely</strong>
+            Use a strong outer box with bubble wrap or foam padding — items should not rattle. Always use registered, tracked, insured post. Keep your proof of postage until payment clears. Many dealers provide pre-paid labels.
+          </li>
+          <li>
+            <strong>Receive and accept the final offer</strong>
+            The dealer tests and verifies your items upon receipt. The confirmed offer is usually within a few percent of the quote for standard items. Reputable dealers always contact you if the final assessment differs significantly before proceeding.
+          </li>
+          <li>
+            <strong>Get paid</strong>
+            Payment is typically made by bank transfer within 1–3 business days of item receipt and verification.
+          </li>
+        </ol>
+      </section>
+
+      <!-- ─── SECTION 7: Comparison table ─── -->
+      <section id="comparison">
+        <h2>Comparing All Selling Options at a Glance</h2>
+        <p>A side-by-side view of every channel covered above — sorted by typical payout. Save this table for your reference.</p>
+
+        <div class="ed-table-wrap">
+          <div class="ed-table-scroll">
+            <table class="ed-table" aria-label="Comparison of gold and silver selling channels">
+              <thead>
+                <tr>
+                  <th>Selling Channel</th>
+                  <th>Payout (% of melt)</th>
+                  <th>Speed</th>
+                  <th>Best for</th>
+                  <th>Min. value</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr class="ed-row-best">
+                  <td class="ed-td-name">Online bullion dealers</td>
+                  <td class="ed-td-payout">95–99%</td>
+                  <td>3–5 days</td>
+                  <td>Investment bars &amp; coins</td>
+                  <td>$500–$1,000</td>
+                </tr>
+                <tr>
+                  <td class="ed-td-name">Direct to refinery</td>
+                  <td class="ed-td-payout">75–95%</td>
+                  <td>1–2 weeks</td>
+                  <td>Large lots of scrap</td>
+                  <td>$2,000+</td>
+                </tr>
+                <tr>
+                  <td class="ed-td-name">Local coin dealers (LCS)</td>
+                  <td class="ed-td-payout">80–93%</td>
+                  <td>Same day</td>
+                  <td>Bullion &amp; numismatic coins</td>
+                  <td>Any</td>
+                </tr>
+                <tr>
+                  <td class="ed-td-name">Specialist precious metal dealers</td>
+                  <td class="ed-td-payout">70–90%</td>
+                  <td>Same day – 3 days</td>
+                  <td>Jewellery, scrap, mixed lots</td>
+                  <td>Any</td>
+                </tr>
+                <tr>
+                  <td class="ed-td-name">Online marketplaces (eBay)</td>
+                  <td class="ed-td-payout">85–105%+</td>
+                  <td>Days–weeks</td>
+                  <td>Designer, branded, rare</td>
+                  <td>Any</td>
+                </tr>
+                <tr>
+                  <td class="ed-td-name">High street jewellers</td>
+                  <td class="ed-td-payout">70–85%</td>
+                  <td>Same day</td>
+                  <td>Plain gold jewellery</td>
+                  <td>Any</td>
+                </tr>
+                <tr>
+                  <td class="ed-td-name">Auction houses</td>
+                  <td class="ed-td-payout">Variable*</td>
+                  <td>Weeks–months</td>
+                  <td>Antique, rare, collector items</td>
+                  <td>$500+</td>
+                </tr>
+                <tr class="ed-row-avoid">
+                  <td class="ed-td-name">Cash-for-gold / pawn shops</td>
+                  <td class="ed-td-payout">25–60%</td>
+                  <td>Same day</td>
+                  <td>Speed only — not value</td>
+                  <td>Any</td>
+                </tr>
+                <tr class="ed-row-avoid">
+                  <td class="ed-td-name">Mall / event kiosks</td>
+                  <td class="ed-td-payout">30–50%</td>
+                  <td>Same day</td>
+                  <td>Not recommended</td>
+                  <td>Any</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="ed-table-scroll-hint">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+            Swipe to see more
+          </div>
+        </div>
+        <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-2)!important">*Auction realised price less 10–25% seller's commission. Can exceed melt by multiples for rare or hallmarked pieces.</p>
+      </section>
+
+      <!-- ─── SECTION 8: Tax ─── -->
+      <section id="tax">
+        <h2>Tax Considerations When Selling Gold and Silver</h2>
+        <p>Tax treatment varies by country, and getting this wrong can result in an unexpected tax bill. The core principles below are consistent across most developed markets, but always consult a qualified tax adviser before significant sales.</p>
+
+        <h3>Capital gains treatment</h3>
+        <p>In most countries, profit from selling gold and silver is subject to capital gains tax (CGT). The gain = selling price − original cost (&quot;cost basis&quot;). Rates and thresholds vary significantly:</p>
+        <ul>
+          <li><strong>United States:</strong> gold held more than one year is taxed as a collectible at a maximum federal rate of <strong>28%</strong>.</li>
+          <li><strong>United Kingdom:</strong> CGT annual allowance is <strong>£3,000</strong> (2024/25 tax year); gains above this are taxable at 18–24% depending on income level.</li>
+        </ul>
+
+        <h3>Important exemptions</h3>
+        <div class="ed-callout ed-callout--tip">
+          <div class="ed-callout__icon">★</div>
+          <p><strong>UK Royal Mint coins are CGT-exempt.</strong> Gold Britannias, Gold Sovereigns (post-1837), Silver Britannias, and other Royal Mint legal tender series are <strong>exempt from CGT regardless of the gain realised</strong> — one of the most significant tax advantages available to UK precious metal investors.</p>
+        </div>
+        <ul>
+          <li>In many jurisdictions, selling within tax-advantaged accounts (Roth IRA, ISA, SIPP) eliminates CGT on gold held within those structures.</li>
+          <li><strong>VAT:</strong> Investment-grade gold (99.5%+ purity bars and coins) is exempt from VAT in the EU and UK. Silver typically carries VAT when sold new; second-hand silver under the Margin Scheme can be effectively VAT-free.</li>
+        </ul>
+
+        <h3>How to sell tax-efficiently</h3>
+        <ul>
+          <li>Prioritise selling CGT-exempt coins (where applicable) before taxable bars or non-legal-tender coins.</li>
+          <li>Where gains exceed your annual allowance, spread sales across two tax years.</li>
+          <li>Offset capital gains with any capital losses from other assets in the same tax year.</li>
+          <li>Keep accurate records of purchase price, date, and associated costs (insurance, storage) — these reduce your taxable gain.</li>
+        </ul>
+      </section>
+
+      <!-- ─── SECTION 9: Scams ─── -->
+      <section id="scams">
+        <h2>Red Flags and Scams to Avoid</h2>
+        <p>The precious metals buying industry is largely honest and professional at the reputable end of the market — but it attracts bad actors targeting sellers who don't know the value of what they hold. Watch for these red flags.</p>
+
+        <div class="ed-warnings">
+          <div class="ed-warning">
+            <div class="ed-warning__icon">!</div>
+            <div class="ed-warning__body">
+              <h3>Door-to-door gold buyers</h3>
+              <p>High-pressure sales technique targeting vulnerable sellers. There is no legitimate reason for a gold buyer to operate this way — always decline.</p>
+            </div>
+          </div>
+          <div class="ed-warning">
+            <div class="ed-warning__icon">!</div>
+            <div class="ed-warning__body">
+              <h3>No price lock or return guarantee</h3>
+              <p>Mail-in services that encourage you to send items before providing a firm offer can make returns expensive and complicated. Lock in advance.</p>
+            </div>
+          </div>
+          <div class="ed-warning">
+            <div class="ed-warning__icon">!</div>
+            <div class="ed-warning__body">
+              <h3>&quot;Cash-for-gold&quot; pop-up events</h3>
+              <p>Hotel and shopping centre events pay 30–50% of melt and create artificial time pressure to prevent comparison shopping. Avoid.</p>
+            </div>
+          </div>
+          <div class="ed-warning">
+            <div class="ed-warning__icon">!</div>
+            <div class="ed-warning__body">
+              <h3>Mixing karats before weighing</h3>
+              <p>A dishonest buyer combines your 18K and 9K pieces, weighing together at the lower-karat price. Always insist on separate weighing by purity.</p>
+            </div>
+          </div>
+          <div class="ed-warning">
+            <div class="ed-warning__icon">!</div>
+            <div class="ed-warning__body">
+              <h3>Pressure to decide immediately</h3>
+              <p>Any legitimate buyer gives you time to compare offers. Urgency = manipulation. Walk away from anyone who won't let you think.</p>
+            </div>
+          </div>
+          <div class="ed-warning">
+            <div class="ed-warning__icon">!</div>
+            <div class="ed-warning__body">
+              <h3>No physical address or unclear credentials</h3>
+              <p>Reputable dealers display business registration, trade association membership, and contactable addresses. Anonymous buyers are a red flag.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ─── SECTION 10: Tips ─── -->
+      <section id="tips">
+        <h2>Tips to Maximise What You Receive</h2>
+        <p>Eight practical actions that compound to a meaningfully better payout — often the difference between 60% and 90% of melt value.</p>
+
+        <ol>
+          <li><strong>Know your melt value before any conversation.</strong> Use a live <a href="/scrap-gold-calculator">price calculator</a> with your weight and karat before approaching any buyer.</li>
+          <li><strong>Get at least three quotes.</strong> Offers for the same piece can vary by 20–30% between buyers. Multiple quotes cost nothing and give you market truth.</li>
+          <li><strong>Sort by purity.</strong> Separate gold by karat before presenting. Mixed lots let unscrupulous buyers average down; sorted items get priced correctly.</li>
+          <li><strong>Sell bullion to bullion dealers, scrap to scrap dealers.</strong> A pawn shop is a poor venue for a PAMP Suisse bar; a scrap dealer is a poor venue for plain broken jewellery. Match channel to asset.</li>
+          <li><strong>Consider timing.</strong> Selling when spot is high — as in 2026 — maximises dollar value per gram. Set price alerts to track spot movements.</li>
+          <li><strong>Check for numismatic value before scrapping coins.</strong> Any coin dated before 1933 or with unusual design should be checked with a specialist first. The difference can be enormous.</li>
+          <li><strong>Use insured, tracked shipping.</strong> For any mail-in sale, declared-value insurance protects against loss in transit. Keep proof of postage until payment clears.</li>
+          <li><strong>Read the fine print.</strong> Before sending anything, read the dealer's terms on price locks, return policies, and payment timelines. Reputable dealers are transparent upfront.</li>
+        </ol>
+      </section>
+
+      <!-- ─── SECTION 11: FAQ ─── -->
+      <section id="faq">
+        <h2>Frequently Asked Questions</h2>
+        <div class="ed-faq">
+          <details>
+            <summary>Where is the best place to sell gold?</summary>
+            <div class="ed-faq__body">
+              <p>For investment-grade bullion coins and bars, online bullion dealers (APMEX, JM Bullion, BullionByPost, SD Bullion) consistently offer the best rates — <strong>95–99% of spot</strong>. For jewellery and scrap, specialist precious metal dealers offer the best combination of fair pricing, speed, and professional testing.</p>
+            </div>
+          </details>
+          <details>
+            <summary>How do I find gold buyers near me?</summary>
+            <div class="ed-faq__body">
+              <p>Search for &quot;precious metal dealers&quot; or &quot;coin dealers&quot; with strong Trustpilot and Google reviews in your area, or ask for recommendations from local collector communities. Avoid anonymous cash-for-gold kiosks and pop-up buyers. National trade association directories (BNTA in the UK, ICTA in the US) list vetted, reputable dealers by location.</p>
+            </div>
+          </details>
+          <details>
+            <summary>What is scrap gold and how do I sell it?</summary>
+            <div class="ed-faq__body">
+              <p>Scrap gold includes any gold jewellery, broken or unwearable pieces, dental gold, or gold items being sold for metal content only — not design or collector value. Scrap is bought at a percentage of its melt value by dealers and refiners. The higher the purity and gold content, the more you receive per gram. Always run the numbers with a <a href="/scrap-gold-calculator">scrap gold calculator</a> first.</p>
+            </div>
+          </details>
+          <details>
+            <summary>How do I sell gold coins near me?</summary>
+            <div class="ed-faq__body">
+              <p>Local coin dealers (LCS) offer same-day assessment and payment for most bullion and numismatic coins. For bullion, online dealers typically offer better rates than local shops for common coins; for rare or collectible coins, a local specialist who knows the numismatic market may provide a better result. Always get 2–3 quotes.</p>
+            </div>
+          </details>
+          <details>
+            <summary>Can I sell silver for cash?</summary>
+            <div class="ed-faq__body">
+              <p>Yes — specialist dealers, bullion buyback services, and local coin dealers all buy silver coins, bars, and jewellery. For sterling silver (925) jewellery and silverware, specialist online buyers often offer better rates than local dealers. <strong>Silver-plated items (EPNS, silver-plated cutlery) have almost no silver value</strong> and cannot be sold as silver.</p>
+            </div>
+          </details>
+          <details>
+            <summary>How do I sell gold and silver tax-free?</summary>
+            <div class="ed-faq__body">
+              <p>Tax rules vary by jurisdiction. In the UK, selling CGT-exempt coins (Gold and Silver Britannias, Gold Sovereigns from the Royal Mint) generates no CGT regardless of profit. In the US, using a Roth IRA or similar tax-advantaged account structure can eliminate capital gains tax on qualifying disposals. Staying within your annual CGT allowance is another route. Always consult a tax professional for advice specific to your situation.</p>
+            </div>
+          </details>
+          <details>
+            <summary>How do I sell gold online safely?</summary>
+            <div class="ed-faq__body">
+              <p>Use only established, reviewed dealers with transparent pricing and clear return policies. Check Trustpilot and Google reviews. Always use tracked, insured shipping with declared value. Keep proof of postage. Lock your price before shipping and confirm the dealer's process for returns if you decline the final offer.</p>
+            </div>
+          </details>
+          <details>
+            <summary>Where can I sell gold bars?</summary>
+            <div class="ed-faq__body">
+              <p>Gold bars — particularly LBMA-accredited bars from refiners like PAMP, Valcambi, and Perth Mint — are best sold to specialist bullion dealers who recognise their provenance and can offer rates close to spot. Banks rarely buy gold bars directly from private sellers; specialist dealers and online bullion buyback services are the primary route for most private individuals.</p>
+            </div>
+          </details>
+          <details>
+            <summary>Do pawn shops pay good money for gold?</summary>
+            <div class="ed-faq__body">
+              <p>Pawn shops typically pay only <strong>25–60% of melt value</strong> for gold jewellery — among the lowest rates in the market. The same 14K ring weighing 5 grams could net $118 at a pawn shop versus $400+ at a specialist dealer. Pawn shops offer speed and immediate cash, but at a steep cost. Only use them when you need cash in your hands within the hour and have no alternative.</p>
+            </div>
+          </details>
+        </div>
+      </section>
+
+    </main>
   </div>
 
+  <!-- ═══ SHARE BUTTONS ═════════════════════════════════════ -->
+  <div class="share-buttons" style="max-width:1200px;margin-left:auto;margin-right:auto;padding-left:var(--space-4);padding-right:var(--space-4)">
+    <span>Share:</span>
+    <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/where-to-sell-gold-silver&text=Where%20to%20Sell%20Gold%20and%20Silver%20in%202026" target="_blank" rel="noopener" data-platform="twitter"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.259 5.63zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg> X</a>
+    <a href="https://reddit.com/submit?url=https://goldpricetools.com/where-to-sell-gold-silver&title=Where%20to%20Sell%20Gold%20and%20Silver%20in%202026" target="_blank" rel="noopener" data-platform="reddit"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+    <a href="https://api.whatsapp.com/send?text=Where%20to%20Sell%20Gold%20and%20Silver%20in%202026%20https://goldpricetools.com/where-to-sell-gold-silver" target="_blank" rel="noopener" data-platform="whatsapp"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+  </div>
 
-<div class="share-buttons">
-  <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/where-to-sell-gold-silver&text=Where%20to%20Sell%20Gold%20&%20Silver" target="_blank" rel="noopener" data-platform="twitter"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.259 5.63zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg> X</a>
-  <a href="https://reddit.com/submit?url=https://goldpricetools.com/where-to-sell-gold-silver&title=Where%20to%20Sell%20Gold%20&%20Silver" target="_blank" rel="noopener" data-platform="reddit"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=Where%20to%20Sell%20Gold%20&%20Silver%20https://goldpricetools.com/where-to-sell-gold-silver" target="_blank" rel="noopener" data-platform="whatsapp"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
-</div>
-<h2>Related Gold &amp; Silver Guides</h2>
-<div class="related-guides-grid">
-  <a href="/scrap-gold-calculator" class="related-card">
-    <span class="related-card__tag">TOOL</span>
-    <span class="related-card__title">Scrap Gold Calculator</span>
-    <span class="related-card__desc">Calculate the melt value of your gold before approaching any buyer.</span>
-  </a>
-  <a href="/guides/how-to-sell-gold-jewellery" class="related-card">
-    <span class="related-card__tag">GUIDE</span>
-    <span class="related-card__title">How to Sell Gold Jewellery</span>
-    <span class="related-card__desc">Get the best price for your gold — which buyers pay more and how to compare offers.</span>
-  </a>
-  <a href="/guides/gold-purity-guide" class="related-card">
-    <span class="related-card__tag">GUIDE</span>
-    <span class="related-card__title">Gold Purity Guide</span>
-    <span class="related-card__desc">Understand gold hallmarks so you know exactly what you own before you sell.</span>
-  </a>
-  <a href="/14k-gold-price-per-gram" class="related-card">
-    <span class="related-card__tag">LIVE PRICE</span>
-    <span class="related-card__title">14K Gold Price Per Gram</span>
-    <span class="related-card__desc">Live 14K gold price per gram — the most common karat for everyday jewellery.</span>
-  </a>
-</div>
+  <!-- ═══ RELATED ═════════════════════════════════════════ -->
+  <section class="ed-related">
+    <h2>Related Guides &amp; Tools</h2>
+    <div class="related-guides-grid">
+      <a href="/scrap-gold-calculator" class="related-card">
+        <span class="related-card__tag">★ Tool</span>
+        <span class="related-card__title">Scrap Gold Calculator</span>
+        <span class="related-card__desc">Calculate the melt value of your gold before approaching any buyer.</span>
+      </a>
+      <a href="/silver-coins-calculator" class="related-card">
+        <span class="related-card__tag">Tool</span>
+        <span class="related-card__title">Silver Coins Calculator</span>
+        <span class="related-card__desc">Live silver value for Eagles, Britannias, Maples and junk silver coins.</span>
+      </a>
+      <a href="/guides/how-to-sell-gold-jewellery" class="related-card">
+        <span class="related-card__tag">Guide</span>
+        <span class="related-card__title">How to Sell Gold Jewellery</span>
+        <span class="related-card__desc">Step-by-step guide to maximising the price on your unwanted jewellery.</span>
+      </a>
+      <a href="/guides/gold-purity-guide" class="related-card">
+        <span class="related-card__tag">Guide</span>
+        <span class="related-card__title">Gold Purity Guide</span>
+        <span class="related-card__desc">Understand 9K to 24K hallmarks so you know exactly what you own before you sell.</span>
+      </a>
+      <a href="/14k-gold-price-per-gram" class="related-card">
+        <span class="related-card__tag">Live Price</span>
+        <span class="related-card__title">14K Gold Price Per Gram</span>
+        <span class="related-card__desc">Live 14K gold price per gram — the most common karat for everyday jewellery.</span>
+      </a>
+      <a href="/silver-purity-grades" class="related-card">
+        <span class="related-card__tag">Live Price</span>
+        <span class="related-card__title">Silver Purity Grades</span>
+        <span class="related-card__desc">Live prices for .999, .925, .900 and .800 silver across all units.</span>
+      </a>
+      <a href="/gold-bar-value" class="related-card">
+        <span class="related-card__tag">Tool</span>
+        <span class="related-card__title">Gold Bar Value</span>
+        <span class="related-card__desc">Calculate the live value of gold bars from 1g up to 1kg.</span>
+      </a>
+      <a href="/blog/best-uk-gold-dealers-2026" class="related-card">
+        <span class="related-card__tag">Article</span>
+        <span class="related-card__title">Best UK Gold Dealers 2026</span>
+        <span class="related-card__desc">The UK's most reputable gold dealers ranked by price, trust and service.</span>
+      </a>
+    </div>
+  </section>
 
+  <!-- ═══ DISCLAIMER ═════════════════════════════════════ -->
+  <div class="ed-disclaimer">
+    <p>This guide is for informational purposes only. It does not constitute financial or tax advice. Always seek independent professional guidance before making significant financial decisions. Precious metal prices and dealer rates are subject to change.</p>
   </div>
 </article>
+
+<!-- Floating TOC button (mobile) -->
+<button class="ed-toc-fab" id="edTocFab" aria-label="Open table of contents" aria-controls="edTocDrawer">
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+</button>
+
+<!-- TOC drawer (mobile) -->
+<div class="ed-toc-drawer" id="edTocDrawer" role="dialog" aria-modal="true" aria-label="Table of contents">
+  <div class="ed-toc-drawer__panel">
+    <div class="ed-toc-drawer__handle"></div>
+    <div class="ed-toc-drawer__title">On this page</div>
+    <a href="#good-time">Is it a good time to sell?</a>
+    <a href="#know-value">Know your metal's value</a>
+    <a href="#channels">All selling channels</a>
+    <a href="#coins">Selling gold coins</a>
+    <a href="#silver">Selling silver</a>
+    <a href="#how-online">How to sell online</a>
+    <a href="#comparison">Comparison at a glance</a>
+    <a href="#tax">Tax considerations</a>
+    <a href="#scams">Red flags &amp; scams</a>
+    <a href="#tips">Tips to maximise</a>
+    <a href="#faq">FAQ</a>
+  </div>
+</div>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">
@@ -766,6 +1752,61 @@ article > a,article > ul li a,article > ol li a{color:var(--color-primary);text-
   document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
+})();</script>
+
+<!-- Editorial article interactions: reading progress, TOC, scroll spy -->
+<script id="ed-article-js">(function(){
+  // Reading progress bar
+  var progressBar = document.getElementById('readingProgressBar');
+  var article = document.querySelector('article.editorial');
+  if (progressBar && article) {
+    var ticking = false;
+    function updateProgress(){
+      var rect = article.getBoundingClientRect();
+      var articleTop = rect.top + window.scrollY;
+      var articleHeight = article.offsetHeight - window.innerHeight;
+      var scrolled = window.scrollY - articleTop;
+      var pct = Math.max(0, Math.min(100, (scrolled / articleHeight) * 100));
+      progressBar.style.width = pct + '%';
+      ticking = false;
+    }
+    window.addEventListener('scroll', function(){
+      if (!ticking) { requestAnimationFrame(updateProgress); ticking = true; }
+    }, { passive: true });
+    updateProgress();
+  }
+
+  // Floating TOC button (mobile)
+  var fab = document.getElementById('edTocFab');
+  var drawer = document.getElementById('edTocDrawer');
+  if (fab && drawer) {
+    function openDrawer(){ drawer.classList.add('is-open'); document.body.style.overflow = 'hidden'; }
+    function closeDrawer(){ drawer.classList.remove('is-open'); document.body.style.overflow = ''; }
+    fab.addEventListener('click', openDrawer);
+    drawer.addEventListener('click', function(e){ if (e.target === drawer) closeDrawer(); });
+    drawer.querySelectorAll('a').forEach(function(a){ a.addEventListener('click', closeDrawer); });
+    document.addEventListener('keydown', function(e){ if (e.key === 'Escape' && drawer.classList.contains('is-open')) closeDrawer(); });
+  }
+
+  // Scroll spy for desktop TOC
+  var tocLinks = document.querySelectorAll('.ed-toc__list a');
+  var sections = Array.from(document.querySelectorAll('.ed-content > section[id]'));
+  if (tocLinks.length && sections.length && 'IntersectionObserver' in window) {
+    var linkMap = {};
+    tocLinks.forEach(function(a){ linkMap[a.getAttribute('href').slice(1)] = a; });
+    var observer = new IntersectionObserver(function(entries){
+      entries.forEach(function(entry){
+        var id = entry.target.id;
+        var link = linkMap[id];
+        if (!link) return;
+        if (entry.isIntersecting) {
+          tocLinks.forEach(function(a){ a.classList.remove('is-active'); });
+          link.classList.add('is-active');
+        }
+      });
+    }, { rootMargin: '-20% 0px -70% 0px', threshold: 0 });
+    sections.forEach(function(s){ observer.observe(s); });
+  }
 })();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Full editorial-grade redesign of `where-to-sell-gold-silver.html`, scaling the article from a short summary into a comprehensive 18-min long-form guide aligned with the published content at goldpricetools.com.

Designed using the `ui-ux-pro-max` skill — mobile-first, scales beautifully to any viewport, premium financial-publication feel with the existing brand tokens (IBM Plex Sans display, Inter body, gold/teal accents, OLED-friendly dark mode).

## Design highlights

- **Reading progress bar** tracking article scroll position
- **Hero** with gradient gold-accent headline, byline chips, deck, and 3 stat cards ($5,055 forecast, 70% gap, 99% best buyback)
- **TL;DR callout** floating over hero/content boundary for quick-answer snippet
- **Sticky desktop TOC** with `IntersectionObserver` scroll spy + **floating FAB → bottom-sheet drawer** on mobile
- **8 channel cards** with colour-coded payout bar visualisations (green=best, gold=mid, amber/red=avoid)
- **3-step methodology** cards with prominent melt-value formula
- **Numbered vertical timeline** for "how to sell online"
- **Premium comparison table** with horizontal scroll + swipe hint on mobile
- **Tax exemption callout**, scam warning cards, info-card grids for coins/silver categories
- **FAQ accordion** using semantic `<details>`/`<summary>`
- Updated FAQPage schema (9 questions, expanded answers) + meta description for SEO

## Test plan

- [x] Renders at 375px / 768px / 1280px / 1440px with no horizontal scroll
- [x] Dark mode (default) renders correctly
- [x] Light mode renders correctly
- [x] FAQ accordion opens / closes
- [x] Mobile TOC drawer opens / closes and scrolls to anchors
- [x] Desktop sticky TOC highlights active section while scrolling
- [x] Reading progress bar fills as user scrolls
- [x] Comparison table scrolls horizontally on small viewports
- [x] HTML tags balanced (`<article>`, `<section>`, `<details>` all closed)
- [x] `prefers-reduced-motion` respected
- [ ] Smoke-check on real mobile device after merge
- [ ] Lighthouse a11y / performance pass after merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01TZbWNMgPGSBXM4QHS3Euf1)_