### PR TITLE
Redesign 925 sterling silver guide (mobile-first editorial)

### DIFF
--- a/guides/what-is-925-sterling-silver.html
+++ b/guides/what-is-925-sterling-silver.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
   <script>
-(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
+(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);r.classList.add('s925-js');})();
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -28,7 +28,7 @@
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"What Is 925 Sterling Silver?","description":"What does 925 mean on silver? Complete guide to 925 sterling silver: purity, hallmarks, value, care, and how to tell real sterling from silver-plated items.","url":"https://goldpricetools.com/guides/what-is-925-sterling-silver","datePublished":"2026-04-24","dateModified":"2026-05-20T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-is-925-sterling-silver"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"What Is 925 Sterling Silver?"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What does 925 mean on silver?","acceptedAnswer":{"@type":"Answer","text":"925 means the item is 92.5% pure silver (sterling silver). The remaining 7.5% is typically copper, which improves hardness and durability."}},{"@type":"Question","name":"Is 925 silver worth anything?","acceptedAnswer":{"@type":"Answer","text":"Yes. 925 sterling silver is worth 92.5% of the silver spot price per gram. At $33/troy oz, sterling silver is worth approximately $0.98/g or about 77p/g."}},{"@type":"Question","name":"How do I know if my silver is real 925?","acceptedAnswer":{"@type":"Answer","text":"Look for a 925 hallmark, or in the UK, look for Assay Office marks (London lion passant, Sheffield rose, Edinburgh castle). Magnetic testing (silver is not magnetic), acid testing, or XRF analysis by a jeweller can confirm purity."}},{"@type":"Question","name":"Does 925 silver tarnish?","acceptedAnswer":{"@type":"Answer","text":"Yes, sterling silver tarnishes when the copper alloy reacts with sulphur in the air. Tarnish appears as a yellowish or dark discolouration. It is easily removed with silver polishing cloth or a mild silver cleaner."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is 925 sterling silver?","acceptedAnswer":{"@type":"Answer","text":"925 sterling silver is an alloy of 92.5% pure silver and 7.5% other metals, usually copper. The 925 stamp is the millesimal fineness hallmark confirming this purity. It is the global standard for quality silver jewellery and silverware."}},{"@type":"Question","name":"What does 925 sterling silver mean?","acceptedAnswer":{"@type":"Answer","text":"It means the item is 925 parts per 1,000 pure silver, or 92.5%, the internationally recognised sterling silver standard. The remaining 7.5% is typically copper, added to improve hardness and durability."}},{"@type":"Question","name":"Is 925 sterling silver real silver?","acceptedAnswer":{"@type":"Answer","text":"Yes, absolutely. 925 sterling silver is genuine silver. The copper alloy does not diminish the authenticity of the silver; it simply makes the alloy practical for wearable applications. The 92.5% silver content is confirmed by the 925 hallmark."}},{"@type":"Question","name":"Is sterling silver and 925 silver the same?","acceptedAnswer":{"@type":"Answer","text":"Yes, they are identical. Sterling silver is the name of the 92.5% purity standard; 925 is the numeric hallmark confirming that standard. The terms are completely interchangeable."}},{"@type":"Question","name":"Does 925 sterling silver tarnish?","acceptedAnswer":{"@type":"Answer","text":"Yes, over time. The copper in the alloy reacts with atmospheric sulfur compounds to form silver sulfide, the brown-black surface discolouration known as tarnish. Tarnish is reversible with cleaning and does not damage the silver structurally."}},{"@type":"Question","name":"Does 925 sterling silver turn green?","acceptedAnswer":{"@type":"Answer","text":"It can, particularly on fingers or skin, but this is caused by the copper reacting with skin acids and moisture, not the silver. The green discolouration is harmless and washes off. It is more likely in people with acidic skin pH and can be reduced by keeping jewellery dry and clean."}},{"@type":"Question","name":"Is 925 sterling silver waterproof?","acceptedAnswer":{"@type":"Answer","text":"It will not dissolve in water, but regular water exposure accelerates tarnishing. Chlorinated pool water, saltwater, and hot water are all harmful. It is advisable to remove sterling silver jewellery before swimming, showering, or using cleaning products."}},{"@type":"Question","name":"How much is 925 sterling silver worth?","acceptedAnswer":{"@type":"Answer","text":"At a silver spot price of approximately $74.96/oz (May 2026), 925 sterling silver has a melt value of around $2.23 per gram. A 100-gram sterling silver item has a melt value of about $223. Dealers buying scrap sterling typically offer 75-90% of melt value."}},{"@type":"Question","name":"How do you clean 925 sterling silver?","acceptedAnswer":{"@type":"Answer","text":"The simplest method is warm soapy water with a soft toothbrush for regular maintenance. For tarnish, a baking soda paste or silver polishing cloth works well. Never use bleach, ammonia, toothpaste, or abrasive chemicals on sterling silver."}},{"@type":"Question","name":"What is the difference between 925 sterling silver and silver plated?","acceptedAnswer":{"@type":"Answer","text":"Solid 925 sterling silver is silver alloy throughout; every part of the item contains 92.5% silver. Silver-plated items have a thin silver coating over a base metal core. When the plating wears away, the base metal is exposed. Sterling silver is significantly more valuable and durable than silver plating."}}]}</script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
@@ -424,6 +424,241 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
 </style>
 
 <link rel="stylesheet" href="/assets/site.css">
