### PR TITLE
Redesign What Affects Gold Price as premium editorial article

### DIFF
--- a/guides/what-affects-gold-price.html
+++ b/guides/what-affects-gold-price.html
@@ -9,7 +9,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>What Affects the Price of Gold? Complete Guide</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Discover the key factors that influence the price of gold, including inflation, interest rates, central bank reserves, geopolitical events, and ETF demand.">
+<meta name="description" content="What affects gold prices? Interest rates, central bank buying, the US dollar, geopolitics, ETFs and 8 more drivers — explained with real correlations, 2025–2026 data, and a quick-reference table.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/guides/what-affects-gold-price">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/what-affects-gold-price">
@@ -19,15 +19,16 @@
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="What Affects the Price of Gold?">
-<meta property="og:description" content="Discover the key factors that influence the price of gold, including inflation, interest rates, central bank reserves, geopolitical events, and ETF demand.">
+<meta property="og:description" content="Twelve forces drive the gold price every day — Fed policy, the US dollar, central bank buying, ETF flows, geopolitics and more. The complete 2026 guide.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/what-affects-gold-price">
 <meta property="og:site_name" content="GoldPriceTools">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"What Affects the Price of Gold?","description":"Discover the key factors that influence the price of gold, including inflation, interest rates, central bank reserves, geopolitical events, and ETF demand.","url":"https://goldpricetools.com/guides/what-affects-gold-price","datePublished":"2026-05-01","dateModified":"2026-05-18T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com/guides/what-affects-gold-price","logo":{"@type":"ImageObject","url":"https://goldpricetools.com/guides/what-affects-gold-price"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-affects-gold-price"},"image":{"@type":"ImageObject","url":"https://goldpricetools.com/guides/what-affects-gold-price"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"What Affects the Price of Gold?","description":"Complete 2026 guide to what affects gold prices: interest rates, US dollar, central bank buying, geopolitics, ETFs, inflation, supply, jewellery demand and more.","url":"https://goldpricetools.com/guides/what-affects-gold-price","datePublished":"2026-05-01","dateModified":"2026-05-18T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com/","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-affects-gold-price"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"What Affects the Price of Gold?"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What factors affect the price of gold most?","acceptedAnswer":{"@type":"Answer","text":"The three most powerful factors are US real interest rates and Federal Reserve monetary policy, the US dollar exchange rate, and central bank gold buying and selling. Together they explain the majority of gold's medium-term price direction. Geopolitical risk, inflation expectations, ETF flows and supply-demand fundamentals add significant noise and can dominate the short term."}},{"@type":"Question","name":"What affects gold prices in forex (XAU/USD)?","acceptedAnswer":{"@type":"Answer","text":"Gold's XAU/USD price is most immediately driven by the US Dollar Index (DXY), real US yields (TIPS), Federal Reserve policy signals, US economic data releases (CPI, NFP), and risk sentiment. Gold trades as a long anti-dollar position with safe-haven properties — traders watch the DXY and Fed rhetoric as their primary gold signals."}},{"@type":"Question","name":"What is affecting gold prices today in 2026?","acceptedAnswer":{"@type":"Answer","text":"As of 2026 the dominant factors are central bank buying at near-record levels (~60 tonnes per month), a weak-to-moderate US dollar, geopolitical uncertainty spanning trade policy and conflict risks, falling real interest rates as the Fed's easing cycle resumes, and record ETF inflows as Western institutional investors increase gold allocations."}},{"@type":"Question","name":"How is the price of gold determined?","acceptedAnswer":{"@type":"Answer","text":"Gold's price is determined through continuous global trading across COMEX futures and the London OTC market, with the twice-daily LBMA Gold Price auction providing the primary benchmark. The auction is electronic, conducted by ICE Benchmark Administration, with 15 participating institutions matching buy and sell orders until net supply-demand imbalance falls within 20,000 troy ounces."}},{"@type":"Question","name":"Who determines the price of gold?","acceptedAnswer":{"@type":"Answer","text":"No single entity sets the gold price. It is the output of continuous global trading activity across futures markets, the London OTC market and the LBMA auction process, plus the aggregate supply and demand decisions of central banks, investors, miners, jewellers, and industrial users worldwide."}},{"@type":"Question","name":"What causes the gold price to go down?","acceptedAnswer":{"@type":"Answer","text":"Gold typically falls when US real interest rates rise (bonds become more attractive), the US dollar strengthens, geopolitical risks subside, economic growth improves and risk appetite increases, or when ETF and speculative long positions unwind. The 2022 bear market is the clearest recent example: the Fed's rate-hiking cycle drove gold from $2,050 to $1,630."}},{"@type":"Question","name":"What will affect gold prices in the future?","acceptedAnswer":{"@type":"Answer","text":"The structural outlook depends on whether central bank de-dollarisation buying, low or negative real interest rates, a structurally weaker US dollar, and elevated global debt and fiscal deficits persist. If these reverse through restored dollar credibility, rising real rates and improved fiscal positions, gold prices would face meaningful headwinds."}}]}</script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
@@ -52,7 +53,7 @@
 </script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,500;1,600&display=swap" rel="stylesheet">
 <style>
 
 /* ── Guides mega panel — category links ── */
@@ -404,6 +405,324 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
 .disclaimer-box{margin-top:var(--space-8);padding:var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-border);font-size:var(--text-sm);color:var(--color-text-faint);line-height:1.6}
 .disclaimer-box strong{color:var(--color-text-muted)}
 .related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin-top:var(--space-4)}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   PREMIUM ARTICLE DESIGN — "What Affects the Price of Gold?"
