### PR TITLE
feat: install Google Stitch skills suite for UX/UI design workflows

### DIFF
--- a/.claude/skills/stitch-code-to-design/SKILL.md
+++ b/.claude/skills/stitch-code-to-design/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: stitch::code-to-design
+description: >-
+  Convert frontend code (Vite, React, etc.) to a Stitch Design by chaining
+  static HTML extraction, design system extraction, and file upload. **ALWAYS** use this skill when the user's intent is to move existing web apps or React components into Stitch (e.g., requests to "save", "migrate", or "upload"). You must use this skill even for simple "save" operations, as it is the only way to ensure the design system is extracted and assets are properly linked.
+allowed-tools:
+  - "stitch*:*"
+  - "Bash"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Code to Design
+
+Transform your existing frontend code into a Stitch Design so you can iterate and improve it using Stitch.
+
+This skill orchestrates three other skills in sequence:
+1. `extract-static-html`: Extract a single self-contained HTML file from your build output.
+2. `extract-design-md`: Analyze the source code to create a design system (DESIGN.md).
+3. `upload-to-stitch`: Upload that HTML file and the design system to your Stitch project.
+
+## Workflow
+
+Follow these steps to convert your existing code.
+
+### Prerequisites
+
+- A built web application directory containing `index.html` and assets.
+- Target Stitch `projectId` (use `list_projects` if unknown).
+
+### Steps
+
+#### 1. Extract Self-Contained HTML
+
+Delegate to the `extract-static-html` skill to generate a standalone HTML file.
+Read [skills/extract-static-html/SKILL.md](../extract-static-html/SKILL.md) for detailed instructions and script usage.
+
+Expected output: A single file like `/path/to/extracted/standalone.html`.
+
+#### 2. Verify HTML (Optional — User-Driven)
+
+After extraction, inform the user of the output file path so they can manually
+verify in a browser if desired. **Do not block on verification** — proceed
+directly to Step 3.
+
+If the user reports issues after reviewing, fix them before continuing.
+
+#### 3. Extract Design System (File)
+
+Delegate to the `extract-design-md` skill to analyze the project's source files
+(components, stylesheets, theme configs) and produce a design system. Read
+[skills/extract-design-md/SKILL.md](../extract-design-md/SKILL.md) for the
+full analysis workflow.
+
+Write `.stitch/DESIGN.md` following the `extract-design-md` skill's output
+structure.
+
+#### 4. Upload DESIGN.md and Create Design System in Stitch
+
+Delegate to the `manage-design-system` skill to upload the `DESIGN.md` and
+create the design system in Stitch. Read
+[skills/manage-design-system/SKILL.md](../manage-design-system/SKILL.md) for
+the full workflow (upload script usage, `create_design_system_from_design_md`
+call, and required schemas).
+
+#### 5. Upload HTML to Stitch
+
+Use the same `upload-to-stitch` skill's script to upload the extracted HTML file.
+Read [skills/upload-to-stitch/SKILL.md](../upload-to-stitch/SKILL.md) for detailed instructions and script usage.
+
+You will need:
+- The path to the standalone HTML file generated in Step 1.
+- Your Stitch API Key (same key used in Step 4).
+- The target `projectId`.

--- a/.claude/skills/stitch-design-md/SKILL.md
+++ b/.claude/skills/stitch-design-md/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: design-md
+description: Analyze Stitch projects and synthesize a semantic design system into DESIGN.md files
+allowed-tools:
+  - "stitch*:*"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Stitch DESIGN.md Skill
+
+You are an expert Design Systems Lead. Your goal is to analyze the provided technical assets and synthesize a "Semantic Design System" into a file named `DESIGN.md`.
+
+## Overview
+
+This skill helps you create `DESIGN.md` files that serve as the "source of truth" for prompting Stitch to generate new screens that align perfectly with existing design language. Stitch interprets design through "Visual Descriptions" supported by specific color values.
+
+## Prerequisites
+
+- Access to the Stitch MCP Server
+- A Stitch project with at least one designed screen
+- Access to the Stitch Effective Prompting Guide: https://stitch.withgoogle.com/docs/learn/prompting/
+
+## The Goal
+
+The `DESIGN.md` file will serve as the "source of truth" for prompting Stitch to generate new screens that align perfectly with the existing design language. Stitch interprets design through "Visual Descriptions" supported by specific color values.
+
+## Retrieval and Networking
+
+To analyze a Stitch project, you must retrieve screen metadata and design assets using the Stitch MCP Server tools:
+
+1. **Namespace discovery**: Run `list_tools` to find the Stitch MCP prefix. Use this prefix (e.g., `mcp_stitch:`) for all subsequent calls.
+
+2. **Project lookup** (if Project ID is not provided):
+   - Call `[prefix]:list_projects` with `filter: "view=owned"` to retrieve all user projects
+   - Identify the target project by title or URL pattern
+   - Extract the Project ID from the `name` field (e.g., `projects/13534454087919359824`)
+
+3. **Screen lookup** (if Screen ID is not provided):
+   - Call `[prefix]:list_screens` with the `projectId` (just the numeric ID, not the full path)
+   - Review screen titles to identify the target screen (e.g., "Home", "Landing Page")
+   - Extract the Screen ID from the screen's `name` field
+
+4. **Metadata fetch**: 
+   - Call `[prefix]:get_screen` with both `projectId` and `screenId` (both as numeric IDs only)
+   - This returns the complete screen object including:
+     - `screenshot.downloadUrl` - Visual reference of the design
+     - `htmlCode.downloadUrl` - Full HTML/CSS source code
+     - `width`, `height`, `deviceType` - Screen dimensions and target platform
+     - Project metadata including `designTheme` with color and style information
+
+5. **Asset download**:
+   - Use `web_fetch` or `read_url_content` to download the HTML code from `htmlCode.downloadUrl`
+   - Optionally download the screenshot from `screenshot.downloadUrl` for visual reference
+   - Parse the HTML to extract Tailwind classes, custom CSS, and component patterns
+
+6. **Project metadata extraction**:
+   - Call `[prefix]:get_project` with the project `name` (full path: `projects/{id}`) to get:
+     - `designTheme` object with color mode, fonts, roundness, custom colors
+     - Project-level design guidelines and descriptions
+     - Device type preferences and layout principles
+
+## Analysis & Synthesis Instructions
+
+### 1. Extract Project Identity (JSON)
+- Locate the Project Title
+- Locate the specific Project ID (e.g., from the `name` field in the JSON)
+
+### 2. Define the Atmosphere (Image/HTML)
+Evaluate the screenshot and HTML structure to capture the overall "vibe." Use evocative adjectives to describe the mood (e.g., "Airy," "Dense," "Minimalist," "Utilitarian").
+
+### 3. Map the Color Palette (Tailwind Config/JSON)
+Identify the key colors in the system. For each color, provide:
+- A descriptive, natural language name that conveys its character (e.g., "Deep Muted Teal-Navy")
+- The specific hex code in parentheses for precision (e.g., "#294056")
+- Its specific functional role (e.g., "Used for primary actions")
+
+### 4. Translate Geometry & Shape (CSS/Tailwind)
+Convert technical `border-radius` and layout values into physical descriptions:
+- Describe `rounded-full` as "Pill-shaped"
+- Describe `rounded-lg` as "Subtly rounded corners"
+- Describe `rounded-none` as "Sharp, squared-off edges"
+
+### 5. Describe Depth & Elevation
+Explain how the UI handles layers. Describe the presence and quality of shadows (e.g., "Flat," "Whisper-soft diffused shadows," or "Heavy, high-contrast drop shadows").
+
+## Output Guidelines
+
+- **Language:** Use descriptive design terminology and natural language exclusively
+- **Format:** Generate a clean Markdown file following the structure below
+- **Precision:** Include exact hex codes for colors while using descriptive names
+- **Context:** Explain the "why" behind design decisions, not just the "what"
+
+## Output Format (DESIGN.md Structure)
+
+```markdown
+# Design System: [Project Title]
+**Project ID:** [Insert Project ID Here]
+
+## 1. Visual Theme & Atmosphere
+(Description of the mood, density, and aesthetic philosophy.)
+
+## 2. Color Palette & Roles
+(List colors by Descriptive Name + Hex Code + Functional Role.)
+
+## 3. Typography Rules
+(Description of font family, weight usage for headers vs. body, and letter-spacing character.)
+
+## 4. Component Stylings
+* **Buttons:** (Shape description, color assignment, behavior).
+* **Cards/Containers:** (Corner roundness description, background color, shadow depth).
+* **Inputs/Forms:** (Stroke style, background).
+
+## 5. Layout Principles
+(Description of whitespace strategy, margins, and grid alignment.)
+```
+
+## Usage Example
+
+To use this skill for the Furniture Collection project:
+
+1. **Retrieve project information:**
+   ```
+   Use the Stitch MCP Server to get the Furniture Collection project
+   ```
+
+2. **Get the Home page screen details:**
+   ```
+   Retrieve the Home page screen's code, image, and screen object information
+   ```
+
+3. **Reference best practices:**
+   ```
+   Review the Stitch Effective Prompting Guide at:
+   https://stitch.withgoogle.com/docs/learn/prompting/
+   ```
+
+4. **Analyze and synthesize:**
+   - Extract all relevant design tokens from the screen
+   - Translate technical values into descriptive language
+   - Organize information according to the DESIGN.md structure
+
+5. **Generate the file:**
+   - Create `DESIGN.md` in the project directory
+   - Follow the prescribed format exactly
+   - Ensure all color codes are accurate
+   - Use evocative, designer-friendly language
+
+## Best Practices
+
+- **Be Descriptive:** Avoid generic terms like "blue" or "rounded." Use "Ocean-deep Cerulean (#0077B6)" or "Gently curved edges"
+- **Be Functional:** Always explain what each design element is used for
+- **Be Consistent:** Use the same terminology throughout the document
+- **Be Visual:** Help readers visualize the design through your descriptions
+- **Be Precise:** Include exact values (hex codes, pixel values) in parentheses after natural language descriptions
+
+## Tips for Success
+
+1. **Start with the big picture:** Understand the overall aesthetic before diving into details
+2. **Look for patterns:** Identify consistent spacing, sizing, and styling patterns
+3. **Think semantically:** Name colors by their purpose, not just their appearance
+4. **Consider hierarchy:** Document how visual weight and importance are communicated
+5. **Reference the guide:** Use language and patterns from the Stitch Effective Prompting Guide
+
+## Common Pitfalls to Avoid
+
+- ❌ Using technical jargon without translation (e.g., "rounded-xl" instead of "generously rounded corners")
+- ❌ Omitting color codes or using only descriptive names
+- ❌ Forgetting to explain functional roles of design elements
+- ❌ Being too vague in atmosphere descriptions
+- ❌ Ignoring subtle design details like shadows or spacing patterns

--- a/.claude/skills/stitch-enhance-prompt/SKILL.md
+++ b/.claude/skills/stitch-enhance-prompt/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: enhance-prompt
+description: Transforms vague UI ideas into polished, Stitch-optimized prompts. Enhances specificity, adds UI/UX keywords, injects design system context, and structures output for better generation results.
+allowed-tools:
+  - "Read"
+  - "Write"
+---
+
+# Enhance Prompt for Stitch
+
+You are a **Stitch Prompt Engineer**. Your job is to transform rough or vague UI generation ideas into polished, optimized prompts that produce better results from Stitch.
+
+## Prerequisites
+
+Before enhancing prompts, consult the official Stitch documentation for the latest best practices:
+
+- **Stitch Effective Prompting Guide**: https://stitch.withgoogle.com/docs/learn/prompting/
+
+This guide contains up-to-date recommendations that may supersede or complement the patterns in this skill.
+
+## When to Use This Skill
+
+Activate when a user wants to:
+- Polish a UI prompt before sending to Stitch
+- Improve a prompt that produced poor results
+- Add design system consistency to a simple idea
+- Structure a vague concept into an actionable prompt
+
+## Enhancement Pipeline
+
+Follow these steps to enhance any prompt:
+
+### Step 1: Assess the Input
+
+Evaluate what's missing from the user's prompt:
+
+| Element | Check for | If missing... |
+|---------|-----------|---------------|
+| **Platform** | "web", "mobile", "desktop" | Add based on context or ask |
+| **Page type** | "landing page", "dashboard", "form" | Infer from description |
+| **Structure** | Numbered sections/components | Create logical page structure |
+| **Visual style** | Adjectives, mood, vibe | Add appropriate descriptors |
+| **Colors** | Specific values or roles | Add design system or suggest |
+| **Components** | UI-specific terms | Translate to proper keywords |
+
+### Step 2: Check for DESIGN.md
+
+Look for a `DESIGN.md` file in the current project:
+
+**If DESIGN.md exists:**
+1. Read the file to extract the design system block
+2. Include the color palette, typography, and component styles
+3. Format as a "DESIGN SYSTEM (REQUIRED)" section in the output
+
+**If DESIGN.md does not exist:**
+1. Add this note at the end of the enhanced prompt:
+
+```
+---
+💡 **Tip:** For consistent designs across multiple screens, create a DESIGN.md 
+file using the `design-md` skill. This ensures all generated pages share the 
+same visual language.
+```
+
+### Step 3: Apply Enhancements
+
+Transform the input using these techniques:
+
+#### A. Add UI/UX Keywords
+
+Replace vague terms with specific component names:
+
+| Vague | Enhanced |
+|-------|----------|
+| "menu at the top" | "navigation bar with logo and menu items" |
+| "button" | "primary call-to-action button" |
+| "list of items" | "card grid layout" or "vertical list with thumbnails" |
+| "form" | "form with labeled input fields and submit button" |
+| "picture area" | "hero section with full-width image" |
+
+#### B. Amplify the Vibe
+
+Add descriptive adjectives to set the mood:
+
+| Basic | Enhanced |
+|-------|----------|
+| "modern" | "clean, minimal, with generous whitespace" |
+| "professional" | "sophisticated, trustworthy, with subtle shadows" |
+| "fun" | "vibrant, playful, with rounded corners and bold colors" |
+| "dark mode" | "dark theme with high-contrast accents on deep backgrounds" |
+
+#### C. Structure the Page
+
+Organize content into numbered sections:
+
+```markdown
+**Page Structure:**
+1. **Header:** Navigation with logo and menu items
+2. **Hero Section:** Headline, subtext, and primary CTA
+3. **Content Area:** [Describe the main content]
+4. **Footer:** Links, social icons, copyright
+```
+
+#### D. Format Colors Properly
+
+When colors are mentioned, format them as:
+```
+Descriptive Name (#hexcode) for functional role
+```
+
+Examples:
+- "Deep Ocean Blue (#1a365d) for primary buttons and links"
+- "Warm Cream (#faf5f0) for page background"
+- "Soft Gray (#6b7280) for secondary text"
+
+### Step 4: Format the Output
+
+Structure the enhanced prompt in this order:
+
+```markdown
+[One-line description of the page purpose and vibe]
+
+**DESIGN SYSTEM (REQUIRED):**
+- Platform: [Web/Mobile], [Desktop/Mobile]-first
+- Theme: [Light/Dark], [style descriptors]
+- Background: [Color description] (#hex)
+- Primary Accent: [Color description] (#hex) for [role]
+- Text Primary: [Color description] (#hex)
+- [Additional design tokens...]
+
+**Page Structure:**
+1. **[Section]:** [Description]
+2. **[Section]:** [Description]
+...
+```
+
+## Output Options
+
+**Default:** Return the enhanced prompt as text for the user to copy.
+
+**Optional file output:** If the user requests, write to a file:
+- `next-prompt.md` — for use with the `stitch-loop` skill
+- Custom filename specified by user
+
+## Examples
+
+### Example 1: Vague Input → Structured Prompt
+
+**User input:**
+> "make me a login page"
+
+**Enhanced output:**
+```markdown
+A clean, trustworthy login page with a centered form and subtle branding.
+
+**DESIGN SYSTEM (REQUIRED):**
+- Platform: Web, Desktop-first
+- Theme: Light, minimal, professional
+- Background: Clean White (#ffffff)
+- Surface: Soft Gray (#f9fafb) for form card
+- Primary Accent: Deep Blue (#2563eb) for submit button and links
+- Text Primary: Near Black (#111827) for headings
+- Text Secondary: Medium Gray (#6b7280) for labels
+- Buttons: Subtly rounded (8px), full-width on form
+- Cards: Gently rounded (12px), soft shadow for elevation
+
+**Page Structure:**
+1. **Header:** Minimal logo, centered
+2. **Login Card:** Centered form with email, password fields, "Forgot password?" link
+3. **Submit Button:** Primary blue "Sign In" button
+4. **Footer:** "Don't have an account? Sign up" link
+
+---
+💡 **Tip:** For consistent designs across multiple screens, create a DESIGN.md 
+file using the `design-md` skill.
+```
+
+### Example 2: Feature Request → Targeted Edit
+
+**User input:**
+> "add a search bar"
+
+**Enhanced output:**
+```markdown
+Add a search bar to the header navigation.
+
+**Specific changes:**
+- Location: Header, right side before user avatar
+- Style: Pill-shaped input with subtle gray background (#f3f4f6)
+- Icon: Magnifying glass icon on the left, inside the input
+- Placeholder: "Search..." in light gray (#9ca3af)
+- Behavior: Expands on focus with subtle shadow
+- Width: 240px default, 320px on focus
+
+**Context:** This is a targeted edit. Make only this change while preserving all existing elements.
+```
+
+## Tips for Best Results
+
+1. **Be specific early** — Vague inputs need more enhancement
+2. **Match the user's intent** — Don't over-design if they want simple
+3. **Keep it structured** — Numbered sections help Stitch understand hierarchy
+4. **Include the design system** — Consistency is key for multi-page projects
+5. **One change at a time for edits** — Don't bundle unrelated changes

