### PR TITLE
fix: remove empty space above Gold vs Bitcoin article (grid row placement)

### DIFF
--- a/blog/gold-vs-bitcoin-2026.html
+++ b/blog/gold-vs-bitcoin-2026.html
@@ -525,9 +525,9 @@ html.gvb-js .gvb-fill.is-in{width:var(--w,0);transition:width 1.1s cubic-bezier(
 .gvb-toc{margin:var(--space-6) 0}
 
 @media(min-width:1080px){
-  .gvb-layout{display:grid;grid-template-columns:minmax(0,1fr) 232px;gap:var(--space-10);align-items:start}
-  .gvb-main{grid-column:1;max-width:none;margin:0}
-  .gvb-toc{grid-column:2;position:sticky;top:84px;margin:0}
+  .gvb-layout{display:grid;grid-template-columns:minmax(0,1fr) 232px;grid-template-areas:"main toc";gap:var(--space-10);align-items:start}
+  .gvb-main{grid-area:main;max-width:none;margin:0}
+  .gvb-toc{grid-area:toc;position:sticky;top:84px;margin:0}
 }
 .gvb-toc__box{border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface);overflow:hidden}
 .gvb-toc summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}


### PR DESCRIPTION
## Summary

Fixes the large empty space above the article on `/blog/gold-vs-bitcoin-2026` (desktop ≥1080px). The previous fix (#367) correctly moved the TOC into the right rail, but exposed a CSS Grid **auto-placement** quirk.

### Root cause
The TOC `<aside>` comes first in the DOM and was pinned to `grid-column:2`. With sparse auto-placement, after the TOC was placed at row 1 / column 2, the article (`grid-column:1`, auto row) couldn't go to a column *before* the cursor on the same row, so it was bumped to **row 2** — leaving a full TOC-height gap above it in column 1.

### Fix
Use explicit **named grid areas** so both items share row 1 regardless of source order:
```css
.gvb-layout{grid-template-columns:minmax(0,1fr) 232px;grid-template-areas:"main toc"}
.gvb-main{grid-area:main}
.gvb-toc {grid-area:toc}
```
Now the article fills the wide left column starting at the top, with the TOC as the sticky right rail beside it. Mobile (<1080px) is unaffected.

1 file changed, +3/−3.

## Test plan
- [ ] Desktop ≥1080px: article starts at the top of the wide left column (no gap); TOC sticky on the right.
- [ ] 360 / 375 / 768 / 1024px: single column, no regressions.
- [ ] Light + dark themes.
- [ ] `python3 tools/playwright_audit.py` against the deploy preview.

https://claude.ai/code/session_01GPGhWitqxuKMNtBD6RBJ8L

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPGhWitqxuKMNtBD6RBJ8L)_