+   Mobile-first · Editorial tone · Gold accent system · WCAG AA
+   All classes prefixed `wa-` to avoid global collisions.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.wa-page{--wa-gold:var(--color-gold-bright);--wa-up:#4ade80;--wa-down:#f87171;--wa-serif:'Playfair Display','Georgia',serif;font-feature-settings:"ss01","cv11"}
+
+/* Reading progress bar */
+.wa-progress{position:fixed;top:0;left:0;right:0;height:2px;z-index:201;background:transparent;pointer-events:none}
+.wa-progress__bar{height:100%;width:0%;background:linear-gradient(90deg,var(--color-gold),var(--wa-gold));box-shadow:0 0 10px color-mix(in oklch,var(--wa-gold) 40%,transparent);transition:width .08s linear}
+
+/* Override existing article-wrap to be full-bleed for new design */
+.wa-page.article-wrap{max-width:none;padding:0;margin:0}
+
+/* ── HERO ── */
+.wa-hero{position:relative;overflow:hidden;padding:var(--space-8) var(--space-4) var(--space-6);text-align:center}
+@media(min-width:768px){.wa-hero{padding:var(--space-12) var(--space-4) var(--space-8)}}
+.wa-hero::before{content:"";position:absolute;top:-20%;left:50%;transform:translateX(-50%);width:min(120%,1400px);height:600px;background:radial-gradient(ellipse 60% 50% at 50% 30%,color-mix(in oklch,var(--wa-gold) 14%,transparent),transparent 65%);pointer-events:none;z-index:0}
+[data-theme="light"] .wa-hero::before{background:radial-gradient(ellipse 60% 50% at 50% 30%,color-mix(in oklch,var(--wa-gold) 10%,transparent),transparent 65%)}
+.wa-hero::after{content:"";position:absolute;left:0;right:0;bottom:0;height:1px;background:linear-gradient(90deg,transparent,var(--color-border),transparent);z-index:0}
+.wa-hero__inner{position:relative;z-index:1;max-width:880px;margin:0 auto}
+.wa-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--wa-gold) 10%,var(--color-surface));border:1px solid color-mix(in oklch,var(--wa-gold) 30%,var(--color-border));padding:6px var(--space-3);border-radius:var(--radius-full);font-size:11px;font-weight:700;color:var(--wa-gold);text-transform:uppercase;letter-spacing:.12em;margin-bottom:var(--space-5)}
+.wa-eyebrow svg{flex-shrink:0;color:var(--wa-gold)}
+.wa-eyebrow__dot{display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--wa-gold);box-shadow:0 0 8px var(--wa-gold);animation:waPulse 2.5s ease-in-out infinite}
+@keyframes waPulse{0%,100%{opacity:1}50%{opacity:.4}}
+@media(prefers-reduced-motion:reduce){.wa-eyebrow__dot{animation:none}}
+.wa-hero__title{font-family:var(--wa-serif);font-size:clamp(2rem,1.3rem + 3.4vw,3.75rem);font-weight:600;color:var(--color-text);line-height:1.05;letter-spacing:-.02em;margin:0 0 var(--space-5);text-wrap:balance}
+.wa-hero__title em{font-style:italic;color:var(--wa-gold);font-weight:500}
+.wa-hero__meta{display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6)}
+.wa-hero__meta a{color:var(--color-primary);text-decoration:none;font-weight:500}
+.wa-hero__meta a:hover{text-decoration:underline}
+.wa-hero__dot{display:inline-block;width:3px;height:3px;border-radius:50%;background:var(--color-text-faint);flex-shrink:0}
+.wa-hero__lead{font-size:clamp(1.0625rem,1rem + .4vw,1.25rem);color:var(--color-text-muted);line-height:1.7;max-width:62ch;margin:0 auto var(--space-8);text-wrap:pretty}
+
+/* Hero stats */
+.wa-stats{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);max-width:880px;margin:0 auto}
+@media(min-width:768px){.wa-stats{grid-template-columns:repeat(4,1fr);gap:var(--space-4)}}
+.wa-stat{position:relative;padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;text-align:left;box-shadow:var(--shadow-sm);transition:border-color var(--transition),transform var(--transition)}
+.wa-stat:hover{border-color:color-mix(in oklch,var(--wa-gold) 40%,var(--color-border));transform:translateY(-2px)}
+.wa-stat::after{content:"";position:absolute;left:0;right:0;bottom:0;height:2px;background:linear-gradient(90deg,transparent,var(--wa-gold),transparent);opacity:.7}
+.wa-stat__value{font-family:var(--wa-serif);font-size:clamp(1.5rem,1.1rem + 1.3vw,2rem);font-weight:700;color:var(--wa-gold);font-variant-numeric:tabular-nums;line-height:1.05;letter-spacing:-.02em}
+.wa-stat__label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-top:var(--space-2);line-height:1.4}
+.wa-stat__sub{font-size:11px;color:var(--color-text-faint);margin-top:3px;line-height:1.45}
+
+/* ── LAYOUT ── */
+.wa-layout{max-width:1200px;margin:0 auto;padding:var(--space-6) var(--space-4) var(--space-12);display:grid;grid-template-columns:1fr;gap:var(--space-6);align-items:start}
+@media(min-width:1024px){.wa-layout{grid-template-columns:260px minmax(0,1fr);gap:var(--space-10);padding:var(--space-8) var(--space-4) var(--space-16)}}
+
+/* ── MOBILE TOC ── */
+.wa-mtoc{display:block;margin-bottom:0}
+@media(min-width:1024px){.wa-mtoc{display:none}}
+.wa-mtoc__toggle{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);font-size:var(--text-sm);font-weight:600;color:var(--color-text);cursor:pointer;transition:border-color var(--transition),background var(--transition);min-height:48px;font-family:inherit}
+.wa-mtoc__toggle:hover{border-color:var(--wa-gold);background:color-mix(in oklch,var(--wa-gold) 5%,var(--color-surface))}
+.wa-mtoc__toggle-l{display:flex;align-items:center;gap:var(--space-2);min-width:0}
+.wa-mtoc__toggle-l svg{color:var(--wa-gold);flex-shrink:0}
+.wa-mtoc__chev{transition:transform .2s;color:var(--color-text-muted);flex-shrink:0}
+.wa-mtoc__toggle[aria-expanded="true"] .wa-mtoc__chev{transform:rotate(180deg)}
+.wa-mtoc__toggle[aria-expanded="true"]{border-color:var(--wa-gold);border-bottom-left-radius:0;border-bottom-right-radius:0}
+.wa-mtoc__panel{display:none;background:var(--color-surface);border:1px solid var(--wa-gold);border-top:none;border-radius:0 0 var(--radius-lg) var(--radius-lg);padding:var(--space-3);max-height:60vh;overflow-y:auto;-webkit-overflow-scrolling:touch}
+.wa-mtoc__panel.open{display:block}
+.wa-mtoc__list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:1px;counter-reset:wamtoc}
+.wa-mtoc__list a{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);min-height:44px;transition:color var(--transition),background var(--transition);line-height:1.4}
+.wa-mtoc__list a::before{counter-increment:wamtoc;content:counter(wamtoc,decimal-leading-zero);font-size:11px;font-weight:700;color:var(--wa-gold);font-variant-numeric:tabular-nums;font-family:var(--wa-serif);flex-shrink:0;min-width:1.8em}
+.wa-mtoc__list a:hover,.wa-mtoc__list a:focus-visible{color:var(--color-text);background:var(--color-surface-offset);outline:none}
+
+/* ── DESKTOP SIDEBAR ── */
+.wa-sidebar{display:none}
+@media(min-width:1024px){.wa-sidebar{display:block;position:sticky;top:80px;align-self:start;max-height:calc(100dvh - 96px);overflow-y:auto;scrollbar-width:thin}}
+.wa-toc{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+[data-theme="dark"] .wa-toc{background:color-mix(in oklch,var(--color-surface) 92%,transparent);backdrop-filter:blur(8px)}
+.wa-toc__head{display:flex;align-items:center;gap:var(--space-2);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-4)}
+.wa-toc__head svg{color:var(--wa-gold);flex-shrink:0}
+.wa-toc__list{list-style:none;display:flex;flex-direction:column;gap:1px;padding:0;margin:0;counter-reset:watoc}
+.wa-toc__list a{display:flex;align-items:flex-start;gap:var(--space-2);padding:8px var(--space-2);font-size:13px;color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);border-left:2px solid transparent;line-height:1.4;transition:color var(--transition),background var(--transition),border-color var(--transition);position:relative}
+.wa-toc__list a::before{counter-increment:watoc;content:counter(watoc,decimal-leading-zero);font-size:10px;font-weight:700;color:var(--wa-gold);font-variant-numeric:tabular-nums;font-family:var(--wa-serif);flex-shrink:0;min-width:1.6em;padding-top:2px;opacity:.7}
+.wa-toc__list a:hover{color:var(--color-text);background:var(--color-surface-offset);border-left-color:color-mix(in oklch,var(--wa-gold) 50%,transparent)}
+.wa-toc__list a.is-active{color:var(--wa-gold);background:color-mix(in oklch,var(--wa-gold) 8%,transparent);border-left-color:var(--wa-gold)}
+.wa-toc__list a.is-active::before{opacity:1}
+.wa-toc__foot{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-border);display:flex;flex-direction:column;gap:var(--space-2)}
+.wa-toc__foot-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-faint)}
+.wa-toc__foot a{font-size:13px;color:var(--color-primary);text-decoration:none;display:flex;align-items:center;gap:var(--space-1);padding:4px 0}
+.wa-toc__foot a:hover{color:var(--color-primary-hover)}
+
+/* ── ARTICLE ── */
+.wa-article{min-width:0}
+.wa-section{margin-bottom:var(--space-12);scroll-margin-top:80px}
+.wa-section:last-child{margin-bottom:var(--space-8)}
+.wa-section__eyebrow{display:inline-flex;align-items:center;gap:var(--space-3);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--wa-gold);margin-bottom:var(--space-3)}
+.wa-section__eyebrow::before{content:"";width:24px;height:1px;background:var(--wa-gold);flex-shrink:0}
+.wa-section__title{font-family:var(--wa-serif);font-size:clamp(1.625rem,1.2rem + 1.8vw,2.375rem);font-weight:600;color:var(--color-text);line-height:1.15;letter-spacing:-.015em;margin:0 0 var(--space-4);text-wrap:balance}
+.wa-section__lead{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;max-width:68ch;margin:0 0 var(--space-6)}
+.wa-section h3{font-family:var(--wa-serif);font-size:clamp(1.25rem,1.1rem + .5vw,1.5rem);font-weight:600;color:var(--color-text);line-height:1.25;margin:var(--space-8) 0 var(--space-3);max-width:60ch;letter-spacing:-.01em}
+
+/* Prose */
+.wa-prose p{font-size:var(--text-base);color:var(--color-text);line-height:1.78;max-width:68ch;margin:0 0 var(--space-4)}
+.wa-prose p:last-child{margin-bottom:0}
+.wa-prose strong{color:var(--color-text);font-weight:700}
+.wa-prose em{font-style:italic}
+.wa-prose a{color:var(--color-primary);text-decoration:underline;text-underline-offset:.2em;text-decoration-thickness:1px;font-weight:500}
+.wa-prose a:hover{color:var(--color-primary-hover);text-decoration-thickness:2px}
+.wa-prose ul,.wa-prose ol{padding-left:var(--space-5);margin:0 0 var(--space-4);max-width:68ch}
+.wa-prose li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:var(--space-2)}
+.wa-prose li::marker{color:var(--wa-gold);font-weight:700}
+
+/* Inline citation chip */
+.wa-cite{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;margin:0 1px;font-size:10px;font-weight:700;color:var(--wa-gold);background:color-mix(in oklch,var(--wa-gold) 10%,transparent);border:1px solid color-mix(in oklch,var(--wa-gold) 25%,transparent);border-radius:4px;vertical-align:super;line-height:1;font-variant-numeric:tabular-nums;text-decoration:none!important;font-family:var(--font-body)}
+.wa-cite:hover{background:color-mix(in oklch,var(--wa-gold) 20%,transparent);color:var(--wa-gold);text-decoration:none!important}
+
+/* ── DETERMINATION CARDS ── */
+.wa-det-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0}
+@media(min-width:640px){.wa-det-grid{grid-template-columns:repeat(2,1fr)}}
+.wa-det-card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);box-shadow:var(--shadow-sm);overflow:hidden}
+.wa-det-card::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--color-gold),var(--wa-gold),transparent)}
+.wa-det-card__icon{display:inline-flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:var(--radius-md);background:color-mix(in oklch,var(--wa-gold) 10%,var(--color-surface-offset));color:var(--wa-gold);margin-bottom:var(--space-3)}
+.wa-det-card__title{font-family:var(--wa-serif);font-size:var(--text-lg);font-weight:600;color:var(--color-text);margin:0 0 var(--space-2);line-height:1.25;letter-spacing:-.01em}
+.wa-det-card__body{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0}
+.wa-det-card__body strong{color:var(--color-text);font-weight:600}
+.wa-det-card__stat{display:flex;align-items:baseline;gap:var(--space-2);margin-top:var(--space-3);padding-top:var(--space-3);border-top:1px solid var(--color-border)}
+.wa-det-card__stat-val{font-family:var(--wa-serif);font-size:var(--text-lg);font-weight:700;color:var(--wa-gold);font-variant-numeric:tabular-nums;line-height:1}
+.wa-det-card__stat-label{font-size:11px;color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.05em}
+
+/* Process steps */
+.wa-process{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0;counter-reset:wapro}
+@media(min-width:640px){.wa-process{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:768px){.wa-process{grid-template-columns:repeat(5,1fr);gap:var(--space-2)}}
+.wa-process__step{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-3);counter-increment:wapro;display:flex;flex-direction:column;align-items:flex-start;text-align:left}
+.wa-process__step::before{content:counter(wapro,decimal-leading-zero);font-family:var(--wa-serif);font-size:11px;font-weight:700;color:var(--wa-gold);font-variant-numeric:tabular-nums;padding-bottom:var(--space-2);letter-spacing:.05em}
+.wa-process__title{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin:0 0 var(--space-1);line-height:1.3}
+.wa-process__desc{font-size:11px;color:var(--color-text-muted);line-height:1.5;margin:0}
+
+/* ── FACTOR CARDS (the 12) ── */
+.wa-factor{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);margin-bottom:var(--space-6);overflow:hidden;box-shadow:var(--shadow-sm);scroll-margin-top:80px;transition:border-color var(--transition),box-shadow var(--transition)}
+@media(min-width:768px){.wa-factor{padding:var(--space-6) var(--space-8)}}
+.wa-factor:target{border-color:var(--wa-gold);box-shadow:0 0 0 1px var(--wa-gold),var(--shadow-md)}
+.wa-factor::before{content:"";position:absolute;top:0;bottom:0;left:0;width:3px;background:linear-gradient(180deg,var(--wa-gold),transparent 65%)}
+.wa-factor__head{display:flex;align-items:flex-start;gap:var(--space-3);margin-bottom:var(--space-4)}
+@media(min-width:640px){.wa-factor__head{gap:var(--space-4)}}
+.wa-factor__num{font-family:var(--wa-serif);font-size:clamp(2.5rem,2rem + 2vw,3.75rem);font-weight:700;color:var(--wa-gold);line-height:.85;font-variant-numeric:tabular-nums;letter-spacing:-.03em;flex-shrink:0;opacity:.95}
+.wa-factor__head-text{flex:1;min-width:0;padding-top:var(--space-1)}
+.wa-factor__cat{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--wa-gold);background:color-mix(in oklch,var(--wa-gold) 10%,transparent);padding:3px 9px;border-radius:var(--radius-full);margin-bottom:var(--space-2);border:1px solid color-mix(in oklch,var(--wa-gold) 25%,transparent)}
+.wa-factor__title{font-family:var(--wa-serif);font-size:clamp(1.25rem,1.1rem + .7vw,1.75rem);font-weight:600;color:var(--color-text);line-height:1.2;letter-spacing:-.015em;margin:0;text-wrap:balance}
+.wa-factor__body{}
+.wa-factor__body p{font-size:var(--text-base);color:var(--color-text);line-height:1.78;max-width:64ch;margin:0 0 var(--space-4)}
+.wa-factor__body p:last-child{margin-bottom:0}
+.wa-factor__body strong{color:var(--color-text);font-weight:700}
+.wa-factor__body em{font-style:italic;color:var(--color-text)}
+.wa-factor__body a{color:var(--color-primary);text-decoration:underline;text-underline-offset:.2em}
+.wa-factor__body ul{padding-left:var(--space-5);margin:0 0 var(--space-4);max-width:64ch}
+.wa-factor__body li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:var(--space-2)}
+.wa-factor__body li::marker{color:var(--wa-gold);font-weight:700}
+
+/* Insight callout (gold) */
+.wa-insight{background:color-mix(in oklch,var(--wa-gold) 6%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--wa-gold) 22%,var(--color-border));border-left:3px solid var(--wa-gold);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);margin:var(--space-5) 0;display:grid;grid-template-columns:auto 1fr;gap:var(--space-3) var(--space-4);align-items:start;max-width:64ch}
+.wa-insight__icon{width:32px;height:32px;display:inline-flex;align-items:center;justify-content:center;background:color-mix(in oklch,var(--wa-gold) 14%,transparent);border-radius:var(--radius-md);color:var(--wa-gold);flex-shrink:0}
+.wa-insight__body{min-width:0}
+.wa-insight__title{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--wa-gold);margin-bottom:var(--space-1)}
+.wa-insight__text{font-size:var(--text-sm);color:var(--color-text);line-height:1.7;margin:0}
+.wa-insight__text strong{color:var(--color-text);font-weight:700}
+.wa-insight__text+.wa-insight__text{margin-top:var(--space-2)}
+
+/* Timeline cards */
+.wa-timeline{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:640px){.wa-timeline{grid-template-columns:repeat(3,1fr)}}
+.wa-tl{position:relative;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);overflow:hidden}
+.wa-tl__year{font-family:var(--wa-serif);font-size:11px;font-weight:700;color:var(--color-text-muted);letter-spacing:.05em;text-transform:uppercase;display:block;margin-bottom:var(--space-1)}
+.wa-tl__price{font-family:var(--wa-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.01em;display:flex;align-items:baseline;gap:var(--space-2);flex-wrap:wrap}
+.wa-tl__arrow{font-size:.9em;font-weight:700;line-height:1}
+.wa-tl__arrow.up{color:var(--wa-up)}
+.wa-tl__arrow.down{color:var(--wa-down)}
+.wa-tl__detail{font-size:13px;color:var(--color-text-muted);margin-top:var(--space-2);line-height:1.55}
+.wa-tl--pos{border-color:color-mix(in oklch,var(--wa-up) 30%,var(--color-border));background:color-mix(in oklch,var(--wa-up) 5%,var(--color-surface-offset))}
+.wa-tl--neg{border-color:color-mix(in oklch,var(--wa-down) 30%,var(--color-border));background:color-mix(in oklch,var(--wa-down) 5%,var(--color-surface-offset))}
+
+/* Strength meter */
+.wa-meter{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);margin:var(--space-4) 0;max-width:64ch}
+.wa-meter__label{font-size:10px;font-weight:700;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;flex-shrink:0}
+.wa-meter__bar{flex:1;height:6px;background:var(--color-surface-dynamic);border-radius:99px;overflow:hidden;position:relative;min-width:60px}
+.wa-meter__bar-fill{position:absolute;inset:0 auto 0 0;background:linear-gradient(90deg,var(--color-gold),var(--wa-gold));border-radius:99px}
+.wa-meter__value{font-size:11px;font-weight:700;color:var(--wa-gold);flex-shrink:0;font-variant-numeric:tabular-nums;text-transform:uppercase;letter-spacing:.05em}
+
+/* Big stat row (data callouts) */
+.wa-bigrow{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-4) 0}
+@media(min-width:600px){.wa-bigrow{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:768px){.wa-bigrow--3{grid-template-columns:repeat(3,1fr)}}
+.wa-big{padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);position:relative;overflow:hidden}
+.wa-big__val{font-family:var(--wa-serif);font-size:clamp(1.5rem,1.2rem + 1vw,1.875rem);font-weight:700;color:var(--wa-gold);font-variant-numeric:tabular-nums;line-height:1.05;letter-spacing:-.01em}
+.wa-big__label{font-size:10px;font-weight:700;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.09em;margin-top:var(--space-1);line-height:1.4}
+.wa-big__sub{font-size:12px;color:var(--color-text-faint);margin-top:4px;line-height:1.5}
+
+/* Pull quote */
+.wa-pq{border-left:3px solid var(--wa-gold);padding:var(--space-4) var(--space-5);margin:var(--space-5) 0;background:color-mix(in oklch,var(--wa-gold) 5%,var(--color-surface));border-radius:0 var(--radius-lg) var(--radius-lg) 0;max-width:64ch}
+.wa-pq__text{font-family:var(--wa-serif);font-size:clamp(1.0625rem,1rem + .35vw,1.25rem);font-style:italic;color:var(--color-text);line-height:1.55;margin:0 0 var(--space-2);text-wrap:pretty}
+.wa-pq__cite{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--wa-gold);display:flex;align-items:center;gap:var(--space-2)}
+.wa-pq__cite::before{content:"—";opacity:.7}
+
+/* Comparison columns */
+.wa-compare{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:640px){.wa-compare{grid-template-columns:repeat(2,1fr)}}
+.wa-comp{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);position:relative;overflow:hidden}
+.wa-comp--gold::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--color-gold),var(--wa-gold))}
+.wa-comp--silver::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#6b7280,#cbd5e1)}
+.wa-comp__head{display:flex;align-items:center;gap:var(--space-2);margin-bottom:var(--space-3)}
+.wa-comp__icon{width:32px;height:32px;display:inline-flex;align-items:center;justify-content:center;border-radius:var(--radius-md)}
+.wa-comp--gold .wa-comp__icon{background:color-mix(in oklch,var(--wa-gold) 12%,transparent);color:var(--wa-gold)}
+.wa-comp--silver .wa-comp__icon{background:color-mix(in oklch,#94a3b8 18%,transparent);color:#94a3b8}
+.wa-comp__title{font-family:var(--wa-serif);font-size:var(--text-base);font-weight:600;color:var(--color-text);letter-spacing:-.01em}
+.wa-comp__list{list-style:none;padding:0;margin:0}
+.wa-comp__list li{font-size:13px;color:var(--color-text-muted);line-height:1.6;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);display:flex;gap:var(--space-2);align-items:flex-start}
+.wa-comp__list li:last-child{border-bottom:none}
+.wa-comp__list li::before{content:"";display:inline-block;width:4px;height:4px;border-radius:50%;background:var(--wa-gold);margin-top:9px;flex-shrink:0}
+.wa-comp--silver .wa-comp__list li::before{background:#94a3b8}
+.wa-comp__list strong{color:var(--color-text);font-weight:600}
+
+/* Trigger list (XAU/USD) */
+.wa-triggers{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-4) 0}
+@media(min-width:640px){.wa-triggers{grid-template-columns:repeat(2,1fr)}}
+.wa-trigger{display:flex;align-items:flex-start;gap:var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--wa-gold);border-radius:var(--radius-md)}
+.wa-trigger__icon{flex-shrink:0;width:28px;height:28px;display:inline-flex;align-items:center;justify-content:center;border-radius:var(--radius-sm);background:color-mix(in oklch,var(--wa-gold) 10%,transparent);color:var(--wa-gold)}
+.wa-trigger__body{min-width:0;flex:1}
+.wa-trigger__name{font-size:13px;font-weight:700;color:var(--color-text);margin-bottom:2px;line-height:1.3}
+.wa-trigger__detail{font-size:12px;color:var(--color-text-muted);line-height:1.55}
+.wa-trigger__detail strong{color:var(--color-text);font-weight:600}
+
+/* Numbered summary list (Who Sets the Price) */
+.wa-numbered{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0;counter-reset:waNum;list-style:none;padding:0}
+.wa-numbered__item{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);padding-left:calc(var(--space-5) + 36px);counter-increment:waNum}
+.wa-numbered__item::before{content:counter(waNum,decimal-leading-zero);position:absolute;left:var(--space-4);top:50%;transform:translateY(-50%);font-family:var(--wa-serif);font-size:var(--text-lg);font-weight:700;color:var(--wa-gold);font-variant-numeric:tabular-nums;line-height:1}
+.wa-numbered__title{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin:0 0 4px;line-height:1.3}
+.wa-numbered__desc{font-size:13px;color:var(--color-text-muted);line-height:1.55;margin:0}
+
+/* ── QUICK-REFERENCE TABLE / CARDS ── */
+.wa-ref-section{margin:var(--space-10) 0}
+.wa-ref-wrap{display:none;overflow-x:auto;border:1px solid var(--color-border);border-radius:var(--radius-xl);background:var(--color-surface);box-shadow:var(--shadow-sm);margin-top:var(--space-5)}
+@media(min-width:768px){.wa-ref-wrap{display:block}}
+.wa-ref-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:520px}
+.wa-ref-table thead{background:color-mix(in oklch,var(--wa-gold) 8%,var(--color-surface-offset))}
+.wa-ref-table th{padding:var(--space-3) var(--space-4);text-align:left;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--wa-gold);border-bottom:2px solid color-mix(in oklch,var(--wa-gold) 25%,var(--color-border));white-space:nowrap}
+.wa-ref-table th:nth-child(2),.wa-ref-table th:nth-child(3){text-align:center;width:25%}
+.wa-ref-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text);vertical-align:middle;line-height:1.4}
+.wa-ref-table td:first-child{font-weight:500;color:var(--color-text)}
+.wa-ref-table td:nth-child(2),.wa-ref-table td:nth-child(3){text-align:center;white-space:nowrap}
+.wa-ref-table tbody tr:nth-child(even){background:color-mix(in oklch,var(--color-surface-offset) 50%,transparent)}
+.wa-ref-table tbody tr:hover{background:var(--color-surface-offset)}
+.wa-ref-table tbody tr:last-child td{border-bottom:none}
+
+/* Effect pill */
+.wa-pill{display:inline-flex;align-items:center;gap:4px;padding:3px 10px;border-radius:var(--radius-full);font-size:11px;font-weight:600;white-space:nowrap;line-height:1.4;font-variant-numeric:tabular-nums}
+.wa-pill--up{background:color-mix(in oklch,var(--wa-up) 12%,transparent);color:#16703a;border:1px solid color-mix(in oklch,var(--wa-up) 28%,transparent)}
+[data-theme="dark"] .wa-pill--up{color:var(--wa-up)}
+.wa-pill--down{background:color-mix(in oklch,var(--wa-down) 12%,transparent);color:#a83333;border:1px solid color-mix(in oklch,var(--wa-down) 28%,transparent)}
+[data-theme="dark"] .wa-pill--down{color:var(--wa-down)}
+
+/* Strength dots */
+.wa-strn{display:inline-flex;align-items:center;justify-content:center;gap:3px}
+.wa-strn__dot{width:7px;height:7px;border-radius:50%;background:var(--color-border)}
+.wa-strn__dot.on{background:var(--wa-gold);box-shadow:0 0 4px color-mix(in oklch,var(--wa-gold) 50%,transparent)}
+.wa-strn__txt{margin-left:var(--space-2);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:var(--color-text-muted)}
+
+/* Mobile cards */
+.wa-ref-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:768px){.wa-ref-cards{display:none}}
+.wa-ref-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-2)}
+.wa-ref-card__factor{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.35;margin-bottom:var(--space-2);padding-bottom:var(--space-2);border-bottom:1px solid var(--color-divider)}
+.wa-ref-card__row{display:flex;justify-content:space-between;align-items:center;gap:var(--space-3)}
+.wa-ref-card__lab{font-size:10px;color:var(--color-text-muted);font-weight:700;text-transform:uppercase;letter-spacing:.08em}
+
+/* ── FAQ ACCORDION ── */
+.wa-faq{display:flex;flex-direction:column;gap:var(--space-2);margin:var(--space-5) 0}
+.wa-faq__item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.wa-faq__item[open]{border-color:color-mix(in oklch,var(--wa-gold) 35%,var(--color-border))}
+.wa-faq__q{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);cursor:pointer;font-size:var(--text-base);font-weight:600;color:var(--color-text);user-select:none;list-style:none;min-height:56px;transition:background var(--transition);line-height:1.4}
+.wa-faq__q::-webkit-details-marker{display:none}
+.wa-faq__q::marker{display:none}
+.wa-faq__q:hover{background:var(--color-surface-offset)}
+.wa-faq__icon{flex-shrink:0;width:28px;height:28px;display:inline-flex;align-items:center;justify-content:center;border-radius:var(--radius-full);background:color-mix(in oklch,var(--wa-gold) 12%,transparent);color:var(--wa-gold);transition:transform var(--transition)}
+.wa-faq__item[open] .wa-faq__icon{transform:rotate(45deg)}
+.wa-faq__a{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;max-width:68ch}
+.wa-faq__a p{margin:0 0 var(--space-2)}
+.wa-faq__a p:last-child{margin-bottom:0}
+.wa-faq__a strong{color:var(--color-text);font-weight:600}
+
+/* ── PREMIUM CTA ── */
+.wa-cta{background:linear-gradient(135deg,color-mix(in oklch,var(--wa-gold) 10%,var(--color-surface)),color-mix(in oklch,var(--wa-gold) 4%,var(--color-surface)));border:1px solid color-mix(in oklch,var(--wa-gold) 28%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-6);margin:var(--space-8) 0;position:relative;overflow:hidden;text-align:center}
+@media(min-width:768px){.wa-cta{padding:var(--space-8) var(--space-6)}}
+.wa-cta::before{content:"";position:absolute;top:-50%;left:-10%;width:60%;height:200%;background:radial-gradient(ellipse 40% 30% at center,color-mix(in oklch,var(--wa-gold) 22%,transparent),transparent 65%);pointer-events:none;z-index:0}
+.wa-cta__inner{position:relative;z-index:1}
+.wa-cta__title{font-family:var(--wa-serif);font-size:clamp(1.375rem,1.15rem + .9vw,1.875rem);font-weight:600;color:var(--color-text);margin:0 0 var(--space-2);letter-spacing:-.01em;text-wrap:balance}
+.wa-cta__lead{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:54ch;margin:0 auto var(--space-4)}
+.wa-cta__btns{display:flex;flex-wrap:wrap;gap:var(--space-2);justify-content:center}
+.wa-cta-btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:12px var(--space-5);background:var(--wa-gold);color:#0f0e0c;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;text-decoration:none;transition:background var(--transition),transform var(--transition);min-height:44px;border:1px solid transparent}
+.wa-cta-btn:hover{background:var(--color-gold);color:#0f0e0c;text-decoration:none;transform:translateY(-1px)}
+.wa-cta-btn--ghost{background:transparent;color:var(--color-text);border-color:var(--color-border)}
+.wa-cta-btn--ghost:hover{background:var(--color-surface-offset);color:var(--color-text);border-color:var(--wa-gold)}
+
+/* Section divider */
+.wa-divider{height:1px;background:linear-gradient(90deg,transparent,var(--color-border),transparent);margin:var(--space-10) 0;position:relative}
+.wa-divider::after{content:"";position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:7px;height:7px;background:var(--wa-gold);border-radius:50%;box-shadow:0 0 14px color-mix(in oklch,var(--wa-gold) 45%,transparent)}
+
+/* Major-Factors section opener */
+.wa-major-opener{padding:var(--space-6) 0;margin-bottom:var(--space-4);text-align:center;position:relative}
+.wa-major-opener__count{font-family:var(--wa-serif);font-size:clamp(3rem,2rem + 4vw,5rem);font-weight:700;color:var(--wa-gold);line-height:.85;font-variant-numeric:tabular-nums;letter-spacing:-.04em;margin:0;display:inline-block}
+.wa-major-opener__label{font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.15em;margin-top:var(--space-2)}
+
+/* Share buttons override - tighter */
+.share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-3);margin:var(--space-8) 0 var(--space-4);padding:var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.share-buttons span{font-size:11px;font-weight:700;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em}
+.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:8px 14px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:13px;font-weight:600;color:var(--color-text);text-decoration:none;transition:border-color var(--transition),color var(--transition);min-height:36px}
+.share-buttons a:hover{border-color:var(--wa-gold);color:var(--wa-gold);text-decoration:none}
+
+/* Disclaimer in flow */
+.wa-disclaim{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--color-border);border-radius:var(--radius-md);font-size:13px;color:var(--color-text-muted);line-height:1.65}
+.wa-disclaim strong{color:var(--color-text)}
+
+/* Reduced motion */
+@media(prefers-reduced-motion:reduce){.wa-stat:hover,.wa-cta-btn:hover{transform:none}.wa-progress__bar{transition:none}}
+
 </style>
 
 <link rel="stylesheet" href="/assets/site.css">
