### PR TITLE
fix: correct Gold vs Bitcoin desktop layout (article column vs TOC rail)

### DIFF
--- a/blog/gold-vs-bitcoin-2026.html
+++ b/blog/gold-vs-bitcoin-2026.html
@@ -518,15 +518,17 @@ html.gvb-js .gvb-fill.is-in{width:var(--w,0);transition:width 1.1s cubic-bezier(
 /* ── ARTICLE SHELL + STICKY TOC ────────────────────────── */
 .gvb-shell{max-width:var(--gvb-maxw);margin:0 auto;padding:0 var(--space-4) var(--space-16)}
 .gvb-layout{display:block}
-@media(min-width:1080px){
-  .gvb-layout{display:grid;grid-template-columns:minmax(0,1fr) 232px;gap:var(--space-10);align-items:start}
-  .gvb-toc{position:sticky;top:84px;order:2}
-}
 .gvb-main{min-width:0;max-width:var(--gvb-read);margin:0 auto;width:100%}
 .gvb-main>*{margin-left:auto;margin-right:auto}
 
 /* TOC */
-.gvb-toc{order:-1;margin:var(--space-6) 0}
+.gvb-toc{margin:var(--space-6) 0}
+
+@media(min-width:1080px){
+  .gvb-layout{display:grid;grid-template-columns:minmax(0,1fr) 232px;gap:var(--space-10);align-items:start}
+  .gvb-main{grid-column:1;max-width:none;margin:0}
+  .gvb-toc{grid-column:2;position:sticky;top:84px;margin:0}
+}
 .gvb-toc__box{border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface);overflow:hidden}
 .gvb-toc summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
 .gvb-toc summary::-webkit-details-marker{display:none}


### PR DESCRIPTION
## Summary

Fixes the broken desktop layout on `/blog/gold-vs-bitcoin-2026` reported after #366 merged: the "On this page" table-of-contents was filling the wide main column while the article was squeezed into the 232px right rail.

### Root cause
The base `.gvb-toc{order:-1}` rule was declared **after** the `@media(min-width:1080px)` block. CSS media queries don't raise specificity, so with equal specificity the later plain rule won and overrode the desktop `order:2` — placing the sticky TOC into the first/wide grid track and pushing the article into the narrow rail.

### Fix
- Moved the base (mobile) rules **before** the desktop media query so the desktop overrides win when active.
- Replaced the fragile `order`-based placement with **explicit `grid-column`**: article → `grid-column:1` (wide), TOC → `grid-column:2` (232px rail). This is robust regardless of source order.
- On desktop the article column now uses full width; paragraphs stay readable via the site's global `p{max-width:72ch}`, while cards/tables/the versus card use the fuller measure.

Mobile/tablet (<1080px) is unchanged: single column, collapsible TOC on top.

1 file changed, +7/−5.

## Test plan
- [ ] Desktop ≥1080px: article occupies the wide left column; TOC is the narrow sticky right rail.
- [ ] 360 / 375 / 768 / 1024px: single column, no horizontal overflow, TOC collapsible.
- [ ] Light + dark themes both correct.
- [ ] Run `python3 tools/playwright_audit.py` against the deploy preview.

https://claude.ai/code/session_01GPGhWitqxuKMNtBD6RBJ8L

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPGhWitqxuKMNtBD6RBJ8L)_