+<style id="s925-design">
+/* ============================================================
+   925 STERLING SILVER — flagship editorial design (scoped .s925)
+   Mobile-first. Built on site design tokens. Pure-CSS visuals.
+   ============================================================ */
+.s925{--s925-silver:#cbd0d8;--s925-silver-2:#9aa1ad;--s925-copper:#cf8a52;--s925-copper-2:#b06a36}
+[data-theme="light"] .s925{--s925-silver:#aab1bd;--s925-silver-2:#7c8390;--s925-copper:#b8703a;--s925-copper-2:#9a5a2c}
+.s925 section[id]{scroll-margin-top:88px}
+.s925 .prose{max-width:880px}
+.s925 .prose h2{display:flex;align-items:baseline;gap:.55rem;position:relative}
+.s925 .prose h2::before{content:"";flex:none;align-self:center;width:10px;height:10px;border-radius:3px;background:linear-gradient(135deg,var(--color-gold-bright),var(--s925-copper));box-shadow:0 0 0 4px color-mix(in oklch,var(--color-gold-bright) 14%,transparent)}
+
+/* ── HERO ── */
+.s925-hero{display:grid;gap:var(--space-6);align-items:center;margin:var(--space-2) 0 var(--space-4)}
+@media(min-width:840px){.s925-hero{grid-template-columns:1fr minmax(260px,360px);gap:var(--space-10)}}
+.s925-lede{font-size:var(--text-lg);line-height:1.55;color:var(--color-text);max-width:40ch;margin:var(--space-2) 0 var(--space-4);text-wrap:pretty}
+.s925-hero .article-byline{margin-bottom:0;border-bottom:none;padding-bottom:0}
+.s925-hero__visual{justify-self:center;position:relative;width:min(300px,80vw);aspect-ratio:1;display:grid;place-items:center}
+.s925-aura{position:absolute;inset:0;border-radius:50%;background:radial-gradient(circle at 50% 45%,color-mix(in oklch,var(--color-gold-bright) 22%,transparent),transparent 62%)}
+.s925-stamp{position:relative;width:74%;aspect-ratio:1;border-radius:50%;display:grid;place-items:center;text-align:center;background:radial-gradient(circle at 36% 28%,#fbfcfe 0%,#e2e6ec 28%,#bcc2cc 56%,#929aa5 78%,#6f7680 100%);box-shadow:0 20px 44px -14px rgba(0,0,0,.55),inset 0 2px 3px #fff,inset 0 -8px 16px rgba(0,0,0,.32)}
+.s925-stamp::before{content:"";position:absolute;inset:7%;border-radius:50%;border:2px solid rgba(0,0,0,.22)}
+.s925-stamp__num{font-family:var(--font-display);font-weight:700;font-size:clamp(2.5rem,1rem+8vw,3.6rem);color:#363b43;letter-spacing:.02em;line-height:.86;text-shadow:0 1px 0 #fff,0 -1px 1px rgba(0,0,0,.35)}
+.s925-stamp__word{display:block;font-size:clamp(.58rem,.4rem+1vw,.75rem);font-weight:700;letter-spacing:.32em;color:#4a5058;margin-top:7px;text-indent:.32em;text-shadow:0 1px 0 #fff}
+.s925-pill{position:absolute;font-size:var(--text-xs);font-weight:700;padding:7px 12px;border-radius:var(--radius-full);background:var(--color-surface);border:1px solid var(--color-border);color:var(--color-text);box-shadow:var(--shadow-md);font-variant-numeric:tabular-nums}
+.s925-pill--a{top:4%;right:-2%}
+.s925-pill--b{bottom:7%;left:-4%}
+.s925-pill b{color:var(--color-silver)}
+
+/* ── STAT STRIP ── */
+.s925-stats{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin:var(--space-2) 0 var(--space-6)}
+@media(min-width:600px){.s925-stats{grid-template-columns:repeat(4,1fr)}}
+.s925-stat{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.s925-stat__v{font-family:var(--font-display);font-weight:700;font-size:var(--text-lg);line-height:1.05;color:var(--color-text);font-variant-numeric:tabular-nums}
+.s925-stat__v.is-gold{color:var(--color-gold-bright)}
+.s925-stat__v.is-silver{color:var(--color-silver)}
+.s925-stat__v.is-copper{color:var(--s925-copper)}
+.s925-stat__l{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:6px;text-transform:uppercase;letter-spacing:.05em}
+
+/* ── TOC ── */
+.s925-toc{background:color-mix(in oklch,var(--color-primary) 5%,var(--color-surface));border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-5) var(--space-4);margin:var(--space-6) 0}
+.s925-toc__h{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.s925-toc__grid{display:grid;grid-template-columns:1fr;gap:1px}
+@media(min-width:620px){.s925-toc__grid{grid-template-columns:1fr 1fr;column-gap:var(--space-6)}}
+.s925-toc a{display:flex;gap:10px;align-items:baseline;padding:9px 8px;border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;min-height:40px}
+.s925-toc a:hover{color:var(--color-primary);background:var(--color-surface-offset)}
+.s925-toc a span{color:var(--color-gold-bright);font-weight:700;font-variant-numeric:tabular-nums;flex:none}
+
+/* ── COMPOSITION DONUT ── */
+.s925-comp{display:grid;gap:var(--space-6);align-items:center;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);box-shadow:var(--shadow-sm);margin:var(--space-6) 0}
+@media(min-width:680px){.s925-comp{grid-template-columns:auto 1fr;gap:var(--space-8);padding:var(--space-8)}}
+.s925-donut{--p:92.5;width:min(220px,58vw);aspect-ratio:1;border-radius:50%;justify-self:center;position:relative;display:grid;place-items:center;background:conic-gradient(var(--s925-silver) 0 calc(var(--p)*1%),var(--s925-copper) calc(var(--p)*1%) 100%);box-shadow:var(--shadow-md),inset 0 0 0 1px rgba(255,255,255,.08)}
+.s925-donut::after{content:"";position:absolute;inset:24%;border-radius:50%;background:var(--color-surface);box-shadow:inset 0 1px 7px rgba(0,0,0,.2)}
+.s925-donut__hole{position:relative;z-index:1;text-align:center}
+.s925-donut__pct{display:block;font-family:var(--font-display);font-weight:700;font-size:clamp(1.6rem,1rem+3.4vw,2.2rem);color:var(--color-text);font-variant-numeric:tabular-nums;line-height:1}
+.s925-donut__cap{display:block;font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.1em;margin-top:5px}
+.s925-legend{display:grid;gap:var(--space-3)}
+.s925-leg{display:flex;align-items:flex-start;gap:var(--space-3)}
+.s925-leg__sw{flex:none;width:15px;height:15px;border-radius:5px;margin-top:3px}
+.s925-leg__sw--ag{background:var(--s925-silver)}
+.s925-leg__sw--cu{background:var(--s925-copper)}
+.s925-leg__t{font-weight:700;color:var(--color-text)}
+.s925-leg__t b{font-variant-numeric:tabular-nums}
+.s925-leg__d{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.5;margin:2px 0 0}
+
+/* ── ANSWER CARD ── */
+.s925-answer{display:flex;gap:var(--space-4);align-items:flex-start;background:var(--color-surface);border:1px solid var(--color-border);border-left:4px solid var(--color-up,#4ade80);border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-5) 0}
+.s925-answer__ic{flex:none;width:40px;height:40px;border-radius:50%;display:grid;place-items:center;background:color-mix(in oklch,var(--color-up,#4ade80) 16%,var(--color-surface));color:var(--color-up,#4ade80)}
+.s925-answer__q{font-weight:700;color:var(--color-text);margin:0 0 4px}
+.s925-answer__a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+.s925-answer__a b{color:var(--color-text)}
+
+/* ── GENERIC CARD GRID ── */
+.s925-grid{display:grid;gap:var(--space-4);grid-template-columns:1fr;margin:var(--space-5) 0}
+@media(min-width:560px){.s925-grid--2{grid-template-columns:1fr 1fr}.s925-grid--4{grid-template-columns:1fr 1fr}}
+@media(min-width:560px){.s925-grid--3{grid-template-columns:1fr 1fr}}
+@media(min-width:900px){.s925-grid--3{grid-template-columns:repeat(3,1fr)}.s925-grid--4{grid-template-columns:repeat(4,1fr)}}
+.s925-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.s925-card__ic{width:42px;height:42px;border-radius:var(--radius-md);display:grid;place-items:center;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface));color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.s925-card__ic--silver{background:color-mix(in oklch,var(--color-silver) 16%,var(--color-surface));color:var(--color-silver)}
+.s925-card__t{font-weight:700;color:var(--color-text);margin:0 0 6px;font-size:var(--text-base)}
+.s925-card__d{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+
+/* ── TIMELINE ── */
+.s925-timeline{display:flex;flex-direction:column;margin:var(--space-6) 0}
+.s925-tl{position:relative;padding:0 0 var(--space-6) var(--space-8)}
+.s925-tl:last-child{padding-bottom:0}
+.s925-tl::before{content:"";position:absolute;left:9px;top:8px;bottom:0;width:2px;background:var(--color-border)}
+.s925-tl:last-child::before{display:none}
+.s925-tl::after{content:"";position:absolute;left:1px;top:5px;width:18px;height:18px;border-radius:50%;background:var(--color-gold-bright);box-shadow:0 0 0 4px color-mix(in oklch,var(--color-gold-bright) 16%,transparent)}
+.s925-tl__y{font-family:var(--font-display);font-weight:700;color:var(--color-gold-bright);font-size:var(--text-base);font-variant-numeric:tabular-nums}
+.s925-tl__t{font-weight:700;color:var(--color-text);margin:1px 0 4px}
+.s925-tl__d{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0;max-width:64ch}
+
+/* ── STAMP VARIATION CARDS ── */
+.s925-marks{display:grid;gap:var(--space-3);grid-template-columns:1fr;margin:var(--space-5) 0}
+@media(min-width:540px){.s925-marks{grid-template-columns:1fr 1fr}}
+@media(min-width:920px){.s925-marks{grid-template-columns:repeat(3,1fr)}}
+.s925-mark{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);display:flex;flex-direction:column;gap:8px}
+.s925-mark__tag{align-self:flex-start;font-family:var(--font-display);font-weight:700;font-size:var(--text-lg);letter-spacing:.03em;color:var(--color-text);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:5px 13px;font-variant-numeric:tabular-nums}
+.s925-mark__m{font-size:var(--text-sm);color:var(--color-text);font-weight:600}
+.s925-mark__c{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.5;margin:0}
+
+/* ── COMPARE TWO-COL ── */
+.s925-compare{display:grid;gap:var(--space-4);grid-template-columns:1fr;margin:var(--space-5) 0}
+@media(min-width:640px){.s925-compare{grid-template-columns:1fr 1fr}}
+.s925-cc{border-radius:var(--radius-lg);padding:var(--space-5);border:1px solid var(--color-border)}
+.s925-cc--good{background:color-mix(in oklch,var(--color-up,#4ade80) 7%,var(--color-surface));border-color:color-mix(in oklch,var(--color-up,#4ade80) 28%,var(--color-border))}
+.s925-cc--bad{background:color-mix(in oklch,var(--s925-copper) 7%,var(--color-surface));border-color:color-mix(in oklch,var(--s925-copper) 26%,var(--color-border))}
+.s925-cc__h{display:flex;align-items:center;gap:10px;font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.s925-cc--good .s925-cc__h svg{color:var(--color-up,#4ade80)}
+.s925-cc--bad .s925-cc__h svg{color:var(--s925-copper)}
+.s925-cc p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+
+/* ── NUMBERED TESTS ── */
+.s925-tests{display:grid;gap:var(--space-3);margin:var(--space-5) 0}
+.s925-test{display:flex;gap:var(--space-4);align-items:flex-start;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5)}
+.s925-test__n{flex:none;width:34px;height:34px;border-radius:50%;display:grid;place-items:center;background:var(--color-gold-bright);color:#0f0e0c;font-weight:700;font-variant-numeric:tabular-nums}
+.s925-test__t{font-weight:700;color:var(--color-text);margin:0 0 3px}
+.s925-test__d{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+
+/* ── CALLOUTS ── */
+.s925-note{display:flex;gap:var(--space-3);align-items:flex-start;border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);margin:var(--space-5) 0;border:1px solid var(--color-border);background:var(--color-surface-offset)}
+.s925-note__ic{flex:none;color:var(--color-primary);margin-top:1px}
+.s925-note p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+.s925-note p+p{margin-top:var(--space-2)}
+.s925-note b{color:var(--color-text)}
+.s925-note--info{border-left:4px solid var(--color-primary)}
+.s925-note--gold{border-left:4px solid var(--color-gold-bright)}
+.s925-note--gold .s925-note__ic{color:var(--color-gold-bright)}
+.s925-note--warn{border-left:4px solid var(--s925-copper);background:color-mix(in oklch,var(--s925-copper) 6%,var(--color-surface))}
+.s925-note--warn .s925-note__ic{color:var(--s925-copper)}
+
+/* ── WARNING CHIPS ── */
+.s925-chips{display:flex;flex-wrap:wrap;gap:var(--space-2);margin:var(--space-4) 0}
+.s925-wchip{display:inline-flex;align-items:center;gap:8px;padding:9px 14px;border-radius:var(--radius-full);background:color-mix(in oklch,var(--s925-copper) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--s925-copper) 24%,var(--color-border));font-size:var(--text-sm);color:var(--color-text)}
+.s925-wchip svg{color:var(--s925-copper);flex:none}
+.s925-chips--neutral .s925-wchip{background:var(--color-surface-offset);border-color:var(--color-border)}
+.s925-chips--neutral .s925-wchip svg{color:var(--color-text-muted)}
+
+/* ── FACTS LIST ── */
+.s925-facts{list-style:none;padding:0;margin:var(--space-4) 0;display:grid;gap:var(--space-3)}
+.s925-facts li{display:flex;gap:12px;align-items:flex-start;font-size:var(--text-base);color:var(--color-text-muted);line-height:1.6;max-width:72ch}
+.s925-facts svg{flex:none;color:var(--color-up,#4ade80);margin-top:3px}
+.s925-facts b{color:var(--color-text)}
+
+/* ── WATER SEVERITY ── */
+.s925-water{display:grid;gap:var(--space-2);margin:var(--space-5) 0}
+.s925-wrow{display:grid;grid-template-columns:auto 1fr;gap:var(--space-3);align-items:start;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4)}
+.s925-sev{align-self:start;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;padding:5px 10px;border-radius:var(--radius-full);white-space:nowrap}
+.s925-sev--high{background:color-mix(in oklch,var(--color-down,#f87171) 16%,var(--color-surface));color:var(--color-down,#f87171)}
+.s925-sev--med{background:color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-surface));color:var(--color-gold-bright)}
+.s925-wrow p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.5}
+.s925-wrow b{color:var(--color-text)}
+
+/* ── CLEANING METHODS ── */
+.s925-methods{display:grid;gap:var(--space-4);grid-template-columns:1fr;margin:var(--space-5) 0}
+@media(min-width:680px){.s925-methods{grid-template-columns:1fr 1fr}}
+.s925-method{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
+.s925-method__b{display:inline-block;font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px}
+.s925-method__t{font-weight:700;color:var(--color-text);font-size:var(--text-base);margin:0 0 var(--space-3)}
+.s925-method ol{margin:0;padding-left:1.15rem;display:grid;gap:7px}
+.s925-method li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.5}
+.s925-method>p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+
+/* ── VALUE: FORMULA + TABLE + PRICES ── */
+.s925-formula{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-5) 0;text-align:center}
+.s925-formula__eq{font-family:var(--font-display);font-size:var(--text-base);color:var(--color-text);line-height:1.7;font-variant-numeric:tabular-nums}
+.s925-formula__eq b{color:var(--color-gold-bright)}
+.s925-formula__n{font-size:var(--text-xs);color:var(--color-text-muted);margin:var(--space-3) 0 0}
+.s925-vtable{width:100%;border-collapse:collapse;margin:var(--space-5) 0;font-variant-numeric:tabular-nums}
+.s925-vtable caption{text-align:left;font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.s925-vtable th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:var(--color-text-muted);padding:var(--space-3);border-bottom:2px solid var(--color-border)}
+.s925-vtable td{padding:var(--space-3);border-bottom:1px solid var(--color-divider);color:var(--color-text)}
+.s925-vtable td:last-child,.s925-vtable th:last-child{text-align:right;color:var(--color-gold-bright);font-weight:700}
+.s925-vtable tr:last-child td{border-bottom:none}
+.s925-vtable tbody tr:hover{background:var(--color-surface-offset)}
+.s925-prices{display:grid;gap:var(--space-3);grid-template-columns:1fr;margin:var(--space-5) 0}
+@media(min-width:560px){.s925-prices{grid-template-columns:repeat(3,1fr)}}
+.s925-price{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-align:center;box-shadow:var(--shadow-sm)}
+.s925-price__l{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
+.s925-price__v{font-family:var(--font-display);font-weight:700;font-size:var(--text-xl);color:var(--color-gold-bright);font-variant-numeric:tabular-nums;margin:7px 0 2px}
+.s925-price__s{font-size:var(--text-xs);color:var(--color-text-muted)}
+
+/* ── ESTIMATOR ── */
+.s925-est{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface)),var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-6);margin:var(--space-6) 0}
+.s925-est__t{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:0 0 4px}
+.s925-est__sub{font-size:var(--text-sm);color:var(--color-text-muted);margin:0 0 var(--space-4)}
+.s925-est__row{display:grid;gap:var(--space-4);grid-template-columns:1fr;align-items:end}
+@media(min-width:560px){.s925-est__row{grid-template-columns:1fr auto}}
+.s925-est label{font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);display:block;margin-bottom:8px}
+.s925-est input{width:100%;padding:12px 16px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);min-height:48px}
+.s925-est input:focus{border-color:var(--color-primary);outline:none;background:var(--color-surface-2)}
+.s925-est__out{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:10px 22px;text-align:center;min-width:150px}
+.s925-est__out .v{display:block;font-family:var(--font-display);font-weight:700;font-size:var(--text-xl);color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.2}
+.s925-est__out .l{font-size:var(--text-xs);color:var(--color-text-muted)}
+.s925-est__n{font-size:var(--text-xs);color:var(--color-text-muted);margin:var(--space-3) 0 0}
+.s925-est__n a{color:var(--color-primary)}
+
+/* ── QUALITY TIERS ── */
+.s925-tiers{display:grid;gap:8px;margin:var(--space-5) 0}
+.s925-tier{display:grid;grid-template-columns:1fr;gap:8px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4)}
+@media(min-width:640px){.s925-tier{grid-template-columns:160px 1fr 180px;align-items:center;gap:var(--space-4)}}
+.s925-tier--hl{border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface))}
+.s925-tier__name b{color:var(--color-text)}
+.s925-tier__name span{display:block;font-size:var(--text-xs);color:var(--color-text-muted);font-variant-numeric:tabular-nums;margin-top:1px}
+.s925-tier__bar{height:9px;border-radius:99px;background:var(--color-surface-dynamic);overflow:hidden}
+.s925-tier__bar i{display:block;height:100%;border-radius:99px;background:linear-gradient(90deg,var(--s925-silver-2),var(--s925-silver))}
+.s925-tier--hl .s925-tier__bar i{background:linear-gradient(90deg,var(--color-gold),var(--color-gold-bright))}
+.s925-tier__note{font-size:var(--text-sm);color:var(--color-text-muted)}
+.s925-tier--hl .s925-tier__note{color:var(--color-text);font-weight:600}
+
+/* ── FAQ ACCORDION ── */
+.s925-faq{display:grid;gap:var(--space-3);margin:var(--space-5) 0}
+.s925-faq details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden}
+.s925-faq details[open]{border-color:color-mix(in oklch,var(--color-primary) 40%,var(--color-border))}
+.s925-faq summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);padding:var(--space-4) var(--space-5);font-weight:700;color:var(--color-text);font-size:var(--text-base);min-height:56px}
+.s925-faq summary::-webkit-details-marker{display:none}
+.s925-faq summary .ic{flex:none;color:var(--color-primary);transition:transform .25s ease}
+.s925-faq details[open] summary .ic{transform:rotate(45deg)}
+.s925-faq summary:hover{color:var(--color-primary)}
+.s925-faq__a{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65}
+.s925-faq__a p{margin:0}
+.s925-faq__a b{color:var(--color-text)}
+
+/* ── REVEAL ON SCROLL ── */
+.s925-js .s925-reveal{opacity:0;transform:translateY(18px)}
+.s925-js .s925-reveal.is-in{opacity:1;transform:none;transition:opacity .6s ease-out,transform .6s ease-out}
+@media(prefers-reduced-motion:reduce){.s925-js .s925-reveal{opacity:1!important;transform:none!important}}
+
+/* ── RELATED CARD TAG (was unstyled) ── */
+.s925 ~ .related-guides .related-card__tag,.related-guides .related-card__tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:#8B6914;margin-bottom:2px}
+.related-guides .container{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
+.related-guides{padding:var(--space-4) 0 var(--space-10)}
+.related-guides h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:0 0 var(--space-5);max-width:1200px;margin-left:auto;margin-right:auto;padding:0 var(--space-4)}
+</style>
 <!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
 </head>
@@ -505,85 +740,421 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
   </ol>
 </div>
 
-<article class="article-wrap" itemscope itemtype="https://schema.org/Article">
-  <div class="article-tag">Silver Guide</div>
-  <h1 class="article-title" itemprop="headline">What Is 925 Sterling Silver?</h1>
-  <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
-    <span>&middot;</span>
-    <span>Published <time datetime="2026-05-20" itemprop="dateModified">3 May 2026</time></span>
-    <span>&middot;</span>
-    <span>Updated <time datetime="2026-05-20" itemprop="dateModified">3 May 2026</time></span>
+<article class="article-wrap s925" itemscope itemtype="https://schema.org/Article">
+  <header class="s925-hero">
+    <div class="s925-hero__content">
+      <div class="article-tag">Silver Guide</div>
+      <h1 class="article-title" itemprop="headline">What Is 925 Sterling Silver?</h1>
+      <p class="s925-lede">Pick up almost any piece of silver jewellery and look for a small stamped number &mdash; chances are it says <strong>925</strong>. That tiny hallmark means real silver, at a purity standard used for centuries.</p>
+      <div class="article-byline">
+        <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
+        <span>&middot;</span>
+        <span>Published <time datetime="2026-04-24" itemprop="datePublished">24 April 2026</time></span>
+        <span>&middot;</span>
+        <span>Updated <time datetime="2026-05-20" itemprop="dateModified">20 May 2026</time></span>
+      </div>
+    </div>
+    <div class="s925-hero__visual" aria-hidden="true">
+      <div class="s925-aura"></div>
+      <div class="s925-stamp">
+        <div>
+          <span class="s925-stamp__num">925</span>
+          <span class="s925-stamp__word">STERLING</span>
+        </div>
+      </div>
+      <span class="s925-pill s925-pill--a">.925</span>
+      <span class="s925-pill s925-pill--b"><b>S</b>925</span>
+    </div>
+  </header>
+
+  <div class="s925-stats">
+    <div class="s925-stat"><div class="s925-stat__v is-silver">92.5%</div><div class="s925-stat__l">Pure silver</div></div>
+    <div class="s925-stat"><div class="s925-stat__v is-copper">7.5%</div><div class="s925-stat__l">Copper alloy</div></div>
+    <div class="s925-stat"><div class="s925-stat__v">1300</div><div class="s925-stat__l">Standard since</div></div>
+    <div class="s925-stat"><div class="s925-stat__v is-gold">~$2.23</div><div class="s925-stat__l">Melt / gram</div></div>
   </div>
 
   <div class="prose">
-    <p>925 sterling silver is an alloy containing <strong>92.5% pure silver</strong> and 7.5% other metals, typically copper. The &ldquo;925&rdquo; stamp is the hallmark that confirms this purity level. Sterling silver has been the standard for silverware, jewellery, and coins in the UK since at least the 14th century, and remains the most widely traded silver purity worldwide.</p>
+    <p>That tiny hallmark carries a lot of meaning. It tells you the metal is real silver, that it meets an internationally recognised purity standard, and that it is the same material used for fine jewellery, cutlery, and silverware for centuries. But it also raises questions most people have never had properly answered: What does 925 actually mean? Is it the same as sterling silver? Does it tarnish? Will it turn your finger green? Is it worth anything?</p>
+    <p>This guide answers every one of those questions &mdash; clearly, accurately, and in enough depth that you&rsquo;ll understand sterling silver better than most people who sell it.</p>
 
-    <h2>925 Sterling Silver Facts</h2>
-    <table class="data-table" aria-label="925 sterling silver facts">
-      <thead><tr><th>Property</th><th>Value</th></tr></thead>
-      <tbody>
-        <tr><td>Purity</td><td>92.5% silver (925 fineness)</td></tr>
-        <tr><td>UK hallmark</td><td>925 + Assay Office mark (lion passant for London)</td></tr>
-        <tr><td>Alloy metals</td><td>Usually copper (7.5%); sometimes zinc or germanium</td></tr>
-        <tr><td>Tarnish resistance</td><td>Moderate (copper reacts with sulphur)</td></tr>
-        <tr><td>UK VAT on physical</td><td>20% VAT (unlike investment gold)</td></tr>
-        <tr><td>Hypoallergenic?</td><td>Usually yes (nickel-free 925 is hypoallergenic)</td></tr>
-      </tbody>
-    </table>
+    <nav class="s925-toc" aria-label="In this guide">
+      <div class="s925-toc__h">In this guide</div>
+      <div class="s925-toc__grid">
+        <a href="#meaning"><span>01</span> What 925 sterling silver means</a>
+        <a href="#why-alloyed"><span>02</span> Why pure silver is alloyed</a>
+        <a href="#history"><span>03</span> History of the 925 standard</a>
+        <a href="#variations"><span>04</span> 925, .925, S925 &amp; AG925</a>
+        <a href="#hallmark"><span>05</span> Identifying the hallmark</a>
+        <a href="#real"><span>06</span> Is it real silver?</a>
+        <a href="#tarnish"><span>07</span> Does it tarnish?</a>
+        <a href="#green"><span>08</span> Does it turn fingers green?</a>
+        <a href="#waterproof"><span>09</span> Is it waterproof?</a>
+        <a href="#clean"><span>10</span> How to clean it</a>
+        <a href="#worth"><span>11</span> How much it&rsquo;s worth</a>
+        <a href="#quality"><span>12</span> Is it good quality?</a>
+        <a href="#vs"><span>13</span> Sterling vs 925 silver</a>
+        <a href="#plated"><span>14</span> &ldquo;Sterling silver plated&rdquo;</a>
+        <a href="#faq"><span>15</span> Frequently asked questions</a>
+      </div>
+    </nav>
 
-    <h2>What Is 925 Silver Worth Per Gram?</h2>
-    <p>Sterling silver is worth 92.5% of the pure (999) silver spot price. At $33 per troy ounce (XAG/USD), the calculation is:</p>
-    <div class="callout">
-      <p><strong>$33 &divide; 31.1035 = $1.062/g (fine silver) &times; 0.925 = $0.982/g (sterling silver)</strong><br>At GBP/USD 0.79: approximately <strong>77.6p per gram for sterling silver</strong>. Our live calculator shows today&rsquo;s exact rate.</p>
-    </div>
+    <section id="meaning">
+      <h2>What Does 925 Sterling Silver Mean?</h2>
+      <p>The &ldquo;925&rdquo; stamp on silver jewellery and silverware is a <strong>millesimal fineness mark</strong> &mdash; a number that tells you exactly what proportion of the item is pure silver, expressed as parts per thousand.</p>
 
-    <h2>How to Identify Real 925 Sterling Silver</h2>
-    <ul>
-      <li><strong>Look for the hallmark:</strong> In the UK, genuine sterling silver will have a &ldquo;925&rdquo; stamp plus an Assay Office mark (lion passant for London, crown for Sheffield, castle for Edinburgh)</li>
-      <li><strong>Magnet test:</strong> Real silver is not magnetic. If a magnet sticks strongly, it&rsquo;s likely a base metal with silver plating</li>
-      <li><strong>Tarnish test:</strong> Genuine silver tarnishes slowly to yellow/grey. Silver-plated items tarnish faster and more unevenly</li>
-      <li><strong>Acid test:</strong> A jeweller can apply nitric acid; sterling silver produces a creamy white reaction</li>
-      <li><strong>XRF analysis:</strong> The most accurate test &mdash; available at most reputable jewellers and assay offices</li>
-    </ul>
+      <div class="s925-comp s925-reveal">
+        <div class="s925-donut" role="img" aria-label="Sterling silver composition: 92.5 percent pure silver, 7.5 percent copper">
+          <div class="s925-donut__hole">
+            <span class="s925-donut__pct">92.5%</span>
+            <span class="s925-donut__cap">Pure silver</span>
+          </div>
+        </div>
+        <div class="s925-legend">
+          <div class="s925-leg">
+            <span class="s925-leg__sw s925-leg__sw--ag" aria-hidden="true"></span>
+            <div><div class="s925-leg__t">Pure silver &mdash; <b>92.5%</b></div><p class="s925-leg__d">925 parts per 1,000 are genuine, refined silver.</p></div>
+          </div>
+          <div class="s925-leg">
+            <span class="s925-leg__sw s925-leg__sw--cu" aria-hidden="true"></span>
+            <div><div class="s925-leg__t">Copper alloy &mdash; <b>7.5%</b></div><p class="s925-leg__d">Added to make the metal harder, more durable and practical for everyday use.</p></div>
+          </div>
+        </div>
+      </div>
 
-    <h2>Sterling vs Silver-Plated: What&rsquo;s the Difference?</h2>
-    <p>Silver-plated items have only a thin layer of silver over a base metal (usually brass or copper). The silver content is negligible &mdash; typically less than 1% of the item&rsquo;s weight. Silver-plated jewellery and silverware have almost no scrap value. Sterling silver items are solid silver alloy throughout and have real melt value based on weight and purity.</p>
+      <p>This specific blend &mdash; 92.5% silver, 7.5% copper &mdash; is what the world recognises as <strong>sterling silver</strong>, a standard in use for hundreds of years and still the global benchmark for quality silver jewellery and silverware today. So when someone asks &ldquo;what is 925 sterling silver?&rdquo; the answer is: it is real silver alloy at 92.5% purity, internationally recognised as the sterling standard, confirmed by the 925 hallmark.</p>
 
-    <h2>Caring for 925 Sterling Silver</h2>
-    <p>To slow tarnishing: store silver in anti-tarnish bags or with silica gel; avoid exposure to chlorine, bleach, and perfumes; remove jewellery before swimming or cleaning. To remove tarnish: use a specialist silver polishing cloth (e.g. Goddard&rsquo;s), mild silver dip, or a baking soda paste for heavier tarnish.</p>
+      <div class="s925-answer s925-answer--yes s925-reveal">
+        <span class="s925-answer__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></span>
+        <div>
+          <p class="s925-answer__q">Is 925 silver the same as sterling silver?</p>
+          <p class="s925-answer__a"><b>Yes, completely.</b> &ldquo;925 silver,&rdquo; &ldquo;.925 silver,&rdquo; &ldquo;sterling silver&rdquo; and &ldquo;925 sterling silver&rdquo; all describe exactly the same material &mdash; 92.5% pure silver alloyed with 7.5% copper. The terms are interchangeable.</p>
+        </div>
+      </div>
+    </section>
 
-    <h2>The History of the 925 Hallmark</h2>
-    <p>Sterling silver's 92.5% standard dates to 13th-century England, when the English Crown established a minimum silver content for coinage. The word "sterling" may derive from "Easterling" (the Hanseatic League merchants whose coins were known for consistent quality) or from the Old Norman French word for "little star" (which appeared on early Norman pennies).</p>
-    <p>The <strong>925 hallmark</strong> means 925 parts per thousand of pure silver — equivalent to 92.5%. It is applied in the UK by one of the four Assay Offices (London, Birmingham, Sheffield, Edinburgh) and is the most common silver standard in UK and US jewellery, flatware, and decorative items. You may also encounter the mark <strong>STER</strong> or <strong>STERLING</strong> on older American pieces.</p>
+    <section id="why-alloyed">
+      <h2>Why Pure Silver Needs to Be Alloyed</h2>
+      <p>A question that often follows the definition is: why not just use 99.9% pure silver? The answer is practical &mdash; <strong>pure silver is far too soft</strong> for most applications. Fine silver (marked 999) is beautiful but extremely malleable: it bends, scratches and deforms easily under everyday wear. A pure silver ring would be scratched within days; a pure silver fork would bend under moderate pressure. That is why fine silver is used for bullion bars and some coins &mdash; items that aren&rsquo;t handled repeatedly.</p>
+      <p>By alloying silver with 7.5% copper, silversmiths achieve a metal that strikes a genuinely optimal balance between purity and practicality:</p>
 
-    <h2>Why Copper? The Role of Alloy in Sterling Silver</h2>
-    <p>Pure silver (999 fine) is too soft for most practical applications — it bends easily and scratches quickly. Adding <strong>7.5% copper</strong> to create 925 sterling dramatically increases hardness and durability while preserving silver's bright appearance and lustre. Copper is the preferred alloy partner because it is compatible with silver's melting temperature and doesn't significantly alter the colour.</p>
-    <p>Some modern sterling alloys replace part of the copper with <strong>germanium</strong> (Argentium silver) or <strong>platinum</strong> to improve tarnish resistance, though these are more expensive to produce and less common in standard UK hallmarked items.</p>
+      <div class="s925-grid s925-grid--4">
+        <div class="s925-card">
+          <span class="s925-card__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3 6 6 .9-4.5 4.2L18 20l-6-3.2L6 20l1.5-6.9L3 8.9 9 8z"/></svg></span>
+          <h3 class="s925-card__t">Substantially harder</h3>
+          <p class="s925-card__d">Durable enough for everyday jewellery and flatware, unlike soft pure silver.</p>
+        </div>
+        <div class="s925-card">
+          <span class="s925-card__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M5 5l2 2M17 17l2 2M19 5l-2 2M7 17l-2 2"/></svg></span>
+          <h3 class="s925-card__t">Keeps its lustre</h3>
+          <p class="s925-card__d">Maintains silver&rsquo;s characteristic bright, reflective appearance.</p>
+        </div>
+        <div class="s925-card">
+          <span class="s925-card__ic s925-card__ic--silver" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z"/><path d="M12 12l8-4.5M12 12v9M12 12L4 7.5"/></svg></span>
+          <h3 class="s925-card__t">High silver content</h3>
+          <p class="s925-card__d">92.5% is a very high purity for a working, wearable alloy.</p>
+        </div>
+        <div class="s925-card">
+          <span class="s925-card__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a4 4 0 0 0-5.4 5.4l-6 6V21h3.3l6-6a4 4 0 0 0 5.4-5.4l-2.3 2.3-2-2z"/></svg></span>
+          <h3 class="s925-card__t">Remains workable</h3>
+          <p class="s925-card__d">Can be cast, formed, stamped and engraved with precision.</p>
+        </div>
+      </div>
 
-    <h2>Understanding Tarnish: Causes and Prevention</h2>
-    <p>Sterling silver tarnishes through a chemical reaction between the copper alloy and <strong>hydrogen sulphide</strong> (H₂S) in the atmosphere, forming a dark layer of silver sulphide on the surface. Tarnish is accelerated by:</p>
-    <ul>
-      <li>Humidity and moisture</li>
-      <li>Exposure to rubber, wool, eggs, and onions (high sulphur content)</li>
-      <li>Chlorine (swimming pools, tap water)</li>
-      <li>Skin contact (perspiration contains sulphur compounds)</li>
-      <li>Air pollution in urban environments</li>
-    </ul>
-    <p>To slow tarnishing: store silver in <strong>anti-tarnish pouches</strong> or zip-lock bags with the air squeezed out, avoid contact with rubber bands, and clean regularly with a <strong>microfibre silver cloth</strong>. For heavily tarnished pieces, an electrolytic cleaning bath (aluminium foil + bicarbonate of soda + hot water) removes tarnish safely without abrasion.</p>
+      <p>The 92.5/7.5 ratio has stood the test of time not because it was arbitrary, but because it represents a real sweet spot: higher silver content produces too soft an alloy, while lower silver content reduces quality and value without proportionate gains in hardness.</p>
+    </section>
 
-    <h2>Calculating 925 Sterling Silver Melt Value</h2>
-    <p>The melt value of sterling silver items is straightforward to calculate:</p>
-    <ol>
-      <li>Weigh the item in grams (remove any non-silver components — handles, clasps made from other metals)</li>
-      <li>Find the current silver spot price per gram (use our <a href="/silver-price-per-kilo">silver calculator</a>)</li>
-      <li>Multiply: <strong>Melt value = weight (g) × silver gram price × 0.925</strong></li>
-    </ol>
-    <p>Example: 100g sterling silver tea spoons, silver at £0.82/g: 100 × £0.82 × 0.925 = <strong>£75.85 melt value</strong>.</p>
-    <p>Note: UK scrap silver dealers typically pay 70–90% of melt value. For antique or designer sterling pieces in good condition, specialist dealers or auction houses may offer significantly more than melt value.</p>
+    <section id="history">
+      <h2>The History of the 925 Sterling Standard</h2>
+      <p>The word &ldquo;sterling&rdquo; predates the 925 hallmark by centuries. Its exact origin is disputed &mdash; some trace it to the Old English &ldquo;steorling&rdquo; (little star) on early Norman coins, others to the Easterling merchants of the Hanseatic League who traded silver in medieval England.</p>
 
-    <h2>Internal Links</h2>
-    <p>For live silver melt value calculations, see our <a href="/silver-price-per-kilo">silver price per gram calculator</a>. For silver price by the kilogram, see <a href="/silver-price-per-kilo">silver price per kilo</a>. For lower-purity silver standards (800, 900), see our <a href="/800-silver-price-per-gram">800 silver</a> and <a href="/900-silver-price-per-gram">900 silver</a> pages.</p>
+      <div class="s925-timeline s925-reveal">
+        <div class="s925-tl">
+          <div class="s925-tl__y">1300</div>
+          <div class="s925-tl__t">English law sets the standard</div>
+          <p class="s925-tl__d">King Edward I mandates that silver articles meet a minimum 92.5% composition. The London Goldsmiths&rsquo; Company is granted authority to test and hallmark silver &mdash; a role assay offices still perform. It is one of the oldest quality specifications still in active commercial use.</p>
+        </div>
+        <div class="s925-tl">
+          <div class="s925-tl__y">19th&ndash;20th c.</div>
+          <div class="s925-tl__t">The numeric &ldquo;925&rdquo; mark spreads</div>
+          <p class="s925-tl__d">As international trade grew, a universal numeric millesimal mark became preferable to national symbolic hallmarks that were hard to read across borders. Today the 925 mark is understood and accepted in virtually every market worldwide.</p>
+        </div>
+        <div class="s925-tl">
+          <div class="s925-tl__y">Modern</div>
+          <div class="s925-tl__t">A single global benchmark</div>
+          <p class="s925-tl__d">US colonial silversmiths once worked to the 91.5% London standard, but the modern US Federal Trade Commission recognises sterling as requiring at least 92.5% pure silver &mdash; the same standard used globally.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="variations">
+      <h2>925, .925, S925 and AG925 &mdash; What&rsquo;s the Difference?</h2>
+      <p>Several variations of the sterling stamp exist. They almost all mean the same thing &mdash; 92.5% silver &mdash; but knowing each avoids confusion:</p>
+
+      <div class="s925-marks s925-reveal">
+        <div class="s925-mark"><span class="s925-mark__tag">925</span><span class="s925-mark__m">92.5% pure silver &mdash; sterling</span><p class="s925-mark__c">The global standard, used worldwide.</p></div>
+        <div class="s925-mark"><span class="s925-mark__tag">.925</span><span class="s925-mark__m">Decimal format &mdash; same as 925</span><p class="s925-mark__c">Common in American and international markets.</p></div>
+        <div class="s925-mark"><span class="s925-mark__tag">S925</span><span class="s925-mark__m">&ldquo;Sterling 925&rdquo; &mdash; same purity</span><p class="s925-mark__c">Most common in Asian manufacturing (China, Thailand, South Korea).</p></div>
+        <div class="s925-mark"><span class="s925-mark__tag">AG925</span><span class="s925-mark__m">Silver symbol (Ag) + 925 purity</span><p class="s925-mark__c">Seen on some European and scientific-grade items.</p></div>
+        <div class="s925-mark"><span class="s925-mark__tag">Sterling</span><span class="s925-mark__m">Text mark indicating 925</span><p class="s925-mark__c">Common on older British and American pieces.</p></div>
+        <div class="s925-mark"><span class="s925-mark__tag">925 Sterling</span><span class="s925-mark__m">Combined text + numeric</span><p class="s925-mark__c">Redundant but clear &mdash; frequent on mass-market jewellery.</p></div>
+      </div>
+
+      <div class="s925-note s925-note--info">
+        <span class="s925-note__ic" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg></span>
+        <div>
+          <p><b>Is S925 the same as 925?</b> Yes &mdash; S925 simply adds &ldquo;S&rdquo; for &ldquo;Sterling&rdquo; in front of the purity number; the silver content is identical at 92.5%. One practical note: S925 jewellery from some Asian manufacturers may use zinc rather than copper as the secondary alloy, which can tarnish slightly faster in humidity and occasionally contains trace nickel that some people find irritating.</p>
+          <p><b>AG925</b> uses the chemical symbol for silver (Ag, from the Latin <em>argentum</em>) followed by the purity mark, and is mostly seen on Continental European and industrial silver products.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="hallmark">
+      <h2>How to Identify a 925 Sterling Silver Hallmark</h2>
+      <p>The 925 mark appears in different places depending on the item. It is usually very small &mdash; use a loupe or magnifying glass if you can&rsquo;t read it with the naked eye. On older antique silver the mark may be worn, but should still be visible as an indentation in the metal.</p>
+
+      <div class="s925-grid s925-grid--3 s925-reveal">
+        <div class="s925-card"><h3 class="s925-card__t">Rings</h3><p class="s925-card__d">Inside the band, often on the shank.</p></div>
+        <div class="s925-card"><h3 class="s925-card__t">Necklaces &amp; bracelets</h3><p class="s925-card__d">On the clasp mechanism or tag.</p></div>
+        <div class="s925-card"><h3 class="s925-card__t">Pendants</h3><p class="s925-card__d">On the back of the pendant or the bail.</p></div>
+        <div class="s925-card"><h3 class="s925-card__t">Earrings</h3><p class="s925-card__d">On the post or back fitting.</p></div>
+        <div class="s925-card"><h3 class="s925-card__t">Cutlery &amp; silverware</h3><p class="s925-card__d">On the back of the handle or underside of bowls.</p></div>
+        <div class="s925-card"><h3 class="s925-card__t">Flatware &amp; decor</h3><p class="s925-card__d">On the base or back of the item.</p></div>
+      </div>
+
+      <div class="s925-note s925-note--gold">
+        <span class="s925-note__ic" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.4 4.9 5.4.8-3.9 3.8.9 5.4L12 19.3 7.2 21.7l.9-5.4L4.2 7.7l5.4-.8z"/></svg></span>
+        <div><p><b>The British lion passant.</b> British silver carries a more elaborate system: the walking lion (lion passant) is the traditional sterling guarantee, usually accompanied by a date letter, maker&rsquo;s mark and assay office mark (an anchor for Birmingham, a crown for Sheffield, and so on). It guarantees at least 92.5% silver and is one of the most trusted hallmarks in the world for antique collectors.</p></div>
+      </div>
+    </section>
+
+    <section id="real">
+      <h2>Is 925 Sterling Silver Real Silver?</h2>
+      <p>Yes &mdash; 925 sterling silver is absolutely real silver. The 92.5% silver content is genuine, refined silver. The question arises because low-quality or fraudulent items are sometimes falsely stamped &ldquo;925,&rdquo; and silver-<em>plated</em> items are sometimes confused with solid sterling.</p>
+
+      <div class="s925-compare s925-reveal">
+        <div class="s925-cc s925-cc--good">
+          <div class="s925-cc__h"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> 925 sterling silver</div>
+          <p>Solid silver alloy all the way through &mdash; every part of the item contains 92.5% silver. Holds real, weight-based melt value.</p>
+        </div>
+        <div class="s925-cc s925-cc--bad">
+          <div class="s925-cc__h"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Silver-plated</div>
+          <p>A base-metal core (brass, copper or nickel) with a microns-thin silver coating that wears away over time. Should never be stamped &ldquo;925.&rdquo;</p>
+        </div>
+      </div>
+
+      <p>If you find what looks like a 925 mark but suspect plating, check edges and high-contact points for wear where the base metal would show through. To confirm, here are five practical tests, from easiest to most definitive:</p>
+
+      <div class="s925-tests">
+        <div class="s925-test"><span class="s925-test__n">1</span><div><p class="s925-test__t">Hallmark check</p><p class="s925-test__d">Genuine sterling carries a clear, sharp 925 stamp (or a variant). No hallmark at all is suspicious &mdash; though some older or handmade items are unmarked.</p></div></div>
+        <div class="s925-test"><span class="s925-test__n">2</span><div><p class="s925-test__t">Magnet test</p><p class="s925-test__d">Silver is not magnetic. A strong magnet won&rsquo;t stick to sterling. Strong attraction means it isn&rsquo;t silver.</p></div></div>
+        <div class="s925-test"><span class="s925-test__n">3</span><div><p class="s925-test__t">Flexibility test</p><p class="s925-test__d">Solid 925 is malleable and flexes slightly under gentle pressure. Plated items over hard base metals feel rigid and stiff.</p></div></div>
+        <div class="s925-test"><span class="s925-test__n">4</span><div><p class="s925-test__t">Acid test</p><p class="s925-test__d">A silver testing kit uses nitric acid to confirm content: genuine 925 shows a cream-coloured reaction; plating reacts differently depending on the base metal.</p></div></div>
+        <div class="s925-test"><span class="s925-test__n">5</span><div><p class="s925-test__t">Ice test</p><p class="s925-test__d">Silver has exceptionally high thermal conductivity &mdash; ice placed on a sterling surface melts noticeably faster than on other metals.</p></div></div>
+      </div>
+    </section>
+
+    <section id="tarnish">
+      <h2>Does 925 Sterling Silver Tarnish?</h2>
+      <p>Yes &mdash; sterling silver does tarnish over time, though more slowly than lower-purity alloys. Tarnish appears as a dull yellowish, brown or eventually black discolouration. It is a chemical reaction, not structural damage, and can always be reversed with cleaning.</p>
+      <p>The primary cause is the copper in the alloy reacting with <strong>sulfur compounds</strong> in the air &mdash; particularly hydrogen sulfide &mdash; forming silver sulfide (Ag&#8322;S), the dark compound you see. Moisture accelerates the reaction, which is why sterling tarnishes faster in humid environments. Common accelerators to keep away from your silver:</p>
+
+      <div class="s925-chips s925-reveal">
+        <span class="s925-wchip"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Rubber &amp; latex</span>
+        <span class="s925-wchip"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Eggs &amp; mayonnaise</span>
+        <span class="s925-wchip"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Wool &amp; natural fibres</span>
+        <span class="s925-wchip"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Pool water (chlorine)</span>
+        <span class="s925-wchip"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Hot tubs &amp; Jacuzzis</span>
+        <span class="s925-wchip"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Perfume &amp; hairspray</span>
+        <span class="s925-wchip"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Bleach &amp; ammonia</span>
+        <span class="s925-wchip"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Salty coastal air</span>
+      </div>
+
+      <div class="s925-note s925-note--info">
+        <span class="s925-note__ic" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg></span>
+        <div><p><b>Tarnish vs rust.</b> These are completely different. Tarnish is a surface oxidation &mdash; it doesn&rsquo;t penetrate the metal, causes no structural damage and polishes off easily. Rust (iron oxidation) is progressive and destructive. Silver does not rust.</p></div>
+      </div>
+    </section>
+
+    <section id="green">
+      <h2>Does 925 Sterling Silver Turn Your Finger Green?</h2>
+      <p>Sometimes &mdash; and it depends on the copper reacting with your individual skin chemistry, not the silver itself. When the copper in the 7.5% alloy meets sweat, acidic skin pH or skincare products, it oxidises and produces greenish copper salts. It&rsquo;s the same chemistry that turns copper coins and copper roofs green (the patina on the Statue of Liberty is the same process at scale).</p>
+
+      <ul class="s925-facts s925-reveal">
+        <li><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg><span><b>Entirely harmless</b> &mdash; the copper oxide is non-toxic.</span></li>
+        <li><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg><span><b>Not a sign of low quality</b> &mdash; it can happen even with genuine, high-quality 925.</span></li>
+        <li><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg><span><b>Not permanent</b> &mdash; it washes off easily with soap and water.</span></li>
+        <li><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg><span><b>More likely</b> with acidic skin pH, heavy sweating, or frequent lotions, perfumes and sanitisers.</span></li>
+      </ul>
+
+      <div class="s925-note s925-note--gold">
+        <span class="s925-note__ic" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7c.6.5 1 1.3 1 2.1V17h6v-.2c0-.8.4-1.6 1-2.1A7 7 0 0 0 12 2z"/></svg></span>
+        <div><p><b>If green marks are a regular issue:</b> keep the jewellery dry and clean, apply a thin coat of clear nail polish to the inside of rings as a barrier, choose rhodium-plated 925 (a tarnish-resistant platinum-group coating), and remove jewellery before exercise, swimming or applying products.</p></div>
+      </div>
+    </section>
+
+    <section id="waterproof">
+      <h2>Is 925 Sterling Silver Waterproof?</h2>
+      <p>Sterling silver won&rsquo;t dissolve in water, but that&rsquo;s not the same as being truly waterproof. The accurate answer is: <strong>925 is water-resistant, but regular exposure accelerates tarnishing and degrades both the metal and any stone settings.</strong> Clean fresh water doesn&rsquo;t immediately harm it &mdash; but these do:</p>
+
+      <div class="s925-water s925-reveal">
+        <div class="s925-wrow"><span class="s925-sev s925-sev--high">Avoid</span><p><b>Saltwater</b> is corrosive to sterling silver and should always be avoided.</p></div>
+        <div class="s925-wrow"><span class="s925-sev s925-sev--high">Avoid</span><p><b>Chlorinated water</b> (pools) reacts with the alloy, accelerating tarnish and risking surface pitting with prolonged exposure.</p></div>
+        <div class="s925-wrow"><span class="s925-sev s925-sev--med">Caution</span><p><b>Hot water &amp; steam</b> speed up the oxidation reaction, causing faster tarnishing.</p></div>
+        <div class="s925-wrow"><span class="s925-sev s925-sev--med">Caution</span><p><b>Hard water</b> deposits minerals that dull the finish; <b>soap &amp; shower-gel residue</b> builds up in intricate settings.</p></div>
+      </div>
+
+      <p>The practical rule: remove sterling silver before swimming in pools or the sea, before showering or bathing where possible, and always before using household cleaners. For brief contact with fresh water &mdash; handwashing, light rain &mdash; well-maintained 925 will be fine.</p>
+    </section>
+
+    <section id="clean">
+      <h2>How to Clean 925 Sterling Silver</h2>
+      <p>Regular cleaning is the single most effective way to keep sterling bright and to stop tarnish building up to the point where it needs aggressive treatment.</p>
+
+      <div class="s925-methods s925-reveal">
+        <div class="s925-method">
+          <span class="s925-method__b">Everyday</span>
+          <h3 class="s925-method__t">Warm soapy water</h3>
+          <ol>
+            <li>Add a few drops of mild dish soap to a bowl of warm (not hot) water.</li>
+            <li>Soak the jewellery for 20&ndash;40 minutes.</li>
+            <li>Gently scrub with a soft-bristled toothbrush, working into settings and engravings.</li>
+            <li>Rinse thoroughly with warm water.</li>
+            <li>Pat dry with a soft cloth and air-dry fully before storing.</li>
+          </ol>
+        </div>
+        <div class="s925-method">
+          <span class="s925-method__b">Light&ndash;moderate tarnish</span>
+          <h3 class="s925-method__t">Baking soda paste</h3>
+          <ol>
+            <li>Mix &frac14; tsp baking soda with 1&ndash;2 drops of water into a paste.</li>
+            <li>Apply with a soft cloth or cotton pad using back-and-forth (not circular) strokes.</li>
+            <li>The paste turns grey as it lifts the tarnish.</li>
+            <li>Rinse thoroughly with warm water and dry immediately.</li>
+          </ol>
+        </div>
+        <div class="s925-method">
+          <span class="s925-method__b">Routine maintenance</span>
+          <h3 class="s925-method__t">Silver polishing cloth</h3>
+          <p>A purpose-made cloth contains micro-abrasives and anti-tarnish compounds that restore shine and leave a protective coating. Use gentle, back-and-forth strokes &mdash; never circular &mdash; to avoid fine scratches.</p>
+        </div>
+        <div class="s925-method">
+          <span class="s925-method__b">Heavy tarnish</span>
+          <h3 class="s925-method__t">Foil &amp; baking soda bath</h3>
+          <p>Line a bowl with foil (shiny side up), place the silver on it, and pour over boiling water with 1 tbsp each of baking soda and salt. The electrochemical reaction transfers the silver sulfide onto the foil, restoring shine. Rinse and dry thoroughly.</p>
+        </div>
+      </div>
+
+      <div class="s925-note s925-note--warn">
+        <span class="s925-note__ic" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg></span>
+        <div><p><b>Never use</b> bleach, ammonia-based cleaners, chlorine, acetone, or toothpaste (too abrasive) on sterling silver. Ultrasonic cleaners can damage soft stones in settings even when they&rsquo;re safe for plain silver.</p></div>
+      </div>
+    </section>
+
+    <section id="worth">
+      <h2>How Much Is 925 Sterling Silver Worth?</h2>
+      <p>The value of 925 sterling silver is calculated directly from the live silver spot price per gram, adjusted for the 92.5% silver content:</p>
+
+      <div class="s925-formula">
+        <div class="s925-formula__eq">Value = weight (g) &times; <b>(spot&nbsp;price&nbsp;&divide;&nbsp;31.1035)</b> &times; 0.925</div>
+        <p class="s925-formula__n">At a silver spot of ~$74.96/oz (May 2026): pure 999 silver &asymp; $2.41/g &middot; 925 sterling &asymp; <strong>$2.23/g</strong>.</p>
+      </div>
+
+      <div class="s925-est">
+        <h3 class="s925-est__t">Estimate your sterling silver value</h3>
+        <p class="s925-est__sub">Enter the weight of your solid 925 item for an approximate melt value.</p>
+        <div class="s925-est__row">
+          <div>
+            <label for="s925-grams">Weight in grams</label>
+            <input type="number" id="s925-grams" inputmode="decimal" min="0" step="0.1" value="50" aria-describedby="s925-est-note">
+          </div>
+          <div class="s925-est__out"><span class="v" id="s925-val">$111.50</span><span class="l">est. melt value</span></div>
+        </div>
+        <p class="s925-est__n" id="s925-est-note">Indicative only, based on $74.96/oz &mdash; check the <a href="/silver-price-per-kilo">live silver price</a> before buying or selling.</p>
+      </div>
+
+      <table class="s925-vtable">
+        <caption>925 sterling silver value quick reference at ~$74.96/oz</caption>
+        <thead><tr><th scope="col">Weight of sterling item</th><th scope="col">Metal (silver) value</th></tr></thead>
+        <tbody>
+          <tr><td>5 grams</td><td>~$11.15</td></tr>
+          <tr><td>10 grams</td><td>~$22.30</td></tr>
+          <tr><td>25 grams</td><td>~$55.75</td></tr>
+          <tr><td>50 grams</td><td>~$111.50</td></tr>
+          <tr><td>100 grams</td><td>~$223.00</td></tr>
+          <tr><td>500 grams</td><td>~$1,115.00</td></tr>
+          <tr><td>1 kilogram</td><td>~$2,230.00</td></tr>
+        </tbody>
+      </table>
+
+      <div class="s925-note s925-note--info">
+        <span class="s925-note__ic" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg></span>
+        <div><p><b>Selling scrap sterling.</b> Dealers typically offer about 75&ndash;90% of the calculated melt value to cover refining and margin (BullionByPost, for example, pays up to 88% of spot for larger quantities, dropping to around 80% for smaller amounts). For hallmarked antique silverware, recognised maker&rsquo;s pieces, or jewellery with design value, a specialist dealer or auction house may pay well above melt.</p></div>
+      </div>
+
+      <h3>925 Sterling Silver Price Today</h3>
+      <p>The price of 925 sterling isn&rsquo;t fixed &mdash; it moves continuously with the live silver spot price. As of 20 May 2026:</p>
+      <div class="s925-prices s925-reveal">
+        <div class="s925-price"><div class="s925-price__l">Silver spot</div><div class="s925-price__v">$74.96</div><div class="s925-price__s">per troy ounce</div></div>
+        <div class="s925-price"><div class="s925-price__l">925 sterling</div><div class="s925-price__v">$2.23</div><div class="s925-price__s">melt value / gram</div></div>
+        <div class="s925-price"><div class="s925-price__l">Scrap dealer offer</div><div class="s925-price__v">$1.67&ndash;2.01</div><div class="s925-price__s">per gram (75&ndash;90%)</div></div>
+      </div>
+      <p>For the current live 925 sterling silver price per gram, our <a href="/silver-price-per-kilo">silver calculator</a> updates every 60 seconds with live-calculated sterling values.</p>
+    </section>
+
+    <section id="quality">
+      <h2>Is 925 Sterling Silver Good Quality?</h2>
+      <p>Yes &mdash; 925 sterling silver is excellent quality and the international standard for fine silver jewellery and silverware. It&rsquo;s not a compromise or a lower grade; it&rsquo;s the recognised optimal balance between purity and durability for wearable silver. Here&rsquo;s where it sits in the wider hierarchy:</p>
+
+      <div class="s925-tiers s925-reveal">
+        <div class="s925-tier"><div class="s925-tier__name"><b>Fine silver</b><span>999 &middot; 99.9%</span></div><div class="s925-tier__bar"><i style="width:99.9%"></i></div><div class="s925-tier__note">Highest purity, too soft for most jewellery</div></div>
+        <div class="s925-tier"><div class="s925-tier__name"><b>Britannia silver</b><span>958 &middot; 95.8%</span></div><div class="s925-tier__bar"><i style="width:95.8%"></i></div><div class="s925-tier__note">Premium grade for specialist jewellery and coins</div></div>
+        <div class="s925-tier s925-tier--hl"><div class="s925-tier__name"><b>Sterling silver</b><span>925 &middot; 92.5%</span></div><div class="s925-tier__bar"><i style="width:92.5%"></i></div><div class="s925-tier__note">Gold standard for jewellery &amp; silverware</div></div>
+        <div class="s925-tier"><div class="s925-tier__name"><b>Coin silver</b><span>900 &middot; 90.0%</span></div><div class="s925-tier__bar"><i style="width:90%"></i></div><div class="s925-tier__note">Used in some coins and older flatware</div></div>
+        <div class="s925-tier"><div class="s925-tier__name"><b>800 silver</b><span>800 &middot; 80.0%</span></div><div class="s925-tier__bar"><i style="width:80%"></i></div><div class="s925-tier__note">Continental European standard, lower purity</div></div>
+        <div class="s925-tier"><div class="s925-tier__name"><b>Silver plate</b><span>Trace coating</span></div><div class="s925-tier__bar"><i style="width:4%"></i></div><div class="s925-tier__note">Base-metal core &mdash; not solid silver</div></div>
+      </div>
+
+      <p>Within 925, the real quality differentiators are craftsmanship and finishing rather than the silver itself: how well it&rsquo;s polished, whether stones are properly set, how robust the construction is, and whether the secondary alloy is copper (preferred) or nickel (which can cause sensitivity in some people).</p>
+    </section>
+
+    <section id="vs">
+      <h2>Sterling Silver vs 925 Silver &mdash; Are They Different?</h2>
+      <p>No &mdash; this is one of the most frequently asked questions, and the answer is definitive: sterling silver and 925 silver are the same thing. Both describe silver at 92.5% purity with 7.5% secondary alloys. &ldquo;Sterling&rdquo; is the name of the standard; &ldquo;925&rdquo; is the numeric millesimal mark confirming it.</p>
+      <div class="s925-answer s925-answer--yes">
+        <span class="s925-answer__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></span>
+        <div>
+          <p class="s925-answer__q">Same silver content, different label</p>
+          <p class="s925-answer__a">The only practical difference is regional marking preference: &ldquo;sterling&rdquo; text on older British and American pieces, &ldquo;925&rdquo; as the modern international numeric standard, and &ldquo;S925&rdquo; on Asian-manufactured jewellery.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="plated">
+      <h2>925 Sterling Silver Plated &mdash; What Does This Mean?</h2>
+      <p>&ldquo;925 sterling silver plated&rdquo; is a combination designation to approach with care. It typically means a base-metal core that is plated (coated) with sterling silver rather than being solid sterling throughout. Technically the <em>coating</em> is genuine sterling quality &mdash; but the critical distinction is that the item is not solid silver.</p>
+
+      <div class="s925-note s925-note--warn">
+        <span class="s925-note__ic" aria-hidden="true"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg></span>
+        <div><p>The base metal (often brass or copper) shows wherever the plating wears through, and the total silver content is a tiny fraction of a solid 925 piece. Plated jewellery is far less valuable than solid sterling and shouldn&rsquo;t be priced as such. If you&rsquo;re buying for intrinsic value, investment, or long-term wear, always confirm the item is <b>solid 925 sterling silver</b> &mdash; not sterling silver plated.</p></div>
+      </div>
+    </section>
+
+    <section id="faq">
+      <h2>Frequently Asked Questions</h2>
+      <div class="s925-faq">
+        <details><summary>What is 925 sterling silver?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>925 sterling silver is an alloy of 92.5% pure silver and 7.5% other metals (usually copper). The &ldquo;925&rdquo; stamp is the millesimal fineness hallmark confirming this purity. It is the global standard for quality silver jewellery and silverware.</p></div></details>
+        <details><summary>What does 925 sterling silver mean?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>It means the item is 925 parts per 1,000 pure silver &mdash; 92.5% &mdash; the internationally recognised sterling standard. The remaining 7.5% is typically copper, added to improve hardness and durability.</p></div></details>
+        <details><summary>Is 925 sterling silver real silver?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>Yes, absolutely. The copper alloy doesn&rsquo;t diminish the authenticity of the silver; it simply makes the alloy practical for wearable use. The 92.5% silver content is confirmed by the 925 hallmark.</p></div></details>
+        <details><summary>Is sterling silver and 925 silver the same?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>Yes, identical. &ldquo;Sterling silver&rdquo; is the name of the 92.5% standard; &ldquo;925&rdquo; is the numeric hallmark confirming it. The terms are completely interchangeable.</p></div></details>
+        <details><summary>Does 925 sterling silver tarnish?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>Yes, over time. The copper reacts with atmospheric sulfur compounds to form silver sulfide &mdash; the brown-black surface discolouration. Tarnish is reversible with cleaning and doesn&rsquo;t damage the silver structurally.</p></div></details>
+        <details><summary>Does 925 sterling silver turn green?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>It can &mdash; but the green comes from copper reacting with skin acids and moisture, not the silver. It&rsquo;s harmless and washes off, is more likely with acidic skin pH, and can be reduced by keeping jewellery dry and clean.</p></div></details>
+        <details><summary>Is 925 sterling silver waterproof?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>It won&rsquo;t dissolve in water, but regular exposure accelerates tarnishing. Chlorinated pool water, saltwater and hot water are all harmful. Remove sterling jewellery before swimming, showering or using cleaning products.</p></div></details>
+        <details><summary>How much is 925 sterling silver worth?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>At a silver spot of ~$74.96/oz (May 2026), 925 sterling has a melt value of about $2.23/g. A 100-gram item is worth around $223 in metal. Dealers buying scrap typically offer 75&ndash;90% of melt value.</p></div></details>
+        <details><summary>How do you clean 925 sterling silver?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>The simplest method is warm soapy water with a soft toothbrush. For tarnish, a baking soda paste or silver polishing cloth works well. Never use bleach, ammonia, toothpaste or abrasive chemicals.</p></div></details>
+        <details><summary>What&rsquo;s the difference between 925 sterling and silver plated?<span class="ic" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></summary><div class="s925-faq__a"><p>Solid 925 is silver alloy throughout &mdash; every part contains 92.5% silver. Silver-plated items have a thin silver coating over a base-metal core that exposes once the plating wears. Sterling is significantly more valuable and durable.</p></div></details>
+      </div>
+    </section>
   </div><!-- Social share buttons (WP-34) -->
 <section class="share-section">
   <div class="share-section-label">Share this guide</div>
@@ -605,9 +1176,9 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
   </script>
 
   <div class="cta-box">
-    <h3>925 Sterling Silver Price Calculator</h3>
-    <p>Find today&rsquo;s exact sterling silver price per gram in GBP and USD, updated live from the LBMA spot price.</p>
-    <a href="/" class="cta-btn">Open Calculator &rarr;</a>
+    <h3>Get the live 925 sterling silver price</h3>
+    <p>See today&rsquo;s exact sterling silver value per gram and kilo &mdash; calculated live from the silver spot price and updated every 60 seconds.</p>
+    <a href="/silver-price-per-kilo" class="cta-btn">Open the silver calculator &rarr;</a>
   </div>
 
   <div class="disclaimer-box" role="note" aria-label="Financial disclaimer">
@@ -759,5 +1330,24 @@ window.addEventListener('scroll', () => {
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
 })();</script>
+<script>
+(function(){
+  /* Sterling silver melt-value estimator (indicative, $74.96/oz) */
+  var g=document.getElementById('s925-grams'),out=document.getElementById('s925-val');
+  if(g&&out){
+    var RATE=2.23; /* USD per gram of 925 sterling at ~$74.96/oz */
+    var fmt=function(n){return '$'+n.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2});};
+    var upd=function(){var v=parseFloat(g.value);out.textContent=(isFinite(v)&&v>0)?fmt(v*RATE):'$0.00';};
+    g.addEventListener('input',upd);upd();
+  }
+  /* Reveal-on-scroll — progressive enhancement, respects reduced motion */
+  var els=document.querySelectorAll('.s925-reveal');
+  if(!els.length)return;
+  var reduce=matchMedia('(prefers-reduced-motion:reduce)').matches;
+  if(reduce||!('IntersectionObserver' in window)){els.forEach(function(e){e.classList.add('is-in');});return;}
+  var io=new IntersectionObserver(function(entries){entries.forEach(function(en){if(en.isIntersecting){en.target.classList.add('is-in');io.unobserve(en.target);}});},{rootMargin:'0px 0px -8% 0px',threshold:.08});
+  els.forEach(function(e){io.observe(e);});
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Fully redesigns `guides/what-is-925-sterling-silver.html` into a standout, mobile-first editorial guide, built with the **ui-ux-pro-max** design skill on top of the existing site design system (dark/light theme, gold + silver accents, IBM Plex Sans / Inter). The article body was also expanded to the complete, comprehensive guide.

All new components are scoped under `.s925-*` so nothing leaks into shared styles, and every visual is **pure CSS** (no images) for performance and accessibility.

### New designed components
- **Hero** with an engraved "925 / STERLING" hallmark disc + floating `.925` / `S925` pills and an at-a-glance **stat strip** (92.5% / 7.5% / since 1300 / ~$2.23 melt)
- **Jump-link Table of Contents** (15 anchored sections, smooth-scroll)
- **Composition donut** (pure-CSS conic-gradient, 92.5% silver / 7.5% copper) with a labelled legend
- **History timeline**, **stamp-variation cards** (925/.925/S925/AG925/Sterling), **hallmark-location cards** + lion-passant feature
- **Sterling vs silver-plated** comparison, **5 numbered authenticity tests**
- Tarnish-accelerator chips, severity-rated water-exposure list, **4 cleaning-method cards**, and warning callouts
- **Interactive melt-value estimator** (grams → value) + value reference table + live-price snapshot cards
- **Quality-tier ladder** (999 → plate, with 925 highlighted) and an accessible **FAQ accordion**

### Correctness / SEO
- Refreshed the **FAQPage JSON-LD** to match the on-page Q&As and current pricing (old schema referenced a stale $33/oz)
- Fixed the byline dates (`datePublished` vs `dateModified` were both mislabelled)
- Removed previously-unstyled `.callout` / `.data-table` markup

### Accessibility & responsiveness
- Mobile-first; all grids collapse to a single column; 44px+ touch targets; 16px+ body text
- Semantic markup, ARIA labels on icon-only/visual elements, visible focus states
- Scroll reveals are progressive enhancement and **respect `prefers-reduced-motion`** (content is fully visible without JS)

## Validation
- HTML parsed clean: **0 errors, 0 unclosed tags**, 15 sections, all TOC anchors resolve, 10 FAQ items
- CSS verified balanced (204/204 braces, 434/434 parens)
- ⚠️ **Browser rendering could not be run in this sandbox** — the Chromium download is blocked by the network policy, so the Playwright audit in `DEVELOPMENT_RULES.md` should be run against the deployed URL (`https://goldpricetools.com/guides/what-is-925-sterling-silver`) after deploy.

## Test plan
- [ ] Run `python3 tools/playwright_audit.py https://goldpricetools.com/guides/what-is-925-sterling-silver` after deploy (review every 400px strip, Chromium desktop + iPhone 14 Pro)
- [ ] Verify no horizontal overflow at 375 / 768 / 1024 / 1440px
- [ ] Toggle dark/light mode and confirm contrast on all components
- [ ] Confirm the melt-value estimator updates on input and the FAQ accordion expands/collapses
- [ ] Validate the FAQ rich result in Google's Rich Results Test

https://claude.ai/code/session_01Wmsb7DYu4xwJcff2HXYgtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wmsb7DYu4xwJcff2HXYgtn)_