@@ -487,99 +806,1020 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
   </ol>
 </div>
 
-<article class="article-wrap" itemscope itemtype="https://schema.org/Article">
-  <div class="article-tag">Gold Guide</div>
-  <h1 class="article-title" itemprop="headline">What Affects the Price of Gold?</h1>
-  <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
-    <span>&middot;</span>
-    <span>Published <time datetime="2026-05-18" itemprop="datePublished">01 May 2026</time></span>
-    <span>&middot;</span>
-    <span>Updated <time datetime="2026-05-18" itemprop="dateModified">01 May 2026</time></span>
-  </div>
+<article class="article-wrap wa-page" itemscope itemtype="https://schema.org/Article">
 
-  <div class="prose">
+  <!-- Reading progress -->
+  <div class="wa-progress" aria-hidden="true"><div class="wa-progress__bar" id="waProgress"></div></div>
 
-<p>Gold has fascinated humanity for millennia, serving as a medium of exchange, a store of value, and a symbol of wealth. But what affects the price of gold? Unlike fiat currencies or corporate stocks, gold does not produce a yield or pay dividends. Instead, its value is determined by a complex interplay of macroeconomic factors, supply and demand dynamics, and investor psychology. In this comprehensive guide, we will explore the primary drivers of gold prices, including inflation, interest rates, central bank activities, and geopolitical tensions.</p>
+  <!-- HERO -->
+  <header class="wa-hero">
+    <div class="wa-hero__inner">
+      <div class="wa-eyebrow">
+        <span class="wa-eyebrow__dot" aria-hidden="true"></span>
+        Editorial · Gold Market Intelligence
+      </div>
+      <h1 class="wa-hero__title" itemprop="headline">What <em>Affects</em> the Price of Gold?</h1>
+      <div class="wa-hero__meta">
+        <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
+        <span class="wa-hero__dot" aria-hidden="true"></span>
+        <span>Updated <time datetime="2026-05-18" itemprop="dateModified">18 May 2026</time></span>
+        <span class="wa-hero__dot" aria-hidden="true"></span>
+        <span>22 min read</span>
+      </div>
+      <p class="wa-hero__lead">Every day, gold moves — sometimes by a few dollars, sometimes by hundreds. The price emerges from the interaction of supply, demand, monetary policy, currency markets, geopolitics, and investor sentiment, all at once, in a market that trades 24 hours a day across every major financial centre on the planet.</p>
 
