### PR TITLE
fix: default Stitch MCP template to OAuth + remove committed API key

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,11 +1,23 @@
 {
+  "_comment_1": "Stitch MCP server config. Copy this file to .mcp.json (the real .mcp.json is gitignored so credentials never get committed). NEVER put a real key in THIS file — it is committed to git.",
+  "_comment_2": "DEFAULT = OAuth. Run 'npx @_davideast/stitch-mcp init' and choose OAuth. Credentials are cached locally by the wizard, so no key belongs in this file. Then restart your editor.",
+  "_comment_3": "IMPORTANT: a plain Stitch API key does NOT authenticate — the API returns 401 'API keys are not supported by this API. Expected OAuth2 access token ... that assert a principal.' Use OAuth (default) or system gcloud below.",
   "mcpServers": {
     "stitch": {
       "command": "npx",
-      "args": ["@_davideast/stitch-mcp", "proxy"],
-      "env": {
-        "STITCH_API_KEY": "AQ.Ab8RN6L64v0kPt7J-Hvp-2XleTUtDutc38FeaCRjt0k_dkWvww"
-      }
+      "args": ["@_davideast/stitch-mcp", "proxy"]
+    }
+  },
+  "_fallback_systemGcloud": {
+    "_comment": "FALLBACK A: if you already have gcloud logged in, add this env block to the 'stitch' server above instead of running the init wizard.",
+    "env": {
+      "STITCH_USE_SYSTEM_GCLOUD": "1"
+    }
+  },
+  "_fallback_apiKey": {
+    "_comment": "FALLBACK B: API-key variant. Currently rejected by the Stitch API (see _comment_3); keep only in case Google enables key auth for your endpoint. Put the key in your gitignored .mcp.json, NOT here.",
+    "env": {
+      "STITCH_API_KEY": "REPLACE_WITH_YOUR_STITCH_API_KEY"
     }
   }
 }


### PR DESCRIPTION
## Summary

Tested the Stitch MCP server with API-key auth and it **fails** — so this changes the template to default to OAuth and removes a real API key that was accidentally committed.

## Test result

Calling `mcp__stitch__list_projects` and `list_design_systems` both returned:

> **401 — API keys are not supported by this API. Expected OAuth2 access token or other authentication credentials that assert a principal.**

The MCP server connects fine; the Stitch API simply doesn't accept API keys for user-scoped endpoints (listing your projects needs a user *principal*, which a key can't provide). OAuth is required.

## Changes to `.mcp.json.example`

- **Default is now OAuth** — `npx @_davideast/stitch-mcp init` (choose OAuth); no key in the committed file
- **Fallback A**: system gcloud (`STITCH_USE_SYSTEM_GCLOUD=1`)
- **Fallback B**: API-key variant (documented, but noted as currently rejected) — with the key kept in the gitignored `.mcp.json`, never the template

## ⚠️ Security — action required

PR #359 committed a **real `STITCH_API_KEY`** value into `.mcp.json.example` on `main`. This PR removes it from the file, but **the key remains in git history** and the repo is a live website project (likely public). 

**Please rotate/revoke that key** in your Google Cloud / Stitch settings. Removing it from history would require a destructive force-push rewrite — I did **not** do that without your say-so. Let me know if you want me to attempt a history purge.

## Test plan

- [ ] Rotate the exposed API key
- [ ] Run `npx @_davideast/stitch-mcp init` locally, choose OAuth
- [ ] Restart editor; once the `stitch` server reconnects, re-run `/stitch ... list_projects` to confirm auth succeeds

https://claude.ai/code/session_01KLG62XH4TwApRo9Rnkm2dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLG62XH4TwApRo9Rnkm2dk)_