### PR TITLE
Redesign Gold Price History guide as editorial-grade article

### DIFF
--- a/guides/gold-price-history.html
+++ b/guides/gold-price-history.html
@@ -7,9 +7,9 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold Price History: All-Time Highs | GoldPriceTools</title>
+<title>Gold Price History — All-Time Highs &amp; Key Milestones (1920–2026) | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Gold price history from 1970 to 2026: Nixon Shock, the 1980 peak, 2008 financial crisis, 2020 all-time high and the record gold prices of 2025 and 2026.">
+<meta name="description" content="Complete gold price history from $35 under Bretton Woods to $5,589 in 2026. The Nixon Shock, 1980 peak, 2008 GFC, COVID highs, and the record-breaking 2024–2026 era.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/guides/gold-price-history">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/gold-price-history">
@@ -18,15 +18,15 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
-<meta property="og:title" content="Gold Price History — All-Time Highs and Key Milestones">
-<meta property="og:description" content="A complete gold price history covering all-time highs, major market events, and long-term price trends from 1970 to 2026.">
+<meta property="og:title" content="Gold Price History — All-Time Highs and Key Milestones (1920–2026)">
+<meta property="og:description" content="From $35 under Bretton Woods to $5,589 in 2026 — the complete history of gold prices, crashes, and milestones in one definitive guide.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/gold-price-history">
 <meta property="og:site_name" content="GoldPriceTools">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Price History — All-Time Highs and Key Milestones","description":"A complete gold price history covering all-time highs, major market events, and long-term price trends from 1970 to 2026.","url":"https://goldpricetools.com/guides/gold-price-history","datePublished":"2026-04-24","dateModified":"2026-05-18T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-price-history"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Gold Price History — All-Time Highs and Key Milestones (1920–2026)","description":"Complete gold price history from $35 under Bretton Woods to $5,589 in 2026 — every major peak, crash, and milestone explained.","url":"https://goldpricetools.com/guides/gold-price-history","datePublished":"2026-04-24","dateModified":"2026-05-18T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/gold-price-history"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -34,50 +34,58 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "What was the highest gold price in history?",
+      "name": "What is the highest price of gold in history?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Gold reached its all-time nominal high of around $3,500 per troy ounce in April 2025, driven by central bank buying and geopolitical uncertainty."
+        "text": "Gold's all-time high is $5,589.38 per troy ounce, reached intraday on January 28, 2026. This price also, for the first time, exceeded the 1980 peak adjusted for inflation."
       }
     },
     {
       "@type": "Question",
-      "name": "Why does the gold price go up during a crisis?",
+      "name": "What was the highest gold price in history when adjusted for inflation?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Gold is considered a safe haven asset. During economic uncertainty, inflation, currency devaluations, or geopolitical crises, investors move capital into gold to preserve value. Unlike currencies or bonds, gold has no counterparty risk."
+        "text": "For decades, the 1980 peak of $850 held the record in real terms — equivalent to approximately $3,500 in today's dollars. The 2026 nominal high of $5,589 finally surpassed it on an inflation-adjusted basis."
       }
     },
     {
       "@type": "Question",
-      "name": "What caused the gold price surge in 2020?",
+      "name": "What caused the biggest crash in gold price history?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "The 2020 COVID-19 pandemic triggered a global flight to safety. Central banks implemented massive quantitative easing programmes, driving real interest rates deeply negative. Gold hit then-record highs of over $2,070/oz in August 2020."
+        "text": "The 1980–1999 bear market is the largest in gold's modern history — a 65% decline over 19 years. It was caused primarily by Paul Volcker's aggressive interest rate hikes (rates above 19%), which crushed inflation, restored dollar credibility, and made interest-bearing assets far more attractive than gold."
       }
     },
     {
       "@type": "Question",
-      "name": "Does gold always go up during inflation?",
+      "name": "What is the historical gold-to-silver ratio?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Gold has historically been an inflation hedge over the long run, but it doesn't always rise in the short term during inflationary periods. The relationship works best over decades rather than months, and gold tends to perform best when real interest rates are negative."
+        "text": "The long-term historical average is approximately 55–65:1. It peaked at a record 124:1 during the COVID-19 panic in March 2020 and compressed to approximately 55:1 by May 2026 as silver recovered strongly."
       }
     },
     {
       "@type": "Question",
-      "name": "How does the US dollar affect the gold price?",
+      "name": "What is gold's historical rate of return compared to stocks?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Gold is priced in US dollars globally, so there is typically an inverse relationship between the dollar and gold. When the dollar strengthens, gold becomes more expensive for non-US buyers, reducing demand and often pushing prices down."
+        "text": "From 2000 to 2026, gold has significantly outperformed equities (+1,580% vs +615% for the S&P 500). Over the very long run (since 1928), equities have averaged approximately 9.9% annually versus gold's approximately 5%. Gold outperforms in specific periods — high inflation, financial crises, and dollar weakness — while equities outperform in periods of growth and price stability."
       }
     },
     {
       "@type": "Question",
-      "name": "Is gold a good long-term investment?",
+      "name": "When did gold first cross $1,000, $2,000, $3,000, $4,000, and $5,000 per ounce?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Gold has averaged approximately 7-8% annual returns over the past 50 years. Most financial advisers suggest a 5-10% portfolio allocation to gold for diversification."
+        "text": "Gold first crossed $1,000 in February 2009, $2,000 on August 4, 2020, $3,000 in mid-March 2025, $4,000 on October 8, 2025, and $5,000 in late January 2026. Each $500 increment was reached faster than the last as bull market momentum accelerated."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the lowest gold price in modern history?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Since the start of free-market gold trading in 1971, the lowest price was approximately $112.50 in August 1976. Before that, the fixed $35 price under the Bretton Woods system (1944–1971) represents the long-term floor of the fixed-price era."
       }
     }
   ]
@@ -461,6 +469,246 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
 .disclaimer-box{margin-top:var(--space-8);padding:var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-border);font-size:var(--text-sm);color:var(--color-text-faint);line-height:1.6}
 .disclaimer-box strong{color:var(--color-text-muted)}
 .related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin-top:var(--space-4)}