--- a/.claude/skills/stitch-extract-design-md/SKILL.md
+++ b/.claude/skills/stitch-extract-design-md/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: stitch::extract-design-md
+description: >-
+  Extract a comprehensive design system (DESIGN.md) directly from frontend source
+  code — React, Vue, Svelte, Angular, plain HTML/CSS, or any web framework. Analyzes
+  component files, stylesheets, Tailwind configs, theme definitions, and design tokens
+  to produce a rich, Stitch-compatible design system document. Use this skill whenever
+  the user wants to reverse-engineer a design system from an existing codebase, audit
+  the visual language of a project, extract design tokens from source files, or
+  understand the styling patterns in a frontend repo — even if they just say "what
+  does this app look like?" or "pull out the design from this code."
+allowed-tools:
+  - "stitch*:*"
+  - "Bash"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Extract Design System from Frontend Code
+
+Analyze frontend source code to extract a comprehensive design system document
+(DESIGN.md) that captures the project's visual language — colors, typography,
+spacing, component patterns, and layout principles — directly from the source
+files, without needing to build or render the application.
+
+## Why This Exists
+
+The `design-md` skill works from rendered HTML. But often you have a codebase
+and want to understand its design system before you can even run the app —
+maybe dependencies are missing, the build is broken, or you just want a quick
+audit. This skill reads the source files themselves: stylesheets, component
+files, theme configs, and Tailwind setups. It's faster and works anywhere.
+
+## When to Use
+
+- User has a frontend codebase and wants to extract or document its design system
+- User wants to migrate a project's visual identity into Stitch
+- User asks to "audit the styling" or "understand the design language" of a repo
+- User wants to create a DESIGN.md from existing source code
+- The app can't be built/rendered but the source is available
+- User wants to unify or reconcile inconsistent styles across a codebase
+
+## Prerequisites
+
+- Access to the frontend project's source directory
+- No build or runtime dependencies needed — this skill reads source files only
+
+---
+
+## Workflow
+
+### Phase 1: Project Discovery
+
+Start by understanding what you're working with. This determines which
+extraction patterns to use.
+
+#### 1. Detect the Framework and Stack
+
+Scan the project root for telltale files:
+
+| Signal File | Framework / Tool |
+|:---|:---|
+| `package.json` with `react` | React / Next.js |
+| `package.json` with `vue` | Vue / Nuxt |
+| `package.json` with `svelte` | Svelte / SvelteKit |
+| `package.json` with `@angular/core` | Angular |
+| `tailwind.config.js/ts` | Tailwind CSS |
+| `postcss.config.js` | PostCSS pipeline |
+| `styled-components` or `@emotion` in deps | CSS-in-JS |
+| `.css` / `.scss` / `.less` files only | Plain CSS / SASS |
+| `theme.js` / `theme.ts` / `tokens.js` | Design token files |
+
+Read `package.json` first — it reveals the framework, CSS tooling, and any
+design-token libraries (e.g., `style-dictionary`, `@chakra-ui/react`,
+`@mui/material`, `ant-design`). This context tells you *where* to look for
+styling information.
+
+#### 2. Map the Source Tree
+
+Identify the key directories and files you'll analyze:
+
+```
+src/
+├── components/     ← Component-level styles
+├── styles/         ← Global stylesheets
+├── theme/          ← Theme definitions, tokens
+├── assets/         ← Fonts, images
+├── app.css         ← Root styles
+└── index.css       ← Entry CSS
+```
+
+Also check for:
+- `tailwind.config.js` / `tailwind.config.ts` — Custom colors, fonts, spacing
+- `globals.css` / `global.css` — CSS custom properties (variables)
+- Any `theme.*` or `tokens.*` files
+- Component library config (e.g., `chakra-theme.ts`, `vuetify.config.ts`)
+
+#### 3. Read Framework-Specific Guidance
+
+Consult the appropriate reference for extraction patterns:
+
+- **React / Next.js / Tailwind** → [references/react-tailwind.md](references/react-tailwind.md)
+- **Vue / Nuxt** → [references/vue.md](references/vue.md)
+- **Svelte / SvelteKit** → [references/svelte.md](references/svelte.md)
+- **Angular** → [references/angular.md](references/angular.md)
+- **Plain CSS / SASS / Less** → [references/plain-css.md](references/plain-css.md)
+
+These references contain framework-specific patterns for locating colors,
+typography, spacing, and component styles. Read the one that matches before
+proceeding.
+
+---
+
+### Phase 2: Deep Extraction
+
+Work through each design dimension systematically. For each one, gather raw
+data from the source files, then synthesize it into descriptive language.
+
+The goal isn't to dump every CSS property — it's to understand the *intent*
+behind the styling choices and describe them in human, editorial language that
+another designer (or Stitch) can use to recreate the same visual feel.
+
+#### 1. Visual Theme & Atmosphere
+
+Read the broadest styling first to understand the overall mood:
+
+- **Root background**: What's the `body` or root element background? Light
+  cream (#f-range) signals airy/clean; dark (#0-#2 range) signals moody/dramatic.
+- **Whitespace philosophy**: Are spacing values generous (32px+) or tight?
+  Check padding/margin values on root containers, section wrappers, and card components.
+- **Density**: Count the components per page/section. Few with space = minimal;
+  many packed tight = information-dense.
+- **Color temperature**: Are the neutrals warm (creams, tans) or cool (blue-grays, slates)?
+- **Overall feel**: Synthesize into 1-2 rich sentences that capture the mood.
+
+Look for these signals in the source:
+
+| Source Location | What It Tells You |
+|:---|:---|
+| Root `background-color` or Tailwind `bg-*` on layouts | Overall lightness/darkness |
+| Spacing scale in Tailwind config or CSS vars | Whitespace philosophy |
+| Number of components vs. wrapper padding | Density |
+| Custom property naming (`--warm-*` vs `--cool-*`) | Color temperature intent |
+| Comments in theme files | Design intent in the developer's own words |
+
+#### 2. Color Palette & Roles
+
+Extract every unique color from the codebase and assign functional roles.
+Search across all layers:
+
+**Where to find colors:**
+
+| Layer | What to Search |
+|:---|:---|
+| CSS custom properties | `--color-*`, `--primary`, `--bg-*` |
+| Tailwind config | `theme.extend.colors` |
+| Theme/token files | Color objects, palettes |
+| Component styles | `background-color`, `color`, `border-color` |
+| Inline/scoped styles | `bg-*`, `text-*` classes in templates |
+| CSS-in-JS theme objects | `colors`, `palette` keys |
+
+**How to organize:** Group colors by function, not by hue:
+
+1. **Primary Foundation** — Background and surface colors
+2. **Accent & Interactive** — CTA buttons, active states, links
+3. **Typography & Text Hierarchy** — Primary, secondary, tertiary text
+4. **Functional States** — Success, error, warning, info
+
+For each color, create a descriptive name that evokes the color's character
+rather than its raw hex value:
+
+- ❌ `#294056` → "Blue"
+- ✅ `#294056` → **"Deep Muted Teal-Navy"** — Primary CTA, active navigation
+
+**Deduplication matters.** Codebases often have near-duplicate colors (e.g.,
+`#333` and `#2C2C2C`). Consolidate them under one name that best represents
+the intended color.
+
+#### 3. Typography Rules
+
+Extract the complete typographic system:
+
+**Font families:**
+- Check CSS `font-family`, Tailwind `fontFamily`, Google Fonts links, or
+  local `@font-face` declarations.
+- Note the **character** of each font: geometric vs humanist, serif vs sans,
+  the feeling it evokes.
+
+**Type scale (hierarchy):**
+- Find every heading level (H1-H6) and body text, noting:
+  - `font-size` (in rem or px)
+  - `font-weight` (numeric value + descriptive name)
+  - `letter-spacing` (and why — elegance? compactness?)
+  - `line-height` (generous for readability? tight for display?)
+- Map component usage: Which heading level do product cards use? What about
+  hero sections?
+
+**Spacing principles:**
+- How does text spacing relate to the overall spacing scale?
+- Letter-spacing patterns on headings vs body
+- Line-height philosophy (generous/relaxed for body, tighter for display)
+
+#### 4. Component Stylings
+
+Analyze the 4-5 most important UI primitives:
+
+**Buttons:**
+- Corner radius (and what it communicates — playful? professional? minimal?)
+- Color scheme for primary, secondary, and ghost variants
+- Hover/focus/active states and transition timing
+- Padding ratios (horizontal vs vertical)
+
+**Cards / Containers:**
+- Corner radius (often different from buttons — slightly rounder)
+- Shadow strategy: flat, subtle hover shadows, or always elevated?
+- Border treatment: hairline borders, colored accents, or none?
+- Internal padding (generous or compact?)
+- Image treatment within cards (full-bleed, padded, rounded?)
+
+**Navigation:**
+- Layout pattern (horizontal bar, vertical sidebar, drawer)
+- Typography treatment (uppercase, letter-spacing, weight)
+- Active/hover state indicators (underline, color, background)
+- Mobile behavior (hamburger, bottom nav, drawer)
+
+**Inputs & Forms:**
+- Border style and focus state behavior
+- Corner style consistency with buttons
+- Padding and touch-target sizing
+
+**Domain-Specific Components:**
+- Identify 1-2 components unique to this project (e.g., product cards,
+  dashboard widgets, chat bubbles) and describe their styling patterns.
+
+#### 5. Layout Principles
+
+Extract the structural system:
+
+**Grid & Structure:**
+- Max content width (from `max-width` on containers)
+- Column system (CSS Grid, Flexbox patterns, defined breakpoints)
+- Responsive breakpoints (from media queries or Tailwind config)
+
+**Whitespace Strategy:**
+- Base spacing unit (8px grid? 4px? custom?)
+- Section margins (how much space between major sections)
+- Edge padding (page margins at different breakpoints)
+
+**Alignment & Visual Balance:**
+- Text alignment patterns (centered heroes, left-aligned body)
+- Image-to-text ratios
+- Visual weight distribution
+
+**Responsive Behavior:**
+- Mobile-first or desktop-first?
+- How do grids collapse? Padding scale?
+- Touch target sizing
+
+#### 6. Stitch Generation Notes
+
+Synthesize the extraction into actionable prompts for Stitch:
+
+- **Atmosphere language**: Translate the mood into natural descriptors
+- **Color references**: List colors by descriptive name + hex
+- **Component prompts**: Write 2-3 example prompts that would recreate
+  key components in Stitch
+- **Iteration guidance**: Tips for refining screens in this design system
+
+---
+
+### Phase 3: Write the DESIGN.md
+
+Assemble everything into the standard DESIGN.md format. Place it at
+`.stitch/DESIGN.md` in the project directory (create the `.stitch/` directory
+if it doesn't exist).
+
+> [!IMPORTANT]
+> You **MUST** include the YAML frontmatter at the top of the file with `name` and `colors` mapping, exactly as shown in the example at [examples/DESIGN.md](examples/DESIGN.md). This structured data is required for other skills to parse the design system.
+>
+> Failure to include this YAML block with at least the core color tokens is a failure to use this skill correctly.
+
+Use the format from the example at [examples/DESIGN.md](examples/DESIGN.md) as your template. The file must start with the YAML block, followed by the markdown sections:
+
+```markdown
+# Design System: [Project Name]
+**Project ID:** [If known, otherwise omit]
+
+## 1. Visual Theme & Atmosphere
+[Rich 2-paragraph description of mood, philosophy, and key characteristics]
+
+## 2. Color Palette & Roles
+### Primary Foundation
+### Accent & Interactive
+### Typography & Text Hierarchy
+### Functional States
+
+## 3. Typography Rules
+### Hierarchy & Weights
+### Spacing Principles
+
+## 4. Component Stylings
+### Buttons
+### Cards & [Domain-Specific Containers]
+### Navigation
+### Inputs & Forms
+### [Domain-Specific Components]
+
+## 5. Layout Principles
+### Grid & Structure
+### Whitespace Strategy
+### Alignment & Visual Balance
+### Responsive Behavior & Touch
+
+## 6. Design System Notes for Stitch Generation
+### Language to Use
+### Color References
+### Component Prompts
+### Incremental Iteration
+```
+
+---
+
+### Phase 4: Integration (Optional)
+
+If the user wants to push the design system into Stitch:
+
+1. Hand off to the `manage-design-system` skill for the MCP create/update calls
+2. The DESIGN.md you wrote is the input — the manage-design-system skill handles
+   the Stitch API integration
+
+If the user just wants the document, you're done after Phase 3.
+
+---
+
+## Quality Checklist
+
+Before delivering the DESIGN.md, verify:
+
+- [ ] Every color has a descriptive name, hex code, and functional role
+- [ ] Typography includes font family, character description, and full hierarchy
+- [ ] Component styles describe shape, color, states, and transitions
+- [ ] Layout includes max-width, grid, breakpoints, and spacing strategy
+- [ ] Stitch generation notes use natural language, not CSS syntax
+- [ ] The atmosphere section reads like editorial copy, not technical docs
+- [ ] Near-duplicate colors are consolidated
+- [ ] The document captures the *intent* behind styling, not just raw values
+
+## Tips for Better Extraction
+
+- **Read comments and commit messages.** Developers often document design
+  intent in code comments (`/* hero section — breathable */`) and commit
+  messages. These are gold for understanding the *why*.
+- **Check for design-token libraries.** If the project uses `style-dictionary`,
+  `@tokens-studio`, or similar, these files are the most authoritative
+  source of design values.
+- **Theme files are higher-signal than component styles.** A `theme.ts` that
+  defines a palette tells you the intended design system; scattered inline
+  styles in components tell you what actually shipped. Both matter, but
+  start from the theme.
+- **Tailwind config is a design system.** If a project has a customized
+  `tailwind.config.js`, that *is* the design system — extract from it first,
+  then spot-check components for overrides.
+- **CSS custom properties are intentional.** If a developer defined
+  `--brand-primary`, they're telling you this is a design token. Respect that.

--- a/.claude/skills/stitch-extract-static-html/SKILL.md
+++ b/.claude/skills/stitch-extract-static-html/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: stitch::extract-static-html
+description: >-
+  Extract self-contained static HTML from a built web application or React components by inlining CSS and images. Use this skill whenever you need to capture a specific UI state, share a static version of a page, or prepare assets for Stitch upload, even if the user just asks to 'save the HTML' or 'mock the view'.
+allowed-tools:
+  - "stitch*:*"
+  - "Bash"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Extract Static HTML
+
+Extract a self-contained static HTML file from any web application.
+
+## Which Strategy to Use
+
+You MUST ask the user to choose which strategy to use before proceeding. Present the options clearly, **recommend Strategy A** as the preferred default, and **provide a brief pros/cons summary** for each option to help them make an informed decision.
+
+| | Strategy A (Puppeteer) | Strategy B (Browser Subagent) |
+| :--- | :--- | :--- |
+| **When** | App runs locally, no auth wall | Need to interact with page first (click, fill forms) |
+| **Fidelity** | **Highest — computed styles resolved** | High — rendered DOM |
+| **Setup** | **Zero — no mock needed** | Zero — no mock needed |
+| **Framework** | **Any** | Any |
+| **Output** | **Writes to file — no size limit** | May truncate in agent context |
+
+> [!WARNING]
+> **Checkpoint — User Confirmation Required.**
+> You **MUST** ask the user which strategy they prefer before proceeding.
+> Present the comparison table above, recommend Strategy A as the default, and
+> wait for explicit approval. Do **NOT** make the decision yourself or proceed
+> until the user confirms.
+
+***
+
+## Strategy A: Puppeteer Snapshot (Recommended)
+
+Launches headless Chrome, captures the fully rendered DOM, and produces a self-contained HTML file with all CSS inlined and images as base64. Works with **any framework** — no MockPage.jsx needed.
+
+### Prerequisites
+
+- App running locally (e.g., `npm run dev`)
+- Node.js with `puppeteer` available (check: `node -e "require('puppeteer')"`)
+
+### Workflow
+
+1.  **Start the App** and note the port.
+
+    > [!WARNING]
+    > **Checkpoint — User Confirmation Required.**
+    > After starting the local server, you **MUST** pause and ask the user for
+    > confirmation before running the snapshot script or launching a browser
+    > subagent. Report the URL and port to the user so they can verify the app
+    > is running and rendering correctly. Do **NOT** proceed to the snapshot
+    > step until the user confirms.
+
+2.  **Run the Snapshot Script**:
+    ```bash
+    npx tsx <SKILL_DIR>/scripts/snapshot.ts \
+      --url http://localhost:5173 \
+      --output .stitch/home.html \
+      --wait 2000
+    ```
+
+3.  **Multiple pages** — run once per route:
+    ```bash
+    npx tsx <SKILL_DIR>/scripts/snapshot.ts \
+      --url http://localhost:5173 --output .stitch/home.html --wait 2000
+    npx tsx <SKILL_DIR>/scripts/snapshot.ts \
+      --url http://localhost:5173/pricing --output .stitch/pricing.html --wait 2000
+    npx tsx <SKILL_DIR>/scripts/snapshot.ts \
+      --url http://localhost:5173/dashboard --output .stitch/dashboard.html --wait 2000 --html-class dark
+    ```
+
+### Script Flags
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `--url` | *(required)* | URL to capture |
+| `--output` | *(required)* | Output file path |
+| `--wait` | `1000` | Extra wait (ms) after network idle. Increase for lazy-loading apps. |
+| `--viewport` | `1280x800` | Viewport size as `WIDTHxHEIGHT` |
+| `--html-class` | — | Class(es) for `<html>` element (e.g., `dark`) |
+| `--remove-fixed` | `false` | Remove fixed/sticky elements (cookie banners, chat widgets) |
+| `--full-height` | `false` | Resize viewport to full scroll height |
+| `--title` | — | Override page title |
+
+### What It Does Automatically
+
+- Inlines all `<link rel="stylesheet">` → `<style>` blocks
+- Converts `<img>` `src` **and `srcset`** → base64 data URIs (skips fonts)
+- Inlines `<source srcset>` URLs as base64
+- Removes failed/dead `srcset` entries so the browser falls back to the inlined `src`
+- Removes `<script>` tags, Vite overlay, Next.js dev indicators
+- Resolves relative CSS `url()` paths before inlining
+
+### Framework Notes
+
+| Framework | Notes |
+| :--- | :--- |
+| **React + Vite** | Works out of the box. `--wait 1000`. |
+| **Next.js** | `--wait 3000` for SSR hydration. URL: `http://localhost:3000`. `<img srcset>` from `/_next/image` is auto-inlined as base64. |
+| **Vue / Nuxt** | Works out of the box. |
+| **Svelte / SvelteKit** | Works out of the box. |
+| **Storybook** | Use story URL: `--url http://localhost:6006/?path=/story/...` |
+| **SSR (Webpack)** | May need longer `--wait`. |
+
+### Troubleshooting
+
+| Issue | Solution |
+| :--- | :--- |
+| Images missing | Increase `--wait` |
+| Images show as broken after server stops | Verify `srcset` was inlined — check log for "Inlined N images". If `srcset` URLs failed, they are auto-removed so `src` (inlined) is used. |
+| Next.js `/_next/image` not inlined | Ensure the dev server is running when snapshot runs — the script fetches optimized images from the running server. |
+| Dark mode not applied | `--html-class dark` |
+| Cookie banner in output | `--remove-fixed` |
+| Page requires login | Use the Static Fallback (appendix below) |
+| `Cannot find module 'puppeteer'` | `npm install -g puppeteer` |
+
+***
+
+## Strategy B: Browser Subagent Capture
+
+Use when you need to **interact with the page** (click buttons, fill forms, navigate tabs) before capturing. The browser subagent gives you full control but output may truncate for large pages.
+
+### Workflow
+
+1.  **Start the App** locally.
+2.  **Navigate** using a browser subagent.
+3.  **Interact** as needed (click, scroll, fill forms).
+4.  **Extract DOM**: `document.documentElement.outerHTML`
+
+    > [!WARNING]
+    > Large pages may truncate. To handle this:
+    > - Remove `<style>` tags before extraction: `document.querySelectorAll('style').forEach(el => el.remove())`
+    > - Re-add styles statically (Tailwind CDN link, source CSS)
+5.  **Save** to file.
+
+***
+
+## Appendix: Static Fallback (MockPage.jsx)
+
+> [!NOTE]
+> This method is a **last resort** for when the app cannot run locally (broken deps, missing backend, auth walls with no bypass). It requires manually flattening React components into a single JSX file. **Prefer Strategy A whenever possible.**
+
+### When to Use
+
+- App can't run locally at all
+- Page requires auth with no mock/bypass
+- You need a specific UI state that's impossible to reach by navigation (error screens, empty states)
+
+### Quick Reference
+
+```bash
+npx tsx <SKILL_DIR>/scripts/extract_inline_html.ts \
+  --index-css src/css/App.css \
+  --extra-css index.html \
+  --outdir .stitch \
+  --page src/MockPage.jsx:Page.html:"Page Title"
+```
+
+**Key flags**: `--no-tailwind` (non-Tailwind apps), `--html-class dark` (dark mode), `--css-files` (extra CSS files).
+
+**Auto-detection**: Tailwind config is auto-detected. `@apply` directives automatically use `<style type="text/tailwindcss">`.
+
+### MockPage.jsx Rules
+
+1. **Include the full layout** — header, sidebar, footer (read `App.js` first)
+2. **Flatten all conditionals** — pick one state, remove all ternaries and `&&` guards
+3. **Hardcode all data** — replace `{variable}` with concrete values, unroll `.map()` loops
+4. **Preserve logos** — use `<img>` with local paths (post-process will inline them)
+5. **Remove floating elements** — cookie banners, chat widgets, feedback buttons
+
+### Post-Processing
+
+Inline local images:
+```bash
+npx tsx <SKILL_DIR>/scripts/post_process.ts \
+  .stitch/Page.html --base-dir <app-directory>
+```

--- a/.claude/skills/stitch-generate-design/SKILL.md
+++ b/.claude/skills/stitch-generate-design/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: stitch::generate-design
+description: >-
+  Generate new screens from text prompts or images, edit existing screens
+  with prompts and design system tokens, and generate design variants using
+  Stitch MCP. Includes prompt enhancement pipeline, design mappings, professional
+  UI/UX terminology, design tokens and theme system capabilities.
+allowed-tools:
+  - "stitch*:*"
+  - "Bash"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Generate Design
+
+Create new design screens from text descriptions, images, or mockups, edit
+existing screens with prompts and design system tokens, and generate design
+variants using Stitch MCP.
+
+> [!NOTE]
+> Refer to your system prompt for instruction on handling MCP tool prefixes for
+> all tools mentioned in this skill (e.g., `list_projects`,
+> `generate_screen_from_text`, `edit_screens`).
+
+## 🎨 Prompt Enhancement Pipeline
+
+Before calling any Stitch generation or editing tool, you MUST enhance the
+user's prompt.
+
+### 1. Analyze Context
+
+- **Project**: Use `list_projects` to find the correct `projectId`. If no
+  suitable project exists, create one using `create_project`.
+- **Design System**: Check if a design system exists for the project via
+  `list_design_systems`. If one exists, design tokens (colors, fonts, roundness)
+  are already applied at the project level — do NOT include any color, font, or
+  theme instructions in the generation prompt. If none exists, delegate to the
+  **manage-design-system** skill first before generating screens.
+
+### 2. Refine UI/UX Terminology
+
+Consult [Design Mappings](references/design-mappings.md) to replace vague terms.
+
+- Vague: "Make a nice header"
+- Professional: "Sticky navigation bar with glassmorphism effect and centered
+  logo"
+
+Use [Prompting Keywords](references/prompt-keywords.md) for component names,
+adjective palettes, color roles, and shape descriptions.
+
+### 3. Structure the Final Prompt
+
+Format the enhanced prompt for Stitch. Focus exclusively on **layout, content,
+and structure** — never include colors, fonts, or theme instructions (these are
+handled by the manage-design-system skill at the project level).
+
+For **new screens**, use this template:
+
+```markdown
+[Overall purpose and user intent of the page]
+
+**PLATFORM:** [Web/Mobile], [Desktop/Mobile]-first
+
+**PAGE STRUCTURE:**
+1. **Header:** [Description of navigation and branding]
+2. **Hero Section:** [Headline, subtext, and primary CTA]
+3. **Primary Content Area:** [Detailed component breakdown]
+4. **Footer:** [Links and copyright information]
+```
+
+For **edits**, be specific about what to change:
+
+- **Location**: "Change the [primary button] in the [hero section]..."
+- **Visuals**: "...to a darker blue (#004080) and add a subtle shadow."
+- **Structure**: "Add a secondary button next to the primary one with the text
+  'Learn More'."
+
+> [!CAUTION]
+> Do NOT include hex codes, font names, color palettes, roundness values, or
+> any design system tokens in a **generation** prompt. These are applied at the
+> project level by the manage-design-system skill and will conflict if
+> duplicated. (For **edit** prompts, hex codes are acceptable for precise
+> color adjustments.)
+
+### 4. Present AI Insights
+
+After any tool call, always surface the `outputComponents` (Text Description and
+Suggestions) to the user.
+
+See [examples/enhanced-prompt.md](examples/enhanced-prompt.md) for a full
+before/after prompt enhancement example.
+
+--------------------------------------------------------------------------------
+
+## Steps
+
+### Determine the Mode
+
+Decide which flow to use based on the user's request:
+
+- User wants to create from a text description → **Generate from Text** flow
+- User provides an image, screenshot, or mockup → **Generate from Image** flow
+- User wants to modify an existing screen → **Edit** flow
+- User wants layout/color/content variations → **Generate Variants** flow
+
+---
+
+### Generate from Text Flow (New Screen)
+
+#### 1. Enhance the User Prompt
+
+Apply the Prompt Enhancement Pipeline above.
+
+#### 2. Identify the Project
+
+Use `list_projects` to find the correct `projectId` if it is not already known.
+
+#### 3. Generate the Screen
+
+Call the `generate_screen_from_text` tool with the enhanced prompt and the
+`designSystem` ID (if found in Step 1).
+
+```json
+{
+  "projectId": "...",
+  "prompt": "[Your Enhanced Prompt]",
+  "designSystem": "assets/...", // Optional: Pass if found in Step 1
+  "deviceType": "DESKTOP"  // Options: MOBILE, DESKTOP, TABLET
+}
+```
+
+#### 4. Present AI Feedback
+
+Always show the text description and suggestions from `outputComponents` to the
+user.
+
+#### 5. Download Design Assets
+
+After generation, download the HTML and screenshot urls from `outputComponents`
+to the `.stitch/designs` directory.
+
+- **Naming**: Use the screen ID or a descriptive slug for the filename.
+- **Tools**: Use `curl -o` via `run_command` or similar.
+- **Directory**: Ensure `.stitch/designs` exists.
+
+#### 6. Review and Refine
+
+- If the result is not exactly as expected, continue with the **Edit** flow
+  to make targeted adjustments.
+- Do NOT re-generate from scratch unless the fundamental layout is wrong.
+
+---
+
+### Generate from Image Flow (Image/Mockup → Design)
+
+Use this flow when the user provides an image, screenshot, or design mockup to
+recreate in Stitch.
+
+#### 1. Identify the Project
+
+Use `list_projects` to find the correct `projectId`. If no suitable project
+exists, create one using `create_project`.
+
+#### 2. Upload the Image
+
+Delegate to the **upload-to-stitch** skill to upload the image to the project.
+This creates a new screen with the image as its content.
+
+#### 3. Refine with Edit
+
+Once uploaded, use `list_screens` to find the newly created `screenId`, then
+call `edit_screens` with a descriptive prompt to refine the design:
+
+```json
+{
+  "projectId": "...",
+  "selectedScreenIds": ["<uploaded-screen-id>"],
+  "prompt": "[Describe what to adjust, enhance, or recreate from this mockup]"
+}
+```
+
+> [!TIP]
+> For best results, describe the intent behind the image rather than just saying
+> "make it look like this". For example: "This is a dashboard mockup — recreate
+> it with a proper data table, sidebar navigation, and chart widgets."
+
+#### 4. Present AI Feedback
+
+Always show the text description and suggestions from `outputComponents` to the
+user.
+
+#### 5. Download Design Assets
+
+Download the HTML and screenshot urls from `outputComponents` to the
+`.stitch/designs` directory.
+
+- **Naming**: Use the screen ID or a descriptive slug for the filename.
+- **Tools**: Use `curl -o` via `run_command` or similar.
+- **Directory**: Ensure `.stitch/designs` exists.
+
+---
+
+### Edit Flow (Modify Existing Screen)
+
+#### 1. Identify the Screen
+
+Use `list_screens` or `get_screen` to find the correct `projectId` and
+`screenId`.
+
+#### 2. Formulate the Edit Prompt
+
+Apply the Prompt Enhancement Pipeline, focusing on specificity:
+
+- **Location**: "Change the color of the [primary button] in the [hero
+  section]..."
+- **Visuals**: "...to a darker blue (#004080) and add a subtle shadow."
+- **Structure**: "Add a secondary button next to the primary one with the text
+  'Learn More'."
+
+#### 3. Apply the Edit
+
+Call the `edit_screens` tool.
+
+```json
+{
+  "projectId": "...",
+  "selectedScreenIds": ["..."],
+  "prompt": "[Your targeted edit prompt]"
+}
+```
+
+#### 4. Present AI Feedback
+
+Always show the text description and suggestions from `outputComponents` to the
+user.
+
+#### 5. Download Design Assets
+
+After editing, download the updated HTML and screenshot urls from
+`outputComponents` to the `.stitch/designs` directory, overwriting previous
+versions to ensure the local files reflect the latest edits.
+
+- **Naming**: Use the screen ID or a descriptive slug for the filename.
+- **Tools**: Use `curl -o` via `run_command` or similar.
+- **Directory**: Ensure `.stitch/designs` exists.
+
+#### 6. Update Project Metadata
+
+After downloading assets, update `.stitch/metadata.json` to reflect any changes
+(e.g., updated screen titles or new screen IDs from the edit). The metadata
+file tracks all screens, their device types, and design system info. See the
+**manage-design-system** skill's `examples/metadata.json` for the format.
+
+#### 7. Verify and Repeat
+
+- Check the output screen to see if the changes were applied correctly.
+- If more polish is needed, repeat the edit flow with a new specific prompt.
+
+---
+
+### Generate Variants Flow (Explore Variations)
+
+Use this flow when the user wants to explore alternative layouts, color schemes,
+or content variations of an existing screen.
+
+#### 1. Identify the Screen
+
+Use `list_screens` or `get_screen` to find the correct `projectId` and
+`screenId`.
+
+#### 2. Configure Variant Options
+
+Call the `generate_variants` tool with the appropriate options:
+
+```json
+{
+  "projectId": "...",
+  "selectedScreenIds": ["..."],
+  "prompt": "[Describe the direction for variants]",
+  "variantOptions": {
+    "variantCount": 3,
+    "creativeRange": "EXPLORE",
+    "aspects": ["LAYOUT", "COLOR_SCHEME"]
+  }
+}
+```
+
+**Variant Options:**
+- **`variantCount`**: 1–5 variants (default: 3)
+- **`creativeRange`**: `REFINE` (subtle), `EXPLORE` (balanced), or `REIMAGINE`
+  (radical)
+- **`aspects`**: Focus on specific dimensions — `LAYOUT`, `COLOR_SCHEME`,
+  `IMAGES`, `TEXT_FONT`, `TEXT_CONTENT`, or leave empty for all
+
+#### 3. Present AI Feedback
+
+Always show the text description and suggestions from `outputComponents` to the
+user.
+
+#### 4. Download Design Assets
+
+Download the variant HTML and screenshot urls from `outputComponents` to the
+`.stitch/designs` directory.
+
+- **Naming**: Use the screen ID or a descriptive slug for the filename.
+- **Tools**: Use `curl -o` via `run_command` or similar.
+- **Directory**: Ensure `.stitch/designs` exists.
+
+--------------------------------------------------------------------------------
+
+## 💡 Tips
+
+- **Be structural**: Break the page down into header, hero, features, and
+  footer in your prompt.
+- **Content first**: Describe what each section contains (text, images, CTAs)
+  rather than how it looks.
+- **Iterative Polish**: Prefer editing for targeted adjustments over full
+  re-generation.
+- **No theme leakage**: Never put hex codes, font names, or color roles in a
+  generation prompt — the design system handles all visual styling.
+- **Specify interactions**: Mention hover states, animations, and click behavior
+  rather than visual styling.
+- **Keep edits focused**: One edit at a time is often better than a long list of
+  changes.
+- **Reference components**: Use professional terms like "navigation bar", "hero
+  section", "footer", "card grid".
+- **Precise colors in edits**: Use hex codes for exact color matching when
+  editing existing screens.
+
+## 📚 References
+
+- [Design Mappings](references/design-mappings.md) — UI/UX keywords and
+  atmosphere descriptors.
+- [Prompting Keywords](references/prompt-keywords.md) — Technical terms Stitch
+  understands best.
+- [Enhanced Prompt Example](examples/enhanced-prompt.md) — Before/after prompt
+  enhancement.

--- a/.claude/skills/stitch-loop/SKILL.md
+++ b/.claude/skills/stitch-loop/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: stitch-loop
+description: Teaches agents to iteratively build websites using Stitch with an autonomous baton-passing loop pattern
+allowed-tools:
+  - "stitch*:*"
+  - "chrome*:*"
+  - "Read"
+  - "Write"
+  - "Bash"
+---
+
+# Stitch Build Loop
+
+You are an **autonomous frontend builder** participating in an iterative site-building loop. Your goal is to generate a page using Stitch, integrate it into the site, and prepare instructions for the next iteration.
+
+## Overview
+
+The Build Loop pattern enables continuous, autonomous website development through a "baton" system. Each iteration:
+1. Reads the current task from a baton file (`.stitch/next-prompt.md`)
+2. Generates a page using Stitch MCP tools
+3. Integrates the page into the site structure
+4. Writes the next task to the baton file for the next iteration
+
+## Prerequisites
+
+**Required:**
+- Access to the Stitch MCP Server
+- A Stitch project (existing or will be created)
+- A `.stitch/DESIGN.md` file (generate one using the `design-md` skill if needed)
+- A `.stitch/SITE.md` file documenting the site vision and roadmap
+
+**Optional:**
+- Chrome DevTools MCP Server — enables visual verification of generated pages
+
+## The Baton System
+
+The `.stitch/next-prompt.md` file acts as a relay baton between iterations:
+
+```markdown
+---
+page: about
+---
+A page describing how jules.top tracking works.
+
+**DESIGN SYSTEM (REQUIRED):**
+[Copy from .stitch/DESIGN.md Section 6]
+
+**Page Structure:**
+1. Header with navigation
+2. Explanation of tracking methodology
+3. Footer with links
+```
+
+**Critical rules:**
+- The `page` field in YAML frontmatter determines the output filename
+- The prompt content must include the design system block from `.stitch/DESIGN.md`
+- You MUST update this file before completing your work to continue the loop
+
+## Execution Protocol
+
+### Step 1: Read the Baton
+
+Parse `.stitch/next-prompt.md` to extract:
+- **Page name** from the `page` frontmatter field
+- **Prompt content** from the markdown body
+
+### Step 2: Consult Context Files
+
+Before generating, read these files:
+
+| File | Purpose |
+|------|---------|
+| `.stitch/SITE.md` | Site vision, **Stitch Project ID**, existing pages (sitemap), roadmap |
+| `.stitch/DESIGN.md` | Required visual style for Stitch prompts |
+
+**Important checks:**
+- Section 4 (Sitemap) — Do NOT recreate pages that already exist
+- Section 5 (Roadmap) — Pick tasks from here if backlog exists
+- Section 6 (Creative Freedom) — Ideas for new pages if roadmap is empty
+
+### Step 3: Generate with Stitch
+
+Use the Stitch MCP tools to generate the page:
+
+1. **Discover namespace**: Run `list_tools` to find the Stitch MCP prefix
+2. **Get or create project**: 
+   - If `.stitch/metadata.json` exists, use the `projectId` from it
+   - Otherwise, call `[prefix]:create_project`, then call `[prefix]:get_project` to retrieve full project details, and save them to `.stitch/metadata.json` (see schema below)
+   - After generating each screen, call `[prefix]:get_project` again and update the `screens` map in `.stitch/metadata.json` with each screen's full metadata (id, sourceScreen, dimensions, canvas position)
+3. **Generate screen**: Call `[prefix]:generate_screen_from_text` with:
+   - `projectId`: The project ID
+   - `prompt`: The full prompt from the baton (including design system block)
+   - `deviceType`: `DESKTOP` (or as specified)
+4. **Retrieve assets**: Before downloading, check if `.stitch/designs/{page}.html` and `.stitch/designs/{page}.png` already exist:
+   - **If files exist**: Ask the user whether to refresh the designs from the Stitch project or reuse the existing local files. Only re-download if the user confirms.
+   - **If files do not exist**: Proceed with download:
+     - `htmlCode.downloadUrl` — Download and save as `.stitch/designs/{page}.html`
+      - `screenshot.downloadUrl` — Append `=w{width}` to the URL before downloading, where `{width}` is the `width` value from the screen metadata (Google CDN serves low-res thumbnails by default). Save as `.stitch/designs/{page}.png`
+
+### Step 4: Integrate into Site
+
+1. Move generated HTML from `.stitch/designs/{page}.html` to `site/public/{page}.html`
+2. Fix any asset paths to be relative to the public folder
+3. Update navigation:
+   - Find existing placeholder links (e.g., `href="#"`) and wire them to the new page
+   - Add the new page to the global navigation if appropriate
+4. Ensure consistent headers/footers across all pages
+
+### Step 4.5: Visual Verification (Optional)
+
+If the **Chrome DevTools MCP Server** is available, verify the generated page:
+
+1. **Check availability**: Run `list_tools` to see if `chrome*` tools are present
+2. **Start dev server**: Use Bash to start a local server (e.g., `npx serve site/public`)
+3. **Navigate to page**: Call `[chrome_prefix]:navigate` to open `http://localhost:3000/{page}.html`
+4. **Capture screenshot**: Call `[chrome_prefix]:screenshot` to capture the rendered page
+5. **Visual comparison**: Compare against the Stitch screenshot (`.stitch/designs/{page}.png`) for fidelity
+6. **Stop server**: Terminate the dev server process
+
+> **Note:** This step is optional. If Chrome DevTools MCP is not installed, skip to Step 5.
+
+### Step 5: Update Site Documentation
+
+Modify `.stitch/SITE.md`:
+- Add the new page to Section 4 (Sitemap) with `[x]`
+- Remove any idea you consumed from Section 6 (Creative Freedom)
+- Update Section 5 (Roadmap) if you completed a backlog item
+
+### Step 6: Prepare the Next Baton (Critical)
+
+**You MUST update `.stitch/next-prompt.md` before completing.** This keeps the loop alive.
+
+1. **Decide the next page**: 
+   - Check `.stitch/SITE.md` Section 5 (Roadmap) for pending items
+   - If empty, pick from Section 6 (Creative Freedom)
+   - Or invent something new that fits the site vision
+2. **Write the baton** with proper YAML frontmatter:
+
+```markdown
+---
+page: achievements
+---
+A competitive achievements page showing developer badges and milestones.
+
+**DESIGN SYSTEM (REQUIRED):**
+[Copy the entire design system block from .stitch/DESIGN.md]
+
+**Page Structure:**
+1. Header with title and navigation
+2. Badge grid showing unlocked/locked states
+3. Progress bars for milestone tracking
+```
+
+## File Structure Reference
+
+```
+project/
+├── .stitch/
+│   ├── metadata.json   # Stitch project & screen IDs (persist this!)
+│   ├── DESIGN.md       # Visual design system (from design-md skill)
+│   ├── SITE.md         # Site vision, sitemap, roadmap
+│   ├── next-prompt.md  # The baton — current task
+│   └── designs/        # Staging area for Stitch output
+│       ├── {page}.html
+│       └── {page}.png
+└── site/public/        # Production pages
+    ├── index.html
+    └── {page}.html
+```
+
+### `.stitch/metadata.json` Schema
+
+This file persists all Stitch identifiers so future iterations can reference them for edits or variants. Populate it by calling `[prefix]:get_project` after creating a project or generating screens.
+
+```json
+{
+  "name": "projects/6139132077804554844",
+  "projectId": "6139132077804554844",
+  "title": "My App",
+  "visibility": "PRIVATE",
+  "createTime": "2026-03-04T23:11:25.514932Z",
+  "updateTime": "2026-03-04T23:34:40.400007Z",
+  "projectType": "PROJECT_DESIGN",
+  "origin": "STITCH",
+  "deviceType": "MOBILE",
+  "designTheme": {
+    "colorMode": "DARK",
+    "font": "INTER",
+    "roundness": "ROUND_EIGHT",
+    "customColor": "#40baf7",
+    "saturation": 3
+  },
+  "screens": {
+    "index": {
+      "id": "d7237c7d78f44befa4f60afb17c818c1",
+      "sourceScreen": "projects/6139132077804554844/screens/d7237c7d78f44befa4f60afb17c818c1",
+      "x": 0,
+      "y": 0,
+      "width": 390,
+      "height": 1249
+    },
+    "about": {
+      "id": "bf6a3fe5c75348e58cf21fc7a9ddeafb",
+      "sourceScreen": "projects/6139132077804554844/screens/bf6a3fe5c75348e58cf21fc7a9ddeafb",
+      "x": 549,
+      "y": 0,
+      "width": 390,
+      "height": 1159
+    }
+  },
+  "metadata": {
+    "userRole": "OWNER"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `name` | Full resource name (`projects/{id}`) |
+| `projectId` | Stitch project ID (from `create_project` or `get_project`) |
+| `title` | Human-readable project title |
+| `designTheme` | Design system tokens: color mode, font, roundness, custom color, saturation |
+| `deviceType` | Target device: `MOBILE`, `DESKTOP`, `TABLET` |
+| `screens` | Map of page name → screen object. Each screen includes `id`, `sourceScreen` (resource path for MCP calls), canvas position (`x`, `y`), and dimensions (`width`, `height`) |
+| `metadata.userRole` | User's role on the project (`OWNER`, `EDITOR`, `VIEWER`) |
+
+## Orchestration Options
+
+The loop can be driven by different orchestration layers:
+
+| Method | How it works |
+|--------|--------------|
+| **CI/CD** | GitHub Actions triggers on `.stitch/next-prompt.md` changes |
+| **Human-in-loop** | Developer reviews each iteration before continuing |
+| **Agent chains** | One agent dispatches to another (e.g., Jules API) |
+| **Manual** | Developer runs the agent repeatedly with the same repo |
+
+The skill is orchestration-agnostic — focus on the pattern, not the trigger mechanism.
+
+## Design System Integration
+
+This skill works best with the `design-md` skill:
+
+1. **First time setup**: Generate `.stitch/DESIGN.md` using the `design-md` skill from an existing Stitch screen
+2. **Every iteration**: Copy Section 6 ("Design System Notes for Stitch Generation") into your baton prompt
+3. **Consistency**: All generated pages will share the same visual language
+
+## Common Pitfalls
+
+- ❌ Forgetting to update `.stitch/next-prompt.md` (breaks the loop)
+- ❌ Recreating a page that already exists in the sitemap
+- ❌ Not including the design system block from `.stitch/DESIGN.md` in the prompt
+- ❌ Leaving placeholder links (`href="#"`) instead of wiring real navigation
+- ❌ Forgetting to persist `.stitch/metadata.json` after creating a new project
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Stitch generation fails | Check that the prompt includes the design system block |
+| Inconsistent styles | Ensure `.stitch/DESIGN.md` is up-to-date and copied correctly |
+| Loop stalls | Verify `.stitch/next-prompt.md` was updated with valid frontmatter |
+| Navigation broken | Check all internal links use correct relative paths |

--- a/.claude/skills/stitch-manage-design-system/SKILL.md
+++ b/.claude/skills/stitch-manage-design-system/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: stitch::manage-design-system
+description: >-
+  Manage design systems in Stitch using MCP tools. Includes retrieval of assets,
+  creating/updating design systems in Stitch, and applying them to screens.
+allowed-tools:
+  - "stitch*:*"
+  - "Bash"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Design-System
+
+Create a "source of truth" for your project's design language to ensure
+consistency across all future screens.
+
+> [!NOTE]
+> Refer to your system prompt for instruction on handling MCP tool prefixes for
+> all tools mentioned in this skill (e.g., `get_screen`,
+> `create_design_system_from_design_md`, `apply_design_system`).
+
+## 📥 Retrieval
+
+To analyze a Stitch project, you must retrieve metadata and assets using the
+Stitch MCP tools:
+
+1. **Project lookup**: Use `list_projects` to find the target `projectId`.
+2. **Screen lookup**: Use `list_screens` for that `projectId` to find
+   representative screens (e.g., "Home", "Main Dashboard").
+3. **Metadata fetch**: Call `get_screen` for the target screen to get
+   `screenshot.downloadUrl` and `htmlCode.downloadUrl`.
+4. **Asset download**: Use `read_url_content` to fetch the HTML code.
+
+## 🧠 Synthesis from Description
+
+If you need to extract a design system from existing screens, use the `design-md` skill (in the `stitch-utilities` plugin).
+
+If there are no existing screens (new project), or the user provides a direct description (e.g., "dark theme, blue and purple, rounded, Inter font"):
+
+1. Map the user's vague terms to precise values using the design mappings (see `design-md` skill in `stitch-utilities` or `generate-design` skill).
+2. Select concrete hex codes, font families, and roundness values.
+3. Generate the `DESIGN.md` file (refer to the `design-md` skill in `stitch-utilities` for structure).
+4. Proceed to the "Create or Update Design System in Stitch" step below.
+
+## 📝 Output Structure
+
+The `DESIGN.md` file should follow the structure defined in the `design-md` skill (in the `stitch-utilities` plugin).
+
+## 🚀 Create or Update Design System in Stitch
+
+After generating `.stitch/DESIGN.md`, make sure to also create or update the
+design system in Stitch.
+
+**Two-step design system creation:**
+
+> [!WARNING]
+> **Checkpoint — User Confirmation Required.**
+> Before uploading, you **MUST** pause and ask the user for
+> confirmation. Present a summary of the design system you are about to create
+> (display name, key colors, fonts, and roundness) and wait for explicit approval
+> before proceeding. Do **NOT** upload until the user confirms.
+
+1. **Upload `DESIGN.md`**:
+   - **Option A (Recommended - Uploader Script)**: Use the modified `upload-to-stitch` Python script which natively handles `.md` files. It base64-encodes the markdown file in-process and sends it to the `/v1/projects/{projectId}/screens:batchCreate` endpoint, bypassing output token limits.
+     ```bash
+     python3 stitch-skills/plugins/stitch-design/skills/upload-to-stitch/scripts/upload_to_stitch.py \
+       --project-id <PROJECT_ID> \
+       --file-path /path/to/DESIGN.md \
+       --api-key <API_KEY>
+     ```
+     This returns the `sourceScreen` ID and the `screenInstance` ID.
+   - **Option B (Direct MCP Tool)**: If the `DESIGN.md` is small (under ~5KB), you can call the `upload_design_md` MCP tool directly, passing the base64-encoded design markdown content as `designMdBase64`.
+2. **Create Design System**: Call the `create_design_system_from_design_md` tool immediately after the upload, passing the `projectId` and the `selectedScreenInstance` (containing the `id` and `sourceScreen` returned from the upload step).
+
+Once the upload script and `create_design_system_from_design_md` have both completed,
+Stitch holds the design tokens at the project level — you do NOT need to repeat
+them in generation prompts.
+
+## 🎨 Apply Design System to Screens
+
+Use `apply_design_system` to apply a design system to existing screens.
+
+> [!IMPORTANT]
+> `selectedScreenInstances` must contain **only** `id` and `sourceScreen` — do
+> NOT include position/dimension fields (`x`, `y`, `width`, `height`) or the
+> request will fail with "invalid argument". Get the screen instance IDs from
+> `get_project`.
+
+```json
+{
+  "projectId": "...",
+  "assetId": "...",
+  "selectedScreenInstances": [
+    {
+      "id": "...",
+      "sourceScreen": "projects/.../screens/..."
+    }
+  ]
+}
+```
+
+**How to get the required IDs:**
+1. Call `get_project` to retrieve `screenInstances` — each has an `id` and
+   `sourceScreen`.
+2. Call `list_design_systems` to retrieve the design system `name` (format:
+   `assets/{assetId}`) — use the part after `assets/` as the `assetId`.
+3. Filter out any instances with `type: "DESIGN_SYSTEM_INSTANCE"` — only pass
+   real screens.
+
+## 📋 Update Project Metadata
+
+After writing `.stitch/DESIGN.md`, also create or update `.stitch/metadata.json`
+to track the `projectId`, `title`, all known screens, and design system summary.
+See [examples/metadata.json](examples/metadata.json) for the format.
+
+## Schema Reference
+
+See [reference/tool-schema.md](reference/tool-schema.md) for the full
+`designSystem` object schema with all available options.
+
+## 💡 Best Practices
+
+Refer to the `design-md` skill (in the `stitch-utilities` plugin) for best practices on describing design elements.

--- a/.claude/skills/stitch-react-components/SKILL.md
+++ b/.claude/skills/stitch-react-components/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: react:components
+description: Converts Stitch designs into modular Vite and React components using system-level networking and AST-based validation.
+allowed-tools:
+  - "stitch*:*"
+  - "Bash"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Stitch to React Components
+
+You are a frontend engineer focused on transforming designs into clean React code. You follow a modular approach and use automated tools to ensure code quality.
+
+## Retrieval and networking
+1. **Namespace discovery**: Run `list_tools` to find the Stitch MCP prefix. Use this prefix (e.g., `stitch:`) for all subsequent calls.
+2. **Metadata fetch**: Call `[prefix]:get_screen` to retrieve the design JSON.
+3. **Check for existing designs**: Before downloading, check if `.stitch/designs/{page}.html` and `.stitch/designs/{page}.png` already exist:
+   - **If files exist**: Ask the user whether to refresh the designs from the Stitch project using the MCP, or reuse the existing local files. Only re-download if the user confirms.
+   - **If files do not exist**: Proceed to step 4.
+4. **High-reliability download**: Internal AI fetch tools can fail on Google Cloud Storage domains.
+   - **HTML**: `bash scripts/fetch-stitch.sh "[htmlCode.downloadUrl]" ".stitch/designs/{page}.html"`
+    - **Screenshot**: Append `=w{width}` to the screenshot URL first, where `{width}` is the `width` value from the screen metadata (Google CDN serves low-res thumbnails by default). Then run: `bash scripts/fetch-stitch.sh "[screenshot.downloadUrl]=w{width}" ".stitch/designs/{page}.png"`
+   - This script handles the necessary redirects and security handshakes.
+5. **Visual audit**: Review the downloaded screenshot (`.stitch/designs/{page}.png`) to confirm design intent and layout details.
+
+## Architectural rules
+* **Modular components**: Break the design into independent files. Avoid large, single-file outputs.
+* **Logic isolation**: Move event handlers and business logic into custom hooks in `src/hooks/`.
+* **Data decoupling**: Move all static text, image URLs, and lists into `src/data/mockData.ts`.
+* **Type safety**: Every component must include a `Readonly` TypeScript interface named `[ComponentName]Props`.
+* **Project specific**: Focus on the target project's needs and constraints. Leave Google license headers out of the generated React components.
+* **Style mapping**:
+    * Extract the `tailwind.config` from the HTML `<head>`.
+    * Sync these values with `resources/style-guide.json`.
+    * Use theme-mapped Tailwind classes instead of arbitrary hex codes.
+
+## Execution steps
+1. **Environment setup**: If `node_modules` is missing, run `npm install` to enable the validation tools.
+2. **Data layer**: Create `src/data/mockData.ts` based on the design content.
+3. **Component drafting**: Use `resources/component-template.tsx` as a base. Find and replace all instances of `StitchComponent` with the actual name of the component you are creating.
+4. **Application wiring**: Update the project entry point (like `App.tsx`) to render the new components.
+5. **Quality check**:
+    * Run `npm run validate <file_path>` for each component.
+    * Verify the final output against the `resources/architecture-checklist.md`.
+    * Start the dev server with `npm run dev` to verify the live result.
+
+## Troubleshooting
+* **Fetch errors**: Ensure the URL is quoted in the bash command to prevent shell errors.
+* **Validation errors**: Review the AST report and fix any missing interfaces or hardcoded styles.

--- a/.claude/skills/stitch-remotion/SKILL.md
+++ b/.claude/skills/stitch-remotion/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: remotion
+description: Generate walkthrough videos from Stitch projects using Remotion with smooth transitions, zooming, and text overlays
+allowed-tools:
+  - "stitch*:*"
+  - "remotion*:*"
+  - "Bash"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Stitch to Remotion Walkthrough Videos
+
+You are a video production specialist focused on creating engaging walkthrough videos from app designs. You combine Stitch's screen retrieval capabilities with Remotion's programmatic video generation to produce smooth, professional presentations.
+
+## Overview
+
+This skill enables you to create walkthrough videos that showcase app screens with professional transitions, zoom effects, and contextual text overlays. The workflow retrieves screens from Stitch projects and orchestrates them into a Remotion video composition.
+
+## Prerequisites
+
+**Required:**
+- Access to the Stitch MCP Server
+- Access to the Remotion MCP Server (or Remotion CLI)
+- Node.js and npm installed
+- A Stitch project with designed screens
+
+**Recommended:**
+- Familiarity with Remotion's video capabilities
+- Understanding of React components (Remotion uses React)
+
+## Retrieval and Networking
+
+### Step 1: Discover Available MCP Servers
+
+Run `list_tools` to identify available MCP servers and their prefixes:
+- **Stitch MCP**: Look for `stitch:` or `mcp_stitch:` prefix
+- **Remotion MCP**: Look for `remotion:` or `mcp_remotion:` prefix
+
+### Step 2: Retrieve Stitch Project Information
+
+1. **Project lookup** (if Project ID is not provided):
+   - Call `[stitch_prefix]:list_projects` with `filter: "view=owned"`
+   - Identify target project by title (e.g., "Calculator App")
+   - Extract Project ID from `name` field (e.g., `projects/13534454087919359824`)
+
+2. **Screen retrieval**:
+   - Call `[stitch_prefix]:list_screens` with the project ID (numeric only)
+   - Review screen titles to identify all screens for the walkthrough
+   - Extract Screen IDs from each screen's `name` field
+
+3. **Screen metadata fetch**:
+   For each screen:
+   - Call `[stitch_prefix]:get_screen` with `projectId` and `screenId`
+   - Retrieve:
+     - `screenshot.downloadUrl` — Visual asset for the video
+     - `htmlCode.downloadUrl` — Optional: for extracting text/content
+     - `width`, `height` — Screen dimensions for proper scaling
+     - Screen title and description for text overlays
+
+4. **Asset download**:
+   - Use `web_fetch` or `Bash` with `curl` to download screenshots
+   - Save to a staging directory: `assets/screens/{screen-name}.png`
+   - Organize assets in order of the intended walkthrough flow
+
+### Step 3: Set Up Remotion Project
+
+1. **Check for existing Remotion project**:
+   - Look for `remotion.config.ts` or `package.json` with Remotion dependencies
+   - If exists, use the existing project structure
+
+2. **Create new Remotion project** (if needed):
+   ```bash
+   npm create video@latest -- --blank
+   ```
+   - Choose TypeScript template
+   - Set up in a dedicated `video/` directory
+
+3. **Install dependencies**:
+   ```bash
+   cd video
+   npm install @remotion/transitions @remotion/animated-emoji
+   ```
+
+## Video Composition Strategy
+
+### Architecture
+
+Create a modular Remotion composition with these components:
+
+1. **`ScreenSlide.tsx`** — Individual screen display component
+   - Props: `imageSrc`, `title`, `description`, `width`, `height`
+   - Features: Zoom-in animation, fade transitions
+   - Duration: Configurable (default 3-5 seconds per screen)
+
+2. **`WalkthroughComposition.tsx`** — Main video composition
+   - Sequences multiple `ScreenSlide` components
+   - Handles transitions between screens
+   - Adds text overlays and annotations
+
+3. **`config.ts`** — Video configuration
+   - Frame rate (default: 30 fps)
+   - Video dimensions (match Stitch screen dimensions or scale appropriately)
+   - Total duration calculation
+
+### Transition Effects
+
+Use Remotion's `@remotion/transitions` for professional effects:
+
+- **Fade**: Smooth cross-fade between screens
+  ```tsx
+  import {fade} from '@remotion/transitions/fade';
+  ```
+
+- **Slide**: Directional slide transitions
+  ```tsx
+  import {slide} from '@remotion/transitions/slide';
+  ```
+
+- **Zoom**: Zoom in/out effects for emphasis
+  - Use `spring()` animation for smooth zoom
+  - Apply to important UI elements
+
+### Text Overlays
+
+Add contextual information using Remotion's text rendering:
+
+1. **Screen titles**: Display at the top or bottom of each frame
+2. **Feature callouts**: Highlight specific UI elements with animated pointers
+3. **Descriptions**: Fade in descriptive text for each screen
+4. **Progress indicator**: Show current screen position in walkthrough
+
+## Execution Steps
+
+### Step 1: Gather Screen Assets
+
+1. Identify target Stitch project
+2. List all screens in the project
+3. Download screenshots for each screen
+4. Organize in order of walkthrough flow
+5. Create a manifest file (`screens.json`):
+
+```json
+{
+  "projectName": "Calculator App",
+  "screens": [
+    {
+      "id": "1",
+      "title": "Home Screen",
+      "description": "Main calculator interface with number pad",
+      "imagePath": "assets/screens/home.png",
+      "width": 1200,
+      "height": 800,
+      "duration": 4
+    },
+    {
+      "id": "2",
+      "title": "History View",
+      "description": "View of previous calculations",
+      "imagePath": "assets/screens/history.png",
+      "width": 1200,
+      "height": 800,
+      "duration": 3
+    }
+  ]
+}
+```
+
+### Step 2: Generate Remotion Components
+
+Create the video components following Remotion best practices:
+
+1. **Create `ScreenSlide.tsx`**:
+   - Use `useCurrentFrame()` and `spring()` for animations
+   - Implement zoom and fade effects
+   - Add text overlays with proper timing
+
+2. **Create `WalkthroughComposition.tsx`**:
+   - Import screen manifest
+   - Sequence screens with `<Sequence>` components
+   - Apply transitions between screens
+   - Calculate proper timing and offsets
+
+3. **Update `remotion.config.ts`**:
+   - Set composition ID
+   - Configure video dimensions
+   - Set frame rate and duration
+
+**Reference Resources:**
+- Use `resources/screen-slide-template.tsx` as starting point
+- Follow `resources/composition-checklist.md` for completeness
+- Review examples in `examples/` directory
+
+### Step 3: Preview and Refine
+
+1. **Start Remotion Studio**:
+   ```bash
+   npm run dev
+   ```
+   - Opens browser-based preview
+   - Allows real-time editing and refinement
+
+2. **Adjust timing**:
+   - Ensure each screen has appropriate display duration
+   - Verify transitions are smooth
+   - Check text overlay timing
+
+3. **Fine-tune animations**:
+   - Adjust spring configurations for zoom effects
+   - Modify easing functions for transitions
+   - Ensure text is readable at all times
+
+### Step 4: Render Video
+
+1. **Render using Remotion CLI**:
+   ```bash
+   npx remotion render WalkthroughComposition output.mp4
+   ```
+
+2. **Alternative: Use Remotion MCP** (if available):
+   - Call `[remotion_prefix]:render` with composition details
+   - Specify output format (MP4, WebM, etc.)
+
+3. **Optimization options**:
+   - Set quality level (`--quality`)
+   - Configure codec (`--codec h264` or `h265`)
+   - Enable parallel rendering (`--concurrency`)
+
+## Advanced Features
+
+### Interactive Hotspots
+
+Highlight clickable elements or important features:
+
+```tsx
+import {interpolate, useCurrentFrame} from 'remotion';
+
+const Hotspot = ({x, y, label}) => {
+  const frame = useCurrentFrame();
+  const scale = spring({
+    frame,
+    fps: 30,
+    config: {damping: 10, stiffness: 100}
+  });
+  
+  return (
+    <div style={{
+      position: 'absolute',
+      left: x,
+      top: y,
+      transform: `scale(${scale})`
+    }}>
+      <div className="pulse-ring" />
+      <span>{label}</span>
+    </div>
+  );
+};
+```
+
+### Voiceover Integration
+
+Add narration to the walkthrough:
+
+1. Generate voiceover script from screen descriptions
+2. Use text-to-speech or record audio
+3. Import audio into Remotion with `<Audio>` component
+4. Sync screen timing with voiceover pacing
+
+### Dynamic Text Extraction
+
+Extract text from Stitch HTML code for automatic annotations:
+
+1. Download `htmlCode.downloadUrl` for each screen
+2. Parse HTML to extract key text elements (headings, buttons, labels)
+3. Generate automatic callouts for important UI elements
+4. Add to composition as timed text overlays
+
+## File Structure
+
+```
+project/
+├── video/                      # Remotion project directory
+│   ├── src/
+│   │   ├── WalkthroughComposition.tsx
+│   │   ├── ScreenSlide.tsx
+│   │   ├── components/
+│   │   │   ├── Hotspot.tsx
+│   │   │   └── TextOverlay.tsx
+│   │   └── Root.tsx
+│   ├── public/
+│   │   └── assets/
+│   │       └── screens/        # Downloaded Stitch screenshots
+│   │           ├── home.png
+│   │           └── history.png
+│   ├── remotion.config.ts
+│   └── package.json
+├── screens.json                # Screen manifest
+└── output.mp4                  # Rendered video
+```
+
+## Integration with Remotion Skills
+
+Remotion maintains its own Agent Skills that define best practices. Review these for advanced techniques:
+
+- **Repository**: https://github.com/remotion-dev/remotion/tree/main/packages/skills
+- **Installation**: `npx skills add remotion-dev/skills`
+
+Key Remotion skills to leverage:
+- Animation timing and easing
+- Composition architecture patterns
+- Performance optimization
+- Audio synchronization
+
+## Common Patterns
+
+### Pattern 1: Simple Slide Show
+
+Basic walkthrough with fade transitions:
+- 3-5 seconds per screen
+- Cross-fade transitions
+- Bottom text overlay with screen title
+- Progress bar at top
+
+### Pattern 2: Feature Highlight
+
+Focus on specific UI elements:
+- Zoom into specific regions
+- Animated circles/arrows pointing to features
+- Slow-motion emphasis on key interactions
+- Side-by-side before/after comparisons
+
+### Pattern 3: User Flow
+
+Show step-by-step user journey:
+- Sequential screen flow with directional slides
+- Numbered steps overlay
+- Highlight user actions (clicks, taps)
+- Connect screens with animated paths
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| **Blurry screenshots** | Ensure downloaded images are at full resolution; check `screenshot.downloadUrl` quality settings |
+| **Misaligned text** | Verify screen dimensions match composition size; adjust text positioning based on actual screen size |
+| **Choppy animations** | Increase frame rate to 60fps; use proper spring configurations with appropriate damping |
+| **Remotion build fails** | Check Node version compatibility; ensure all dependencies are installed; review Remotion docs |
+| **Timing feels off** | Adjust duration per screen in manifest; preview in Remotion Studio; test with actual users |
+
+## Best Practices
+
+1. **Maintain aspect ratio**: Use actual Stitch screen dimensions or scale proportionally
+2. **Consistent timing**: Keep screen display duration consistent unless emphasizing specific screens
+3. **Readable text**: Ensure sufficient contrast; use appropriate font sizes; avoid cluttered overlays
+4. **Smooth transitions**: Use spring animations for natural motion; avoid jarring cuts
+5. **Preview thoroughly**: Always preview in Remotion Studio before final render
+6. **Optimize assets**: Compress images appropriately; use efficient formats (PNG for UI, JPG for photos)
+
+## Example Usage
+
+**User prompt:**
+```
+Look up the screens in my Stitch project "Calculator App" and build a remotion video 
+that shows a walkthrough of the screens.
+```
+
+**Agent workflow:**
+1. List Stitch projects → Find "Calculator App" → Extract project ID
+2. List screens in project → Identify all screens (Home, History, Settings)
+3. Download screenshots for each screen → Save to `assets/screens/`
+4. Create `screens.json` manifest with screen metadata
+5. Generate Remotion components (`ScreenSlide.tsx`, `WalkthroughComposition.tsx`)
+6. Preview in Remotion Studio → Refine timing and transitions
+7. Render final video → `calculator-walkthrough.mp4`
+8. Report completion with video preview link
+
+## Tips for Success
+
+- **Start simple**: Begin with basic fade transitions before adding complex animations
+- **Follow Remotion patterns**: Leverage Remotion's official skills and documentation
+- **Use manifest files**: Keep screen data organized in JSON for easy updates
+- **Preview frequently**: Use Remotion Studio to catch issues early
+- **Consider accessibility**: Add captions; ensure text is readable; use clear visuals
+- **Optimize for platform**: Match video dimensions to target platform (YouTube, social media, etc.)
+
+## References
+
+- **Stitch Documentation**: https://stitch.withgoogle.com/docs/
+- **Remotion Documentation**: https://www.remotion.dev/docs/
+- **Remotion Skills**: https://www.remotion.dev/docs/ai/skills
+- **Remotion MCP**: https://www.remotion.dev/docs/ai/mcp
+- **Remotion Transitions**: https://www.remotion.dev/docs/transitions

--- a/.claude/skills/stitch-shadcn-ui/SKILL.md
+++ b/.claude/skills/stitch-shadcn-ui/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: shadcn-ui
+description: Expert guidance for integrating and building applications with shadcn/ui components, including component discovery, installation, customization, and best practices.
+allowed-tools:
+  - "shadcn*:*"
+  - "mcp_shadcn*"
+  - "Read"
+  - "Write"
+  - "Bash"
+  - "web_fetch"
+---
+
+# shadcn/ui Component Integration
+
+You are a frontend engineer specialized in building applications with shadcn/ui—a collection of beautifully designed, accessible, and customizable components built with Radix UI or Base UI and Tailwind CSS. You help developers discover, integrate, and customize components following best practices.
+
+## Core Principles
+
+shadcn/ui is **not a component library**—it's a collection of reusable components that you copy into your project. This gives you:
+- **Full ownership**: Components live in your codebase, not node_modules
+- **Complete customization**: Modify styling, behavior, and structure freely, including choosing between Radix UI or Base UI primitives
+- **No version lock-in**: Update components selectively at your own pace
+- **Zero runtime overhead**: No library bundle, just the code you need
+
+## Component Discovery and Installation
+
+### 1. Browse Available Components
+
+Use the shadcn MCP tools to explore the component catalog and Registry Directory:
+- **List all components**: Use `list_components` to see the complete catalog
+- **Get component metadata**: Use `get_component_metadata` to understand props, dependencies, and usage
+- **View component demos**: Use `get_component_demo` to see implementation examples
+
+### 2. Component Installation
+
+There are two approaches to adding components:
+
+**A. Direct Installation (Recommended)**
+```bash
+npx shadcn@latest add [component-name]
+```
+
+This command:
+- Downloads the component source code (adapting to your config: Radix vs Base UI)
+- Installs required dependencies
+- Places files in `components/ui/`
+- Updates your `components.json` config
+
+**B. Manual Integration**
+1. Use `get_component` to retrieve the source code
+2. Create the file in `components/ui/[component-name].tsx`
+3. Install peer dependencies manually
+4. Adjust imports if needed
+
+### 3. Registry and Custom Registries
+
+If working with a custom registry (defined in `components.json`) or exploring the Registry Directory:
+- Use `get_project_registries` to list available registries
+- Use `list_items_in_registries` to see registry-specific components
+- Use `view_items_in_registries` for detailed component information
+- Use `search_items_in_registries` to find specific components
+
+## Project Setup
+
+### Initial Configuration
+
+For **new projects**, use the `create` command to customize everything (style, fonts, component library):
+
+```bash
+npx shadcn@latest create
+```
+
+For **existing projects**, initialize configuration:
+
+```bash
+npx shadcn@latest init
+```
+
+This creates `components.json` with your configuration:
+- **style**: default, new-york (classic) OR choose new visual styles like Vega, Nova, Maia, Lyra, Mira
+- **baseColor**: slate, gray, zinc, neutral, stone
+- **cssVariables**: true/false for CSS variable usage
+- **tailwind config**: paths to Tailwind files
+- **aliases**: import path shortcuts
+- **rsc**: Use React Server Components (yes/no)
+- **rtl**: Enable RTL support (optional)
+
+### Required Dependencies
+
+shadcn/ui components require:
+- **React** (18+)
+- **Tailwind CSS** (3.0+)
+- **Primitives**: Radix UI OR Base UI (depending on your choice)
+- **class-variance-authority** (for variant styling)
+- **clsx** and **tailwind-merge** (for class composition)
+
+## Component Architecture
+
+### File Structure
+```
+src/
+├── components/
+│   ├── ui/              # shadcn components
+│   │   ├── button.tsx
+│   │   ├── card.tsx
+│   │   └── dialog.tsx
+│   └── [custom]/        # your composed components
+│       └── user-card.tsx
+├── lib/
+│   └── utils.ts         # cn() utility
+└── app/
+    └── page.tsx
+```
+
+### The `cn()` Utility
+
+All shadcn components use the `cn()` helper for class merging:
+
+```typescript
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+```
+
+This allows you to:
+- Override default styles without conflicts
+- Conditionally apply classes
+- Merge Tailwind classes intelligently
+
+## Customization Best Practices
+
+### 1. Theme Customization
+
+Edit your Tailwind config and CSS variables in `app/globals.css`:
+
+```css
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --primary: 221.2 83.2% 53.3%;
+    /* ... more variables */
+  }
+  
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    /* ... dark mode overrides */
+  }
+}
+```
+
+### 2. Component Variants
+
+Use `class-variance-authority` (cva) for variant logic:
+
+```typescript
+import { cva } from "class-variance-authority"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground",
+        outline: "border border-input",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+```
+
+### 3. Extending Components
+
+Create wrapper components in `components/` (not `components/ui/`):
+
+```typescript
+// components/custom-button.tsx
+import { Button } from "@/components/ui/button"
+import { Loader2 } from "lucide-react"
+
+export function LoadingButton({ 
+  loading, 
+  children, 
+  ...props 
+}: ButtonProps & { loading?: boolean }) {
+  return (
+    <Button disabled={loading} {...props}>
+      {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+      {children}
+    </Button>
+  )
+}
+```
+
+## Blocks and Complex Components
+
+shadcn/ui provides complete UI blocks (authentication forms, dashboards, etc.):
+
+1. **List available blocks**: Use `list_blocks` with optional category filter
+2. **Get block source**: Use `get_block` with the block name
+3. **Install blocks**: Many blocks include multiple component files
+
+Blocks are organized by category:
+- **calendar**: Calendar interfaces
+- **dashboard**: Dashboard layouts
+- **login**: Authentication flows
+- **sidebar**: Navigation sidebars
+- **products**: E-commerce components
+
+## Accessibility
+
+All shadcn/ui components are built on Radix UI primitives, ensuring:
+- **Keyboard navigation**: Full keyboard support out of the box
+- **Screen reader support**: Proper ARIA attributes
+- **Focus management**: Logical focus flow
+- **Disabled states**: Proper disabled and aria-disabled handling
+
+When customizing, maintain accessibility:
+- Keep ARIA attributes
+- Preserve keyboard handlers
+- Test with screen readers
+- Maintain focus indicators
+
+## Common Patterns
+
+### Form Building
+```typescript
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+// Use with react-hook-form for validation
+import { useForm } from "react-hook-form"
+```
+
+### Dialog/Modal Patterns
+```typescript
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+```
+
+### Data Display
+```typescript
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+```
+
+## Troubleshooting
+
+### Import Errors
+- Check `components.json` for correct alias configuration
+- Verify `tsconfig.json` includes the `@` path alias:
+  ```json
+  {
+    "compilerOptions": {
+      "paths": {
+        "@/*": ["./src/*"]
+      }
+    }
+  }
+  ```
+
+### Style Conflicts
+- Ensure Tailwind CSS is properly configured
+- Check that `globals.css` is imported in your root layout
+- Verify CSS variable names match between components and theme
+
+### Missing Dependencies
+- Run component installation via CLI to auto-install deps
+- Manually check `package.json` for required Radix UI packages
+- Use `get_component_metadata` to see dependency lists
+
+### Version Compatibility
+- shadcn/ui v4 requires React 18+ and Next.js 13+ (if using Next.js)
+- Some components require specific Radix UI versions
+- Check documentation for breaking changes between versions
+
+## Validation and Quality
+
+Before committing components:
+1. **Type check**: Run `tsc --noEmit` to verify TypeScript
+2. **Lint**: Run your linter to catch style issues
+3. **Test accessibility**: Use tools like axe DevTools
+4. **Visual QA**: Test in light and dark modes
+5. **Responsive check**: Verify behavior at different breakpoints
+
+## Resources
+
+Refer to the following resource files for detailed guidance:
+- `resources/setup-guide.md` - Step-by-step project initialization
+- `resources/component-catalog.md` - Complete component reference
+- `resources/customization-guide.md` - Theming and variant patterns
+- `resources/migration-guide.md` - Upgrading from other UI libraries
+
+## Examples
+
+See the `examples/` directory for:
+- Complete component implementations
+- Form patterns with validation
+- Dashboard layouts
+- Authentication flows
+- Data table implementations

--- a/.claude/skills/stitch-taste-design/SKILL.md
+++ b/.claude/skills/stitch-taste-design/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: taste-design
+description: Semantic Design System Skill for Google Stitch. Generates agent-friendly DESIGN.md files that enforce premium, anti-generic UI standards — strict typography, calibrated color, asymmetric layouts, perpetual micro-motion, and hardware-accelerated performance.
+allowed-tools:
+  - "StitchMCP"
+  - "Read"
+  - "Write"
+---
+
+# Stitch Design Taste — Semantic Design System Skill
+
+## Overview
+This skill generates `DESIGN.md` files optimized for Google Stitch screen generation. It translates the battle-tested anti-slop frontend engineering directives into Stitch's native semantic design language — descriptive, natural-language rules paired with precise values that Stitch's AI agent can interpret to produce premium, non-generic interfaces.
+
+The generated `DESIGN.md` serves as the **single source of truth** for prompting Stitch to generate new screens that align with a curated, high-agency design language. Stitch interprets design through **"Visual Descriptions"** supported by specific color values, typography specs, and component behaviors.
+
+## Prerequisites
+- Access to Google Stitch via [labs.google.com/stitch](https://labs.google.com/stitch)
+- Optionally: Stitch MCP Server for programmatic integration with Cursor, Antigravity, or Gemini CLI
+
+## The Goal
+Generate a `DESIGN.md` file that encodes:
+1. **Visual atmosphere** — the mood, density, and design philosophy
+2. **Color calibration** — neutrals, accents, and banned patterns with hex codes
+3. **Typographic architecture** — font stacks, scale hierarchy, and anti-patterns
+4. **Component behaviors** — buttons, cards, inputs with interaction states
+5. **Layout principles** — grid systems, spacing philosophy, responsive strategy
+6. **Motion philosophy** — animation engine specs, spring physics, perpetual micro-interactions
+7. **Anti-patterns** — explicit list of banned AI design clichés
+
+## Analysis & Synthesis Instructions
+
+### 1. Define the Atmosphere
+Evaluate the target project's intent. Use evocative adjectives from the taste spectrum:
+- **Density:** "Art Gallery Airy" (1–3) → "Daily App Balanced" (4–7) → "Cockpit Dense" (8–10)
+- **Variance:** "Predictable Symmetric" (1–3) → "Offset Asymmetric" (4–7) → "Artsy Chaotic" (8–10)
+- **Motion:** "Static Restrained" (1–3) → "Fluid CSS" (4–7) → "Cinematic Choreography" (8–10)
+
+Default baseline: Creativity 9, Variance 8, Motion 6, Density 5. Adapt dynamically based on user's vibe description.
+
+### 2. Map the Color Palette
+For each color provide: **Descriptive Name** + **Hex Code** + **Functional Role**.
+
+**Mandatory constraints:**
+- Maximum 1 accent color. Saturation below 80%
+- The "AI Purple/Blue Neon" aesthetic is strictly BANNED — no purple button glows, no neon gradients
+- Use absolute neutral bases (Zinc/Slate) with high-contrast singular accents
+- Stick to one palette for the entire output — no warm/cool gray fluctuation
+- Never use pure black (`#000000`) — use Off-Black, Zinc-950, or Charcoal
+
+### 3. Establish Typography Rules
+- **Display/Headlines:** Track-tight, controlled scale. Not screaming. Hierarchy through weight and color, not just massive size
+- **Body:** Relaxed leading, max 65 characters per line
+- **Font Selection:** `Inter` is BANNED for premium/creative contexts. Force unique character: `Geist`, `Outfit`, `Cabinet Grotesk`, or `Satoshi`
+- **Serif Ban:** Generic serif fonts (`Times New Roman`, `Georgia`, `Garamond`, `Palatino`) are BANNED. If serif is needed for editorial/creative contexts, use only distinctive modern serifs: `Fraunces`, `Gambarino`, `Editorial New`, or `Instrument Serif`. Serif is always BANNED in dashboards or software UIs
+- **Dashboard Constraint:** Use Sans-Serif pairings exclusively (`Geist` + `Geist Mono` or `Satoshi` + `JetBrains Mono`)
+- **High-Density Override:** When density exceeds 7, all numbers must use Monospace
+
+### 4. Define the Hero Section
+The Hero is the first impression and must be creative, striking, and never generic:
+- **Inline Image Typography:** Embed small, contextual photos or visuals directly between words or letters in the headline. Images sit inline at type-height, rounded, acting as visual punctuation. This is the signature creative technique
+- **No Overlapping:** Text must never overlap images or other text. Every element occupies its own clean spatial zone
+- **No Filler Text:** "Scroll to explore", "Swipe down", scroll arrow icons, bouncing chevrons are BANNED. The content should pull users in naturally
+- **Asymmetric Structure:** Centered Hero layouts BANNED when variance exceeds 4
+- **CTA Restraint:** Maximum one primary CTA. No secondary "Learn more" links
+
+### 5. Describe Component Stylings
+For each component type, describe shape, color, shadow depth, and interaction behavior:
+- **Buttons:** Tactile push feedback on active state. No neon outer glows. No custom mouse cursors
+- **Cards:** Use ONLY when elevation communicates hierarchy. Tint shadows to background hue. For high-density layouts, replace cards with border-top dividers or negative space
+- **Inputs/Forms:** Label above input, helper text optional, error text below. Standard gap spacing
+- **Loading States:** Skeletal loaders matching layout dimensions — no generic circular spinners
+- **Empty States:** Composed compositions indicating how to populate data
+- **Error States:** Clear, inline error reporting
+
+### 6. Define Layout Principles
+- No overlapping elements — every element occupies its own clear spatial zone. No absolute-positioned content stacking
+- Centered Hero sections are BANNED when variance exceeds 4 — force Split Screen, Left-Aligned, or Asymmetric Whitespace
+- The generic "3 equal cards horizontally" feature row is BANNED — use 2-column Zig-Zag, asymmetric grid, or horizontal scroll
+- CSS Grid over Flexbox math — never use `calc()` percentage hacks
+- Contain layouts using max-width constraints (e.g., 1400px centered)
+- Full-height sections must use `min-h-[100dvh]` — never `h-screen` (iOS Safari catastrophic jump)
+
+### 7. Define Responsive Rules
+Every design must work across all viewports:
+- **Mobile-First Collapse (< 768px):** All multi-column layouts collapse to single column. No exceptions
+- **No Horizontal Scroll:** Horizontal overflow on mobile is a critical failure
+- **Typography Scaling:** Headlines scale via `clamp()`. Body text minimum `1rem`/`14px`
+- **Touch Targets:** All interactive elements minimum `44px` tap target
+- **Image Behavior:** Inline typography images (photos between words) stack below headline on mobile
+- **Navigation:** Desktop horizontal nav collapses to clean mobile menu
+- **Spacing:** Vertical section gaps reduce proportionally (`clamp(3rem, 8vw, 6rem)`)
+
+### 8. Encode Motion Philosophy
+- **Spring Physics default:** `stiffness: 100, damping: 20` — premium, weighty feel. No linear easing
+- **Perpetual Micro-Interactions:** Every active component should have an infinite loop state (Pulse, Typewriter, Float, Shimmer)
+- **Staggered Orchestration:** Never mount lists instantly — use cascade delays for waterfall reveals
+- **Performance:** Animate exclusively via `transform` and `opacity`. Never animate `top`, `left`, `width`, `height`. Grain/noise filters on fixed pseudo-elements only
+
+### 9. List Anti-Patterns (AI Tells)
+Encode these as explicit "NEVER DO" rules in the DESIGN.md:
+- No emojis anywhere
+- No `Inter` font
+- No generic serif fonts (`Times New Roman`, `Georgia`, `Garamond`) — distinctive modern serifs only if needed
+- No pure black (`#000000`)
+- No neon/outer glow shadows
+- No oversaturated accents
+- No excessive gradient text on large headers
+- No custom mouse cursors
+- No overlapping elements — clean spatial separation always
+- No 3-column equal card layouts
+- No generic names ("John Doe", "Acme", "Nexus")
+- No fake round numbers (`99.99%`, `50%`)
+- No fabricated data or statistics — never generate metrics, performance numbers, uptime percentages, response times, or any data that the user did not explicitly provide. "99.98% UPTIME SLA", "124ms AVG. RESPONSE", "18.5k DEPLOY CYCLES" are invented AI filler. If real data is not available, use clear placeholder labels like `[metric]` instead of making up numbers
+- No fake system/metric sections — "SYSTEM PERFORMANCE METRICS", "KEY STATISTICS", "BY THE NUMBERS" dashboard cards filled with invented data are BANNED
+- No `LABEL // YEAR` formatting — "SYSTEM // 2024", "METRICS // 2025" is a lazy AI convention, not real design typography
+- No AI copywriting clichés ("Elevate", "Seamless", "Unleash", "Next-Gen")
+- No filler UI text: "Scroll to explore", "Swipe down", scroll arrows, bouncing chevrons
+- No broken Unsplash links — use `picsum.photos` or SVG avatars
+- No centered Hero sections (for high-variance projects)
+
+## Output Format (DESIGN.md Structure)
+
+```markdown
+# Design System: [Project Title]
+
+## 1. Visual Theme & Atmosphere
+(Evocative description of the mood, density, variance, and motion intensity.
+Example: "A restrained, gallery-airy interface with confident asymmetric layouts
+and fluid spring-physics motion. The atmosphere is clinical yet warm — like a
+well-lit architecture studio.")
+
+## 2. Color Palette & Roles
+- **Canvas White** (#F9FAFB) — Primary background surface
+- **Pure Surface** (#FFFFFF) — Card and container fill
+- **Charcoal Ink** (#18181B) — Primary text, Zinc-950 depth
+- **Muted Steel** (#71717A) — Secondary text, descriptions, metadata
+- **Whisper Border** (rgba(226,232,240,0.5)) — Card borders, 1px structural lines
+- **[Accent Name]** (#XXXXXX) — Single accent for CTAs, active states, focus rings
+(Max 1 accent. Saturation < 80%. No purple/neon.)
+
+## 3. Typography Rules
+- **Display:** [Font Name] — Track-tight, controlled scale, weight-driven hierarchy
+- **Body:** [Font Name] — Relaxed leading, 65ch max-width, neutral secondary color
+- **Mono:** [Font Name] — For code, metadata, timestamps, high-density numbers
+- **Banned:** Inter, generic system fonts for premium contexts. Serif fonts banned in dashboards.
+
+## 4. Component Stylings
+* **Buttons:** Flat, no outer glow. Tactile -1px translate on active. Accent fill for primary, ghost/outline for secondary.
+* **Cards:** Generously rounded corners (2.5rem). Diffused whisper shadow. Used only when elevation serves hierarchy. High-density: replace with border-top dividers.
+* **Inputs:** Label above, error below. Focus ring in accent color. No floating labels.
+* **Loaders:** Skeletal shimmer matching exact layout dimensions. No circular spinners.
+* **Empty States:** Composed, illustrated compositions — not just "No data" text.
+
+## 5. Layout Principles
+(Grid-first responsive architecture. Asymmetric splits for Hero sections.
+Strict single-column collapse below 768px. Max-width containment.
+No flexbox percentage math. Generous internal padding.)
+
+## 6. Motion & Interaction
+(Spring physics for all interactive elements. Staggered cascade reveals.
+Perpetual micro-loops on active dashboard components. Hardware-accelerated
+transforms only. Isolated Client Components for CPU-heavy animations.)
+
+## 7. Anti-Patterns (Banned)
+(Explicit list of forbidden patterns: no emojis, no Inter, no pure black,
+no neon glows, no 3-column equal grids, no AI copywriting clichés,
+no generic placeholder names, no broken image links.)
+```
+
+## Best Practices
+- **Be Descriptive:** "Deep Charcoal Ink (#18181B)" — not just "dark text"
+- **Be Functional:** Explain what each element is used for
+- **Be Consistent:** Same terminology throughout the document
+- **Be Precise:** Include exact hex codes, rem values, pixel values in parentheses
+- **Be Opinionated:** This is not a neutral template — it enforces a specific, premium aesthetic
+
+## Tips for Success
+1. Start with the atmosphere — understand the vibe before detailing tokens
+2. Look for patterns — identify consistent spacing, sizing, and styling
+3. Think semantically — name colors by purpose, not just appearance
+4. Consider hierarchy — document how visual weight communicates importance
+5. Encode the bans — anti-patterns are as important as the rules themselves
+
+## Common Pitfalls to Avoid
+- Using technical jargon without translation ("rounded-xl" instead of "generously rounded corners")
+- Omitting hex codes or using only descriptive names
+- Forgetting functional roles of design elements
+- Being too vague in atmosphere descriptions
+- Ignoring the anti-pattern list — these are what make the output premium
+- Defaulting to generic "safe" designs instead of enforcing the curated aesthetic

--- a/.claude/skills/stitch-upload-to-stitch/SKILL.md
+++ b/.claude/skills/stitch-upload-to-stitch/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: stitch::upload-to-stitch
+description: >-
+  Upload local assets (images, mockups, extracted HTML) to a Stitch project.
+  ALWAYS use this skill when you need to upload visual assets or full HTML pages
+  to Stitch, particularly when direct MCP tool calls fail or truncate due to
+  base64 token limits.
+allowed-tools:
+  - "stitch*:*"
+  - "Bash"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Upload-to-Stitch
+
+Upload local assets (images, mockups, HTML files) to a Stitch project using the
+provided upload script, which bypasses the MCP tool's base64 output token limits.
+
+> [!NOTE]
+> The AI model cannot upload files via MCP tools directly because the base64
+> encoding of even a small file exceeds the model's output token limit (~16K
+> tokens). This script reads the file and sends it directly over HTTP.
+
+## Steps
+
+### 1. Identify Target Project
+
+Use `list_projects` to find the correct `projectId`.
+
+### 2. Get the API Key
+
+Locate your active MCP server configuration file and extract the API key:
+- **Antigravity**: `.gemini/antigravity/mcp_config.json` or `.gemini/jetski/mcp_config.json`
+- **Gemini CLI**: `~/.gemini/settings.json` or `~/.gemini/extensions/Stitch/gemini-extension.json`
+- **Claude Code**: `~/.claude.json`
+
+Extract:
+- **API Key**: From the `X-Goog-Api-Key` header or auth argument
+- **MCP URL** (optional): From the `httpUrl` or endpoint argument (defaults to
+  `https://stitch.googleapis.com`)
+
+> [!IMPORTANT]
+> If you cannot find the API key in any of these locations, or if you cannot access these files, you MUST ask the user to provide the Stitch API key. Do not proceed without a valid API key.
+
+### 3. Run Upload Script
+
+> [!WARNING]
+> **Checkpoint — User Confirmation Required.**
+> Before running the upload script, you **MUST** pause and present the file(s)
+> to be uploaded (paths, sizes, and types) to the user and wait for explicit
+> approval. Do **NOT** execute the upload script until the user confirms.
+
+Use `run_command` to execute the Python script:
+
+```bash
+python3 <SKILL_DIR>/scripts/upload_to_stitch.py \
+  --project-id <PROJECT_ID> \
+  --file-path <PATH_TO_FILE> \
+  --api-key <API_KEY> \
+  [--api-url <STITCH_API_URL>] \
+  [--title <SCREEN_TITLE>]
+```
+
+> [!TIP]
+> **macOS / SSL Certificate Troubleshooting:**
+> If the upload fails with `ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate`, this means your Python installation does not have root certificate authorities configured.
+> Fix it by prepending `SSL_CERT_FILE` using the `certifi` bundle:
+> ```bash
+> SSL_CERT_FILE=$(python3 -c "import certifi; print(certifi.where())") python3 <SKILL_DIR>/scripts/upload_to_stitch.py \
+>   --project-id <PROJECT_ID> \
+>   --file-path <PATH_TO_FILE> \
+>   --api-key <API_KEY>
+> ```
+
+### Supported File Types
+
+| Extension | MIME Type |
+|:---|:---|
+| `.png` | `image/png` |
+| `.jpg`, `.jpeg` | `image/jpeg` |
+| `.webp` | `image/webp` |
+| `.html`, `.htm` | `text/html` |
+
+The script auto-detects MIME type from the file extension.
+
+### Script Defaults
+
+- `--api-url` defaults to `https://stitch.googleapis.com`
+- `--api-key` is **required**
+- Screen instances are automatically created for display
+- For HTML files, `screenType` is set to `DOCUMENT`; for images, `IMAGE`

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,84 @@
 {
   "version": 1,
   "skills": {
+    "stitch-code-to-design": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-design/skills/code-to-design/SKILL.md",
+      "computedHash": "c08a53b7859ec8323950b295e02e8eaf46d254fd2e896ddacd04c71f8f7e9c47"
+    },
+    "stitch-extract-design-md": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-design/skills/extract-design-md/SKILL.md",
+      "computedHash": "f9c32b30acd9fea3dba7306bf38e3a859f49c1f27bcf44f9cf16d3a60a730276"
+    },
+    "stitch-extract-static-html": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-design/skills/extract-static-html/SKILL.md",
+      "computedHash": "116a8c1307b291ead1e045c4128a9e0c96e3cef60bd25a9ab80326c5b01dd731"
+    },
+    "stitch-generate-design": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-design/skills/generate-design/SKILL.md",
+      "computedHash": "d03d2de3a0cefbde2ca7b8cdc2c96e8164a8b9400fe3a9b97a3aa6ce37ee638d"
+    },
+    "stitch-manage-design-system": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-design/skills/manage-design-system/SKILL.md",
+      "computedHash": "29dbbc9b9483cef9b03cde53d3f87bc59b3d4c47cd28decb11bb3ca2e0e5f8db"
+    },
+    "stitch-upload-to-stitch": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-design/skills/upload-to-stitch/SKILL.md",
+      "computedHash": "c0a97a13131803166fa91cab60fe5b18a857e466aa70c1ae17199eb565330a53"
+    },
+    "stitch-react-components": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-build/skills/react-components/SKILL.md",
+      "computedHash": "d7d97de6990bda48bbc8130a681b5d526c141c1042bbf7a269be8c0b1567ec84"
+    },
+    "stitch-remotion": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-build/skills/remotion/SKILL.md",
+      "computedHash": "7147fc5a627081fceb7b6ab6191426643747e738bb857587de1d3c1b6eecd755"
+    },
+    "stitch-shadcn-ui": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-build/skills/shadcn-ui/SKILL.md",
+      "computedHash": "2ddfe599ac2ba631ca019f7b6e37ee5df9cd34f83fc016f6ea9d4ba5bbfa0304"
+    },
+    "stitch-design-md": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-utilities/skills/design-md/SKILL.md",
+      "computedHash": "eb15f44646528f3a087ce023329ae699c1b6e803662af68338e1eb1c0406b59b"
+    },
+    "stitch-enhance-prompt": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-utilities/skills/enhance-prompt/SKILL.md",
+      "computedHash": "ccb200c798072438b642b1fa6a5c515563159e2fab3d56e813d76d8afa9a7ce6"
+    },
+    "stitch-loop": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-utilities/skills/stitch-loop/SKILL.md",
+      "computedHash": "05f39ecf81b0664872e6f3d6be01c53cf8c1f8b9ef14c741fe01d1ac424ce634"
+    },
+    "stitch-taste-design": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-utilities/skills/taste-design/SKILL.md",
+      "computedHash": "e425fdb7ab250764f6229c48941f97e20bd6a7ba9e25a628f1e0ebeb008e8bff"
+    },
     "ab-test-setup": {
       "source": "coreyhaines31/marketingskills",
       "sourceType": "github",


### PR DESCRIPTION
## Summary

- Installs all 13 Google Stitch skills from `google-labs-code/stitch-skills` into `.claude/skills/`
- Updates `skills-lock.json` to track skill sources, paths, and content hashes
- Skills are now immediately available as `/stitch-*` commands in Claude Code sessions

## Skills Installed

### Design Plugin (`stitch-design`)
| Skill | What it does |
|-------|-------------|
| `/stitch-generate-design` | Create/edit screens from text prompts or images |
| `/stitch-code-to-design` | Upload existing HTML pages to a Stitch project |
| `/stitch-extract-design-md` | Reverse-engineer a design system from source code |
| `/stitch-extract-static-html` | Snapshot a page as self-contained HTML with inlined assets |
| `/stitch-manage-design-system` | Upload/apply design systems across Stitch screens |
| `/stitch-upload-to-stitch` | Transfer local assets or HTML to a Stitch project |

### Build Plugin (`stitch-build`)
| Skill | What it does |
|-------|-------------|
| `/stitch-react-components` | Convert Stitch screens to typed React components |
| `/stitch-shadcn-ui` | Guidance for shadcn/ui integration |
| `/stitch-remotion` | Generate walkthrough videos from Stitch designs |

### Utilities Plugin (`stitch-utilities`)
| Skill | What it does |
|-------|-------------|
| `/stitch-loop` | Autonomously build multi-page sites via baton-passing loop |
| `/stitch-taste-design` | Generate premium DESIGN.md with anti-generic UI standards |
| `/stitch-enhance-prompt` | Refine vague UI ideas into Stitch-optimized prompts |
| `/stitch-design-md` | Synthesize a semantic design system from Stitch screens |

## Prerequisites for MCP-dependent skills

Skills that call Stitch APIs (`generate-design`, `stitch-loop`, `code-to-design`, etc.) require the **Stitch MCP server** to be running and authenticated. Configure it via your Google Stitch account at stitch.withgoogle.com.

Skills that work **without** the MCP server (no Stitch account needed today):
- `/stitch-taste-design` — generate a premium DESIGN.md from scratch
- `/stitch-enhance-prompt` — refine UI prompts
- `/stitch-extract-design-md` — analyze existing source code for design tokens
- `/stitch-extract-static-html` — snapshot pages as standalone HTML

## Test plan

- [ ] Run `/stitch-taste-design` to generate a DESIGN.md for the gold price site
- [ ] Run `/stitch-enhance-prompt` on a page redesign idea
- [ ] Run `/stitch-extract-design-md` against `index.html` to extract the current design system
- [ ] Once Stitch MCP is configured: run `/stitch-generate-design` to create a new page variant

https://claude.ai/code/session_01KLG62XH4TwApRo9Rnkm2dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLG62XH4TwApRo9Rnkm2dk)_