-<h2>1. Inflation and Purchasing Power</h2>
-<p>One of the most significant factors affecting the price of gold is inflation. Inflation represents the rate at which the general level of prices for goods and services is rising, subsequently eroding purchasing power. When fiat currencies, such as the US Dollar, the British Pound, or the Euro, lose their purchasing power due to high inflation, investors often turn to gold as a hedge.</p>
-<p>Historically, gold has maintained its value over the long term. During periods of hyperinflation or sustained moderate inflation, gold prices tend to rise in nominal terms. This is because gold is a tangible asset with an inherently limited supply. It cannot be printed or debased by central banks. Investors view gold as a safe harbor that preserves wealth when the value of paper money diminishes.</p>
-<p>Furthermore, inflation expectations play a crucial role. If markets anticipate higher inflation in the future, demand for gold increases proactively, driving up the price even before official inflation figures are released. Therefore, keeping a close eye on inflation indicators like the Consumer Price Index (CPI) and Producer Price Index (PPI) is essential for understanding gold price movements.</p>
+      <div class="wa-stats" role="list" aria-label="Key 2025–2026 gold market metrics">
+        <div class="wa-stat" role="listitem">
+          <div class="wa-stat__value">$5,500+</div>
+          <div class="wa-stat__label">Gold price 2025–26</div>
+          <div class="wa-stat__sub">USD / troy ounce, record highs</div>
+        </div>
+        <div class="wa-stat" role="listitem">
+          <div class="wa-stat__value">~850 t</div>
+          <div class="wa-stat__label">Central bank buying</div>
+          <div class="wa-stat__sub">2025 net purchases (WGC)</div>
+        </div>
+        <div class="wa-stat" role="listitem">
+          <div class="wa-stat__value">$89 B</div>
+          <div class="wa-stat__label">Gold ETF inflows</div>
+          <div class="wa-stat__sub">Record 2025 annual flow</div>
+        </div>
+        <div class="wa-stat" role="listitem">
+          <div class="wa-stat__value">75%</div>
+          <div class="wa-stat__label">London market share</div>
+          <div class="wa-stat__sub">Of global gold trading</div>
+        </div>
+      </div>
+    </div>
+  </header>
 
-<h2>2. Monetary Policy and Interest Rates</h2>
-<p>Interest rates, primarily set by central banks like the US Federal Reserve (the Fed), have a profound inverse relationship with the price of gold. Because gold does not yield interest or dividends, its "opportunity cost" changes with prevailing interest rates.</p>
-<p>When interest rates are high or rising, yield-bearing assets such as government bonds, savings accounts, and dividend-paying stocks become more attractive to investors. The higher returns on these assets increase the opportunity cost of holding non-yielding gold, leading to decreased demand and downward pressure on gold prices.</p>
-<p>Conversely, when interest rates are low or negative in real terms (interest rates minus inflation), the opportunity cost of holding gold diminishes. In such environments, the lack of yield is less of a deterrent, and gold becomes a more appealing investment. Central bank monetary policies, particularly quantitative easing (QE) and interest rate cuts, often trigger bullish trends in the gold market.</p>
-<p>The US Federal Reserve's decisions are especially critical. Because gold is predominantly priced in US Dollars globally, changes in US interest rates have an immediate and substantial impact on international gold prices.</p>
+  <!-- LAYOUT -->
+  <div class="wa-layout">
 
-<h2>3. The Value of the US Dollar</h2>
-<p>Gold is universally traded and denominated in US Dollars (USD). Therefore, the strength or weakness of the US Dollar is a fundamental driver of the gold price. The relationship between gold and the USD is generally inverse.</p>
-<p>When the US Dollar strengthens against other major currencies, gold becomes relatively more expensive for investors holding foreign currencies. This tends to reduce global demand, putting downward pressure on the gold price. On the other hand, when the US Dollar weakens, gold becomes cheaper for international buyers, stimulating demand and driving prices higher.</p>
-<p>A weakening dollar often coincides with concerns about the US economy, rising national debt, or expansionary monetary policy, all of which are historically bullish factors for gold. Investors tracking gold prices must simultaneously monitor the US Dollar Index (DXY), which measures the greenback's value against a basket of foreign currencies.</p>
+    <!-- DESKTOP SIDEBAR TOC -->
+    <aside class="wa-sidebar" aria-label="Article contents">
+      <nav class="wa-toc">
+        <div class="wa-toc__head">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg>
+          In this article
+        </div>
+        <ol class="wa-toc__list">
+          <li><a href="#determined">How gold price is determined</a></li>
+          <li><a href="#f1">Interest rates &amp; monetary policy</a></li>
+          <li><a href="#f2">The US dollar (XAU/USD)</a></li>
+          <li><a href="#f3">Inflation &amp; purchasing power</a></li>
+          <li><a href="#f4">Central bank buying &amp; selling</a></li>
+          <li><a href="#f5">Geopolitical risk</a></li>
+          <li><a href="#f6">Supply: mining &amp; recycling</a></li>
+          <li><a href="#f7">Jewellery, industrial, retail</a></li>
+          <li><a href="#f8">Gold ETF flows</a></li>
+          <li><a href="#f9">Economic conditions</a></li>
+          <li><a href="#f10">Currency crises &amp; de-dollarisation</a></li>
+          <li><a href="#f11">Seasonality &amp; culture</a></li>
+          <li><a href="#f12">Speculator positioning</a></li>
+          <li><a href="#gold-silver">Gold vs silver</a></li>
+          <li><a href="#forex">XAU/USD in forex</a></li>
+          <li><a href="#who">Who sets the price</a></li>
+          <li><a href="#quick-ref">Quick-reference table</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ol>
+        <div class="wa-toc__foot">
+          <span class="wa-toc__foot-label">Live tools</span>
+          <a href="/gold-price-per-gram">→ Gold per gram</a>
+          <a href="/gold-silver-ratio">→ Gold / silver ratio</a>
+          <a href="/scrap-gold-calculator">→ Scrap calculator</a>
+        </div>
+      </nav>
+    </aside>
 
-<div class="ad-slot" data-ad-slot="YOUR_SLOT_1"></div>
+    <!-- ARTICLE -->
+    <div class="wa-article">
 
-<h2>4. Central Bank Reserves</h2>
-<p>Central banks are among the largest holders of gold globally. They hold gold reserves to diversify their foreign exchange portfolios, hedge against currency volatility, and provide a stable bedrock for their national economies. The buying and selling activities of central banks significantly influence gold prices.</p>
-<p>For several decades following the abandonment of the gold standard, many central banks were net sellers of gold. However, following the 2008 financial crisis, this trend reversed. Today, central banks, particularly those in emerging markets like China, Russia, India, and Turkey, are aggressive net buyers of gold.</p>
-<p>When central banks accumulate gold, they constrain the global supply available to private investors and industries, pushing prices upward. Their continued purchases also signal a lack of confidence in fiat currencies and geopolitical stability, reinforcing gold's status as a premier safe-haven asset.</p>
+      <!-- Mobile TOC accordion -->
+      <div class="wa-mtoc">
+        <button class="wa-mtoc__toggle" id="waMtocBtn" aria-expanded="false" aria-controls="waMtocPanel" type="button">
+          <span class="wa-mtoc__toggle-l">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/></svg>
+            In this article · 12 factors
+          </span>
+          <svg class="wa-mtoc__chev" width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg>
+        </button>
+        <nav id="waMtocPanel" class="wa-mtoc__panel" aria-label="Article navigation">
+          <ol class="wa-mtoc__list">
+            <li><a href="#determined">How gold price is determined</a></li>
+            <li><a href="#f1">Interest rates &amp; monetary policy</a></li>
+            <li><a href="#f2">The US dollar</a></li>
+            <li><a href="#f3">Inflation &amp; purchasing power</a></li>
+            <li><a href="#f4">Central bank buying &amp; selling</a></li>
+            <li><a href="#f5">Geopolitical risk</a></li>
+            <li><a href="#f6">Supply: mining &amp; recycling</a></li>
+            <li><a href="#f7">Jewellery, industrial, retail</a></li>
+            <li><a href="#f8">Gold ETF flows</a></li>
+            <li><a href="#f9">Economic conditions</a></li>
+            <li><a href="#f10">Currency crises &amp; de-dollarisation</a></li>
+            <li><a href="#f11">Seasonality &amp; culture</a></li>
+            <li><a href="#f12">Speculator positioning</a></li>
+            <li><a href="#gold-silver">Gold vs silver</a></li>
+            <li><a href="#forex">XAU/USD in forex</a></li>
+            <li><a href="#who">Who sets the price</a></li>
+            <li><a href="#quick-ref">Quick-reference table</a></li>
+            <li><a href="#faq">FAQ</a></li>
+          </ol>
+        </nav>
+      </div>
 
-<h2>5. Geopolitical Tensions and Safe-Haven Demand</h2>
-<p>Gold is widely recognized as the ultimate safe-haven asset. During times of geopolitical instability, economic crises, or global pandemics, investors flock to gold to protect their wealth from uncertainty and market volatility.</p>
-<p>Events such as wars, trade disputes, political upheavals, and terrorist attacks can trigger immediate spikes in gold prices. The uncertainty surrounding these events often leads to panic selling in equity markets and a flight to safety. Gold, with its intrinsic value and lack of counterparty risk, provides a secure store of wealth during tumultuous times.</p>
-<p>The premium attached to gold during crises is known as the "fear premium." While geopolitical events can cause sharp, short-term rallies, the long-term sustainability of these price increases depends on whether the underlying macroeconomic environment—such as interest rates and inflation—also supports higher gold prices.</p>
-<p>If you are looking to sell your gold during a high-price period, check our guide on <a href="/guides/how-to-sell-gold-jewellery">how to sell gold jewellery</a>.</p>
+      <!-- INTRO -->
+      <section class="wa-section">
+        <div class="wa-prose">
+          <p>Traders, investors, central bankers and jewellers watch gold's moves closely, but most people — even experienced investors — only have a vague sense of <em>why</em> gold goes up or down on any given day, let alone over months and years. The honest answer is that no single factor determines the gold price.</p>
+          <p>This guide breaks down every significant factor that affects gold prices, explains exactly how each one works, shows what the current data looks like, and explains how the gold price is actually set and published each day.</p>
+        </div>
+      </section>
 
-<h2>6. Supply and Demand Dynamics</h2>
-<p>Like any commodity, gold is subject to the fundamental laws of supply and demand. However, gold is unique because practically all the gold ever mined still exists in some form. The total above-ground stock of gold grows by only about 1.5% to 2% annually through new mining production.</p>
-<h3>Gold Supply</h3>
-<p>The primary sources of gold supply are mine production and recycling (scrap gold). Mine production is relatively inelastic in the short term. It takes years and massive capital investment to explore, develop, and bring a new gold mine into production. Therefore, mining output cannot respond quickly to sudden price increases.</p>
-<p>Recycling, on the other hand, is highly price-sensitive. When gold prices surge, more individuals and businesses are incentivized to sell their old jewelry, electronics, and coins. This influx of scrap gold can temporarily temper price rallies. If you're curious about scrap value, use our <a href="/scrap-gold-calculator">scrap gold calculator</a> to find out how much your old items are worth.</p>
+      <!-- HOW IS THE GOLD PRICE DETERMINED -->
+      <section id="determined" class="wa-section">
+        <span class="wa-section__eyebrow">Market mechanics</span>
+        <h2 class="wa-section__title">How Is the Gold Price Determined?</h2>
+        <p class="wa-section__lead">Gold doesn't trade on a single central exchange. Its price emerges from a continuous global auction across futures markets, the London OTC market, and the LBMA twice-daily benchmark fix.</p>
 
-<h3>Gold Demand</h3>
-<p>Gold demand is broadly categorized into four sectors: jewelry, investment, central banks, and technology. Jewelry accounts for the largest share of global demand, particularly driven by major markets like India and China, where gold holds deep cultural and religious significance. Economic growth and rising incomes in these regions historically support higher jewelry demand.</p>
-<p>Investment demand encompasses physical bars and coins, as well as gold-backed Exchange-Traded Funds (ETFs). Investment demand is highly volatile and heavily influenced by the macroeconomic factors discussed earlier. The flow of funds into or out of gold ETFs serves as a crucial barometer of institutional and retail investor sentiment.</p>
-<p>Industrial demand for gold, primarily in electronics, dentistry, and aerospace, accounts for a relatively small percentage of total demand. While steady, it is rarely a primary driver of major price movements.</p>
+        <h3>The LBMA Gold Price — the world's benchmark</h3>
+        <div class="wa-prose">
+          <p>The primary global benchmark for gold is the <strong>LBMA Gold Price</strong>, published twice daily at <strong>10:30 AM and 3:00 PM London time</strong> by the London Bullion Market Association. It's the reference for physical transactions, derivative settlements, mining output valuations and central bank reserve calculations.</p>
+        </div>
 
-<h2>7. Exchange-Traded Funds (ETFs)</h2>
-<p>The advent of gold-backed Exchange-Traded Funds, such as the SPDR Gold Shares (GLD), has revolutionized the gold market. ETFs allow investors to gain exposure to gold prices without the logistical challenges and costs associated with buying, storing, and insuring physical bullion.</p>
-<p>Gold ETFs hold physical gold on behalf of their shareholders. When investors buy shares of a gold ETF, the fund must purchase and vault an equivalent amount of physical gold. Conversely, when investors sell their shares, the fund liquidates its physical holdings.</p>
-<p>The massive influx of capital into gold ETFs during bullish periods significantly boosts overall demand and drives up prices. Conversely, heavy outflows from ETFs during bearish periods can exacerbate price declines. Monitoring ETF holdings provides valuable insights into broader market sentiment.</p>
+        <div class="wa-process" role="list" aria-label="LBMA Gold Price auction steps">
+          <div class="wa-process__step" role="listitem">
+            <div class="wa-process__title">Auction opens</div>
+            <p class="wa-process__desc">ICE Benchmark Administration starts electronic auction with 15 accredited banks.</p>
+          </div>
+          <div class="wa-process__step" role="listitem">
+            <div class="wa-process__title">Orders submitted</div>
+            <p class="wa-process__desc">Banks submit buy/sell orders for clients and house books at the indicative price.</p>
+          </div>
+          <div class="wa-process__step" role="listitem">
+            <div class="wa-process__title">Imbalance calculated</div>
+            <p class="wa-process__desc">Platform computes net supply-demand imbalance at each price point.</p>
+          </div>
+          <div class="wa-process__step" role="listitem">
+            <div class="wa-process__title">Price adjusted</div>
+            <p class="wa-process__desc">Adjusts in rounds until imbalance falls within ±20,000 troy ounces.</p>
+          </div>
+          <div class="wa-process__step" role="listitem">
+            <div class="wa-process__title">Fix published</div>
+            <p class="wa-process__desc">Equilibrium reached. Price fixed and published as the AM/PM benchmark.</p>
+          </div>
+        </div>
 