+
+/* ════════════════════════════════════════════════════════
+   GOLD PRICE HISTORY ─ EDITORIAL DESIGN SYSTEM
+   Mobile-first, scales to 1440px+
+   ════════════════════════════════════════════════════════ */
+
+/* Reading progress bar */
+.gph-progress{position:fixed;top:0;left:0;right:0;height:3px;background:transparent;z-index:201;pointer-events:none}
+.gph-progress-bar{height:100%;width:0;background:linear-gradient(90deg,var(--color-gold) 0%,var(--color-gold-bright) 50%,#fbd078 100%);transition:width 80ms linear;box-shadow:0 0 12px color-mix(in oklch,var(--color-gold-bright) 60%,transparent)}
+
+/* Article shell — wider than default prose for richer layout */
+.gph-article{max-width:1280px;margin:0 auto;padding:0 var(--space-4) var(--space-12)}
+
+/* ── HERO ── */
+.gph-hero{position:relative;padding:var(--space-6) 0 var(--space-8);overflow:hidden;isolation:isolate}
+.gph-hero::before{content:'';position:absolute;top:-180px;right:-160px;width:520px;height:520px;background:radial-gradient(circle,color-mix(in oklch,var(--color-gold-bright) 28%,transparent),transparent 65%);pointer-events:none;z-index:-1;filter:blur(40px);opacity:.7}
+.gph-hero::after{content:'';position:absolute;bottom:-140px;left:-140px;width:380px;height:380px;background:radial-gradient(circle,color-mix(in oklch,var(--color-primary) 22%,transparent),transparent 65%);pointer-events:none;z-index:-1;filter:blur(40px);opacity:.6}
+.gph-hero-inner{position:relative;z-index:1;max-width:920px;margin:0 auto}
+.gph-eyebrow{display:inline-flex;align-items:center;gap:8px;padding:6px 14px;background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 32%,var(--color-border));border-radius:99px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright)}
+.gph-eyebrow-dot{width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 25%,transparent);animation:gph-pulse 2.5s ease-in-out infinite}
+@keyframes gph-pulse{0%,100%{opacity:1}50%{opacity:.4}}
+.gph-h1{font-family:var(--font-display);font-size:clamp(1.85rem,5.2vw,3.85rem);font-weight:700;line-height:1.05;letter-spacing:-.02em;margin:var(--space-4) 0 var(--space-4);color:var(--color-text);text-wrap:balance}
+.gph-h1 .gph-gradient{background:linear-gradient(135deg,#e8af34 0%,#fbd078 45%,#e8af34 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;color:transparent;display:inline-block}
+.gph-lede{font-size:clamp(1rem,1.55vw,1.18rem);line-height:1.7;color:var(--color-text-muted);max-width:64ch;margin:0 0 var(--space-5)}
+.gph-byline{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);font-size:13px;color:var(--color-text-faint);margin:0 0 var(--space-6);padding-bottom:var(--space-5);border-bottom:1px solid var(--color-divider)}
+.gph-byline a{color:var(--color-primary);font-weight:500;text-decoration:none}
+.gph-byline a:hover{text-decoration:underline}
+.gph-byline-sep{opacity:.5}
+
+/* Hero stat cards */
+.gph-hero-stats{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-6)}
+@media(min-width:520px){.gph-hero-stats{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:860px){.gph-hero-stats{grid-template-columns:repeat(4,1fr)}}
+.gph-stat-card{position:relative;background:linear-gradient(155deg,color-mix(in oklch,var(--color-gold-bright) 7%,var(--color-surface)) 0%,var(--color-surface) 65%);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.gph-stat-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 45%,var(--color-border));transform:translateY(-2px)}
+.gph-stat-card::before{content:'';position:absolute;top:0;right:0;width:90px;height:90px;background:radial-gradient(circle at top right,color-mix(in oklch,var(--color-gold-bright) 18%,transparent),transparent 70%);pointer-events:none}
+.gph-stat-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-faint);margin:0 0 6px;display:flex;align-items:center;gap:6px}
+.gph-stat-label svg{flex-shrink:0;color:var(--color-gold-bright);opacity:.8}
+.gph-stat-value{font-family:var(--font-display);font-size:clamp(1.45rem,2.4vw,2rem);font-weight:700;line-height:1;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em;margin-bottom:6px}
+.gph-stat-value-sm{font-size:14px;font-weight:500;color:var(--color-text-muted);margin-left:4px;letter-spacing:0}
+.gph-stat-sub{font-size:12px;color:var(--color-text-muted);line-height:1.5;margin:0}
+
+/* TOC */
+.gph-toc{margin:var(--space-6) 0 var(--space-4);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.gph-toc-title{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-text-faint);margin:0 0 var(--space-3);display:flex;align-items:center;gap:8px}
+.gph-toc-title svg{color:var(--color-gold-bright)}
+.gph-toc-list{list-style:none;padding:0;margin:0;display:grid;grid-template-columns:1fr;gap:4px}
+@media(min-width:600px){.gph-toc-list{grid-template-columns:repeat(2,1fr);column-gap:var(--space-3)}}
+@media(min-width:900px){.gph-toc-list{grid-template-columns:repeat(3,1fr)}}
+.gph-toc-list a{display:flex;align-items:center;gap:10px;padding:8px 10px;font-size:13px;color:var(--color-text-muted);border-radius:var(--radius-md);text-decoration:none;transition:color var(--transition),background var(--transition);min-height:36px}
+.gph-toc-list a:hover{color:var(--color-gold-bright);background:var(--color-surface-offset);text-decoration:none}
+.gph-toc-num{font-family:var(--font-display);font-size:11px;font-weight:700;color:var(--color-text-faint);letter-spacing:.04em;flex-shrink:0;min-width:22px;text-align:right}
+.gph-toc-list a:hover .gph-toc-num{color:var(--color-gold-bright)}
+
+/* Section shell */
+.gph-section{padding:var(--space-10) 0 var(--space-6);scroll-margin-top:80px}
+.gph-section--lede{padding-top:var(--space-6)}
+.gph-section-head{display:flex;align-items:flex-start;gap:var(--space-4);margin:0 0 var(--space-5)}
+.gph-era-num{display:flex;align-items:center;justify-content:center;width:48px;height:48px;background:linear-gradient(135deg,var(--color-gold) 0%,var(--color-gold-bright) 100%);color:#0f0e0c;border-radius:var(--radius-md);font-family:var(--font-display);font-size:18px;font-weight:700;flex-shrink:0;box-shadow:0 4px 18px color-mix(in oklch,var(--color-gold-bright) 25%,transparent)}
+@media(min-width:768px){.gph-era-num{width:56px;height:56px;font-size:22px}}
+.gph-section-head-text{flex:1;min-width:0}
+.gph-section-date{display:inline-block;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin:2px 0 6px}
+.gph-h2{font-family:var(--font-display);font-size:clamp(1.4rem,2.5vw,2.05rem);font-weight:700;line-height:1.15;letter-spacing:-.015em;color:var(--color-text);margin:0;text-wrap:balance}
+.gph-h3{font-family:var(--font-display);font-size:clamp(1.1rem,1.6vw,1.32rem);font-weight:700;line-height:1.3;color:var(--color-text);margin:var(--space-6) 0 var(--space-3);text-wrap:balance}
+.gph-p{font-size:clamp(15px,1.45vw,17px);line-height:1.75;color:var(--color-text-muted);max-width:72ch;margin:0 0 var(--space-4)}
+.gph-p strong{color:var(--color-text);font-weight:600}
+.gph-p em{font-style:italic;color:var(--color-text)}
+
+/* Timeline (vertical, mobile-friendly) */
+.gph-timeline{position:relative;padding:0;margin:var(--space-5) 0 var(--space-4);list-style:none}
+.gph-timeline::before{content:'';position:absolute;left:11px;top:8px;bottom:8px;width:2px;background:linear-gradient(to bottom,color-mix(in oklch,var(--color-gold-bright) 20%,transparent),color-mix(in oklch,var(--color-gold-bright) 55%,transparent),color-mix(in oklch,var(--color-gold-bright) 20%,transparent))}
+.gph-timeline-item{position:relative;padding:0 0 var(--space-4) 36px;font-size:15px;color:var(--color-text-muted);line-height:1.65}
+.gph-timeline-item::before{content:'';position:absolute;left:5px;top:6px;width:14px;height:14px;border-radius:50%;background:var(--color-bg);border:2px solid var(--color-gold-bright);box-shadow:0 0 0 3px var(--color-bg)}
+.gph-timeline-item:last-child{padding-bottom:0}
+.gph-timeline-date{display:inline-block;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin:0 0 2px}
+.gph-timeline-price{font-family:var(--font-display);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;font-size:16px}
+
+/* Callout */
+.gph-callout{position:relative;background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 7%,var(--color-surface)) 0%,var(--color-surface) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-5) 0}
+.gph-callout-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright);margin:0 0 8px;display:flex;align-items:center;gap:6px}
+.gph-callout-text{font-size:15px;line-height:1.7;color:var(--color-text);margin:0;max-width:none}
+.gph-callout-text strong{color:var(--color-text);font-weight:700}
+
+/* Featured peak / record card */
+.gph-peak-card{position:relative;background:linear-gradient(135deg,#0f0e0c 0%,#1a1612 50%,#0f0e0c 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-7) var(--space-5);margin:var(--space-6) 0;overflow:hidden;text-align:center}
+[data-theme="light"] .gph-peak-card{background:linear-gradient(135deg,#fdf9ef 0%,#fbf5e8 50%,#fdf9ef 100%);border-color:color-mix(in oklch,var(--color-gold) 35%,var(--color-border))}
+.gph-peak-card::before{content:'';position:absolute;top:-50%;left:-50%;width:200%;height:200%;background:radial-gradient(circle,color-mix(in oklch,var(--color-gold-bright) 14%,transparent),transparent 50%);pointer-events:none;animation:gph-shimmer 12s ease-in-out infinite}
+@keyframes gph-shimmer{0%,100%{transform:translate(0,0) rotate(0deg)}50%{transform:translate(-5%,-5%) rotate(45deg)}}
+@media(prefers-reduced-motion:reduce){.gph-peak-card::before{animation:none}}
+.gph-peak-inner{position:relative;z-index:1}
+.gph-peak-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.18em;color:var(--color-gold-bright);margin:0 0 var(--space-3)}
+.gph-peak-value{font-family:var(--font-display);font-size:clamp(2.25rem,7vw,4.5rem);font-weight:700;line-height:1;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.03em;margin:var(--space-2) 0;text-shadow:0 0 40px color-mix(in oklch,var(--color-gold-bright) 30%,transparent)}
+.gph-peak-meta{font-size:14px;color:var(--color-text-muted);max-width:60ch;margin:var(--space-3) auto 0;line-height:1.6}
+.gph-peak-meta strong{color:var(--color-text)}
+@media(min-width:768px){.gph-peak-card{padding:var(--space-10) var(--space-8)}}
+
+/* Milestone cards grid */
+.gph-milestone-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:var(--space-3);margin:var(--space-5) 0}
+.gph-milestone-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);transition:border-color var(--transition),transform var(--transition);position:relative;overflow:hidden}
+.gph-milestone-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-2px)}
+.gph-milestone-card::after{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--color-gold) 0%,var(--color-gold-bright) 100%);opacity:.8}
+.gph-milestone-date{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin:0 0 6px}
+.gph-milestone-price{font-family:var(--font-display);font-size:24px;font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;margin:0 0 6px;letter-spacing:-.02em}
+.gph-milestone-desc{font-size:13px;color:var(--color-text-muted);line-height:1.5;margin:0}
+
+/* Bear market comparison cards */
+.gph-bear-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-5) 0}
+@media(min-width:740px){.gph-bear-grid{grid-template-columns:repeat(3,1fr)}}
+.gph-bear-card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-6) var(--space-5);overflow:hidden;transition:transform var(--transition),border-color var(--transition)}
+.gph-bear-card:hover{transform:translateY(-3px);border-color:color-mix(in oklch,#f87171 30%,var(--color-border))}
+.gph-bear-card::before{content:'';position:absolute;top:0;left:0;right:0;height:4px;background:linear-gradient(90deg,#fca5a5,#ef4444)}
+.gph-bear-num{display:inline-block;font-family:var(--font-display);font-size:11px;font-weight:700;color:var(--color-text-faint);margin:0 0 6px;letter-spacing:.1em;text-transform:uppercase}
+.gph-bear-title{font-family:var(--font-display);font-size:17px;font-weight:700;color:var(--color-text);margin:0 0 var(--space-4);line-height:1.3}
+.gph-bear-stats{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);padding:var(--space-3) 0;border-top:1px solid var(--color-divider);border-bottom:1px solid var(--color-divider);margin-bottom:var(--space-3)}
+.gph-bear-stat-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin:0 0 4px}
+.gph-bear-stat-value{font-family:var(--font-display);font-size:22px;font-weight:700;font-variant-numeric:tabular-nums;line-height:1;letter-spacing:-.02em}
+.gph-bear-stat-value.decline{color:#f87171}
+.gph-bear-stat-value.duration{color:var(--color-text)}
+.gph-bear-desc{font-size:13px;color:var(--color-text-muted);line-height:1.6;margin:0}
+
+/* Gold-silver ratio gauge */
+.gph-ratio-gauge{margin:var(--space-6) 0;padding:var(--space-6) var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.gph-ratio-title{font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-faint);margin:0 0 var(--space-2)}
+.gph-ratio-desc{font-size:13px;color:var(--color-text-muted);margin:0 0 var(--space-5);line-height:1.6}
+.gph-ratio-bar-wrap{position:relative;padding:36px 0 44px;margin:0}
+.gph-ratio-bar{position:relative;height:8px;background:linear-gradient(90deg,#22c55e 0%,#84cc16 22%,#eab308 50%,#f97316 75%,#ef4444 100%);border-radius:99px}
+.gph-ratio-marker{position:absolute;top:-12px;width:2px;height:32px;background:var(--color-text);transform:translateX(-50%);border-radius:1px}
+.gph-ratio-marker .v{position:absolute;top:-20px;left:50%;transform:translateX(-50%);font-size:11px;font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;white-space:nowrap;background:var(--color-surface);padding:1px 6px;border-radius:99px;border:1px solid var(--color-border)}
+.gph-ratio-marker .l{position:absolute;top:34px;left:50%;transform:translateX(-50%);font-size:10px;color:var(--color-text-muted);font-weight:600;white-space:nowrap;text-transform:uppercase;letter-spacing:.06em}
+.gph-ratio-marker:nth-child(odd) .l{top:34px}
+.gph-ratio-marker:nth-child(even) .l{top:50px}
+.gph-ratio-scale{display:flex;justify-content:space-between;font-size:11px;color:var(--color-text-faint);font-variant-numeric:tabular-nums;margin-top:18px;font-weight:500}
+@media(max-width:520px){
+  .gph-ratio-bar-wrap{padding:32px 0 56px}
+  .gph-ratio-marker .v{font-size:10px;padding:1px 4px}
+  .gph-ratio-marker .l{font-size:9px}
+  .gph-ratio-marker:nth-child(odd) .l{top:30px}
+  .gph-ratio-marker:nth-child(even) .l{top:46px}
+}
+
+/* Returns comparison cards */
+.gph-compare-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:560px){.gph-compare-grid{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:860px){.gph-compare-grid{grid-template-columns:repeat(4,1fr)}}
+.gph-compare-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);position:relative;overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.gph-compare-card:hover{transform:translateY(-2px)}
+.gph-compare-card[data-asset="gold"]{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border))}
+.gph-compare-card[data-asset="gold"]:hover{border-color:var(--color-gold-bright)}
+.gph-compare-card[data-asset="gold"] .gph-compare-value{color:var(--color-gold-bright)}
+.gph-compare-card[data-asset="stocks"] .gph-compare-value{color:var(--color-primary)}
+.gph-compare-card[data-asset="bonds"] .gph-compare-value{color:var(--color-silver)}
+.gph-compare-card[data-asset="cash"] .gph-compare-value{color:var(--color-text-faint)}
+.gph-compare-asset{display:flex;align-items:center;gap:8px;margin:0 0 var(--space-3)}
+.gph-compare-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0}
+.gph-compare-card[data-asset="gold"] .gph-compare-dot{background:var(--color-gold-bright)}
+.gph-compare-card[data-asset="stocks"] .gph-compare-dot{background:var(--color-primary)}
+.gph-compare-card[data-asset="bonds"] .gph-compare-dot{background:var(--color-silver)}
+.gph-compare-card[data-asset="cash"] .gph-compare-dot{background:var(--color-text-faint)}
+.gph-compare-asset-name{font-size:13px;font-weight:600;color:var(--color-text);text-transform:uppercase;letter-spacing:.06em}
+.gph-compare-value{font-family:var(--font-display);font-size:32px;font-weight:700;font-variant-numeric:tabular-nums;line-height:1;letter-spacing:-.02em;margin:0 0 6px}
+.gph-compare-value .unit{font-size:14px;font-weight:500;color:var(--color-text-muted);margin-left:2px}
+.gph-compare-period{font-size:11px;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;font-weight:600}
+
+/* Daily drivers — icon + text grid */
+.gph-drivers{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:600px){.gph-drivers{grid-template-columns:repeat(2,1fr)}}
+.gph-driver{display:flex;gap:var(--space-3);padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);transition:border-color var(--transition)}
+.gph-driver:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border))}
+.gph-driver-icon{flex-shrink:0;width:38px;height:38px;display:flex;align-items:center;justify-content:center;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-radius:var(--radius-md);color:var(--color-gold-bright)}
+.gph-driver-icon svg{width:18px;height:18px}
+.gph-driver-content h4{font-size:14px;font-weight:700;color:var(--color-text);margin:0 0 4px;font-family:var(--font-display)}
+.gph-driver-content p{font-size:13px;color:var(--color-text-muted);line-height:1.6;margin:0;max-width:none}
+
+/* Milestone table */
+.gph-table-wrap{margin:var(--space-5) 0;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden}
+.gph-table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.gph-table{width:100%;border-collapse:collapse;font-size:14px;min-width:560px}
+.gph-table thead{background:var(--color-surface-offset)}
+.gph-table th{text-align:left;padding:var(--space-3) var(--space-4);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);border-bottom:1px solid var(--color-border);white-space:nowrap}
+.gph-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text-muted);vertical-align:middle}
+.gph-table tr:last-child td{border-bottom:none}
+.gph-table td.year{color:var(--color-text);font-weight:600;font-size:13px;white-space:nowrap}
+.gph-table td.price{color:var(--color-gold-bright);font-weight:700;font-variant-numeric:tabular-nums;white-space:nowrap;font-family:var(--font-display)}
+.gph-table tr.peak{background:color-mix(in oklch,var(--color-gold-bright) 5%,transparent)}
+.gph-table tr.trough{background:color-mix(in oklch,#f87171 4%,transparent)}
+.gph-table tr.trough td.price{color:#f87171}
+.gph-table tbody tr:hover{background:var(--color-surface-offset)}
+.gph-table-caption{font-size:11px;color:var(--color-text-faint);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-top:1px solid var(--color-divider);text-align:right;font-style:italic}
+
+/* Inflation comparison */
+.gph-infl-table{margin:var(--space-5) 0;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden}
+.gph-infl-row{display:grid;grid-template-columns:0.9fr 1fr 1fr;align-items:center;gap:var(--space-3);padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider)}
+.gph-infl-row:last-child{border-bottom:none}
+.gph-infl-head{background:var(--color-surface-offset);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint)}
+.gph-infl-year{font-size:13px;font-weight:600;color:var(--color-text)}
+.gph-infl-nominal{font-family:var(--font-display);font-size:15px;font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.gph-infl-real{font-family:var(--font-display);font-size:15px;font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+.gph-infl-row.highlight{background:color-mix(in oklch,var(--color-gold-bright) 6%,transparent)}
+
+/* FAQ accordion */
+.gph-faq-list{display:flex;flex-direction:column;gap:var(--space-3);margin:var(--space-5) 0 0}
+.gph-faq-item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.gph-faq-item:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border))}
+.gph-faq-item summary{list-style:none;cursor:pointer}
+.gph-faq-item summary::-webkit-details-marker{display:none}
+.gph-faq-q{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-size:15px;font-weight:600;color:var(--color-text);text-align:left;transition:background var(--transition);min-height:56px}
+.gph-faq-q:hover{background:var(--color-surface-offset)}
+.gph-faq-q-icon{flex-shrink:0;width:24px;height:24px;display:flex;align-items:center;justify-content:center;color:var(--color-gold-bright);transition:transform var(--transition)}
+.gph-faq-item[open] .gph-faq-q-icon{transform:rotate(45deg)}
+.gph-faq-a{padding:0 var(--space-5) var(--space-5);font-size:14px;color:var(--color-text-muted);line-height:1.7}
+.gph-faq-a p{margin:0 0 var(--space-3);max-width:none}
+.gph-faq-a p:last-child{margin-bottom:0}
+.gph-faq-a ul{margin:var(--space-2) 0;padding-left:var(--space-5)}
+.gph-faq-a li{margin-bottom:4px;font-size:14px;color:var(--color-text-muted)}
+.gph-faq-a strong{color:var(--color-text);font-weight:700}
+
+/* Section divider with star */
+.gph-divider{display:flex;align-items:center;gap:var(--space-3);margin:var(--space-10) 0 0;color:var(--color-text-faint)}
+.gph-divider::before,.gph-divider::after{content:'';flex:1;height:1px;background:var(--color-divider)}
+.gph-divider svg{flex-shrink:0;color:var(--color-gold-bright);opacity:.7}
+
+/* CTA box (article internal) */
+.gph-cta{position:relative;background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface)) 0%,var(--color-surface) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 26%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-6) var(--space-5);margin:var(--space-8) 0;overflow:hidden}
+.gph-cta::before{content:'';position:absolute;top:-30px;right:-30px;width:140px;height:140px;background:radial-gradient(circle,color-mix(in oklch,var(--color-gold-bright) 18%,transparent),transparent 70%);pointer-events:none}
+.gph-cta-inner{position:relative;z-index:1}
+.gph-cta h3{font-family:var(--font-display);font-size:20px;color:var(--color-text);margin:0 0 8px}
+.gph-cta p{font-size:14px;color:var(--color-text-muted);line-height:1.6;margin:0 0 var(--space-4);max-width:60ch}
+.gph-cta-btn{display:inline-flex;align-items:center;gap:6px;padding:10px 22px;background:var(--color-gold-bright);color:#0f0e0c;border-radius:var(--radius-md);font-size:14px;font-weight:700;text-decoration:none;transition:background var(--transition),transform var(--transition)}
+.gph-cta-btn:hover{background:#fbd078;transform:translateY(-1px);color:#0f0e0c;text-decoration:none}
+
+/* Sources note */
+.gph-sources{font-size:12px;color:var(--color-text-faint);margin-top:var(--space-4);font-style:italic;line-height:1.6}
+.gph-sources strong{color:var(--color-text-muted);font-weight:600;font-style:normal}
+
+/* Share buttons within article */
+.share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);padding:var(--space-5) 0;border-top:1px solid var(--color-divider);border-bottom:1px solid var(--color-divider)}
+.share-buttons > span{font-size:13px;font-weight:600;color:var(--color-text-muted);margin-right:var(--space-2)}
+.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border:1px solid var(--color-border);border-radius:99px;background:var(--color-surface);color:var(--color-text-muted);font-size:13px;font-weight:500;text-decoration:none;transition:border-color var(--transition),color var(--transition);min-height:36px}
+.share-buttons a:hover{border-color:var(--color-gold-bright);color:var(--color-gold-bright);text-decoration:none}
+.share-buttons a svg{flex-shrink:0}
 </style>
 
 <link rel="stylesheet" href="/assets/site.css">
