### PR TITLE
chore: scaffold Stitch MCP config template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules/
 # AI Skills (installed per-machine)
 .agent/
 .agents/
+
+# Stitch MCP — local config holds the real API key (use .mcp.json.example as template)
+.mcp.json

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "stitch": {
+      "command": "npx",
+      "args": ["@_davideast/stitch-mcp", "proxy"],
+      "env": {
+        "STITCH_API_KEY": "REPLACE_WITH_YOUR_STITCH_API_KEY"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Scaffolds the Stitch MCP server config so the MCP-backed Stitch skills (installed in #357) are ready the moment a real API key is added.

- **`.mcp.json.example`** (committed) — template with the official `@_davideast/stitch-mcp` proxy command and a `STITCH_API_KEY` placeholder
- **`.gitignore`** — now ignores the real `.mcp.json` so the API key is never committed

## How to activate

```bash
cp .mcp.json.example .mcp.json
# edit .mcp.json and replace REPLACE_WITH_YOUR_STITCH_API_KEY with your key
```

Generate the key in your Google Stitch settings (Stitch API is free; needs a Google Cloud project with the Stitch API enabled). Alternatively run the guided OAuth wizard: `npx @_davideast/stitch-mcp init`.

Once `.mcp.json` has a valid key, Claude Code exposes the `stitch:*` tools that power `/stitch-generate-design`, `/stitch-loop`, `/stitch-code-to-design`, and the other MCP-backed skills.

## Security

The real `.mcp.json` is gitignored — verified with `git check-ignore`. Only the placeholder template is tracked.

## Test plan

- [ ] `cp .mcp.json.example .mcp.json`, add a real key, confirm `git status` does NOT list `.mcp.json`
- [ ] Restart Claude Code and confirm the `stitch` MCP server connects
- [ ] Run `/stitch-generate-design` to confirm `stitch:*` tools are available

https://claude.ai/code/session_01KLG62XH4TwApRo9Rnkm2dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLG62XH4TwApRo9Rnkm2dk)_