-<h2>Conclusion</h2>
-<p>Understanding what affects the price of gold is crucial for any investor looking to navigate the precious metals market. Gold prices are not driven by a single factor but by a complex, interconnected web of macroeconomic indicators, monetary policies, and global events.</p>
-<p>Inflation, interest rates, the strength of the US Dollar, central bank activities, geopolitical stability, and supply/demand dynamics all play vital roles in determining the value of gold. By closely monitoring these factors, investors can make more informed decisions about when to buy, hold, or sell this timeless asset.</p>
-<p>Whether you are considering purchasing physical gold, investing in ETFs, or evaluating your existing holdings, staying informed about the underlying drivers of gold prices is your best defense against market volatility.</p>
+        <div class="wa-prose">
+          <p>The LBMA Gold Price is published in US dollars as the primary currency, with indicative prices available in 16 other currencies including euros, pounds sterling and Chinese renminbi.</p>
+        </div>
 
-  </div><!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
-  <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/what-affects-gold-price&text=What+Affects+the+Price+of+Gold%3F" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
-  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/guides/what-affects-gold-price&title=What+Affects+the+Price+of+Gold%3F" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=What+Affects+the+Price+of+Gold%3F" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
-</div>
-  <script>
-  document.querySelectorAll('.share-buttons a').forEach(btn => {
-    btn.addEventListener('click', () => {
-      if (typeof gtag === 'function') {
-        gtag('event', 'share', { method: btn.dataset.platform, content_type: 'article', item_id: window.location.pathname });
-      }
-    });
-  });
-  </script>
+        <h3>The spot price and COMEX futures</h3>
+        <div class="wa-det-grid">
+          <div class="wa-det-card">
+            <div class="wa-det-card__icon" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/><circle cx="12" cy="12" r="3"/></svg>
+            </div>
+            <h3 class="wa-det-card__title">LBMA fix (London)</h3>
+            <p class="wa-det-card__body">Twice daily, 10:30 AM &amp; 3:00 PM London time. The reference price for physical gold transactions and central bank reserves. London handles roughly three-quarters of global trading volume between LBMA clients.</p>
+            <div class="wa-det-card__stat">
+              <span class="wa-det-card__stat-val">75%</span>
+              <span class="wa-det-card__stat-label">of global gold trading</span>
+            </div>
+          </div>
 