@@ -544,71 +792,812 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
   </ol>
 </div>
 
-<article class="article-wrap" itemscope itemtype="https://schema.org/Article">
-  <div class="article-tag">Market Guide</div>
-  <h1 class="article-title" itemprop="headline">Gold Price History &mdash; All-Time Highs and Key Milestones</h1>
-  <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
-    <span>&middot;</span>
-    <span>Published <time datetime="2026-05-18" itemprop="datePublished">24 April 2026</time></span>
-    <span>&middot;</span>
-    <span>Updated <time datetime="2026-05-18" itemprop="dateModified">25 April 2026</time></span>
+<div class="gph-progress" aria-hidden="true"><div class="gph-progress-bar" id="gphProgress"></div></div>
+
+<main>
+<article class="gph-article" itemscope itemtype="https://schema.org/Article">
+
+  <!-- ── HERO ── -->
+  <header class="gph-hero">
+    <div class="gph-hero-inner">
+      <span class="gph-eyebrow"><span class="gph-eyebrow-dot"></span>Market History &middot; Deep Dive</span>
+      <h1 class="gph-h1" itemprop="headline">Gold Price History &mdash; <span class="gph-gradient">All-Time Highs</span> and Key Milestones</h1>
+      <p class="gph-lede">From a fixed rate of $20.67 per troy ounce that held for decades, gold has journeyed through monetary upheaval, runaway inflation, global crises, and bull markets so powerful they seemed unthinkable just years earlier. In January 2026, gold struck an intraday record of <strong style="color:var(--color-gold-bright)">$5,589.38 per troy ounce</strong> &mdash; exceeding the inflation-adjusted 1980 peak for the first time in over four decades.</p>
+
+      <div class="gph-byline">
+        <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
+        <span class="gph-byline-sep">&middot;</span>
+        <span>Published <time datetime="2026-04-24" itemprop="datePublished">24 April 2026</time></span>
+        <span class="gph-byline-sep">&middot;</span>
+        <span>Updated <time datetime="2026-05-18" itemprop="dateModified">18 May 2026</time></span>
+        <span class="gph-byline-sep">&middot;</span>
+        <span>15 min read</span>
+      </div>
+
+      <!-- Hero stat cards -->
+      <div class="gph-hero-stats" aria-label="Key statistics">
+        <div class="gph-stat-card">
+          <div class="gph-stat-label">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
+            All-Time High
+          </div>
+          <div class="gph-stat-value">$5,589<span class="gph-stat-value-sm">.38</span></div>
+          <p class="gph-stat-sub">Intraday peak, 28 Jan 2026</p>
+        </div>
+        <div class="gph-stat-card">
+          <div class="gph-stat-label">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+            Modern Market Start
+          </div>
+          <div class="gph-stat-value">1971</div>
+          <p class="gph-stat-sub">Nixon Shock ends gold standard</p>
+        </div>
+        <div class="gph-stat-card">
+          <div class="gph-stat-label">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+            25-Year Return
+          </div>
+          <div class="gph-stat-value">+1,580<span class="gph-stat-value-sm">%</span></div>
+          <p class="gph-stat-sub">Gold from 2000 to 2026</p>
+        </div>
+        <div class="gph-stat-card">
+          <div class="gph-stat-label">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 18 13.5 8.5 8.5 13.5 1 6"/><polyline points="17 18 23 18 23 12"/></svg>
+            Deepest Crash
+          </div>
+          <div class="gph-stat-value">&minus;65<span class="gph-stat-value-sm">%</span></div>
+          <p class="gph-stat-sub">1980&ndash;1999 bear market</p>
+        </div>
+      </div>
+
+      <!-- Table of Contents -->
+      <nav class="gph-toc" aria-label="Table of contents">
+        <div class="gph-toc-title">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+          In This Guide
+        </div>
+        <ol class="gph-toc-list">
+          <li><a href="#gold-standard"><span class="gph-toc-num">01</span>The Gold Standard Era</a></li>
+          <li><a href="#nixon-shock"><span class="gph-toc-num">02</span>The Nixon Shock (1971)</a></li>
+          <li><a href="#bull-1970s"><span class="gph-toc-num">03</span>1970s: First Bull Market</a></li>
+          <li><a href="#peak-1980"><span class="gph-toc-num">04</span>January 1980: $850 Peak</a></li>
+          <li><a href="#bear-1980-1999"><span class="gph-toc-num">05</span>1980&ndash;1999 Bear Market</a></li>
+          <li><a href="#bull-2000-2011"><span class="gph-toc-num">06</span>2000&ndash;2011 Bull Market</a></li>
+          <li><a href="#bear-2011-2015"><span class="gph-toc-num">07</span>2011&ndash;2015 Correction</a></li>
+          <li><a href="#recovery-2016-2019"><span class="gph-toc-num">08</span>2016&ndash;2019 Recovery</a></li>
+          <li><a href="#covid-2020"><span class="gph-toc-num">09</span>2020: COVID Breakthrough</a></li>
+          <li><a href="#record-era"><span class="gph-toc-num">10</span>2024&ndash;2026: Record Era</a></li>
+          <li><a href="#milestone-table"><span class="gph-toc-num">11</span>Full Milestone Table</a></li>
+          <li><a href="#bear-markets"><span class="gph-toc-num">12</span>3 Major Bear Markets</a></li>
+          <li><a href="#gsr"><span class="gph-toc-num">13</span>Gold-to-Silver Ratio</a></li>
+          <li><a href="#returns"><span class="gph-toc-num">14</span>Historical Returns</a></li>
+          <li><a href="#inflation"><span class="gph-toc-num">15</span>Inflation-Adjusted</a></li>
+          <li><a href="#drivers"><span class="gph-toc-num">16</span>What Drives Daily Moves</a></li>
+          <li><a href="#faq"><span class="gph-toc-num">17</span>FAQ</a></li>
+        </ol>
+      </nav>
+    </div>
+  </header>
+
+  <!-- ── 1. GOLD STANDARD ── -->
+  <section class="gph-section gph-section--lede" id="gold-standard">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">01</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">Pre-1971 &middot; The Fixed Era</div>
+        <h2 class="gph-h2">The Gold Standard Era: Price Fixed Before the Modern Market</h2>
+      </div>
+    </div>
+    <p class="gph-p">For most of the 19th and early 20th centuries, the price of gold was not a market price at all &mdash; it was a government decree. The gold standard meant major currencies were directly convertible to gold at fixed rates, making the gold price effectively static for long stretches of time.</p>
+    <p class="gph-p">The most significant fixed price in US history was set in 1934 by President Franklin D. Roosevelt, who signed the Gold Reserve Act and raised the official gold price from $20.67 to <strong>$35.00 per troy ounce</strong> &mdash; a 69% devaluation of the dollar against gold. This $35 price would hold for the next 37 years.</p>
+    <p class="gph-p">The post-World War II <strong>Bretton Woods Agreement of 1944</strong> formalised this arrangement on an international scale: major world currencies were pegged to the US dollar, which was in turn convertible to gold at exactly $35 per ounce. Central banks around the world held dollars as reserves, trusting they could always exchange them for gold at that price. The system worked while the United States ran trade surpluses and held sufficient gold reserves &mdash; but by the late 1960s, the pressures were becoming impossible to sustain.</p>
+  </section>
+
+  <!-- ── 2. NIXON SHOCK ── -->
+  <section class="gph-section" id="nixon-shock">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">02</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">August 15, 1971 &middot; The Founding Event</div>
+        <h2 class="gph-h2">The Nixon Shock &mdash; Birth of the Modern Gold Market</h2>
+      </div>
+    </div>
+    <p class="gph-p">On the evening of <strong>August 15, 1971</strong>, President Richard Nixon appeared on television and announced what became known as the Nixon Shock: the United States would suspend the convertibility of the US dollar into gold, effective immediately. Foreign governments could no longer send dollars to Washington and expect gold in return. The Bretton Woods system &mdash; the international monetary architecture that had governed the global economy for 27 years &mdash; was over.</p>
+    <p class="gph-p">The implications were immediate and far-reaching. For the first time in modern history, gold was free to find its price in open markets. The result was a price explosion. Within months, gold surged past the old $35 fixed rate into the high $40s, then approached $70 by mid-1972 &mdash; effectively <strong>doubling within a year</strong> of being freed from its peg. Investors and governments around the world had known for years that $35 an ounce was artificial. The moment the constraint was removed, the market rapidly closed the gap between the fixed price and gold's perceived real value.</p>
+
+    <aside class="gph-callout" role="note">
+      <div class="gph-callout-label">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+        Key Takeaway
+      </div>
+      <p class="gph-callout-text">Every modern analysis of gold price history effectively starts here. The pre-1971 &ldquo;price history&rdquo; is largely an administrative record, not a market price. The Nixon Shock is the founding event of the gold market as it exists today.</p>
+    </aside>
+  </section>
+
+  <!-- ── 3. 1970s BULL ── -->
+  <section class="gph-section" id="bull-1970s">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">03</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">1971&ndash;1979 &middot; +2,300% Bull Run</div>
+        <h2 class="gph-h2">The 1970s: Inflation, Oil, and Gold's First Great Bull Market</h2>
+      </div>
+    </div>
+    <p class="gph-p">The decade following the Nixon Shock was gold's first experience of open-market price discovery &mdash; and the result was extraordinary. Gold gained roughly <strong>2,300% from 1971 to its peak in early 1980</strong> as a confluence of forces drove prices higher with increasing urgency.</p>
+
+    <h3 class="gph-h3">1973&ndash;1974: The first oil crisis</h3>
+    <p class="gph-p">The Arab oil embargo of 1973 quadrupled oil prices and triggered the first global inflationary shock of the modern era. Investors recognised that the dollar's purchasing power was eroding at an accelerating rate, and gold moved above $100 per ounce for the first time in January 1974 &mdash; a level it has never fallen below since. By December 1974, gold had set a then-record of $193 per ounce.</p>
+
+    <h3 class="gph-h3">1976&ndash;1977: Temporary pullback</h3>
+    <p class="gph-p">After the initial surge, gold briefly corrected to a low of $112.50 in August 1976 as markets stabilised and confidence in the dollar briefly recovered. This proved to be the last significant buying opportunity before the decade's climactic rally.</p>
+
+    <h3 class="gph-h3">1978&ndash;1979: The second oil crisis and inflation panic</h3>
+    <p class="gph-p">The Iranian Revolution of 1979 triggered the second oil shock, removing Iran's substantial oil production from global markets and sending energy prices soaring again. US consumer price inflation exceeded <strong>13% in 1979</strong> while real interest rates turned sharply negative. Investors who held cash or bonds were watching their purchasing power erode in real time. Gold responded with unprecedented force:</p>
+
+    <ul class="gph-timeline" aria-label="1979 gold price trajectory">
+      <li class="gph-timeline-item"><span class="gph-timeline-date">Start of 1979</span><span class="gph-timeline-price">$233 / oz</span></li>
+      <li class="gph-timeline-item"><span class="gph-timeline-date">July 1979</span><span class="gph-timeline-price">$300 / oz</span></li>
+      <li class="gph-timeline-item"><span class="gph-timeline-date">October 1979</span><span class="gph-timeline-price">$400 / oz</span></li>
+      <li class="gph-timeline-item"><span class="gph-timeline-date">November 1979</span><span class="gph-timeline-price">$500 / oz</span></li>
+      <li class="gph-timeline-item"><span class="gph-timeline-date">New Year's Day 1980</span><span class="gph-timeline-price">$600 / oz</span></li>
+    </ul>
+
+    <p class="gph-p">The pace was extraordinary &mdash; gold added $367 in the final six months of 1979 alone. The Soviet invasion of Afghanistan in December 1979 added a geopolitical premium on top of the inflation panic, and the two forces together created the environment for gold's most dramatic single month in history.</p>
+  </section>
+
+  <!-- ── 4. 1980 PEAK ── -->
+  <section class="gph-section" id="peak-1980">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">04</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">January 21, 1980 &middot; The First Great Peak</div>
+        <h2 class="gph-h2">January 1980: The First Great Peak &mdash; $850 per Ounce</h2>
+      </div>
+    </div>
+
+    <div class="gph-peak-card" role="figure" aria-label="1980 peak price">
+      <div class="gph-peak-inner">
+        <div class="gph-peak-label">Intraday All-Time High</div>
+        <div class="gph-peak-value">$850</div>
+        <p class="gph-peak-meta">21 January 1980 &middot; The inflation-adjusted record that would stand for <strong>45 years</strong>. Equivalent to approximately <strong>$3,500 in 2025 dollars</strong>.</p>
+      </div>
+    </div>
+
+    <p class="gph-p">On <strong>January 21, 1980</strong>, gold reached what would remain the highest <em>real</em> (inflation-adjusted) price ever recorded for the next 45 years: <strong>$850 per troy ounce</strong> intraday. The official London PM Fix recorded a peak close of approximately $665&ndash;$850 depending on the specific date reference, with some sources citing the intraday spike as the defining mark.</p>
+    <p class="gph-p">To put that 1980 peak in context: adjusting for inflation, $850 in January 1980 was equivalent to approximately $3,500 in 2025 dollars. This inflation-adjusted record would not be broken until April 2025 &mdash; a 45-year wait. The nominal record of $850 itself would stand until February 2008, when gold finally reclaimed that level after a 28-year absence.</p>
+    <p class="gph-p">The simultaneous collapse of the gold-silver ratio to approximately <strong>17:1</strong> during this period reflects the extraordinary intensity of the panic. Silver hit $49.45 per ounce on January 17, 1980, partly driven by the Hunt Brothers' famous attempt to corner the silver market, which also contributed to gold's atmospheric prices at the time.</p>
+  </section>
+
+  <!-- ── 5. 1980-1999 BEAR ── -->
+  <section class="gph-section" id="bear-1980-1999">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">05</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">1980&ndash;1999 &middot; The Long Decline</div>
+        <h2 class="gph-h2">The Forgotten Two Decades: Gold's Deepest Bear Market</h2>
+      </div>
+    </div>
+    <p class="gph-p">What followed the 1980 peak was one of the most sustained bear markets in gold's modern history &mdash; 20 years during which the metal ground lower in both nominal and real terms while equity markets delivered their greatest bull run of the century.</p>
+
+    <h3 class="gph-h3">The Volcker shock</h3>
+    <p class="gph-p">The reversal came through decisive, painful monetary policy. Federal Reserve Chairman Paul Volcker raised the federal funds rate above <strong>19% in 1981</strong> to break the back of inflation. This policy was brutal for the economy in the short term &mdash; it triggered a deep recession &mdash; but it worked. Inflation fell sharply, the dollar strengthened, and the rationale for holding gold as an inflation hedge evaporated almost overnight.</p>
+    <p class="gph-p">Gold dropped from its $850 peak to around $300 by the mid-1980s &mdash; a <strong>65% decline</strong> &mdash; in what remains the deepest crash in gold's modern history. It then spent most of the decade oscillating between $300 and $500 while stocks surged.</p>
+
+    <h3 class="gph-h3">1990s: Goldilocks era for everything except gold</h3>
+    <p class="gph-p">The 1990s brought a combination of low inflation, strong economic growth, rising equity valuations (the dot-com boom), and a strong dollar &mdash; the perfect environment for everything except gold. By 1999, gold hit a 20-year low of approximately <strong>$252 per ounce</strong>, reflecting widespread institutional belief that inflation had been permanently tamed and that gold's role as a monetary hedge was an artefact of a bygone era.</p>
+    <p class="gph-p">The 1990s bear market was also deepened by central bank gold sales. The UK's infamous sale of 395 tonnes of its gold reserves between 1999 and 2002 &mdash; at prices near the market bottom, averaging approximately $275 per ounce &mdash; became widely known as one of the most costly policy decisions in British monetary history.</p>
+
+    <aside class="gph-callout" role="note">
+      <div class="gph-callout-label">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 0 0-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"/></svg>
+        The Lesson of 1980&ndash;1999
+      </div>
+      <p class="gph-callout-text">Long gold bear markets are real, can last decades, and typically follow periods of very high real interest rates combined with strong equity market performance. <strong>Investors who bought gold at the 1980 peak did not break even in nominal terms for almost 30 years.</strong></p>
+    </aside>
+  </section>
+
+  <!-- ── 6. 2000-2011 BULL ── -->
+  <section class="gph-section" id="bull-2000-2011">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">06</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">2000&ndash;2011 &middot; +660% Bull Market</div>
+        <h2 class="gph-h2">Gold's Second Great Bull Market &mdash; $252 to $1,921</h2>
+      </div>
+    </div>
+    <p class="gph-p">Gold's recovery from its 1999 lows was gradual at first, then accelerating. Several structural shifts drove the new bull market:</p>
+
+    <h3 class="gph-h3">2001&ndash;2004: Dollar weakness and geopolitical risk</h3>
+    <p class="gph-p">The bursting of the dot-com bubble in 2000 damaged confidence in equities. The September 11, 2001 attacks added geopolitical uncertainty. The dollar began a prolonged weakening trend as the US ran large trade deficits. Gold responded, rising steadily from $252 to cross <strong>$400 per ounce for the first time since the early 1980s</strong> in late 2003.</p>
+
+    <h3 class="gph-h3">2005&ndash;2007: The commodities supercycle</h3>
+    <p class="gph-p">Rising demand from China, India, and other emerging markets drove a broad commodities boom. Gold followed, pushing through <strong>$500 in late 2005</strong>, then <strong>$600 in 2006</strong>, then <strong>$700 in 2007</strong>, and finally reclaiming the old 1980 nominal high of <strong>$850 in early 2008</strong> for the first time in 28 years.</p>
+
+    <h3 class="gph-h3">2008&ndash;2009: The global financial crisis</h3>
+    <p class="gph-p">The collapse of Lehman Brothers in September 2008 triggered the worst financial crisis since the Great Depression. In the immediate panic, gold was initially sold alongside equities as investors desperately sought cash &mdash; a short-term reaction that temporarily pushed gold down to $765 in November 2008. But as central banks responded with unprecedented monetary stimulus, gold reasserted its role as a safe haven. The Federal Reserve cut rates to near zero and launched the first quantitative easing programme. Gold crossed <strong>$1,000 per ounce for the first time in history</strong> on February 20, 2009.</p>
+
+    <h3 class="gph-h3">2010&ndash;2011: QE, sovereign debt crisis, and peak</h3>
+    <p class="gph-p">As the recovery struggled and the European sovereign debt crisis raised questions about the survival of the eurozone, gold continued to rise. From $1,000 in early 2009, gold hit <strong>$1,500 in April 2011</strong>, then <strong>$1,900 in August 2011</strong> before reaching its 2011 peak of approximately <strong>$1,921 per troy ounce in September 2011</strong>. The 2000&ndash;2011 bull market produced a total gain of approximately <strong>660% from the 1999 low to the 2011 peak</strong>.</p>
+  </section>
+
+  <!-- ── 7. 2011-2015 BEAR ── -->
+  <section class="gph-section" id="bear-2011-2015">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">07</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">2011&ndash;2015 &middot; &minus;46% Correction</div>
+        <h2 class="gph-h2">The Second Major Correction</h2>
+      </div>
+    </div>
+    <p class="gph-p">The 2011 peak marked the beginning of a four-year bear market in gold. As the global economy stabilised, the European debt crisis receded, and the Federal Reserve began signalling the eventual end of its emergency monetary policy, the rationale for holding gold at above $1,900 faded.</p>
+    <p class="gph-p">Gold fell from $1,921 to approximately $1,200 by mid-2013 &mdash; a decline of 38% &mdash; and continued grinding lower through 2015 to reach a trough near <strong>$1,050 in December 2015</strong>. The total decline from the 2011 peak to the 2015 low was approximately 46% &mdash; substantial, though far less severe than the 65% crash of 1980&ndash;1985.</p>
+    <p class="gph-p">The drivers were a mirror image of the bull market conditions: normalising inflation expectations, a stronger dollar, rising real interest rates as the Fed discussed tapering its bond purchases, and improving equity markets that drew investors away from defensive assets.</p>
+  </section>
+
+  <!-- ── 8. 2016-2019 RECOVERY ── -->
+  <section class="gph-section" id="recovery-2016-2019">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">08</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">2016&ndash;2019 &middot; Recovery &amp; Consolidation</div>
+        <h2 class="gph-h2">Quiet Years That Set the Stage</h2>
+      </div>
+    </div>
+    <p class="gph-p">Gold began its recovery in January 2016, rising from its $1,050 trough as the Fed's rate-hiking cycle proved more modest than feared and global growth showed signs of faltering. From 2016 to 2019, gold traded in a broadly consolidating pattern between $1,200 and $1,350, punctuated by periods of strength:</p>
+
+    <div class="gph-milestone-grid">
+      <div class="gph-milestone-card">
+        <div class="gph-milestone-date">Full Year 2016</div>
+        <div class="gph-milestone-price">+8.1%</div>
+        <p class="gph-milestone-desc">Brexit uncertainty drove safe-haven demand through the second half</p>
+      </div>
+      <div class="gph-milestone-card">
+        <div class="gph-milestone-date">Full Year 2017</div>
+        <div class="gph-milestone-price">+14.6%</div>
+        <p class="gph-milestone-desc">Weakening US dollar provided strong tailwinds for gold</p>
+      </div>
+      <div class="gph-milestone-card">
+        <div class="gph-milestone-date">Full Year 2018</div>
+        <div class="gph-milestone-price">&minus;1.6%</div>
+        <p class="gph-milestone-desc">Fed rate hikes and a strong dollar pressured gold, finishing flat</p>
+      </div>
+      <div class="gph-milestone-card">
+        <div class="gph-milestone-date">December 2019</div>
+        <div class="gph-milestone-price">$1,611</div>
+        <p class="gph-milestone-desc">US-China trade war prompted Fed pivot; gold ended 2019 up 21.2%</p>
+      </div>
+    </div>
+
+    <p class="gph-p">By late 2019, gold was approaching the 2011 highs, and COVID-19 would provide the catalyst for the next breakout.</p>
+  </section>
+
+  <!-- ── 9. COVID 2020 ── -->
+  <section class="gph-section" id="covid-2020">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">09</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">August 2020 &middot; First $2,000 Breakthrough</div>
+        <h2 class="gph-h2">COVID-19 and the $2,000 Breakthrough</h2>
+      </div>
+    </div>
+    <p class="gph-p">The COVID-19 pandemic of 2020 produced exactly the conditions that drive gold higher: extraordinary monetary stimulus, negative real interest rates, currency debasement concerns, and broad economic uncertainty. The Federal Reserve cut rates to near zero and launched unlimited quantitative easing. Governments worldwide announced multi-trillion-dollar fiscal stimulus programmes. Financial investors added a record <strong>734 tonnes worth $39.5 billion</strong> to gold holdings in the first half of 2020 alone.</p>
+
+    <div class="gph-peak-card" role="figure" aria-label="2020 COVID peak">
+      <div class="gph-peak-inner">
+        <div class="gph-peak-label">COVID Pandemic Peak</div>
+        <div class="gph-peak-value">$2,075</div>
+        <p class="gph-peak-meta">Intraday, 7 August 2020 &middot; The first cross of $2,000 in history. Gold gained <strong>32% in the first eight months of 2020</strong> &mdash; one of the strongest annual performances in the modern era.</p>
+      </div>
+    </div>
+
+    <p class="gph-p">Gold crossed <strong>$2,000 per ounce for the first time in history</strong> on August 4, 2020, and hit an intraday all-time high of <strong>$2,075.47 on August 7, 2020</strong>. The 2020 high would hold as the nominal record for the next three and a half years, until gold's 2024 breakout launched the current era of new highs.</p>
+  </section>
+
+  <!-- ── 10. RECORD ERA 2024-2026 ── -->
+  <section class="gph-section" id="record-era">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">10</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">2024&ndash;2026 &middot; The $3,000 &middot; $4,000 &middot; $5,000 Era</div>
+        <h2 class="gph-h2">New Records, New Territory: The Most Sustained Bull Market in History</h2>
+      </div>
+    </div>
+    <p class="gph-p">The period from late 2023 through early 2026 has been the most sustained, record-breaking bull market in gold's history &mdash; surpassing even the 1970s run in terms of consistency and pace.</p>
+
+    <h3 class="gph-h3">2024: The breakout year</h3>
+    <p class="gph-p">Gold entered 2024 at approximately $2,000 and proceeded to break the 2020 record multiple times. The metal crossed <strong>$3,000 for the first time</strong> in mid-March 2025 and set 50+ new all-time highs during 2025 alone.</p>
+
+    <h3 class="gph-h3">2025: An extraordinary year</h3>
+    <p class="gph-p">One of the most extraordinary years in the gold price record. Gold gained approximately <strong>64&ndash;67% during 2025</strong>, a performance that outpaced essentially every other major asset class. The key milestones came in rapid succession &mdash; each $500 increment was reached faster than the last:</p>
+
+    <div class="gph-milestone-grid">
+      <div class="gph-milestone-card">
+        <div class="gph-milestone-date">Mid-March 2025</div>
+        <div class="gph-milestone-price">$3,000</div>
+        <p class="gph-milestone-desc">First cross of $3,000 per ounce in history</p>
+      </div>
+      <div class="gph-milestone-card">
+        <div class="gph-milestone-date">~39 Days Later</div>
+        <div class="gph-milestone-price">$3,500</div>
+        <p class="gph-milestone-desc">Acceleration begins &mdash; momentum compresses</p>
+      </div>
+      <div class="gph-milestone-card">
+        <div class="gph-milestone-date">8 October 2025</div>
+        <div class="gph-milestone-price">$4,000</div>
+        <p class="gph-milestone-desc">Just 36 days after $3,500 &mdash; pace accelerating</p>
+      </div>
+      <div class="gph-milestone-card">
+        <div class="gph-milestone-date">December 2025</div>
+        <div class="gph-milestone-price">~$4,325</div>
+        <p class="gph-milestone-desc">Closing the year at unprecedented levels</p>
+      </div>
+    </div>
+
+    <h3 class="gph-h3">January 2026: The historic $5,000 and $5,589 peak</h3>
+    <p class="gph-p">The new year opened with gold already above $4,700 and still climbing. On <strong>January 19, 2026</strong>, gold hit $4,689 intraday. Then, on <strong>January 26, 2026</strong>, spot gold surged past <strong>$5,100</strong> &mdash; breaching the psychologically significant $5,000 level for the first time in history. Just two days later, on <strong>January 28, 2026</strong>, gold struck its all-time record high:</p>
+
+    <div class="gph-peak-card" role="figure" aria-label="2026 all-time high">
+      <div class="gph-peak-inner">
+        <div class="gph-peak-label">All-Time Record High &middot; Intraday</div>
+        <div class="gph-peak-value">$5,589.38</div>
+        <p class="gph-peak-meta">28 January 2026 &middot; The first nominal gold price to <strong>also exceed the inflation-adjusted 1980 peak</strong> &mdash; a 45-year wait for true real-terms parity.</p>
+      </div>
+    </div>
+
+    <p class="gph-p">The drivers of 2025&ndash;2026: escalating geopolitical tensions (particularly US-China trade conflict), central bank buying at record levels, de-dollarisation pressure, persistent inflation concerns, and weakening confidence in fiat currencies &mdash; a constellation of forces that mirrors, in updated form, the dynamics of the 1970s.</p>
+    <p class="gph-p"><strong>May 2026:</strong> Gold consolidated below the January high, trading in the $3,200&ndash;$3,500 range as markets processed the extraordinary gains of the prior 12 months.</p>
+  </section>
+
+  <!-- ── 11. MILESTONE TABLE ── -->
+  <section class="gph-section" id="milestone-table">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">11</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">100 Years of Gold &middot; Chronological</div>
+        <h2 class="gph-h2">Gold Price Record Table: Key Milestones</h2>
+      </div>
+    </div>
+    <p class="gph-p">Every defining moment in gold's price history, from the fixed-rate era through to the 2026 all-time high &mdash; chronologically.</p>
+
+    <div class="gph-table-wrap">
+      <div class="gph-table-scroll">
+        <table class="gph-table" aria-label="Gold price milestones chronologically">
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Gold Price (USD/oz)</th>
+              <th scope="col">Milestone</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td class="year">Pre-1934</td><td class="price">$20.67</td><td>Fixed under gold standard</td></tr>
+            <tr><td class="year">1934</td><td class="price">$35.00</td><td>FDR resets price; holds for 37 years</td></tr>
+            <tr><td class="year">Aug 1971</td><td class="price">~$40&ndash;42</td><td>Nixon Shock &mdash; gold freed to float</td></tr>
+            <tr><td class="year">Jan 1974</td><td class="price">$100+</td><td>Gold crosses $100 for first time</td></tr>
+            <tr class="peak"><td class="year">Dec 1974</td><td class="price">$193</td><td>First modern free-market peak</td></tr>
+            <tr class="trough"><td class="year">Aug 1976</td><td class="price">$112.50</td><td>Last great pre-1980 buying opportunity</td></tr>
+            <tr class="peak"><td class="year">Jan 1980</td><td class="price">$850</td><td>First great peak (intraday); 45-year real record</td></tr>
+            <tr class="trough"><td class="year">Jun 1982</td><td class="price">~$305</td><td>Bear market trough after Volcker rate hikes</td></tr>
+            <tr class="trough"><td class="year">Dec 1999</td><td class="price">~$252</td><td>20-year low; nadir of 1980&ndash;1999 bear market</td></tr>
+            <tr><td class="year">Feb 2009</td><td class="price">~$1,000</td><td>Gold crosses $1,000 for first time</td></tr>
+            <tr class="peak"><td class="year">Sep 2011</td><td class="price">~$1,921</td><td>Peak of second great bull market</td></tr>
+            <tr class="trough"><td class="year">Dec 2015</td><td class="price">~$1,050</td><td>Post-2011 bear market trough</td></tr>
+            <tr class="peak"><td class="year">Aug 2020</td><td class="price">$2,075</td><td>COVID pandemic peak &middot; first $2,000 breach</td></tr>
+            <tr><td class="year">Mar 2025</td><td class="price">~$3,000</td><td>First breach of $3,000</td></tr>
+            <tr><td class="year">Oct 2025</td><td class="price">~$4,000</td><td>First breach of $4,000</td></tr>
+            <tr><td class="year">26 Jan 2026</td><td class="price">$5,100+</td><td>First breach of $5,000</td></tr>
+            <tr class="peak"><td class="year">28 Jan 2026</td><td class="price">$5,589.38</td><td><strong>All-time record high (intraday)</strong></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="gph-table-caption">Sources: LBMA, Kitco, World Gold Council, US Federal Reserve</div>
+    </div>
+  </section>
+
+  <!-- ── 12. BEAR MARKETS ── -->
+  <section class="gph-section" id="bear-markets">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">12</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">Crash History &middot; Three Major Declines</div>
+        <h2 class="gph-h2">Gold Price Crash History: The Three Major Bear Markets</h2>
+      </div>
+    </div>
+    <p class="gph-p">Understanding gold's crashes is as important as understanding its peaks. There have been three major bear markets since the modern gold market began in 1971.</p>
+
+    <div class="gph-bear-grid">
+      <div class="gph-bear-card">
+        <div class="gph-bear-num">Bear Market 01</div>
+        <div class="gph-bear-title">1980&ndash;1999: The Long Decline</div>
+        <div class="gph-bear-stats">
+          <div>
+            <div class="gph-bear-stat-label">Decline</div>
+            <div class="gph-bear-stat-value decline">&minus;65%</div>
+          </div>
+          <div>
+            <div class="gph-bear-stat-label">Duration</div>
+            <div class="gph-bear-stat-value duration">19 yrs</div>
+          </div>
+        </div>
+        <p class="gph-bear-desc">Volcker's 19%+ rates crushed inflation and restored dollar credibility. S&amp;P 500 delivered extraordinary returns. Investors didn't break even in nominal terms for nearly 30 years.</p>
+      </div>
+
+      <div class="gph-bear-card">
+        <div class="gph-bear-num">Bear Market 02</div>
+        <div class="gph-bear-title">2011&ndash;2015: The Taper Tantrum</div>
+        <div class="gph-bear-stats">
+          <div>
+            <div class="gph-bear-stat-label">Decline</div>
+            <div class="gph-bear-stat-value decline">&minus;45%</div>
+          </div>
+          <div>
+            <div class="gph-bear-stat-label">Duration</div>
+            <div class="gph-bear-stat-value duration">4 yrs</div>
+          </div>
+        </div>
+        <p class="gph-bear-desc">Fed signalled end of QE, improving economy, strong dollar, falling inflation expectations. Shorter and shallower than 1980&ndash;1999, but still significant.</p>
+      </div>
+
+      <div class="gph-bear-card">
+        <div class="gph-bear-num">Bear Market 03</div>
+        <div class="gph-bear-title">2020&ndash;2022: Brief Reset</div>
+        <div class="gph-bear-stats">
+          <div>
+            <div class="gph-bear-stat-label">Decline</div>
+            <div class="gph-bear-stat-value decline">&minus;18%</div>
+          </div>
+          <div>
+            <div class="gph-bear-stat-label">Duration</div>
+            <div class="gph-bear-stat-value duration">2 yrs</div>
+          </div>
+        </div>
+        <p class="gph-bear-desc">Fed's aggressive rate hiking cycle vs post-pandemic inflation. Mildest of the three, partly cushioned by record central bank buying.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── 13. GOLD-SILVER RATIO ── -->
+  <section class="gph-section" id="gsr">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">13</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">Gold-to-Silver Ratio &middot; Historical Context</div>
+        <h2 class="gph-h2">The GSR Through History</h2>
+      </div>
+    </div>
+    <p class="gph-p">The <strong>gold-to-silver ratio</strong> (GSR) measures how many ounces of silver are needed to purchase one ounce of gold. It is one of the most closely watched metrics in the precious metals market because it reflects both relative supply-demand dynamics and broader market sentiment.</p>
+
+    <div class="gph-ratio-gauge">
+      <div class="gph-ratio-title">Historical GSR Scale &middot; Where We Stand</div>
+      <p class="gph-ratio-desc">The long-term historical average sits at approximately <strong>55&ndash;65:1</strong>. When the ratio moves significantly above this range, silver is historically undervalued relative to gold.</p>
+      <div class="gph-ratio-bar-wrap">
+        <div class="gph-ratio-bar" aria-hidden="true"></div>
+        <div class="gph-ratio-marker" style="left:8%"><span class="v">17</span><span class="l">1980</span></div>
+        <div class="gph-ratio-marker" style="left:20%"><span class="v">32</span><span class="l">2011</span></div>
+        <div class="gph-ratio-marker" style="left:46%"><span class="v">55</span><span class="l">May 2026</span></div>
+        <div class="gph-ratio-marker" style="left:68%"><span class="v">83</span><span class="l">Oct 2025</span></div>
+        <div class="gph-ratio-marker" style="left:97%"><span class="v">124</span><span class="l">Mar 2020</span></div>
+      </div>
+      <div class="gph-ratio-scale">
+        <span>0</span><span>25</span><span>50</span><span>75</span><span>100</span><span>125+</span>
+      </div>
+    </div>
+
+    <div class="gph-table-wrap">
+      <div class="gph-table-scroll">
+        <table class="gph-table" aria-label="Historical gold-to-silver ratio">
+          <thead>
+            <tr><th scope="col">Period</th><th scope="col">Approx. Ratio</th><th scope="col">Context</th></tr>
+          </thead>
+          <tbody>
+            <tr><td class="year">Ancient Rome</td><td class="price">~12:1</td><td>Statutory ratio established by law</td></tr>
+            <tr><td class="year">19th century</td><td class="price">~15&ndash;16:1</td><td>US and UK bi-metallic standards</td></tr>
+            <tr><td class="year">January 1980</td><td class="price">~17:1</td><td>Hunt Brothers silver squeeze; both metals at peaks</td></tr>
+            <tr><td class="year">April 2011</td><td class="price">~32:1</td><td>Silver at $49/oz following GFC bull market</td></tr>
+            <tr class="peak"><td class="year">March 2020</td><td class="price">~124:1</td><td>COVID panic &mdash; all-time high for the ratio</td></tr>
+            <tr><td class="year">2021</td><td class="price">~62:1</td><td>Post-COVID recovery compression</td></tr>
+            <tr><td class="year">October 2025</td><td class="price">~83:1</td><td>Silver lagging gold's 2025 rally</td></tr>
+            <tr><td class="year">January 2026</td><td class="price">~60:1</td><td>Silver catching up to gold's gains</td></tr>
+            <tr><td class="year">May 2026</td><td class="price">~55:1</td><td>Rapid compression as silver surges</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <p class="gph-p">The March 2020 peak of 124:1 was the highest ratio ever recorded in modern markets &mdash; reflecting the extreme panic conditions of the early pandemic, when gold held up far better than silver as investors sought liquidity. The subsequent compression from 124 to 55 represents one of the most powerful silver moves in decades.</p>
+  </section>
+
+  <!-- ── 14. RETURNS ANALYSIS ── -->
+  <section class="gph-section" id="returns">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">14</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">Returns Analysis &middot; A Century of Data</div>
+        <h2 class="gph-h2">Gold's Historical Rate of Return: What the Numbers Show</h2>
+      </div>
+    </div>
+    <p class="gph-p">For investors evaluating gold as a long-term asset, the return data carries some important nuances.</p>
+
+    <h3 class="gph-h3">Long-run annualised returns since 1928</h3>
+    <p class="gph-p">Over the full century from 1928, asset class returns tell a clear story: equities lead in absolute terms, but gold has dramatically outperformed in specific decades.</p>
+
+    <div class="gph-compare-grid">
+      <div class="gph-compare-card" data-asset="stocks">
+        <div class="gph-compare-asset">
+          <span class="gph-compare-dot"></span>
+          <span class="gph-compare-asset-name">Stocks (S&amp;P 500)</span>
+        </div>
+        <div class="gph-compare-value">9.9<span class="unit">%</span></div>
+        <div class="gph-compare-period">Annual CAGR since 1928</div>
+      </div>
+      <div class="gph-compare-card" data-asset="gold">
+        <div class="gph-compare-asset">
+          <span class="gph-compare-dot"></span>
+          <span class="gph-compare-asset-name">Gold</span>
+        </div>
+        <div class="gph-compare-value">5.0<span class="unit">%</span></div>
+        <div class="gph-compare-period">Annual CAGR since 1928</div>
+      </div>
+      <div class="gph-compare-card" data-asset="bonds">
+        <div class="gph-compare-asset">
+          <span class="gph-compare-dot"></span>
+          <span class="gph-compare-asset-name">Bonds (10y Treasury)</span>
+        </div>
+        <div class="gph-compare-value">4.6<span class="unit">%</span></div>
+        <div class="gph-compare-period">Annual CAGR since 1928</div>
+      </div>
+      <div class="gph-compare-card" data-asset="cash">
+        <div class="gph-compare-asset">
+          <span class="gph-compare-dot"></span>
+          <span class="gph-compare-asset-name">Cash (T-Bills)</span>
+        </div>
+        <div class="gph-compare-value">3.3<span class="unit">%</span></div>
+        <div class="gph-compare-period">Annual CAGR since 1928</div>
+      </div>
+    </div>
+
+    <h3 class="gph-h3">The 2000&ndash;2026 reversal</h3>
+    <p class="gph-p">Look at the past 25 years and the picture flips. From 2000 to March 2026, gold delivered a <strong>total return of approximately +1,580%</strong> &mdash; compared to <strong>+615% for the S&amp;P 500</strong> over the same period. The 2000&ndash;2026 period is unusual in gold's favour because it includes two major equity bear markets (2000&ndash;2003 and 2008&ndash;2009) and a period of sustained monetary expansion.</p>
+
+    <aside class="gph-callout" role="note">
+      <div class="gph-callout-label">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5z"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+        The Critical Investor Takeaway
+      </div>
+      <p class="gph-callout-text">Gold is not a consistent wealth-compounder in the way diversified equity portfolios are &mdash; it pays no dividends and generates no cash flow. Its primary role is as a <strong>store of value</strong> and <strong>portfolio hedge</strong>: it tends to hold value relative to fiat currencies over the very long run, and it tends to rise in periods of high inflation, dollar weakness, financial stress, and geopolitical crisis.</p>
+    </aside>
+  </section>
+
+  <!-- ── 15. INFLATION-ADJUSTED ── -->
+  <section class="gph-section" id="inflation">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">15</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">Real Returns &middot; Nominal vs Inflation-Adjusted</div>
+        <h2 class="gph-h2">Inflation-Adjusted Gold Price: The Real History</h2>
+      </div>
+    </div>
+    <p class="gph-p">Looking at gold's nominal price history overstates the gains for investors in periods of high inflation. The real story emerges when prices are adjusted for inflation.</p>
+
+    <div class="gph-infl-table">
+      <div class="gph-infl-row gph-infl-head">
+        <span>Year</span>
+        <span>Nominal (USD/oz)</span>
+        <span>2026 USD</span>
+      </div>
+      <div class="gph-infl-row">
+        <span class="gph-infl-year">1934</span>
+        <span class="gph-infl-nominal">$35</span>
+        <span class="gph-infl-real">~$780</span>
+      </div>
+      <div class="gph-infl-row">
+        <span class="gph-infl-year">1971</span>
+        <span class="gph-infl-nominal">$35</span>
+        <span class="gph-infl-real">~$270</span>
+      </div>
+      <div class="gph-infl-row highlight">
+        <span class="gph-infl-year">1980 peak</span>
+        <span class="gph-infl-nominal">$850</span>
+        <span class="gph-infl-real">~$3,500</span>
+      </div>
+      <div class="gph-infl-row">
+        <span class="gph-infl-year">1999 low</span>
+        <span class="gph-infl-nominal">$252</span>
+        <span class="gph-infl-real">~$460</span>
+      </div>
+      <div class="gph-infl-row">
+        <span class="gph-infl-year">2011 peak</span>
+        <span class="gph-infl-nominal">$1,921</span>
+        <span class="gph-infl-real">~$2,650</span>
+      </div>
+      <div class="gph-infl-row">
+        <span class="gph-infl-year">2020 peak</span>
+        <span class="gph-infl-nominal">$2,075</span>
+        <span class="gph-infl-real">~$2,500</span>
+      </div>
+      <div class="gph-infl-row highlight">
+        <span class="gph-infl-year">2026 ATH</span>
+        <span class="gph-infl-nominal">$5,589</span>
+        <span class="gph-infl-real">$5,589</span>
+      </div>
+    </div>
+
+    <p class="gph-p">The inflation-adjusted picture clarifies something important: in real terms, the 2020 peak of $2,075 was actually <em>lower</em> than the 1980 peak of $850 &mdash; because 40 years of inflation eroded the purchasing power of dollars substantially. The 2026 all-time high at $5,589 is the first nominal gold price that also exceeds the 1980 inflation-adjusted peak &mdash; a genuinely historic threshold.</p>
+  </section>
+
+  <!-- ── 16. DAILY DRIVERS ── -->
+  <section class="gph-section" id="drivers">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">16</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">Market Mechanics &middot; Day-to-Day Drivers</div>
+        <h2 class="gph-h2">What Drives Daily Gold Price Moves</h2>
+      </div>
+    </div>
+    <p class="gph-p">Understanding the big milestones is one thing; understanding what moves gold on any given day helps investors interpret current price action in its historical context.</p>
+
+    <div class="gph-drivers">
+      <div class="gph-driver">
+        <div class="gph-driver-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        </div>
+        <div class="gph-driver-content">
+          <h4>The Dollar Relationship</h4>
+          <p>Gold is priced in US dollars globally, so a weaker dollar generally makes gold cheaper for buyers using other currencies, increasing demand and pushing prices up.</p>
+        </div>
+      </div>
+      <div class="gph-driver">
+        <div class="gph-driver-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+        </div>
+        <div class="gph-driver-content">
+          <h4>Real Interest Rates</h4>
+          <p>The most important medium-term variable. When real rates turn negative (inflation exceeds yields), holding gold becomes attractive vs. interest-bearing assets.</p>
+        </div>
+      </div>
+      <div class="gph-driver">
+        <div class="gph-driver-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21h18M5 21V7l8-4v18M19 21V11l-6-4"/></svg>
+        </div>
+        <div class="gph-driver-content">
+          <h4>Central Bank Activity</h4>
+          <p>Central banks hold ~35,000 tonnes of gold &mdash; over 20% of all gold ever mined. Their record buying in 2022&ndash;2025 has been a major support for prices.</p>
+        </div>
+      </div>
+      <div class="gph-driver">
+        <div class="gph-driver-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+        </div>
+        <div class="gph-driver-content">
+          <h4>Geopolitical Events</h4>
+          <p>Iranian Revolution (1979), Gulf War (1990), 9/11 (2001), Russia-Ukraine (2022), US-China trade conflict (2025) &mdash; all visible as sharp upward spikes.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Internal CTA -->
+  <div class="gph-cta">
+    <div class="gph-cta-inner">
+      <h3>Track Today's Gold Price Live</h3>
+      <p>The all-time high may be $5,589, but where is gold trading right now? See the current spot price and calculate the value of any karat or weight &mdash; updated every 60 seconds.</p>
+      <a href="/" class="gph-cta-btn">Open Live Gold Calculator
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+      </a>
+    </div>
   </div>
 
