### PR TITLE
Fix: TOC overlapping article on the 925 sterling silver guide

### DIFF
--- a/guides/what-is-925-sterling-silver.html
+++ b/guides/what-is-925-sterling-silver.html
@@ -463,7 +463,8 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
 .s925-stat__l{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:6px;text-transform:uppercase;letter-spacing:.05em}
 
 /* ── TOC ── */
-.s925-toc{background:color-mix(in oklch,var(--color-primary) 5%,var(--color-surface));border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-5) var(--space-4);margin:var(--space-6) 0}
+/* override global nav{position:sticky} — the TOC is a flow element, not a sticky bar */
+.s925-toc{position:static;top:auto;z-index:auto;backdrop-filter:none;background:color-mix(in oklch,var(--color-primary) 5%,var(--color-surface));border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-5) var(--space-4);margin:var(--space-6) 0}
 .s925-toc__h{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-2)}
 .s925-toc__grid{display:grid;grid-template-columns:1fr;gap:1px}
 @media(min-width:620px){.s925-toc__grid{grid-template-columns:1fr 1fr;column-gap:var(--space-6)}}


### PR DESCRIPTION
## Summary

Follow-up fix for the redesigned 925 sterling silver guide (PR #352, already merged).

The **"In this guide" table of contents** was rendering as a sticky overlay that pinned to the top of the viewport and covered the article text while scrolling.

**Root cause:** the TOC uses a semantic `<nav>` element, which inherited the site-wide rule `nav{position:sticky;top:0;z-index:100}` (intended only for the main site navigation bar).

**Fix:** reset `.s925-toc` to `position:static` (plus `top:auto;z-index:auto;backdrop-filter:none`) so it stays in normal document flow. The main site nav (`.site-nav`) is unaffected and remains sticky as intended.

One-line CSS change; no markup or content changes.

## Test plan
- [ ] Scroll the guide — the TOC scrolls away with the content and never overlaps the article
- [ ] Confirm the main site navigation bar still sticks to the top
- [ ] Verify in both light and dark mode, mobile + desktop

https://claude.ai/code/session_01Wmsb7DYu4xwJcff2HXYgtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wmsb7DYu4xwJcff2HXYgtn)_