### PR TITLE
Bump service worker cache to v3 (flush stale precached assets)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
-// GoldPriceTools Service Worker v2
+// GoldPriceTools Service Worker v3
 // WP-47 PWA: Cache-first for static assets, network-first for live API price data
-const CACHE_NAME = 'goldpricetools-v2';
+const CACHE_NAME = 'goldpricetools-v3';
 const STATIC_ASSETS = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
Bumps the service worker cache name `goldpricetools-v2` → `v3`. On the next visit the SW `activate` handler deletes the old cache and re-fetches its precached static assets, flushing any stale copies for returning visitors. Belt-and-braces cache hygiene following the Indian Gold & Silver Prices guide rebuild (#364).

Note: this guide page was never precached by the SW (not in the static-assets list, and the fetch handler doesn't `cache.put`), so this is precautionary — the primary path for fresh content remains the normal Cloudflare deploy + `max-age=0, must-revalidate` HTML headers.

## Test plan
- [x] `sw.js` still valid (single-line constant change)
- [ ] After deploy: DevTools → Application → Service Workers shows `goldpricetools-v3` active; old cache removed

https://claude.ai/code/session_01FjtueVU5VBX1ESnZn3uSMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjtueVU5VBX1ESnZn3uSMF)_