-  <div class="prose">
-    <p>Gold has served as a store of value, monetary standard, and financial safe haven for millennia. In modern financial markets, the gold price has moved from a fixed $35 per troy ounce under the Bretton Woods system to over $3,300 in April 2026. This guide traces the key milestones in gold price history and explains the market forces behind each major move.</p>
-
-    <h2>The Gold Standard Era (pre-1971)</h2>
-    <p>For most of the 20th century, the US dollar was pegged to gold at $35 per troy ounce under the Bretton Woods Agreement (1944). Other major currencies were in turn pegged to the dollar, creating a fixed exchange rate system anchored to gold. This kept the nominal gold price essentially frozen for nearly three decades.</p>
-    <p>In August 1971, President Nixon ended dollar convertibility to gold &mdash; the &ldquo;Nixon Shock&rdquo; &mdash; which floated the gold price for the first time in the modern era. Within two years, gold had doubled to $65/oz.</p>
-
-    <h2>1970s Inflation Surge</h2>
-    <p>The 1970s saw gold rocket from $35 to $850 per troy ounce by January 1980 &mdash; a 24x increase in under a decade. This was driven by the oil price shocks of 1973 and 1979, runaway US inflation (CPI peaked at 14.8% in 1980), and the Soviet invasion of Afghanistan in December 1979 which triggered geopolitical demand for safe-haven assets.</p>
-
-    <h2>The Long Bear Market (1980&ndash;2001)</h2>
-    <p>After peaking at $850 in January 1980, gold entered a prolonged bear market lasting over two decades. The Federal Reserve raised interest rates aggressively under Chairman Paul Volcker (Fed funds rate reached 20% in 1981), crushing inflation and making gold less attractive relative to high-yield bonds. Gold fell to around $255 by 2001.</p>
-
-    <h2>The 2000s Bull Market</h2>
-    <p>Gold began a new bull market in 2001, rising steadily throughout the decade as the US dollar weakened, commodity supercycle demand from China and India grew, and the 2008 Global Financial Crisis drove investors to safe havens. Gold reached $1,011 in March 2008 &mdash; briefly breaking $1,000 for the first time.</p>
-
-    <h2>Post-GFC Peak: $1,921 (September 2011)</h2>
-    <p>Following the 2008 crisis, central banks globally implemented quantitative easing programmes. Gold surged to an all-time high of $1,921 per troy ounce in September 2011 as investors hedged against currency debasement and US debt ceiling fears. This record stood for nearly a decade.</p>
-
-    <h2>2011&ndash;2018 Correction</h2>
-    <p>As the post-GFC recovery strengthened and the Federal Reserve began tapering QE in 2013, gold entered a significant correction, falling to around $1,050 by late 2015. Rising US real interest rates made gold less competitive versus bonds. The price recovered modestly to $1,300&ndash;$1,350 by 2017&ndash;2018 as geopolitical uncertainty (US-China trade tensions, North Korea) supported demand.</p>
-
-    <h2>COVID-19 All-Time High: $2,089 (August 2020)</h2>
-    <p>The COVID-19 pandemic triggered the largest peacetime fiscal and monetary stimulus in history. The US Federal Reserve cut rates to near zero and launched unlimited QE; the US Congress passed $5 trillion+ in stimulus. Gold surged past its 2011 record in July 2020, reaching $2,089 per troy ounce in August 2020 as real yields turned deeply negative.</p>
-
-    <h2>2022&ndash;2023 Consolidation</h2>
-    <p>As central banks pivoted to aggressive interest rate hikes in 2022 to fight post-pandemic inflation (the Fed raised rates from 0.25% to 5.5% in 16 months), gold faced pressure from rising real yields. It traded in a range of $1,600&ndash;$2,000, supported by central bank buying at record levels. Emerging market central banks (China, India, Turkey, Poland) bought over 1,000 tonnes of gold in 2022 alone.</p>
-
-    <h2>2024&ndash;2026 New Bull Market</h2>
-    <p>Gold broke decisively above $2,000 in late 2023 and accelerated sharply through 2024 and 2025, driven by anticipated Fed rate cuts, sustained central bank demand, geopolitical tensions (Middle East conflict, Ukraine), and de-dollarisation by BRICS nations. By April 2026, gold has traded above $3,300 per troy ounce, setting a series of new all-time highs.</p>
-
-    <table class="data-table" aria-label="Gold price milestones">
-      <thead><tr><th>Year</th><th>Price (USD/oz)</th><th>Key Driver</th></tr></thead>
-      <tbody>
-        <tr><td>1971</td><td>$40</td><td>Nixon ends gold standard</td></tr>
-        <tr><td>1980</td><td>$850 ATH</td><td>Inflation surge, Soviet invasion of Afghanistan</td></tr>
-        <tr><td>2001</td><td>$255</td><td>20-year bear market low</td></tr>
-        <tr><td>2011</td><td>$1,921 ATH</td><td>Post-GFC QE, US debt ceiling crisis</td></tr>
-        <tr><td>2020</td><td>$2,089 ATH</td><td>COVID stimulus, negative real rates</td></tr>
-        <tr><td>2024</td><td>$2,600+</td><td>Fed pivot, central bank buying</td></tr>
-        <tr><td>2026</td><td>$3,300+</td><td>De-dollarisation, geopolitical demand</td></tr>
-      </tbody>
-    </table>
-
-    <div class="callout">
-      <p><strong>Historical context:</strong> Adjusted for inflation, the 1980 peak of $850 would be approximately $3,200&ndash;$3,500 in 2026 dollars, suggesting that gold in 2026 is only now reaching inflation-adjusted parity with its 1980 peak in real terms.</p>
+  <!-- ── 17. FAQ ── -->
+  <section class="gph-section" id="faq">
+    <div class="gph-section-head">
+      <div class="gph-era-num" aria-hidden="true">17</div>
+      <div class="gph-section-head-text">
+        <div class="gph-section-date">FAQ &middot; Common Questions</div>
+        <h2 class="gph-h2">Frequently Asked Questions</h2>
+      </div>
     </div>
