### PR TITLE
Fix sticky TOC card overlapping article content on spot-price guide

### DIFF
--- a/guides/how-to-read-gold-spot-price.html
+++ b/guides/how-to-read-gold-spot-price.html
@@ -825,7 +825,7 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
   <meta itemprop="headline" content="How to Read the Gold Spot Price">
 
   <!-- ── TABLE OF CONTENTS ── -->
-  <nav class="toc-card" role="navigation" aria-label="Article contents">
+  <div class="toc-card" role="navigation" aria-label="Article contents">
     <div class="toc-card__title">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h12"/></svg>
       In This Guide
@@ -843,7 +843,7 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
       <li><a href="#mistakes"><span class="toc-num">10</span> Common Reading Mistakes</a></li>
       <li><a href="#faq"><span class="toc-num">11</span> Frequently Asked Questions</a></li>
     </ol>
-  </nav>
+  </div>
 
   <div class="prose">
     <p>These aren't complicated questions, but getting them wrong is surprisingly costly — and surprisingly common. This guide covers the spot price end-to-end: what it is, how it is set, how to convert it across weights and currencies, the relationship between spot and physical prices, and how to make sense of a live gold price chart.</p>


### PR DESCRIPTION
## Summary

Follow-up to #346. The Table of Contents card on `/guides/how-to-read-gold-spot-price` was pinning itself to the viewport and overlapping the article body as readers scrolled.

## Root cause

The TOC was wrapped in a `<nav>` element. The site's global stylesheet has a catch-all `nav { position: sticky; top: 0; z-index: 100; }` rule (originally written for the site header), and the TOC inherited that behaviour.

## Fix

Replaced `<nav class="toc-card">` with `<div class="toc-card" role="navigation" aria-label="Article contents">`. The `role="navigation"` + `aria-label` preserves the landmark for assistive tech without picking up the global `nav` style.

## Verification

- TOC's computed `position` is now `static` (was `sticky`)
- After scrolling 2000px, TOC `getBoundingClientRect().bottom = -593` — fully off-screen as expected
- HTML still validates — zero unclosed tags

## Test plan

- [ ] Visit `/guides/how-to-read-gold-spot-price` and scroll past the TOC — it should disappear like any normal block element
- [ ] Confirm site header nav is still sticky (separate `<nav>`)
- [ ] Screen reader still announces the TOC as a navigation landmark

---
_Generated by [Claude Code](https://claude.ai/code/session_017o2b6Upp2w9h6ykLBuoWar)_