-  <div class="cta-box">
-    <h3>Live Gold Price Calculator</h3>
-    <p>Check live gold prices and calculate the value of your gold investments today.</p>
-    <a href="/gold-price-per-gram" class="cta-btn">Open Calculator &rarr;</a>
-  </div>
+          <div class="wa-det-card">
+            <div class="wa-det-card__icon" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18"/><path d="M7 14l3-3 4 4 5-6"/></svg>
+            </div>
+            <h3 class="wa-det-card__title">Spot &amp; COMEX (continuous)</h3>
+            <p class="wa-det-card__body">Between fixings, gold trades continuously on the spot market. The most important venue for price discovery is the <strong>COMEX futures exchange</strong> in New York — futures move first on new information, the spot price tracks them in real time.</p>
+            <div class="wa-det-card__stat">
+              <span class="wa-det-card__stat-val">24h</span>
+              <span class="wa-det-card__stat-label">continuous global trading</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="wa-insight">
+          <div class="wa-insight__icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.5c1 1 1.5 2 1.5 3.5h5c0-1.5.5-2.5 1.5-3.5A7 7 0 0 0 12 2z"/></svg>
+          </div>
+          <div class="wa-insight__body">
+            <div class="wa-insight__title">The bottom line</div>
+            <p class="wa-insight__text">The gold price is a <strong>continuous, globally connected market output</strong> — not a decision made by any single person, institution or government. The LBMA fix establishes two stable daily reference points; between them, gold's price reflects real-time global trading in the world's deepest commodity market.</p>
+          </div>
+        </div>
+      </section>
+
+      <div class="wa-divider" aria-hidden="true"></div>
+
+      <!-- BIG SECTION OPENER -->
+      <div class="wa-major-opener">
+        <span class="wa-section__eyebrow" style="margin-bottom:var(--space-2)">The forces in detail</span>
+        <div class="wa-major-opener__count">12</div>
+        <div class="wa-major-opener__label">Major factors moving gold</div>
+      </div>
+
+      <!-- FACTOR 1: INTEREST RATES -->
+      <section id="f1" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">01</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Monetary policy</span>
+            <h2 class="wa-factor__title">Interest Rates &amp; Monetary Policy</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>Interest rates are arguably the single most powerful determinant of gold's medium-term direction. The logic is direct: gold pays no interest or dividend — it just sits there. When rates are high, investors can park money in government bonds or savings accounts and earn a meaningful return. Gold becomes a less attractive alternative.</p>
+
+          <div class="wa-insight">
+            <div class="wa-insight__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg>
+            </div>
+            <div class="wa-insight__body">
+              <div class="wa-insight__title">Key concept · The real interest rate</div>
+              <p class="wa-insight__text">The <strong>real</strong> rate is the nominal rate minus inflation. A 5% bond yield with 3% inflation = 2% real yield. When real rates are <strong>negative</strong> — inflation exceeds the bond yield — gold's zero yield is actually competitive, because bonds are losing purchasing power.</p>
+            </div>
+          </div>
+
+          <p>This relationship explains some of gold's most dramatic moves:</p>
+
+          <div class="wa-timeline" role="list" aria-label="Historical gold price moves driven by real interest rates">
+            <div class="wa-tl wa-tl--pos" role="listitem">
+              <span class="wa-tl__year">2020 – 2021</span>
+              <div class="wa-tl__price">$1,600 <span class="wa-tl__arrow up" aria-hidden="true">↑</span> $2,075</div>
+              <p class="wa-tl__detail">Fed cuts rates to near zero, launches unlimited QE. Real yields turn deeply negative. Gold surges.</p>
+            </div>
+            <div class="wa-tl wa-tl--neg" role="listitem">
+              <span class="wa-tl__year">2022</span>
+              <div class="wa-tl__price">$2,050 <span class="wa-tl__arrow down" aria-hidden="true">↓</span> $1,630</div>
+              <p class="wa-tl__detail">Most aggressive hiking cycle since Volcker. Real yields rise rapidly. Gold falls 20%.</p>
+            </div>
+            <div class="wa-tl wa-tl--pos" role="listitem">
+              <span class="wa-tl__year">2025 – 2026</span>
+              <div class="wa-tl__price">→ $5,500+ <span class="wa-tl__arrow up" aria-hidden="true">↑</span></div>
+              <p class="wa-tl__detail">Fed shifts back to easing bias; real yields fall. Gold breaks every previous record.</p>
+            </div>
+          </div>
+
+          <div class="wa-meter" role="img" aria-label="Correlation strength: very strong">
+            <span class="wa-meter__label">Correlation</span>
+            <div class="wa-meter__bar"><div class="wa-meter__bar-fill" style="width:92%"></div></div>
+            <span class="wa-meter__value">Very strong</span>
+          </div>
+
+          <p>Each <strong>1% rise</strong> in US real yields has historically correlated with an <strong>8–10% decline</strong> in gold. Monitoring the 10-year TIPS yield is therefore one of the most reliable short-to-medium-term signals for gold's direction.</p>
+
+          <p><strong>The Fed's role.</strong> Federal Reserve decisions have outsized influence on gold globally — not because gold is a dollar asset, but because dollar interest rates set the global risk-free rate of return that all assets are benchmarked against. When the Fed cuts, real yields fall, the dollar often weakens, and gold typically rises. When the Fed hikes, the reverse applies.</p>
+        </div>
+      </section>
+
+      <!-- FACTOR 2: US DOLLAR -->
+      <section id="f2" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">02</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Currency</span>
+            <h2 class="wa-factor__title">The US Dollar — Gold's Most Direct Inverse Relationship</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>Gold is priced globally in US dollars. When the dollar strengthens — meaning each dollar buys more euros, yuan or sterling — it also buys more gold in the eyes of non-dollar buyers, making gold effectively more expensive for the majority of the world that does not transact in dollars. This reduces demand and pushes prices down.</p>
+
+          <p>Conversely, when the dollar weakens, gold becomes cheaper in other currencies — stimulating demand from India, China, Europe and the Middle East — and the dollar price of gold rises to reflect this broader buying.</p>
+
+          <div class="wa-meter" role="img" aria-label="Correlation strength: strong (negative)">
+            <span class="wa-meter__label">DXY ↔ Gold</span>
+            <div class="wa-meter__bar"><div class="wa-meter__bar-fill" style="width:65%"></div></div>
+            <span class="wa-meter__value">−0.4 to −0.7</span>
+          </div>
+
+          <div class="wa-insight">
+            <div class="wa-insight__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+            </div>
+            <div class="wa-insight__body">
+              <div class="wa-insight__title">XAU/USD in forex</div>
+              <p class="wa-insight__text">In currency markets, gold trades as <strong>XAU/USD</strong> — a currency pair, not just a commodity price. When dollar bulls dominate, XAU/USD falls; when dollar bears dominate, XAU/USD rises. Traders watch the DXY in lock-step with gold.</p>
+            </div>
+          </div>
+
+          <p>A weakening US dollar has been one of the key structural forces behind the 2025–2026 gold bull market, with Goldman Sachs, J.P. Morgan and State Street all specifically citing dollar weakness as a core pillar of their bullish gold outlook.</p>
+        </div>
+      </section>
+
+      <!-- FACTOR 3: INFLATION -->
+      <section id="f3" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">03</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Macro</span>
+            <h2 class="wa-factor__title">Inflation &amp; Purchasing Power</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>Gold's oldest narrative is as an inflation hedge — a store of value that preserves purchasing power when paper currencies lose theirs. The data shows the relationship is real, but more complex than simple messaging suggests.</p>
+
+          <div class="wa-pq">
+            <p class="wa-pq__text">One ounce of gold that bought a fine Roman toga 2,000 years ago roughly buys a quality business suit today — the same underlying purchasing power across millennia.</p>
+            <div class="wa-pq__cite">Long-run purchasing power</div>
+          </div>
+
+          <p>In the <strong>medium term</strong>, gold tends to perform best not just when inflation is high in absolute terms, but when <em>real returns</em> on financial assets turn negative — when inflation exceeds what savers and bond holders can earn. The 1970s and 2020–2022 are both examples.</p>
+
+          <p>In the <strong>short term</strong>, the relationship can be counterintuitive. A higher-than-expected CPI reading can cause gold to <em>fall</em> temporarily if it implies the central bank will raise rates (increasing real yields). The market's <strong>interpretation</strong> of what an inflation number means for policy often matters more than the number itself.</p>
+
+          <div class="wa-insight">
+            <div class="wa-insight__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12h4l3 9 4-18 3 9h6"/></svg>
+            </div>
+            <div class="wa-insight__body">
+              <div class="wa-insight__title">Watch · TIPS breakeven rates</div>
+              <p class="wa-insight__text">Inflation <strong>expectations</strong> matter as much as current inflation. The TIPS breakeven rate (the spread between nominal and inflation-protected Treasury yields) is a widely-watched proxy, and gold tracks breakevens closely in the short term.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- FACTOR 4: CENTRAL BANKS -->
+      <section id="f4" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">04</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Structural demand</span>
+            <h2 class="wa-factor__title">Central Bank Buying &amp; Selling</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>Central banks collectively hold approximately <strong>35,000–40,000 tonnes</strong> of gold — roughly 20% of all the gold ever mined. Their buying and selling decisions directly shift the fundamental supply-demand balance and have been one of the most important structural forces behind the 2022–2026 bull market.</p>
+
+          <p>The wave of central bank gold buying began in earnest after the <strong>2022 freezing of Russian foreign reserves</strong> — a decision that alarmed many emerging market central banks about the risk of holding dollar-denominated assets subject to potential sanctions. Gold, as a physical asset that cannot be frozen, seized or defaulted on by a counterparty, became the obvious alternative.</p>
+
+          <div class="wa-bigrow wa-bigrow--3" role="list" aria-label="Central bank gold buying statistics">
+            <div class="wa-big" role="listitem">
+              <div class="wa-big__val">~850 t</div>
+              <div class="wa-big__label">Net purchases 2025</div>
+              <div class="wa-big__sub">Third-highest annual total on record (WGC)</div>
+            </div>
+            <div class="wa-big" role="listitem">
+              <div class="wa-big__val">60 t / mo</div>
+              <div class="wa-big__label">Goldman 2026 forecast</div>
+              <div class="wa-big__sub">Continued accelerated buying pace</div>
+            </div>
+            <div class="wa-big" role="listitem">
+              <div class="wa-big__val">68%</div>
+              <div class="wa-big__label">Plan to add gold in 2026</div>
+              <div class="wa-big__sub">Up from 62% — WGC March '26 survey</div>
+            </div>
+          </div>
+
+          <div class="wa-pq">
+            <p class="wa-pq__text">The primary catalyst behind the rise in gold prices is central banks looking to de-dollarise… and where else could you turn except into gold?</p>
+            <div class="wa-pq__cite">Philip Newman, Metals Focus · January 2026</div>
+          </div>
+
+          <p>Indonesia, Malaysia, Guatemala and dozens of smaller emerging market central banks have entered or re-entered the market. Poland's central bank governor stated the goal is to hold <strong>20% of reserves in gold</strong>. Since central banks became net buyers in 2010 and dramatically accelerated buying after 2022, they have provided a structural price floor that has made each correction shallower than the last.</p>
+        </div>
+      </section>
+
+      <!-- FACTOR 5: GEOPOLITICAL RISK -->
+      <section id="f5" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">05</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Risk premium</span>
+            <h2 class="wa-factor__title">Geopolitical Risk &amp; Uncertainty</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>Gold's identity as a safe haven — an asset that holds value when everything else looks uncertain — is one of its most fundamental price drivers. When geopolitical risk rises sharply, investors seek assets with no counterparty risk. Gold, with no issuer and no default risk, is the canonical choice.</p>
+
+          <div class="wa-timeline" role="list" aria-label="Historical gold spikes during geopolitical events">
+            <div class="wa-tl wa-tl--pos" role="listitem">
+              <span class="wa-tl__year">1973 / 1979</span>
+              <div class="wa-tl__price">Oil embargo · Iran</div>
+              <p class="wa-tl__detail">Twin crises drive gold from $35 to over $800 by 1980.</p>
+            </div>
+            <div class="wa-tl wa-tl--pos" role="listitem">
+              <span class="wa-tl__year">2008 · 2020</span>
+              <div class="wa-tl__price">GFC · COVID</div>
+              <p class="wa-tl__detail">Financial crisis and pandemic each drive sharp rallies to new highs.</p>
+            </div>
+            <div class="wa-tl wa-tl--pos" role="listitem">
+              <span class="wa-tl__year">2022 → 2026</span>
+              <div class="wa-tl__price">Ukraine · Tariffs · Fed</div>
+              <p class="wa-tl__detail">Multi-year compounding risks drive structural bull market.</p>
+            </div>
+          </div>
+
+          <p>In 2026, geopolitical forces have been particularly multifaceted: <strong>US-NATO disputes</strong> over European commitments, <strong>tariff unpredictability</strong> from the Trump administration, questions about <strong>Federal Reserve independence</strong>, and ongoing Middle East tensions have collectively sustained an elevated risk premium in gold.</p>
+
+          <div class="wa-insight">
+            <div class="wa-insight__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+            </div>
+            <div class="wa-insight__body">
+              <div class="wa-insight__title">Important nuance</div>
+              <p class="wa-insight__text">Not all geopolitical events affect gold equally. Short-term spikes driven by a single crisis headline often <strong>partially reverse</strong> once the acute fear passes. Structural shifts — like the fracturing of the Western-led financial system — provide more sustained price support.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- FACTOR 6: SUPPLY -->
+      <section id="f6" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">06</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Supply</span>
+            <h2 class="wa-factor__title">Mining Production &amp; Recycling</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>The supply side has two major sources: <strong>mine production</strong> (new gold extracted from the earth) and <strong>recycled gold</strong> (previously refined gold returned to the market, primarily from jewellery and industrial uses).</p>
+
+          <div class="wa-bigrow">
+            <div class="wa-big">
+              <div class="wa-big__val">~3,500 t</div>
+              <div class="wa-big__label">Mine production / year</div>
+              <div class="wa-big__sub">Broadly flat for a decade despite rising prices</div>
+            </div>
+            <div class="wa-big">
+              <div class="wa-big__val">1,200–1,400 t</div>
+              <div class="wa-big__label">Recycled gold / year</div>
+              <div class="wa-big__sub">Price-sensitive: surges when gold rallies</div>
+            </div>
+          </div>
+
+          <p><strong>Mine production is inelastic.</strong> Unlike most commodities where higher prices quickly incentivise more production, gold mining is capital-intensive and decade-long. New mines take 10–20 years from discovery to production. Declining ore grades and rising depth of new deposits mean production costs are rising steadily, supporting a structural floor under prices.</p>
+
+          <p>Top producers in 2025 include <strong>China</strong> (largest), <strong>Australia, Russia, Canada and the United States</strong>. Political or operational disruptions in major producing countries can create short-term supply shocks.</p>
+
+          <p><strong>Recycling acts as a partial brake.</strong> High prices increase the flow of recycled gold, which partially offsets demand-driven appreciation. This is why sharp gold price spikes are often followed by increased scrap supply that caps the rally. Total annual supply (mining + recycling) is roughly <strong>4,700–4,900 tonnes</strong> and changes slowly — meaning demand fluctuations are the primary driver of price movements.</p>
+        </div>
+      </section>
+
+      <!-- FACTOR 7: JEWELLERY -->
+      <section id="f7" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">07</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Physical demand</span>
+            <h2 class="wa-factor__title">Jewellery, Industrial &amp; Retail Demand</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p><strong>Jewellery demand</strong> is the largest single category of physical gold consumption — approximately <strong>44–50%</strong> of total annual gold demand in non-peak years. India and China collectively account for over half of global jewellery demand and have historically provided a consistent baseline of price-supportive buying, particularly during cultural festivals like <em>Diwali</em>, <em>Dhanteras</em> and Chinese New Year.</p>
+
+          <div class="wa-bigrow wa-bigrow--3">
+            <div class="wa-big">
+              <div class="wa-big__val">~47%</div>
+              <div class="wa-big__label">Jewellery demand</div>
+              <div class="wa-big__sub">India + China = 50%+ of total</div>
+            </div>
+            <div class="wa-big">
+              <div class="wa-big__val">7–8%</div>
+              <div class="wa-big__label">Industrial / tech</div>
+              <div class="wa-big__sub">Electronics, dental, aerospace, AI chips</div>
+            </div>
+            <div class="wa-big">
+              <div class="wa-big__val">20–25%</div>
+              <div class="wa-big__label">Bars &amp; coins</div>
+              <div class="wa-big__sub">Retail investor physical demand</div>
+            </div>
+          </div>
+
+          <p>Jewellery demand is somewhat <strong>price-sensitive</strong> — when gold spikes sharply, jewellery buyers reduce purchases or buy lighter pieces. This acts as a partial natural brake on runaway bull markets. Conversely, a sustained decline can trigger a surge in jewellery demand from price-sensitive consumer markets, supporting a price floor.</p>
+
+          <p><strong>Industrial demand</strong> uses gold's unique properties — exceptional electrical conductivity, corrosion resistance, biocompatibility — in electronics, dentistry, aerospace and medical devices. The growing importance of <strong>AI chip manufacturing</strong> and semiconductor production is creating a small but growing incremental demand source.</p>
+        </div>
+      </section>
+
+      <!-- FACTOR 8: ETF FLOWS -->
+      <section id="f8" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">08</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Investment flows</span>
+            <h2 class="wa-factor__title">Gold ETF Flows — the Western Investment Channel</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p><strong>Gold exchange-traded funds</strong> like SPDR Gold Trust (GLD) and iShares Gold Trust (IAU) have fundamentally changed gold price dynamics since the early 2000s. By allowing institutional and retail investors to gain gold exposure without holding physical metal, ETFs created a new, highly liquid channel of investment demand.</p>
+
+          <p>ETF flows are especially important because they reflect <strong>Western institutional investor sentiment</strong> — a category of buyer whose participation can add or remove enormous quantities of demand very quickly. When ETFs see large inflows, fund operators must purchase physical gold to back those shares, adding direct demand to the market.</p>
+
+          <div class="wa-bigrow">
+            <div class="wa-big">
+              <div class="wa-big__val">$89 B</div>
+              <div class="wa-big__label">2025 ETF inflows</div>
+              <div class="wa-big__sub">Record annual figure</div>
+            </div>
+            <div class="wa-big">
+              <div class="wa-big__val">&lt; 1%</div>
+              <div class="wa-big__label">Typical Western allocation</div>
+              <div class="wa-big__sub">Vs 5–10% strategic benchmark</div>
+            </div>
+          </div>
+
+          <div class="wa-insight">
+            <div class="wa-insight__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+            </div>
+            <div class="wa-insight__body">
+              <div class="wa-insight__title">2026 outlook</div>
+              <p class="wa-insight__text">Goldman Sachs and J.P. Morgan both highlight ETF rebalancing flows as a key upside driver for 2026, noting that Western institutional portfolios remain <strong>historically under-allocated to gold</strong>. The GLD ETF is closely watched as a real-time indicator of institutional gold sentiment.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- FACTOR 9: ECONOMIC CONDITIONS -->
+      <section id="f9" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">09</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Macro regime</span>
+            <h2 class="wa-factor__title">Global Economic Conditions &amp; Risk Sentiment</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>Gold behaves differently in different economic environments. Understanding these patterns helps investors interpret price movements:</p>
+
+          <div class="wa-triggers" role="list">
+            <div class="wa-trigger" role="listitem">
+              <div class="wa-trigger__icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18"/><path d="M21 9l-7 7-4-4-5 5"/></svg>
+              </div>
+              <div class="wa-trigger__body">
+                <div class="wa-trigger__name">Recession / crisis</div>
+                <p class="wa-trigger__detail"><strong>Bullish.</strong> Safe-haven demand overwhelms every other factor. 2008 GFC, 2020 COVID, 2023 banking crisis.</p>
+              </div>
+            </div>
+            <div class="wa-trigger" role="listitem">
+              <div class="wa-trigger__icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/></svg>
+              </div>
+              <div class="wa-trigger__body">
+                <div class="wa-trigger__name">Strong growth / risk-on</div>
+                <p class="wa-trigger__detail"><strong>Bearish.</strong> Robust global growth pressures gold as investors shift to equities. The 1990s and 2017 saw gold underperform.</p>
+              </div>
+            </div>
+            <div class="wa-trigger" role="listitem">
+              <div class="wa-trigger__icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20M4 12h16M4 4l16 16"/></svg>
+              </div>
+              <div class="wa-trigger__body">
+                <div class="wa-trigger__name">Stagflation</div>
+                <p class="wa-trigger__detail"><strong>Most bullish.</strong> Rising inflation + weak growth. The 1970s and 2022–2026 are classic examples.</p>
+              </div>
+            </div>
+            <div class="wa-trigger" role="listitem">
+              <div class="wa-trigger__icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+              </div>
+              <div class="wa-trigger__body">
+                <div class="wa-trigger__name">Disinflation + growth</div>
+                <p class="wa-trigger__detail"><strong>Bearish.</strong> "Goldilocks" environment is gold's weakest historical setup.</p>
+              </div>
+            </div>
+          </div>
+
+          <p>The World Gold Council's analysis consistently shows that gold's best environments combine <strong>weak or declining real interest rates, dollar weakness, and elevated uncertainty</strong> — conditions that have characterised 2024–2026.</p>
+        </div>
+      </section>
+
+      <!-- FACTOR 10: CURRENCY CRISES -->
+      <section id="f10" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">10</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Debasement hedge</span>
+            <h2 class="wa-factor__title">Currency Crises &amp; De-dollarisation</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>Beyond its relationship with the US dollar specifically, gold responds to broader <strong>currency credibility crises</strong>. When trust in a national currency erodes — through hyperinflation, political instability, sanctions risk or debt default — demand for gold in that currency surges as citizens and institutions seek assets that cannot be devalued by government decision.</p>
+
+          <p>The de-dollarisation trend driving much of the 2022–2026 bull market is a structural version of this phenomenon at the reserve currency level. Emerging market central banks are reducing dollar holdings to reduce the percentage of reserves held in an asset that can theoretically be frozen or subject to US foreign policy decisions.</p>
+
+          <div class="wa-bigrow">
+            <div class="wa-big">
+              <div class="wa-big__val">$340 T</div>
+              <div class="wa-big__label">Global debt</div>
+              <div class="wa-big__sub">~330% of global GDP</div>
+            </div>
+            <div class="wa-big">
+              <div class="wa-big__val">20%</div>
+              <div class="wa-big__label">Poland's reserve target</div>
+              <div class="wa-big__sub">Held in gold (stated goal)</div>
+            </div>
+          </div>
+
+          <div class="wa-pq">
+            <p class="wa-pq__text">Goldman Sachs specifically describes the current gold bull market in part as a <strong>"debasement hedge"</strong> — a response to record global debt levels that raise fundamental questions about the long-term credibility of fiat currencies.</p>
+            <div class="wa-pq__cite">Goldman Sachs · 2026 commodities outlook</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- FACTOR 11: SEASONALITY -->
+      <section id="f11" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">11</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Cyclical</span>
+            <h2 class="wa-factor__title">Seasonality &amp; Cultural Demand Patterns</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>Gold price movements have a seasonal component driven by consumer demand cycles. Historically, demand tends to be stronger during:</p>
+
+          <div class="wa-timeline">
+            <div class="wa-tl wa-tl--pos">
+              <span class="wa-tl__year">Aug – Oct</span>
+              <div class="wa-tl__price">India festivals</div>
+              <p class="wa-tl__detail">Pre-Diwali, Dhanteras and wedding-season buying.</p>
+            </div>
+            <div class="wa-tl wa-tl--pos">
+              <span class="wa-tl__year">Jan – Feb</span>
+              <div class="wa-tl__price">Chinese New Year</div>
+              <p class="wa-tl__detail">Gifting and festive buying across Greater China.</p>
+            </div>
+            <div class="wa-tl wa-tl--pos">
+              <span class="wa-tl__year">Spring</span>
+              <div class="wa-tl__price">Wedding season</div>
+              <p class="wa-tl__detail">Wedding demand in several major consumer markets.</p>
+            </div>
+          </div>
+
+          <div class="wa-insight">
+            <div class="wa-insight__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="wa-insight__body">
+              <div class="wa-insight__title">When seasonality matters</div>
+              <p class="wa-insight__text">These patterns are real but are frequently <strong>overwhelmed by macro factors</strong> in major bull or bear markets. They are more relevant during periods of broadly flat or consolidating markets, when seasonal demand pulses become more visible drivers of shorter-term price moves.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- FACTOR 12: SPECULATOR POSITIONING -->
+      <section id="f12" class="wa-factor">
+        <div class="wa-factor__head">
+          <span class="wa-factor__num" aria-hidden="true">12</span>
+          <div class="wa-factor__head-text">
+            <span class="wa-factor__cat">Sentiment</span>
+            <h2 class="wa-factor__title">Speculator Positioning in the Futures Market</h2>
+          </div>
+        </div>
+        <div class="wa-factor__body">
+          <p>The <strong>Commitment of Traders (COT) report</strong>, published weekly by the US CFTC, shows the net positioning of large speculative traders in COMEX gold futures. This data provides a useful indicator of market sentiment extremes.</p>
+
+          <p>When speculative long positions become very crowded, the market may be vulnerable to a sharp correction as longs take profit simultaneously. Conversely, when positioning is heavily short, it creates conditions for a rapid <strong>short-covering rally</strong> when the market turns.</p>
+
+          <div class="wa-insight">
+            <div class="wa-insight__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 18 0 9 9 0 0 0-18 0z"/><path d="M3 12h18M12 3v18"/></svg>
+            </div>
+            <div class="wa-insight__body">
+              <div class="wa-insight__title">Use as a contrarian indicator</div>
+              <p class="wa-insight__text">Very heavy speculative longs warn of vulnerability; very heavy speculative shorts often precede rallies. <strong>Best used in combination</strong> with macro analysis rather than in isolation.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="wa-divider" aria-hidden="true"></div>
+
+      <!-- GOLD vs SILVER -->
+      <section id="gold-silver" class="wa-section">
+        <span class="wa-section__eyebrow">Cross-asset</span>
+        <h2 class="wa-section__title">What Affects Gold &amp; Silver Prices Differently?</h2>
+        <p class="wa-section__lead">Silver and gold often move together — both respond to the dollar, real rates and risk sentiment — but several structural factors affect them differently.</p>
+
+        <div class="wa-compare">
+          <div class="wa-comp wa-comp--gold">
+            <div class="wa-comp__head">
+              <span class="wa-comp__icon" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v10M9 9h6M9 15h6"/></svg>
+              </span>
+              <div class="wa-comp__title">Gold — monetary metal</div>
+            </div>
+            <ul class="wa-comp__list">
+              <li><strong>~8% industrial use</strong> — predominantly investment / monetary</li>
+              <li><strong>Larger, deeper market</strong> — less volatile per dollar of flow</li>
+              <li><strong>Central bank reserves</strong> — structural buyer of last resort</li>
+              <li><strong>Less correlated</strong> with manufacturing / PMI cycles</li>
+            </ul>
+          </div>
+          <div class="wa-comp wa-comp--silver">
+            <div class="wa-comp__head">
+              <span class="wa-comp__icon" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M8 8l8 8M16 8l-8 8"/></svg>
+              </span>
+              <div class="wa-comp__title">Silver — industrial + investment</div>
+            </div>
+            <ul class="wa-comp__list">
+              <li><strong>50–55% industrial use</strong> — solar, electronics, medical</li>
+              <li><strong>Smaller market</strong> — larger % moves on same capital flow</li>
+              <li><strong>Tracks manufacturing</strong> — bullish on strong PMI data</li>
+              <li><strong>Gold / silver ratio</strong> traders rotate when ratio extreme</li>
+            </ul>
+          </div>
+        </div>
+
+        <p style="font-size:13px;color:var(--color-text-muted);margin-top:var(--space-3);max-width:64ch">Track the relationship live with our <a href="/gold-silver-ratio" style="color:var(--color-primary);text-decoration:underline">gold-silver ratio tool</a>.</p>
+      </section>
+
+      <!-- XAU/USD FOREX -->
+      <section id="forex" class="wa-section">
+        <span class="wa-section__eyebrow">For traders</span>
+        <h2 class="wa-section__title">What Affects Gold in Forex Trading (XAU/USD)</h2>
+        <p class="wa-section__lead">For traders approaching gold through the FX market, the same factors apply with additional forex-specific dynamics.</p>
+
+        <h3>Short-term triggers</h3>
+        <div class="wa-triggers">
+          <div class="wa-trigger">
+            <div class="wa-trigger__icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg>
+            </div>
+            <div class="wa-trigger__body">
+              <div class="wa-trigger__name">US CPI</div>
+              <p class="wa-trigger__detail">Higher than expected = USD <strong>up</strong>, gold <strong>down</strong>. Lower = gold up.</p>
+            </div>
+          </div>
+          <div class="wa-trigger">
+            <div class="wa-trigger__icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+            </div>
+            <div class="wa-trigger__body">
+              <div class="wa-trigger__name">Non-Farm Payrolls</div>
+              <p class="wa-trigger__detail">Strong data = USD up, gold down. Weak data = gold up.</p>
+            </div>
+          </div>
+          <div class="wa-trigger">
+            <div class="wa-trigger__icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 18v-6a9 9 0 0 1 18 0v6"/><path d="M21 19a2 2 0 0 1-2 2h-1v-7h3z"/><path d="M3 19a2 2 0 0 0 2 2h1v-7H3z"/></svg>
+            </div>
+            <div class="wa-trigger__body">
+              <div class="wa-trigger__name">Fed speeches</div>
+              <p class="wa-trigger__detail">Hawkish tone = gold down; dovish tone = gold up.</p>
+            </div>
+          </div>
+          <div class="wa-trigger">
+            <div class="wa-trigger__icon" aria-hidden="true">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/></svg>
+            </div>
+            <div class="wa-trigger__body">
+              <div class="wa-trigger__name">DXY moves</div>
+              <p class="wa-trigger__detail">Immediate, direct <strong>inverse</strong> relationship with gold.</p>
+            </div>
+          </div>
+        </div>
+
+        <h3>Medium-term drivers</h3>
+        <div class="wa-prose">
+          <ul>
+            <li><strong>Federal Reserve rate cycle direction</strong> — easing vs tightening bias</li>
+            <li><strong>US fiscal deficit trajectory</strong> — debt issuance and credibility</li>
+            <li><strong>Real TIPS yield level</strong> — gold's opportunity cost</li>
+            <li><strong>Central bank gold reserve announcements</strong></li>
+            <li><strong>ETF flow data</strong> — published weekly</li>
+          </ul>
+        </div>
+
+        <div class="wa-insight">
+          <div class="wa-insight__icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 12h-4M6 12H2M12 6V2M12 22v-4"/><circle cx="12" cy="12" r="4"/></svg>
+          </div>
+          <div class="wa-insight__body">
+            <div class="wa-insight__title">Trader tip</div>
+            <p class="wa-insight__text">Monitor gold <strong>alongside the DXY</strong> as a matter of course. A strong dollar move typically translates into a gold move within minutes — making it one of the most tightly coupled relationships in global markets.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- WHO SETS THE PRICE -->
+      <section id="who" class="wa-section">
+        <span class="wa-section__eyebrow">Summary</span>
+        <h2 class="wa-section__title">Who Sets the Price of Gold?</h2>
+        <p class="wa-section__lead">No single entity "sets" the gold price. The price emerges from five interlocking sources of price discovery.</p>
+
+        <ol class="wa-numbered">
+          <li class="wa-numbered__item">
+            <div class="wa-numbered__title">COMEX futures trading (New York)</div>
+            <p class="wa-numbered__desc">Continuous price discovery from millions of daily transactions.</p>
+          </li>
+          <li class="wa-numbered__item">
+            <div class="wa-numbered__title">The London OTC market</div>
+            <p class="wa-numbered__desc">Physical gold trading among LBMA member institutions, 24 hours a day during market hours.</p>
+          </li>
+          <li class="wa-numbered__item">
+            <div class="wa-numbered__title">The LBMA Gold Price auction</div>
+            <p class="wa-numbered__desc">The twice-daily electronic benchmark providing stable reference prices for large institutional and physical transactions.</p>
+          </li>
+          <li class="wa-numbered__item">
+            <div class="wa-numbered__title">Global supply and demand</div>
+            <p class="wa-numbered__desc">Aggregate buying and selling decisions of central banks, jewellers, investors, miners, recyclers and industrial users.</p>
+          </li>
+          <li class="wa-numbered__item">
+            <div class="wa-numbered__title">Macroeconomic conditions</div>
+            <p class="wa-numbered__desc">Interest rates, inflation, dollar movements and economic growth shape the environment in which all of the above interact.</p>
+          </li>
+        </ol>
+
+        <div class="wa-prose">
+          <p>The gold price reflects all of this <strong>simultaneously</strong> — which is why it can and does respond to an unexpected inflation print, a central bank announcement, a geopolitical headline, and a currency move all on the same day.</p>
+        </div>
+      </section>
+
+      <div class="wa-divider" aria-hidden="true"></div>
+
+      <!-- QUICK REFERENCE -->
+      <section id="quick-ref" class="wa-section wa-ref-section">
+        <span class="wa-section__eyebrow">At a glance</span>
+        <h2 class="wa-section__title">Quick-Reference Table</h2>
+        <p class="wa-section__lead">Each factor's directional effect on gold and the strength of the relationship. Three dots = very strong; one dot = weak.</p>
+
+        <!-- Desktop table -->
+        <div class="wa-ref-wrap" role="region" aria-label="Quick reference table">
+          <table class="wa-ref-table">
+            <thead>
+              <tr><th scope="col">Factor</th><th scope="col">Effect on gold</th><th scope="col">Strength</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Rising real interest rates</td><td><span class="wa-pill wa-pill--down">↓ Negative</span></td><td><span class="wa-strn" aria-label="Very strong"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__txt">Very strong</span></span></td></tr>
+              <tr><td>Falling real interest rates</td><td><span class="wa-pill wa-pill--up">↑ Positive</span></td><td><span class="wa-strn" aria-label="Very strong"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__txt">Very strong</span></span></td></tr>
+              <tr><td>Stronger US dollar (DXY up)</td><td><span class="wa-pill wa-pill--down">↓ Negative</span></td><td><span class="wa-strn" aria-label="Strong"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Strong</span></span></td></tr>
+              <tr><td>Weaker US dollar (DXY down)</td><td><span class="wa-pill wa-pill--up">↑ Positive</span></td><td><span class="wa-strn" aria-label="Strong"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Strong</span></span></td></tr>
+              <tr><td>Higher inflation expectations</td><td><span class="wa-pill wa-pill--up">↑ Positive</span></td><td><span class="wa-strn" aria-label="Moderate to strong"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Mod-strong</span></span></td></tr>
+              <tr><td>Central bank net buying</td><td><span class="wa-pill wa-pill--up">↑ Positive</span></td><td><span class="wa-strn" aria-label="Strong, structural"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__txt">Structural</span></span></td></tr>
+              <tr><td>Central bank net selling</td><td><span class="wa-pill wa-pill--down">↓ Negative</span></td><td><span class="wa-strn" aria-label="Strong, structural"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__txt">Structural</span></span></td></tr>
+              <tr><td>Geopolitical escalation</td><td><span class="wa-pill wa-pill--up">↑ Positive</span></td><td><span class="wa-strn" aria-label="Moderate, short-term"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Moderate</span></span></td></tr>
+              <tr><td>Geopolitical de-escalation</td><td><span class="wa-pill wa-pill--down">↓ Negative</span></td><td><span class="wa-strn" aria-label="Moderate"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Moderate</span></span></td></tr>
+              <tr><td>Stock crash / recession</td><td><span class="wa-pill wa-pill--up">↑ Positive</span></td><td><span class="wa-strn" aria-label="Strong"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__txt">Strong</span></span></td></tr>
+              <tr><td>Strong growth / risk-on</td><td><span class="wa-pill wa-pill--down">↓ Negative</span></td><td><span class="wa-strn" aria-label="Moderate"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Moderate</span></span></td></tr>
+              <tr><td>Gold ETF inflows</td><td><span class="wa-pill wa-pill--up">↑ Positive</span></td><td><span class="wa-strn" aria-label="Moderate to strong"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Mod-strong</span></span></td></tr>
+              <tr><td>Gold ETF outflows</td><td><span class="wa-pill wa-pill--down">↓ Negative</span></td><td><span class="wa-strn" aria-label="Moderate to strong"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Mod-strong</span></span></td></tr>
+              <tr><td>Rising mine production</td><td><span class="wa-pill wa-pill--down">↓ Negative</span></td><td><span class="wa-strn" aria-label="Weak"><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Weak</span></span></td></tr>
+              <tr><td>High jewellery season</td><td><span class="wa-pill wa-pill--up">↑ Positive</span></td><td><span class="wa-strn" aria-label="Weak, seasonal"><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__dot"></span><span class="wa-strn__txt">Seasonal</span></span></td></tr>
+              <tr><td>Currency / debasement crisis</td><td><span class="wa-pill wa-pill--up">↑ Positive</span></td><td><span class="wa-strn" aria-label="Strong, structural"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__txt">Structural</span></span></td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Mobile cards -->
+        <div class="wa-ref-cards" aria-label="Quick reference cards">
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Rising real interest rates</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--down">↓ Negative</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Falling real interest rates</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--up">↑ Positive</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Stronger US dollar (DXY up)</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--down">↓ Negative</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Weaker US dollar (DXY down)</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--up">↑ Positive</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Higher inflation expectations</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--up">↑ Positive</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Central bank net buying</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--up">↑ Positive</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Geopolitical escalation</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--up">↑ Positive</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Stock crash / recession</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--up">↑ Positive</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Strong growth / risk-on</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--down">↓ Negative</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Gold ETF inflows</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--up">↑ Positive</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Gold ETF outflows</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--down">↓ Negative</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Rising mine production</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--down">↓ Negative</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__dot"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">High jewellery season</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--up">↑ Positive</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot"></span><span class="wa-strn__dot"></span></span></div></div>
+          <div class="wa-ref-card"><div class="wa-ref-card__factor">Currency / debasement crisis</div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Effect</span><span class="wa-pill wa-pill--up">↑ Positive</span></div><div class="wa-ref-card__row"><span class="wa-ref-card__lab">Strength</span><span class="wa-strn"><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span><span class="wa-strn__dot on"></span></span></div></div>
+        </div>
+      </section>
+
+      <!-- FAQ -->
+      <section id="faq" class="wa-section">
+        <span class="wa-section__eyebrow">Common questions</span>
+        <h2 class="wa-section__title">Frequently Asked Questions</h2>
+
+        <div class="wa-faq">
+          <details class="wa-faq__item">
+            <summary class="wa-faq__q">
+              <span>What factors affect the price of gold most?</span>
+              <span class="wa-faq__icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+            </summary>
+            <div class="wa-faq__a">
+              <p>The three most powerful factors are <strong>US real interest rates and Federal Reserve monetary policy</strong>, <strong>the US dollar exchange rate</strong>, and <strong>central bank gold buying and selling activity</strong>. Together they explain the majority of gold's medium-term price direction.</p>
+              <p>Geopolitical risk, inflation expectations, ETF flows and supply-demand fundamentals add significant noise and can dominate the short term.</p>
+            </div>
+          </details>
+
+          <details class="wa-faq__item">
+            <summary class="wa-faq__q">
+              <span>What affects gold prices in forex (XAU/USD)?</span>
+              <span class="wa-faq__icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+            </summary>
+            <div class="wa-faq__a">
+              <p>In forex, gold's price is most immediately driven by the <strong>dollar index (DXY)</strong>, <strong>real US yields (TIPS)</strong>, <strong>Federal Reserve policy signals</strong>, US economic data releases (CPI, NFP), and risk sentiment.</p>
+              <p>Gold is effectively a long anti-dollar position with safe-haven properties — traders watch the DXY and Fed rhetoric as their primary gold signals.</p>
+            </div>
+          </details>
+
+          <details class="wa-faq__item">
+            <summary class="wa-faq__q">
+              <span>What is affecting gold prices today in 2026?</span>
+              <span class="wa-faq__icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+            </summary>
+            <div class="wa-faq__a">
+              <p>As of 2026, the dominant factors are:</p>
+              <p><strong>Central bank buying</strong> at near-record levels (~60 tonnes/month), a <strong>weak-to-moderate US dollar</strong>, <strong>geopolitical uncertainty</strong> spanning trade policy and conflict risks, <strong>falling real interest rates</strong> as the Fed's easing cycle resumes, and <strong>record ETF inflows</strong> as Western institutional investors increase gold allocations.</p>
+            </div>
+          </details>
+
+          <details class="wa-faq__item">
+            <summary class="wa-faq__q">
+              <span>How is the price of gold determined?</span>
+              <span class="wa-faq__icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+            </summary>
+            <div class="wa-faq__a">
+              <p>Through <strong>continuous global trading</strong> across COMEX futures and the London OTC market, with the <strong>twice-daily LBMA Gold Price auction</strong> providing the primary benchmark for institutional and physical transactions.</p>
+              <p>The auction is electronic, conducted by ICE Benchmark Administration, with 15 participating institutions matching buy and sell orders until equilibrium is reached.</p>
+            </div>
+          </details>
+
+          <details class="wa-faq__item">
+            <summary class="wa-faq__q">
+              <span>Who determines the price of gold?</span>
+              <span class="wa-faq__icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+            </summary>
+            <div class="wa-faq__a">
+              <p><strong>No single entity.</strong> The gold price is the output of continuous global trading activity across futures markets, the London OTC market, the LBMA auction process, and the aggregate supply and demand decisions of central banks, investors, miners, jewellers, and industrial users worldwide.</p>
+            </div>
+          </details>
+
+          <details class="wa-faq__item">
+            <summary class="wa-faq__q">
+              <span>What causes the gold price to go down?</span>
+              <span class="wa-faq__icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+            </summary>
+            <div class="wa-faq__a">
+              <p>Gold typically falls when US real interest rates rise (bonds become more attractive), the US dollar strengthens, geopolitical risks subside, economic growth improves and risk appetite increases, or when ETF and speculative long positions unwind.</p>
+              <p>The <strong>2022 bear market</strong> is the clearest recent example — the Fed's rate-hiking cycle drove gold from $2,050 to $1,630.</p>
+            </div>
+          </details>
+
+          <details class="wa-faq__item">
+            <summary class="wa-faq__q">
+              <span>What will affect gold prices in the future?</span>
+              <span class="wa-faq__icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+            </summary>
+            <div class="wa-faq__a">
+              <p>The structural outlook depends on whether these conditions persist: central bank de-dollarisation buying, low/negative real interest rates, a structurally weaker US dollar, and elevated global debt and fiscal deficits.</p>
+              <p>If these reverse — through restored dollar credibility, rising real rates, and improved fiscal positions — gold prices would face <strong>meaningful headwinds</strong>.</p>
+            </div>
+          </details>
+        </div>
+      </section>
+
+      <!-- Hidden legacy prose container for compatibility -->
+      <div class="prose" style="display:none" aria-hidden="true">
+
+</div><!-- /.prose (legacy compat) -->
+
+      <!-- Social share -->
+      <div class="share-buttons">
+        <span>Share article:</span>
+        <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/what-affects-gold-price&text=What+Affects+the+Price+of+Gold%3F" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+        <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/guides/what-affects-gold-price&title=What+Affects+the+Price+of+Gold%3F" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+        <a href="https://api.whatsapp.com/send?text=What+Affects+the+Price+of+Gold%3F+https%3A%2F%2Fgoldpricetools.com%2Fguides%2Fwhat-affects-gold-price" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+      </div>
+      <script>
+      document.querySelectorAll('.share-buttons a').forEach(btn => {
+        btn.addEventListener('click', () => {
+          if (typeof gtag === 'function') {
+            gtag('event', 'share', { method: btn.dataset.platform, content_type: 'article', item_id: window.location.pathname });
+          }
+        });
+      });
+      </script>
+
+      <!-- Premium CTA -->
+      <div class="wa-cta">
+        <div class="wa-cta__inner">
+          <h2 class="wa-cta__title">Track the factors moving gold — right now</h2>
+          <p class="wa-cta__lead">Live spot prices in every major karat and currency, the gold-silver ratio updated every 60 seconds, and a scrap calculator that pulls today's LBMA fix automatically.</p>
+          <div class="wa-cta__btns">
+            <a href="/gold-price-per-gram" class="wa-cta-btn">
+              Live Gold Calculator
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+            </a>
+            <a href="/gold-silver-ratio" class="wa-cta-btn wa-cta-btn--ghost">Gold / Silver Ratio</a>
+          </div>
+        </div>
+      </div>
+
+      <!-- Inline disclaimer -->
+      <div class="wa-disclaim" role="note" aria-label="Financial disclaimer">
+        <strong>Disclaimer:</strong> This article is provided for informational and educational purposes only. It does not constitute financial or investment advice. Gold market conditions change constantly. Always seek independent professional guidance before making investment decisions involving precious metals.
+      </div>
+
+    </div><!-- /.wa-article -->
+  </div><!-- /.wa-layout -->
 </article>
 