-  </div><!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
-  <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/gold-price-history&text=Gold+Price+History+%E2%80%94+All-Time+Highs+and+Key+Milestones" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
-  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/guides/gold-price-history&title=Gold+Price+History+%E2%80%94+All-Time+Highs+and+Key+Milestones" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=Gold+Price+History+%E2%80%94+All-Time+Highs+and+Key+Milestones%20https%3A%2F%2Fgoldpricetools.com%2Fguides%2Fgold-price-history" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
-</div>
+
+    <div class="gph-faq-list">
+      <details class="gph-faq-item">
+        <summary>
+          <div class="gph-faq-q">
+            <span>What is the highest price of gold in history?</span>
+            <span class="gph-faq-q-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+          </div>
+        </summary>
+        <div class="gph-faq-a">
+          <p>Gold's all-time high is <strong>$5,589.38 per troy ounce</strong>, reached intraday on January 28, 2026. This price also, for the first time, exceeded the 1980 peak adjusted for inflation.</p>
+        </div>
+      </details>
+
+      <details class="gph-faq-item">
+        <summary>
+          <div class="gph-faq-q">
+            <span>What was the highest gold price in history when adjusted for inflation?</span>
+            <span class="gph-faq-q-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+          </div>
+        </summary>
+        <div class="gph-faq-a">
+          <p>For decades, the 1980 peak of $850 held the record in real terms &mdash; equivalent to approximately <strong>$3,500 in today's dollars</strong>. The 2026 nominal high of $5,589 finally surpassed it on an inflation-adjusted basis &mdash; the first time in 45 years that real-terms parity was achieved.</p>
+        </div>
+      </details>
+
+      <details class="gph-faq-item">
+        <summary>
+          <div class="gph-faq-q">
+            <span>What caused the biggest crash in gold price history?</span>
+            <span class="gph-faq-q-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+          </div>
+        </summary>
+        <div class="gph-faq-a">
+          <p>The 1980&ndash;1999 bear market is the largest in gold's modern history &mdash; a <strong>65% decline over 19 years</strong>. It was caused primarily by Paul Volcker's aggressive interest rate hikes (rates above 19%), which crushed inflation, restored dollar credibility, and made interest-bearing assets far more attractive than gold.</p>
+        </div>
+      </details>
+
+      <details class="gph-faq-item">
+        <summary>
+          <div class="gph-faq-q">
+            <span>What is the historical gold-to-silver ratio?</span>
+            <span class="gph-faq-q-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+          </div>
+        </summary>
+        <div class="gph-faq-a">
+          <p>The long-term historical average is approximately <strong>55&ndash;65:1</strong>. It peaked at a record 124:1 during the COVID-19 panic in March 2020 and compressed to approximately 55:1 by May 2026 as silver recovered strongly.</p>
+        </div>
+      </details>
+
+      <details class="gph-faq-item">
+        <summary>
+          <div class="gph-faq-q">
+            <span>What is gold's historical rate of return compared to stocks?</span>
+            <span class="gph-faq-q-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+          </div>
+        </summary>
+        <div class="gph-faq-a">
+          <p>From 2000 to 2026, gold has significantly outperformed equities (<strong>+1,580% vs +615% for the S&amp;P 500</strong>). Over the very long run (since 1928), equities have averaged approximately 9.9% annually versus gold's approximately 5%. Gold outperforms in specific periods &mdash; high inflation, financial crises, and dollar weakness &mdash; while equities outperform in periods of growth and price stability.</p>
+        </div>
+      </details>
+
+      <details class="gph-faq-item">
+        <summary>
+          <div class="gph-faq-q">
+            <span>When did gold first cross $1,000, $2,000, $3,000, $4,000, and $5,000?</span>
+            <span class="gph-faq-q-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+          </div>
+        </summary>
+        <div class="gph-faq-a">
+          <ul>
+            <li><strong>$1,000:</strong> First crossed February 2009</li>
+            <li><strong>$2,000:</strong> First crossed August 4, 2020</li>
+            <li><strong>$3,000:</strong> First crossed mid-March 2025</li>
+            <li><strong>$4,000:</strong> First crossed October 8, 2025</li>
+            <li><strong>$5,000:</strong> First crossed January 24&ndash;26, 2026</li>
+          </ul>
+          <p>Each $500 increment was reached faster than the last &mdash; a compression that reflected the accelerating momentum of the 2024&ndash;2026 bull market.</p>
+        </div>
+      </details>
+
+      <details class="gph-faq-item">
+        <summary>
+          <div class="gph-faq-q">
+            <span>What is the lowest gold price in modern history?</span>
+            <span class="gph-faq-q-icon" aria-hidden="true"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+          </div>
+        </summary>
+        <div class="gph-faq-a">
+          <p>Since the start of free-market gold trading in 1971, the lowest price was approximately <strong>$112.50 in August 1976</strong>. Before that, the fixed $35 price under the Bretton Woods system (1944&ndash;1971) represents the long-term floor of the fixed-price era.</p>
+        </div>
+      </details>
+    </div>
+  </section>
+
+  <!-- Social share buttons -->
+  <div class="share-buttons" style="margin-top:var(--space-8)">
+    <span>Share:</span>
+    <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/gold-price-history&text=Gold+Price+History+%E2%80%94+All-Time+Highs+and+Key+Milestones" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+    <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/guides/gold-price-history&title=Gold+Price+History+%E2%80%94+All-Time+Highs+and+Key+Milestones" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+    <a href="https://api.whatsapp.com/send?text=Gold+Price+History+%E2%80%94+All-Time+Highs+and+Key+Milestones%20https%3A%2F%2Fgoldpricetools.com%2Fguides%2Fgold-price-history" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+  </div>
   <script>
   document.querySelectorAll('.share-buttons a').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -619,49 +1608,34 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
   });
   </script>
 
