### PR TITLE
Stitch MCP: run web setup via async SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SessionStart hook for Claude Code on the web: prepare the Stitch MCP server.
+#
+# Security model (unchanged): this hook NEVER authenticates and stores NO
+# credentials. It only installs gcloud, generates the proxy/helper, writes the
+# gitignored .mcp.json, and reports auth status. Each fresh web session still
+# requires an interactive browser consent when not already logged in.
+set -uo pipefail
+
+# Only run in the remote (web) environment; no-op locally.
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+
+# Async: let the session start immediately while gcloud installs in the
+# background. This affects startup latency only — it does not change the
+# per-session consent requirement or store any credentials.
+echo '{"async": true, "asyncTimeout": 300000}'
+
+bash "${CLAUDE_PROJECT_DIR:-.}/scripts/stitch-web-setup.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"$CLAUDE_CODE_REMOTE\" = \"true\" ] && bash \"$CLAUDE_PROJECT_DIR/scripts/stitch-web-setup.sh\" || true"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Follow-up to #361. Switches the Stitch SessionStart hook to **async** so a Claude Code on the web session starts immediately while gcloud installs in the background, instead of blocking on the ~87 MB download.

- Adds `.claude/hooks/session-start.sh` — web-gated (`$CLAUDE_CODE_REMOTE`), emits `{"async": true, "asyncTimeout": 300000}` as its first line, then runs `scripts/stitch-web-setup.sh`.
- `.claude/settings.json` now points the `SessionStart` hook at that wrapper.

## Security model — unchanged (deliberately)

Per the decision to keep the safer model:
- The hook **authenticates nothing and stores no credentials**.
- **No** long-lived Google refresh token is committed or stored as a secret.
- Each fresh web session still requires a one-time **interactive browser consent** (sign in as `slavkofilipovich@gmail.com`) when not already logged in.

Async only changes startup latency. It does not weaken the security model and does not change the per-session consent requirement.

## Test plan

- [x] `bash -n` syntax check passes.
- [x] `.claude/settings.json` is valid JSON.
- [x] Web mode (`CLAUDE_CODE_REMOTE=true`): first stdout line is the async directive, then setup reports all-green (gcloud present, authed as slavkofilipovich, API enabled, `.mcp.json` written + gitignored).
- [x] Local mode: hook is a clean no-op (no output, rc 0).

https://claude.ai/code/session_01YYAP8kLK3i8i85MNWBwuUx

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYAP8kLK3i8i85MNWBwuUx)_