-
-<div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
-  <p><strong>Disclaimer:</strong> This content is for informational purposes only and does not constitute financial advice. Gold and silver prices fluctuate and past performance is not an indicator of future results. Always consult a qualified financial adviser before making investment decisions. Prices shown are indicative only and may differ from the price offered by any specific dealer.</p>
-</div>
 
 <footer>
   <div class="footer-inner">
@@ -658,6 +1898,70 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
   </div>
 </footer>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+
+<!-- Premium article interactions: reading progress, mobile TOC, scroll-spy -->
+<script>(function(){
+  // Reading progress bar
+  var bar = document.getElementById('waProgress');
+  if (bar) {
+    var ticking = false;
+    function updateProgress(){
+      var scrollTop = window.scrollY || document.documentElement.scrollTop;
+      var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      var pct = docHeight > 0 ? Math.min(100, Math.max(0, (scrollTop / docHeight) * 100)) : 0;
+      bar.style.width = pct + '%';
+      ticking = false;
+    }
+    window.addEventListener('scroll', function(){
+      if (!ticking) { window.requestAnimationFrame(updateProgress); ticking = true; }
+    }, { passive: true });
+    updateProgress();
+  }
+
+  // Mobile TOC toggle
+  var mtocBtn = document.getElementById('waMtocBtn');
+  var mtocPanel = document.getElementById('waMtocPanel');
+  if (mtocBtn && mtocPanel) {
+    mtocBtn.addEventListener('click', function(){
+      var open = mtocPanel.classList.toggle('open');
+      mtocBtn.setAttribute('aria-expanded', open);
+    });
+    mtocPanel.querySelectorAll('a').forEach(function(a){
+      a.addEventListener('click', function(){
+        mtocPanel.classList.remove('open');
+        mtocBtn.setAttribute('aria-expanded', 'false');
+      });
+    });
+  }
+
+  // Desktop TOC scroll-spy
+  var tocLinks = document.querySelectorAll('.wa-toc__list a');
+  if (tocLinks.length && 'IntersectionObserver' in window) {
+    var linksByHash = {};
+    var sections = [];
+    tocLinks.forEach(function(link){
+      var hash = link.getAttribute('href');
+      if (hash && hash.charAt(0) === '#') {
+        linksByHash[hash] = link;
+        var el = document.querySelector(hash);
+        if (el) sections.push(el);
+      }
+    });
+    var spy = new IntersectionObserver(function(entries){
+      entries.forEach(function(entry){
+        var id = '#' + entry.target.id;
+        var link = linksByHash[id];
+        if (!link) return;
+        if (entry.isIntersecting) {
+          tocLinks.forEach(function(l){ l.classList.remove('is-active'); });
+          link.classList.add('is-active');
+        }
+      });
+    }, { rootMargin: '-20% 0px -70% 0px', threshold: 0 });
+    sections.forEach(function(s){ spy.observe(s); });
+  }
+})();</script>
+
 <script>
 let _deepReadFired = false;
 window.addEventListener('scroll', () => {


### PR DESCRIPTION
## Summary

Mobile-first responsive redesign of `/guides/what-affects-gold-price`, transforming it from a flat single-column prose page into a premium editorial article that scales gracefully from 375px to 1440px+.

## What's new

- **Editorial hero** with gold gradient mesh background, Playfair Display headline (with italicised gold accent on "Affects"), reading-time meta, and a 4-card key-metrics grid (gold price, central bank buying, ETF inflows, London market share).
- **Sticky numbered TOC sidebar** on desktop driving scroll-spy; collapses to an accessible accordion on mobile, with the active section highlighted in gold.
- **Fixed reading progress bar** updating in real time as the reader scrolls.
- **5-step LBMA fix process diagram** for the "How is gold priced?" section.
- **12 numbered factor cards** (one per macro driver) mixing prose with bespoke visual treatments — interest-rate timeline (2020 / 2022 / 2025 with up/down arrows), correlation strength meters, big-number stat rows, gold-bordered insight callouts, and Playfair pull quotes for analyst commentary — so each section feels distinct.
- **Quick-reference table** with directional pills (↑ Positive / ↓ Negative) and gold strength dots. Gracefully degrades to a stacked card layout on mobile (no horizontal scroll).
- **Native `<details>` FAQ accordion** with smooth +/× icon rotation.
- **Premium CTA block** with gold gradient + dual buttons.
- **Refreshed metadata + schema** — new meta description and og:description, expanded Article JSON-LD, and a new FAQPage schema covering the 7 Q&A items for richer SERPs.

## Implementation notes

- All new components are scoped under a `wa-` class prefix so nothing in the global stylesheet or sibling guides is affected.
- Playfair Display is added to the existing Google Fonts request for the editorial display type; body remains Inter.
- Touch targets meet 44×44px, tables don't overflow at any breakpoint (verified at 393px), and `prefers-reduced-motion` disables the eyebrow pulse and progress-bar tween.
- Dark + light themes both tested — gold accents and contrast verified in both.

## Test plan

- [x] Mobile (iPhone 14 Pro, 393px) — no horizontal overflow, TOC accordion opens/closes, mobile cards replace the desktop table
- [x] Desktop (1440px) — sticky sidebar TOC visible, scroll-spy highlights the current section (verified jumping to `#f5` activates "Geopolitical risk")
- [x] Reading progress bar updates as user scrolls (37.4% at 85% scroll position in test)
- [x] FAQ accordion opens on click (native details/summary)
- [x] Light + dark mode both rendered cleanly
- [x] All 3 JSON-LD blocks parse (Article, BreadcrumbList, FAQPage)
- [x] Tag balance verified (article/section/div/header/aside/nav/ol/ul/details all open=close)
- [x] Zero JS console errors on load
- [x] All 18 anchor IDs (determined + f1–f12 + gold-silver + forex + who + quick-ref + faq) present and linked from both TOCs

https://claude.ai/code/session_015veGacPi5JE69WF1V1H9nm

---
_Generated by [Claude Code](https://claude.ai/code/session_015veGacPi5JE69WF1V1H9nm)_