-  <div class="cta-box">
-    <h3>Check Today&rsquo;s Live Gold Price</h3>
-    <p>See the current gold spot price and calculate values per gram for every karat &mdash; updated every 60 seconds.</p>
-    <a href="/" class="cta-btn">Open Gold Calculator &rarr;</a>
-  </div>
 </article>
+</main>
+
+<!-- Reading progress bar — JS -->
+<script>
+(function(){
+  var bar = document.getElementById('gphProgress');
+  if(!bar) return;
+  var ticking = false;
+  function update(){
+    var doc = document.documentElement;
+    var scrollTop = window.scrollY || doc.scrollTop;
+    var height = doc.scrollHeight - doc.clientHeight;
+    var pct = height > 0 ? Math.min(100, Math.max(0, (scrollTop / height) * 100)) : 0;
+    bar.style.width = pct + '%';
+    ticking = false;
+  }
+  window.addEventListener('scroll', function(){
+    if(!ticking){window.requestAnimationFrame(update); ticking = true;}
+  }, { passive: true });
+  update();
+})();
+</script>
 
 
 <div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
   <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
 </div>
-
-
-<!-- FAQ Section -->
-<section style="padding:2.5rem 0;max-width:900px;margin:0 auto 0;padding-left:1.5rem;padding-right:1.5rem;">
-  <h2>Frequently Asked Questions</h2>
-  <div class="faq-container">
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">What was the highest gold price in history?</h3>
-      <p class="faq-answer">Gold reached its all-time nominal high of around $3,500 per troy ounce in April 2025, driven by central bank buying and geopolitical uncertainty. In inflation-adjusted terms, the 1980 peak (when gold hit $850) remains historically significant — equivalent to roughly $3,200 in today's dollars.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Why does the gold price go up during a crisis?</h3>
-      <p class="faq-answer">Gold is considered a "safe haven" asset. During economic uncertainty, inflation, currency devaluations, or geopolitical crises, investors move capital into gold to preserve value. Unlike currencies or bonds, gold has no counterparty risk — it cannot default. This drives demand and pushes prices higher during turbulent periods.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">What caused the gold price surge in 2020?</h3>
-      <p class="faq-answer">The 2020 COVID-19 pandemic triggered a global flight to safety. Central banks implemented massive quantitative easing programmes, driving real interest rates deeply negative. Low or negative real rates make gold more attractive as it has no yield to sacrifice. Gold hit then-record highs of over $2,070/oz in August 2020.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Does gold always go up during inflation?</h3>
-      <p class="faq-answer">Gold has historically been an inflation hedge over the long run, but it doesn't always rise in the short term during inflationary periods. For example, gold fell significantly in 1980–1982 and 2022 despite high inflation. The relationship works best over decades rather than months, and gold tends to perform best when real interest rates are negative.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">How does the US dollar affect the gold price?</h3>
-      <p class="faq-answer">Gold is priced in US dollars globally, so there is typically an inverse relationship between the dollar and gold. When the dollar strengthens, gold becomes more expensive for non-US buyers, reducing demand and often pushing prices down. Conversely, a weak dollar makes gold cheaper in other currencies, boosting international demand and the price.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Is gold a good long-term investment?</h3>
-      <p class="faq-answer">Gold has averaged approximately 7–8% annual returns over the past 50 years, roughly matching inflation-adjusted equity returns but with lower correlation to stocks, making it useful for portfolio diversification. However, it produces no income (dividends or interest), and can have prolonged bear markets — gold was flat from 1980 to 2000. Most financial advisers suggest a 5–10% portfolio allocation to gold.</p>
-    </div>
-  </div>
-</section>
 
 
 <!-- Related Guides Section -->


### PR DESCRIPTION
## Summary

Complete rebuild of `/guides/gold-price-history.html` as a magazine-quality, mobile-first editorial piece. Replaces the previous 11-paragraph guide with a 17-section, data-rich deep dive covering 1920 through the January 2026 all-time high of $5,589.38.

Designed with the ui-ux-pro-max skill (Dark Mode editorial pattern, IBM Plex Sans display, gold-on-dark palette) and verified against the site's Playwright audit at 393px iPhone and 1440px desktop.

## Design highlights

- **Cinematic hero** — eyebrow chip with pulsing dot, gradient gold headline ("All-Time Highs" with linear-gradient text), lede with the $5,589 callout, byline + read time, decorative gold/teal blur orbs
- **4 hero stat cards** — All-Time High, Modern Market Start, 25-Year Return, Deepest Crash (1 col → 2 col → 4 col responsive)
- **17-item TOC** with numbered anchor links (1 col mobile → 2 col tablet → 3 col desktop)
- **Era-numbered sections** — gradient gold badge tile (01–17) with date chip + H2
- **3 featured peak cards** for $850 (1980), $2,075 (COVID), $5,589 (2026 ATH) — dark gradient background with animated shimmer, gold-glow on the number
- **Vertical timeline** for 1979 monthly milestones with gradient connecting line
- **17-row milestone table** with peak rows tinted gold, trough rows tinted red, hover state
- **3-card bear market comparison** (1980–1999, 2011–2015, 2020–2022) with decline % and duration
- **Gold-to-silver ratio gauge** — gradient green-to-red bar with chronological pill markers (alternating labels prevent overlap on mobile)
- **4-card returns comparison** (Gold, Stocks, Bonds, Cash) with asset-dot colour coding
- **Inflation-adjusted table** — nominal vs 2026 USD side-by-side
- **4 driver cards** with SVG icons (dollar, interest rates, central banks, geopolitics)
- **Native `<details>` FAQ accordion** with rotating `+` → `×` icons
- **Reading progress bar** at top of viewport (RAF-throttled)
- **FAQ schema, og tags, article schema** all updated to match new content

## Mobile-first

- Single column on mobile, scales up at 520px / 600px / 740px / 860px / 1024px breakpoints
- Tables scroll horizontally with `min-width: 560px` to preserve readability
- Ratio gauge labels alternate above/below on small screens
- 44×44px minimum touch targets on the FAQ accordion summaries

## Test plan

- [x] Playwright audit clean — main/nav/h1/footer visible, no horizontal overflow on 393px iPhone 14 Pro or 1440px desktop
- [x] No stray text nodes, no broken images (except logo from CDN which is expected locally)
- [x] Dark + light mode both render correctly
- [x] FAQ accordion expands/collapses, share buttons styled, internal CTA functional
- [x] HTML well-formed: 18 `<section>` open/close, 7 `<details>` open/close, 1 `<article>` open/close
- [ ] Visual review of all 43 screenshot strips
- [ ] Production deploy verification on goldpricetools.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG7PqDyPDeARKievYg6ZzS)_