### PR TITLE
Redesign UK gold CGT guide as premium mobile-first editorial article

### DIFF
--- a/blog/uk-gold-cgt-guide.html
+++ b/blog/uk-gold-cgt-guide.html
@@ -17,6 +17,9 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,600&display=swap" rel="stylesheet">
 <meta property="og:title" content="Gold CGT UK 2026: Are Gold Coins Tax-Free? | GoldPriceTools">><meta property="og:description" content="Discover which UK gold coins are CGT-exempt, how HMRC taxes gold bars and ETFs, the £3,000 annual allowance, and how to use ISAs and SIPPs to shelter gains.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://goldpricetools.com/blog/uk-gold-cgt-guide">
 <meta property="og:site_name" content="GoldPriceTools">
@@ -29,7 +32,7 @@
   "headline": "Capital Gains Tax on Gold UK: Are Gold Coins Tax-Free?",
   "description": "Discover which UK gold coins are CGT-exempt, how HMRC taxes gold bars and ETFs, the £3,000 annual allowance, and how to use ISAs and SIPPs to shelter gains.",
   "datePublished": "2026-05-03T08:00:00Z",
-  "dateModified": "2026-05-07T08:00:00Z",
+  "dateModified": "2026-05-28T08:00:00Z",
   "author": {
     "@type": "Organization",
     "name": "GoldPriceTools Editorial Team",
@@ -66,34 +69,82 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "Which gold coins are CGT-exempt in the UK?",
+      "name": "Is gold CGT free in the UK?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "UK legal tender gold coins are exempt from Capital Gains Tax. This includes: Gold Britannia (all sizes from 1/10oz to 1oz), Gold Sovereign (full, half, quarter), and any other gold coin that is UK legal tender. Foreign coins — even popular bullion coins like the Canadian Maple Leaf or South African Krugerrand — are NOT CGT-exempt and gains are subject to standard CGT."
+        "text": "It depends on the type of gold. Royal Mint legal tender gold coins — including Sovereigns and Britannias — are completely CGT-free with no limit on gains. Gold bars and foreign coins are subject to CGT on gains above the £3,000 annual allowance."
       }
     },
     {
       "@type": "Question",
-      "name": "What is the CGT rate on gold in the UK?",
+      "name": "How much CGT do you pay on gold bars in the UK?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "For gold assets that are not CGT-exempt (bars, foreign coins, ETFs outside an ISA), gains are taxed at 18% (basic rate taxpayers) or 24% (higher/additional rate taxpayers) as of 2024–25. You also have an annual CGT allowance (£3,000 for 2024–25) that can offset gains. Losses on gold can be offset against other capital gains."
+        "text": "For the 2026/27 tax year: 18% if you are a basic-rate taxpayer and 24% if you are a higher or additional-rate taxpayer, charged on gains above the £3,000 annual exemption."
       }
     },
     {
       "@type": "Question",
-      "name": "Is gold in an ISA CGT-free?",
+      "name": "Are gold bars CGT exempt in the UK?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Gold ETCs (Exchange-Traded Commodities) held in a Stocks & Shares ISA are completely free of CGT regardless of gains. This makes ISA-held gold ETCs more tax-efficient than physical gold bars for most UK investors. The annual ISA allowance is £20,000."
+        "text": "No. Gold bars are not CGT-exempt regardless of size, weight or refiner. The CGT exemption applies only to UK legal tender coins issued by The Royal Mint."
       }
     },
     {
       "@type": "Question",
-      "name": "Do I need to declare gold sales to HMRC?",
+      "name": "Which gold coins are CGT free in the UK?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "You must report gold sales on your Self Assessment tax return if: (1) your total gains exceed the annual CGT allowance (£3,000 for 2024–25), (2) your total proceeds from all asset sales exceed £50,000, or (3) you made a loss you want to carry forward. CGT-exempt coins (Britannias, Sovereigns) don't count toward these thresholds."
+        "text": "All Royal Mint coins that qualify as UK legal tender: Gold Sovereigns (all years from 1837), Gold Britannias (all sizes from 1987), and other Royal Mint coins with a sterling face value such as the Queen's Beasts and Royal Tudor Beasts."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are Krugerrands CGT exempt in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Krugerrands are South African legal tender but not UK legal tender, so they are chargeable assets and CGT applies to gains above the annual allowance."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can you hold gold in an ISA?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "You cannot hold physical gold bars or coins directly in a UK ISA. However, you can hold gold ETCs (physically backed exchange-traded commodities) within a Stocks & Shares ISA, and all gains on these are completely CGT-free. The annual ISA allowance for 2026/27 is £20,000."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the CGT annual allowance on gold for 2026/27?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "£3,000 for individuals and £1,500 for most trusts — unchanged from 2025/26."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the best CGT-free gold to buy in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "For most investors, Gold Sovereigns offer the best combination of CGT exemption, VAT exemption, dealer recognition and tight buy-sell spreads. Gold Britannias suit investors wanting a standard 1 troy ounce coin at 999.9 fineness."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I pay CGT on gold jewellery in the UK?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gold jewellery qualifies for the chattel exemption if sold for £6,000 or less per item, in which case no CGT applies. Sales above £6,000 per item are chargeable, with gains above the annual allowance taxed at 18–24%."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does gold CGT apply to non-UK residents?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Non-UK residents are generally not subject to UK CGT on the disposal of UK gold bullion, as it is a movable asset rather than UK property. Non-residents should take independent tax advice based on their country of residence."
       }
     }
   ]
@@ -420,6 +471,241 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
 .article-card:hover .article-card-title{color:var(--color-primary)}
 
+/* ════════════════════════════════════════════════════════════
+   CGT ARTICLE — premium editorial layout (mobile-first)
+   ════════════════════════════════════════════════════════════ */
+.cgt-article{--font-serif:'Playfair Display',Georgia,'Times New Roman',serif}
+
+/* Breadcrumb */
+.breadcrumb-wrap{max-width:1100px;margin:0 auto;padding:var(--space-4) var(--space-4) 0}
+.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);font-size:var(--text-xs);color:var(--color-text-muted);margin:0;padding:0}
+.breadcrumb li{display:inline-flex;align-items:center;gap:var(--space-2)}
+.breadcrumb li:not(:last-child)::after{content:'/';color:var(--color-text-faint)}
+.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
+.breadcrumb a:hover{color:var(--color-gold-bright);text-decoration:none}
+.breadcrumb [aria-current=page]{color:var(--color-text);font-weight:500}
+
+/* Hero */
+.cgt-hero{position:relative;max-width:1100px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-6);overflow:hidden}
+.cgt-hero__inner{position:relative;z-index:1}
+.cgt-hero::before{content:'';position:absolute;top:-40%;right:-15%;width:65%;height:150%;background:radial-gradient(closest-side,color-mix(in oklch,var(--color-gold) 20%,transparent),transparent);opacity:.5;pointer-events:none;z-index:0}
+.cgt-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 28%,var(--color-border));color:var(--color-gold-bright);font-size:var(--text-xs);font-weight:700;letter-spacing:.08em;text-transform:uppercase;padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);margin-bottom:var(--space-4)}
+.cgt-hero h1{font-family:var(--font-serif);font-weight:600;font-size:clamp(2rem,1.1rem+4.2vw,3.6rem);line-height:1.07;letter-spacing:-.015em;color:var(--color-text);margin:0 0 var(--space-3);max-width:20ch}
+.cgt-hero h1 .accent{color:var(--color-gold-bright)}
+.cgt-hero__dek{font-size:var(--text-lg);line-height:1.5;color:var(--color-text-muted);max-width:60ch;margin:0 0 var(--space-5);font-weight:400}
+.article-byline{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-1) var(--space-2);font-size:var(--text-sm);color:var(--color-text-muted)}
+.article-byline a{color:var(--color-primary);font-weight:600}
+.article-byline .dot{color:var(--color-text-faint)}
+
+/* Hero stat strip */
+.cgt-stats{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);margin-top:var(--space-6)}
+@media(min-width:880px){.cgt-stats{grid-template-columns:repeat(4,1fr)}}
+.cgt-stat{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.cgt-stat__num{font-family:var(--font-serif);font-size:clamp(1.5rem,1.1rem+1.6vw,2rem);font-weight:700;color:var(--color-gold-bright);line-height:1;font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+.cgt-stat__label{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-2);line-height:1.4}
+
+/* Layout: content + sticky TOC */
+.cgt-layout{max-width:1100px;margin:0 auto;padding:var(--space-4) var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr;gap:var(--space-8);align-items:start}
+@media(min-width:1024px){.cgt-layout{grid-template-columns:minmax(0,1fr) 248px}}
+.cgt-main{min-width:0}
+.cgt-aside{display:none}
+@media(min-width:1024px){.cgt-aside{display:block;position:sticky;top:80px}}
+.toc{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4)}
+.toc__title{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:var(--space-3)}
+.toc__list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:2px;max-height:calc(100dvh - 160px);overflow-y:auto}
+.toc__list a{display:block;padding:6px 10px;font-size:var(--text-sm);line-height:1.35;color:var(--color-text-muted);text-decoration:none;border-left:2px solid transparent;border-radius:0 var(--radius-sm) var(--radius-sm) 0}
+.toc__list a:hover{color:var(--color-text);background:var(--color-surface-offset);text-decoration:none}
+.toc__list a.is-active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold) 8%,var(--color-surface));font-weight:600}
+
+/* Mobile TOC (collapsible) */
+.toc-mobile{max-width:1100px;margin:0 auto;padding:var(--space-4) var(--space-4) 0}
+.toc-mobile details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden}
+.toc-mobile summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4);font-weight:700;font-size:var(--text-sm);color:var(--color-text);min-height:44px}
+.toc-mobile summary::-webkit-details-marker{display:none}
+.toc-mobile summary::after{content:'';width:9px;height:9px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:rotate(45deg);transition:transform var(--transition)}
+.toc-mobile details[open] summary::after{transform:rotate(-135deg)}
+.toc-mobile ol{margin:0;padding:0 var(--space-5) var(--space-4) var(--space-6);color:var(--color-text-muted);font-size:var(--text-sm);display:grid;gap:8px}
+.toc-mobile a{color:var(--color-text-muted);text-decoration:none}
+.toc-mobile a:hover{color:var(--color-gold-bright)}
+@media(min-width:1024px){.toc-mobile{display:none}}
+
+/* Prose */
+.prose{color:var(--color-text);font-size:var(--text-base);line-height:1.75}
+.prose>p{margin:0 0 var(--space-5);max-width:68ch}
+.prose h2{font-family:var(--font-serif);font-weight:600;font-size:clamp(1.5rem,1.1rem+1.7vw,2.1rem);line-height:1.18;color:var(--color-text);margin:var(--space-12) 0 var(--space-4);padding-top:var(--space-6);border-top:1px solid var(--color-divider);scroll-margin-top:84px;letter-spacing:-.01em}
+.prose h2:first-of-type{margin-top:var(--space-4);border-top:none;padding-top:0}
+.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-8) 0 var(--space-3);scroll-margin-top:84px}
+.prose strong{color:var(--color-text);font-weight:700}
+.prose em{font-style:italic}
+.prose>p a,.prose li a{color:var(--color-primary);text-decoration:underline;text-underline-offset:2px;text-decoration-thickness:1px}
+.prose a:hover{color:var(--color-primary-hover)}
+.prose>ul,.prose>ol{margin:0 0 var(--space-5);padding-left:1.3rem;max-width:66ch}
+.prose>ul>li,.prose>ol>li{margin-bottom:var(--space-2);padding-left:.2rem}
+.prose>ul>li::marker,.prose>ol>li::marker{color:var(--color-gold-bright)}
+.prose li strong{color:var(--color-text)}
+.prose .lead{font-size:clamp(1.05rem,1rem+.4vw,1.3rem);line-height:1.65;color:var(--color-text)}
+.prose .lead::first-letter{float:left;font-family:var(--font-serif);font-weight:700;font-size:3.6em;line-height:.72;padding:.06em .14em 0 0;color:var(--color-gold-bright)}
+.prose .hl{color:var(--color-gold-bright);font-weight:700;font-variant-numeric:tabular-nums}
+
+/* Callouts */
+.callout{position:relative;display:flex;gap:var(--space-4);background:color-mix(in oklch,var(--color-gold) 7%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 22%,var(--color-border));border-left:4px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-6) 0}
+.callout__icon{flex-shrink:0;color:var(--color-gold-bright);margin-top:2px}
+.callout__body{min-width:0}
+.callout__label{display:block;font-size:var(--text-xs);font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-gold-bright);margin-bottom:var(--space-1)}
+.callout p{margin:0;max-width:64ch;font-size:var(--text-sm);line-height:1.7;color:var(--color-text)}
+.callout p+p{margin-top:var(--space-2)}
+.callout--law{background:color-mix(in oklch,var(--color-primary) 8%,var(--color-surface));border-color:color-mix(in oklch,var(--color-primary) 25%,var(--color-border));border-left-color:var(--color-primary)}
+.callout--law .callout__icon,.callout--law .callout__label{color:var(--color-primary)}
+
+/* Exempt vs taxable split */
+.split{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0}
+@media(min-width:720px){.split{grid-template-columns:1fr 1fr}}
+.split__card{border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);background:var(--color-surface)}
+.split__card--exempt{border-color:color-mix(in oklch,var(--color-up) 35%,var(--color-border));background:color-mix(in oklch,var(--color-up) 7%,var(--color-surface))}
+.split__card--taxable{border-color:color-mix(in oklch,var(--color-down) 32%,var(--color-border));background:color-mix(in oklch,var(--color-down) 6%,var(--color-surface))}
+.split__head{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2);font-weight:700;font-size:var(--text-base);color:var(--color-text);margin-bottom:var(--space-1)}
+.split__head .pill{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.05em;padding:2px 8px;border-radius:var(--radius-full)}
+.split__card--exempt .pill{background:color-mix(in oklch,var(--color-up) 18%,var(--color-surface));color:var(--color-up)}
+.split__card--taxable .pill{background:color-mix(in oklch,var(--color-down) 16%,var(--color-surface));color:var(--color-down)}
+.split__sub{font-size:var(--text-xs);color:var(--color-text-muted);margin:0 0 var(--space-3)}
+.split ul{list-style:none;margin:0;padding:0;max-width:none}
+.split li{display:flex;align-items:flex-start;gap:var(--space-2);padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm);line-height:1.45;color:var(--color-text);margin:0}
+.split li:last-child{border-bottom:none}
+.split li svg{flex-shrink:0;margin-top:3px}
+.split .ic-yes{color:var(--color-up)}
+.split .ic-no{color:var(--color-down)}
+
+/* Tables */
+.table-wrap{margin:var(--space-6) 0;border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;background:var(--color-surface)}
+.table-cap{padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:700;color:var(--color-text);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
+.table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.dtable{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+.dtable th,.dtable td{padding:var(--space-3) var(--space-4);text-align:left;border-bottom:1px solid var(--color-divider);vertical-align:top;line-height:1.45}
+.dtable thead th{background:var(--color-surface-offset);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:var(--color-text-muted);white-space:nowrap}
+.dtable tbody tr:last-child td{border-bottom:none}
+.dtable tbody tr:hover{background:var(--color-surface-offset)}
+.dtable td strong{color:var(--color-text)}
+.dtable .num{font-variant-numeric:tabular-nums;white-space:nowrap}
+.row-exempt{background:color-mix(in oklch,var(--color-up) 6%,transparent)}
+.row-exempt:hover{background:color-mix(in oklch,var(--color-up) 11%,transparent)!important}
+.row-tax{background:color-mix(in oklch,var(--color-down) 5%,transparent)}
+.row-tax:hover{background:color-mix(in oklch,var(--color-down) 10%,transparent)!important}
+.badge{display:inline-flex;align-items:center;gap:4px;font-size:var(--text-xs);font-weight:700;padding:2px 8px;border-radius:var(--radius-full);white-space:nowrap}
+.badge-yes{background:color-mix(in oklch,var(--color-up) 16%,var(--color-surface));color:var(--color-up)}
+.badge-no{background:color-mix(in oklch,var(--color-down) 14%,var(--color-surface));color:var(--color-down)}
+.badge-na{background:var(--color-surface-offset-2);color:var(--color-text-muted)}
+.src-note{padding:var(--space-3) var(--space-4);font-size:var(--text-xs);color:var(--color-text-faint);background:var(--color-surface);border-top:1px solid var(--color-divider);line-height:1.5}
+
+/* Card-reflow for big comparison tables on mobile */
+@media(max-width:600px){
+  .dtable--reflow{display:block}
+  .dtable--reflow thead{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+  .dtable--reflow tbody{display:block}
+  .dtable--reflow tr{display:block;padding:var(--space-2) var(--space-3);border-bottom:6px solid var(--color-bg)}
+  .dtable--reflow td{display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-4);padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);text-align:right}
+  .dtable--reflow td:last-child{border-bottom:none}
+  .dtable--reflow td::before{content:attr(data-label);font-weight:700;font-size:var(--text-xs);color:var(--color-text-muted);text-align:left;text-transform:uppercase;letter-spacing:.03em;flex:0 0 auto;max-width:48%}
+  .dtable--reflow td:first-child{font-weight:700;font-size:var(--text-base);color:var(--color-text)}
+  .dtable--reflow td:first-child::before{content:''}
+}
+
+/* Allowance erosion bars */
+.bars{display:flex;align-items:flex-end;gap:var(--space-2);height:200px;margin:var(--space-6) 0 var(--space-2);padding:var(--space-4) var(--space-4) var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.bar{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:flex-end;height:100%;gap:6px;min-width:0}
+.bar__val{font-size:var(--text-xs);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;white-space:nowrap}
+.bar__fill{width:100%;max-width:60px;background:linear-gradient(180deg,var(--color-gold-bright),var(--color-gold));border-radius:var(--radius-sm) var(--radius-sm) 0 0;min-height:6px}
+.bar--now .bar__fill{background:linear-gradient(180deg,var(--color-primary-hover),var(--color-primary))}
+.bar__year{font-size:10px;color:var(--color-text-muted);white-space:nowrap;text-align:center;line-height:1.2}
+
+/* Steps */
+.steps{display:grid;gap:var(--space-3);margin:var(--space-6) 0}
+.step{display:grid;grid-template-columns:auto 1fr;gap:var(--space-4);align-items:start;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5)}
+.step__n{width:32px;height:32px;border-radius:var(--radius-full);background:color-mix(in oklch,var(--color-gold) 14%,var(--color-surface));color:var(--color-gold-bright);font-weight:700;display:flex;align-items:center;justify-content:center;font-size:var(--text-sm)}
+.step__body{min-width:0}
+.step__body strong{display:block;color:var(--color-text);margin-bottom:var(--space-1)}
+.step__body p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);max-width:none}
+.formula{font-family:'IBM Plex Mono',ui-monospace,SFMono-Regular,Consolas,monospace;font-size:var(--text-sm);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4);margin:var(--space-2) 0 0;color:var(--color-text);overflow-x:auto;white-space:nowrap}
+
+/* Worked example calc cards */
+.calc-cards{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0}
+@media(min-width:780px){.calc-cards{grid-template-columns:repeat(3,1fr)}}
+.calc-card{display:flex;flex-direction:column;border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface);overflow:hidden}
+.calc-card__head{padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);font-weight:700;font-size:var(--text-sm);color:var(--color-text)}
+.calc-card__head span{display:block;font-weight:400;font-size:var(--text-xs);color:var(--color-text-muted);margin-top:2px}
+.calc-card__rows{padding:var(--space-4) var(--space-5);display:flex;flex-direction:column;flex:1}
+.calc-card__row{display:flex;justify-content:space-between;gap:var(--space-3);padding:var(--space-2) 0;border-bottom:1px dashed var(--color-divider);font-size:var(--text-sm);color:var(--color-text-muted)}
+.calc-card__row:last-child{border-bottom:none}
+.calc-card__row span:last-child{color:var(--color-text);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
+.calc-card__result{margin-top:auto;padding:var(--space-4) var(--space-5);border-top:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between;gap:var(--space-3)}
+.calc-card__result-label{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted);font-weight:700}
+.calc-card__result-val{font-family:var(--font-serif);font-size:var(--text-xl);font-weight:700;font-variant-numeric:tabular-nums;line-height:1}
+.calc-card--nil .calc-card__result{background:color-mix(in oklch,var(--color-up) 9%,var(--color-surface))}
+.calc-card--nil .calc-card__result-val{color:var(--color-up)}
+.calc-card--due .calc-card__result{background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface))}
+.calc-card--due .calc-card__result-val{color:var(--color-gold-bright)}
+
+/* Strategy cards */
+.strategy-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0;counter-reset:strat}
+@media(min-width:600px){.strategy-grid{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:980px){.strategy-grid{grid-template-columns:repeat(3,1fr)}}
+.strategy{position:relative;border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface);padding:var(--space-5);transition:border-color var(--transition),box-shadow var(--transition)}
+.strategy:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.strategy__n{counter-increment:strat;font-family:var(--font-serif);font-size:2.1rem;font-weight:700;color:var(--color-gold-bright);line-height:1;opacity:.9}
+.strategy__n::before{content:counter(strat,decimal-leading-zero)}
+.strategy h3{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-2) 0;scroll-margin-top:84px}
+.strategy p{font-size:var(--text-sm);line-height:1.6;color:var(--color-text-muted);margin:0;max-width:none}
+.strategy ul{margin:var(--space-3) 0 0;padding-left:1.1rem;max-width:none}
+.strategy li{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:4px}
+.strategy li::marker{color:var(--color-gold-bright)}
+
+/* FAQ accordion */
+.faq{margin:var(--space-6) 0}
+.faq__item{border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface);margin-bottom:var(--space-3);overflow:hidden}
+.faq__item[open]{border-color:color-mix(in oklch,var(--color-gold) 30%,var(--color-border))}
+.faq__q{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);padding:var(--space-4) var(--space-5);font-weight:600;font-size:var(--text-base);color:var(--color-text);min-height:44px}
+.faq__q::-webkit-details-marker{display:none}
+.faq__q::after{content:'';flex-shrink:0;width:11px;height:11px;border-right:2px solid var(--color-gold-bright);border-bottom:2px solid var(--color-gold-bright);transform:rotate(45deg);transition:transform var(--transition)}
+.faq__item[open] .faq__q::after{transform:rotate(-135deg)}
+.faq__a{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);line-height:1.7;color:var(--color-text-muted);max-width:68ch}
+.faq__a strong{color:var(--color-text)}
+
+/* CTA */
+.cta-box{margin:var(--space-10) 0;padding:var(--space-8) var(--space-6);text-align:center;border-radius:var(--radius-xl);background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold) 13%,var(--color-surface)),var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border))}
+.cta-box h3{font-family:var(--font-serif);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin:0 0 var(--space-2)}
+.cta-box p{font-size:var(--text-base);color:var(--color-text-muted);max-width:52ch;margin:0 auto var(--space-5)}
+.cta-btn{display:inline-flex;align-items:center;gap:var(--space-2);background:var(--color-primary);color:#fff;font-weight:700;font-size:var(--text-base);padding:var(--space-3) var(--space-6);border-radius:var(--radius-full);text-decoration:none;box-shadow:var(--shadow-sm)}
+.cta-btn:hover{background:var(--color-primary-hover);text-decoration:none}
+
+/* Aside note */
+.aside-note{margin:var(--space-6) 0;padding:var(--space-5);background:var(--color-surface-offset);border-radius:var(--radius-lg);border:1px dashed var(--color-border)}
+.aside-note h3{margin:0 0 var(--space-2)}
+.aside-note p{font-size:var(--text-sm);color:var(--color-text-muted);margin:0;max-width:none}
+
+/* Disclaimer */
+.disclaimer{margin:var(--space-10) 0 0;padding-top:var(--space-5);border-top:1px solid var(--color-divider);font-size:var(--text-xs);font-style:italic;line-height:1.7;color:var(--color-text-faint);max-width:74ch}
+
+/* Related */
+.related-guides{max-width:1100px;margin:0 auto;padding:var(--space-4) var(--space-4) var(--space-16)}
+.related-guides h2{font-family:var(--font-serif);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin:0 0 var(--space-5)}
+.related-guides-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:600px){.related-guides-grid{grid-template-columns:1fr 1fr}}
+@media(min-width:960px){.related-guides-grid{grid-template-columns:repeat(3,1fr)}}
+.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
+.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);text-decoration:none}
+.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.related-card__title{font-size:var(--text-base);font-weight:700;color:var(--color-text);line-height:1.3;margin-bottom:var(--space-2)}
+.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55}
+
+/* Light-mode contrast: bright up/down tokens are tuned for dark surfaces, so
+   darken the semantic green/red where it carries meaning as text */
+[data-theme="light"] .badge-yes{color:#15803d;background:color-mix(in oklch,#15803d 12%,var(--color-surface))}
+[data-theme="light"] .badge-no{color:#b91c1c;background:color-mix(in oklch,#b91c1c 10%,var(--color-surface))}
+[data-theme="light"] .split .ic-yes,[data-theme="light"] .split__card--exempt .pill{color:#15803d}
+[data-theme="light"] .split .ic-no,[data-theme="light"] .split__card--taxable .pill{color:#b91c1c}
+[data-theme="light"] .split__card--exempt .pill{background:color-mix(in oklch,#15803d 14%,var(--color-surface))}
+[data-theme="light"] .split__card--taxable .pill{background:color-mix(in oklch,#b91c1c 12%,var(--color-surface))}
+[data-theme="light"] .calc-card--nil .calc-card__result-val{color:#15803d}
+
 </style>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
@@ -517,94 +803,403 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </div>
 </nav>
 
-<div class="breadcrumb-wrap">
-  <ol class="breadcrumb" aria-label="Breadcrumb">
+<nav class="breadcrumb-wrap" aria-label="Breadcrumb">
+  <ol class="breadcrumb">
     <li><a href="/">Home</a></li>
     <li><a href="/blog/">Blog</a></li>
-    <li aria-current="page">Gold &amp; Silver Price Outlook</li>
+    <li aria-current="page">Capital Gains Tax on Gold UK</li>
   </ol>
-</div>
+</nav>
 
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb">
-<li><a href="/">Home</a></li><li><a href="/blog/">Blog</a></li><li aria-current="page">Capital Gains Tax on Gold UK: Are Gold Coins Tax-Free?</li>
-</ol></div>
-<article class="article-wrap" itemscope itemtype="https://schema.org/BlogPosting">
-  <div class="article-tag">UK Tax Guide</div>
-  <h1 class="article-title" itemprop="headline">Capital Gains Tax on Gold UK: Are Gold Coins Tax-Free?</h1>
-  <div class="article-byline">
-    By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a>
-    &middot; <time datetime="2026-05-28" itemprop="datePublished">2026-05-03</time>
-    &middot; <span style="font-size:0.8em;color:var(--color-text-faint)">Last updated: 3 May 2026</span>
+<article class="cgt-article" itemscope itemtype="https://schema.org/BlogPosting">
+  <header class="cgt-hero">
+    <div class="cgt-hero__inner">
+      <span class="cgt-eyebrow">UK Tax Guide &middot; 2026/27</span>
+      <h1 itemprop="headline">Capital Gains Tax on Gold in the <span class="accent">UK</span></h1>
+      <p class="cgt-hero__dek">The 2026 guide to what's taxable, what's not, and how to legally pay less &mdash; CGT rates, the £3,000 exemption, exactly which coins are exempt, and seven ways to shelter your gains.</p>
+      <div class="article-byline">
+        <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
+        <span class="dot">&middot;</span>
+        <span>Published <time datetime="2026-05-03" itemprop="datePublished">3 May 2026</time></span>
+        <span class="dot">&middot;</span>
+        <span>Updated <time datetime="2026-05-28" itemprop="dateModified">28 May 2026</time></span>
+        <span class="dot">&middot;</span>
+        <span>16 min read</span>
+      </div>
+      <div class="cgt-stats">
+        <div class="cgt-stat"><div class="cgt-stat__num">18&ndash;24%</div><div class="cgt-stat__label">CGT on bars, foreign coins &amp; unwrapped ETFs</div></div>
+        <div class="cgt-stat"><div class="cgt-stat__num">£3,000</div><div class="cgt-stat__label">Annual exempt amount (2026/27)</div></div>
+        <div class="cgt-stat"><div class="cgt-stat__num">£0</div><div class="cgt-stat__label">CGT on Sovereigns &amp; Britannias &mdash; unlimited gain</div></div>
+        <div class="cgt-stat"><div class="cgt-stat__num">0%</div><div class="cgt-stat__label">VAT on investment-grade gold</div></div>
+      </div>
+    </div>
+  </header>
+
+  <div class="toc-mobile">
+    <details>
+      <summary>On this page</summary>
+      <ol>
+        <li><a href="#what-is-cgt">What is CGT on gold?</a></li>
+        <li><a href="#rates">Rates &amp; annual exemption 2026/27</a></li>
+        <li><a href="#depends">What you own decides everything</a></li>
+        <li><a href="#vat">VAT on gold</a></li>
+        <li><a href="#calculate">How to calculate CGT</a></li>
+        <li><a href="#chattel">The chattel exemption</a></li>
+        <li><a href="#cgt-free">Is gold CGT-free? The verdict</a></li>
+        <li><a href="#bars">Are gold bars exempt?</a></li>
+        <li><a href="#sovereigns">Gold Sovereigns: a special case</a></li>
+        <li><a href="#avoid">7 ways to pay less CGT</a></li>
+        <li><a href="#etfs">CGT on gold ETFs</a></li>
+        <li><a href="#physical-vs-etf">Physical vs ETFs</a></li>
+        <li><a href="#report">Reporting to HMRC</a></li>
+        <li><a href="#records">Record-keeping</a></li>
+        <li><a href="#australia">CGT on gold in Australia</a></li>
+        <li><a href="#faq">FAQ</a></li>
+      </ol>
+    </details>
   </div>
-  <div class="prose">
-    <p>One of the most common questions UK gold investors ask is: "Do I have to pay Capital Gains Tax when I sell my gold?" The short answer is: it depends entirely on what type of gold you own. Certain UK gold coins are completely CGT-exempt — you can make an unlimited tax-free profit, no matter how large the gain. Other gold assets are fully subject to CGT in the normal way. Getting this wrong could cost you thousands of pounds.</p>
 
-    <h2>How Capital Gains Tax Works for Gold</h2>
-    <p>HMRC treats most gold as a capital asset. When you sell it for more than you paid, the profit is a chargeable gain. For the 2025–26 tax year, every individual has an <strong>annual exempt amount of £3,000</strong> — gains below this threshold are tax-free. Gains above £3,000 are taxed at 18% if your total taxable income (including the gain) falls within the basic-rate band, or 24% if any of the gain falls in the higher or additional-rate band. These rates were updated in the October 2024 Budget and apply from 30 October 2024 onwards. CGT on gold is reported via Self Assessment — the 60-day reporting rule that applies to UK residential property does <em>not</em> apply to gold.</p>
+  <div class="cgt-layout">
+    <main class="cgt-main">
+      <div class="prose" itemprop="articleBody">
 
-    <h2>CGT-Exempt Gold Coins: The Legal Tender Exemption</h2>
-    <p>Under <strong>TCGA 1992 s21(1)(b)</strong>, sterling currency is not a chargeable asset — meaning gains on sterling currency are completely outside the scope of CGT. HMRC's own guidance confirms this at CG76881 and CG78305: "Sovereigns minted from 1837 onwards and Britannia gold coins are sterling currency and, like all sterling currency, exempt under s21(1)(b)." Because these coins carry a face value in pounds sterling and are UK legal tender, HMRC treats them as currency rather than an investment asset. Currency is not subject to CGT.</p>
+        <div class="callout">
+          <span class="callout__icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01"/><path d="M11 12h1v4h1"/></svg></span>
+          <div class="callout__body">
+            <span class="callout__label">Key point</span>
+            <p>Gold bars, foreign coins (Krugerrands, Maples, Eagles) and gold ETFs held outside tax wrappers are <strong>subject to CGT</strong> in the UK. Gold Sovereigns and Gold Britannias &mdash; and other Royal Mint legal tender coins &mdash; are <strong>entirely exempt</strong> from CGT, with no cap on the amount of gain.</p>
+          </div>
+        </div>
 
-    <h2>Which Gold Coins Are CGT-Exempt?</h2>
-    <p>The following Royal Mint coins qualify for full CGT exemption as UK legal tender:</p>
-    <ul>
-      <li><strong>Gold Sovereigns (minted 1837 onwards)</strong> — face value £1, available in Quarter (1/4 oz), Half, and full Sovereign sizes. All 22-carat (916.7 fine) gold.</li>
-      <li><strong>Gold Britannia coins</strong> — face value £100 (1 oz, 999.9 fine), £50 (1/2 oz), £25 (1/4 oz), £10 (1/10 oz), £5 (1/20 oz), £2.50 (1/40 oz). The 2026 Britannia includes four security features.</li>
-      <li><strong>Queen's Beasts series</strong> — completed 10-coin Royal Mint series (2016–2021), all CGT-exempt as UK legal tender.</li>
-      <li><strong>Tudor Beasts series</strong> — ongoing Royal Mint legal tender series from 2022 onwards.</li>
-      <li><strong>Any other Royal Mint coin bearing a GBP face value denomination</strong>.</li>
-    </ul>
-    <p>There is <strong>no cap on the gain</strong> and no limit on the number of coins sold. A UK investor who buys £500,000 worth of Gold Britannias and sells them for £2 million pays zero CGT on the £1.5 million profit. This is one of the most powerful tax advantages available to UK retail investors in any asset class.</p>
+        <p class="lead">If you own gold in the UK, one of the most important things you can know about your investment has nothing to do with the gold price itself &mdash; it is understanding exactly when Capital Gains Tax applies, when it does not, and what you can do to legitimately reduce or eliminate your tax bill. The rules are more favourable than many investors realise, but only if you own the right type of gold in the first place.</p>
 
-    <h2>What Gold Is NOT Exempt from CGT?</h2>
-    <p>The exemption only applies to qualifying UK legal tender coins. All of the following are fully subject to CGT:</p>
-    <ul>
-      <li><strong>Gold bars and wafers</strong> — LBMA Good Delivery bars, retail bars (1g, 5g, 10g, 100g, 1 kg), cast bars.</li>
-      <li><strong>Gold ETFs and ETCs</strong> — iShares Physical Gold ETC (IGLN/SGLN), WisdomTree Physical Gold (PHAU), Invesco Physical Gold (SGLD) — all chargeable to CGT unless held inside an ISA or SIPP.</li>
-      <li><strong>Foreign gold coins</strong> — Canadian Maple Leaf, South African Krugerrand, American Gold Eagle, Austrian Philharmonic — not UK legal tender, fully chargeable.</li>
-      <li><strong>Gold jewellery</strong> — subject to CGT, though the chattel exemption may reduce the liability if the piece is worth under £6,000.</li>
-    </ul>
+        <p>This guide lays out the full picture for the 2026/27 tax year: the CGT rates, the annual exemption, precisely which gold is exempt and why, how to calculate tax on gold bars and foreign coins, and the legal strategies available to reduce your CGT exposure to zero.</p>
 
-    <h2>Allowable Costs You Can Deduct</h2>
-    <p>When calculating CGT on taxable gold, you can deduct the following from your gross gain: the original purchase price (including dealer premium); transaction costs (dealing commissions, brokerage fees); storage and insurance costs paid over the holding period for an allocated vault account; and any enhancement expenditure. You cannot deduct the cost of home contents insurance on personally held gold — HMRC treats this as a personal security expense rather than an investment cost.</p>
+        <h2 id="what-is-cgt">What Is Capital Gains Tax on Gold?</h2>
+        <p>Capital Gains Tax (CGT) is a tax charged on the <strong>profit</strong> you make when you dispose of an asset that has increased in value &mdash; not on the total proceeds of the sale. Disposing of gold means selling it, gifting it, or transferring it in most circumstances (transfers between spouses are excluded).</p>
+        <p>The critical point is that CGT is only due on the <em>gain</em> &mdash; the difference between what you paid (your "base cost") and what you received when you sold. If you paid <span class="hl">£3,000</span> for a gold bar and sold it for <span class="hl">£4,200</span>, your gain is <span class="hl">£1,200</span>, not £4,200.</p>
+        <p>CGT does not apply automatically when you sell gold. It only becomes relevant when:</p>
+        <ol>
+          <li>The gold you own is a <strong>chargeable asset</strong> for UK CGT purposes (not all gold is); and</li>
+          <li>Your total net gains across all assets in the tax year exceed the <strong>annual CGT exemption</strong>.</li>
+        </ol>
 
-    <h2>Reporting CGT on Gold to HMRC</h2>
-    <p>If your total gains from all assets in a tax year exceed £3,000, you must report them via Self Assessment by 31 January following the end of the tax year. This applies even if no tax is due (for example, if losses from other assets cancel out the gain). Gains on CGT-exempt Sovereigns and Britannias do not need to be declared at all — there is no reporting requirement, as they do not constitute chargeable gains.</p>
+        <h2 id="rates">UK CGT Rates &amp; Annual Exemption for 2026/27</h2>
+        <p>For the 2026/27 tax year, the rules are as follows.</p>
+        <div class="table-wrap">
+          <div class="table-cap">CGT rates &amp; allowances &mdash; 2026/27</div>
+          <div class="table-scroll">
+            <table class="dtable">
+              <thead><tr><th>CGT detail</th><th>2026/27 rate / amount</th></tr></thead>
+              <tbody>
+                <tr><td>Annual exempt amount (individual)</td><td class="num"><strong>£3,000</strong></td></tr>
+                <tr><td>Annual exempt amount (most trusts)</td><td class="num">£1,500</td></tr>
+                <tr><td>Basic-rate taxpayers</td><td class="num">18% on gains above the allowance</td></tr>
+                <tr><td>Higher / additional-rate taxpayers</td><td class="num">24% on gains above the allowance</td></tr>
+                <tr><td>Allowance carry-forward</td><td>None &mdash; use it or lose it each year</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="src-note">Source: HMRC; Hargreaves Lansdown 2026/27 tax facts.</div>
+        </div>
+        <p>The annual exemption has been fixed at £3,000 for both 2025/26 and 2026/27 &mdash; a dramatic fall from recent years. The allowance was £12,300 as recently as 2022/23, dropped to £6,000 in 2023/24, and was cut again to £3,000 in April 2024.</p>
+        <div class="bars" role="img" aria-label="Annual CGT exemption by tax year: 2022/23 £12,300; 2023/24 £6,000; 2024/25 £3,000; 2025/26 £3,000; 2026/27 £3,000.">
+          <div class="bar"><span class="bar__val">£12,300</span><span class="bar__fill" style="height:130px"></span><span class="bar__year">2022/23</span></div>
+          <div class="bar"><span class="bar__val">£6,000</span><span class="bar__fill" style="height:63px"></span><span class="bar__year">2023/24</span></div>
+          <div class="bar"><span class="bar__val">£3,000</span><span class="bar__fill" style="height:32px"></span><span class="bar__year">2024/25</span></div>
+          <div class="bar"><span class="bar__val">£3,000</span><span class="bar__fill" style="height:32px"></span><span class="bar__year">2025/26</span></div>
+          <div class="bar bar--now"><span class="bar__val">£3,000</span><span class="bar__fill" style="height:32px"></span><span class="bar__year">2026/27</span></div>
+        </div>
+        <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:0">Annual CGT exemption by tax year &mdash; a 76% cut in three years.</p>
+        <div class="callout">
+          <span class="callout__icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01"/><path d="M11 12h1v4h1"/></svg></span>
+          <div class="callout__body">
+            <span class="callout__label">What this means for gold investors</span>
+            <p>With the allowance now just £3,000, even a moderate profit on a gold bar can trigger a CGT liability if you have made other gains in the same year. Careful planning around your gold holdings matters more than it ever has.</p>
+          </div>
+        </div>
+        <p>The rates themselves rose in the October 2024 Budget: basic-rate taxpayers now pay <strong>18%</strong> (up from 10%) and higher-rate taxpayers <strong>24%</strong> (up from 20%) on most assets, including gold bars and foreign coins. These rates apply to all disposals from 30 October 2024 onwards.</p>
 
-    <h2>Tax-Efficient Strategy: Bed-and-ISA and SIPPs</h2>
-    <p>If you hold gold ETCs outside an ISA, the <strong>Bed-and-ISA</strong> strategy lets you shelter future gains. Sell your ETC holding (which may trigger a gain, potentially within your £3,000 exempt amount) and simultaneously repurchase inside a Stocks &amp; Shares ISA. Once inside, all future gains and income are permanently free from CGT and income tax. The annual ISA allowance is £20,000 per person. For pension investors, holding gold ETCs inside a SIPP gives tax relief on contributions at your marginal rate (20%–45%) plus CGT-free growth within the wrapper.</p>
+        <h2 id="depends">The Most Important Rule: It Depends on What You Own</h2>
+        <p>Unlike income tax, which applies broadly under the same rules, CGT on gold in the UK depends heavily on the <strong>specific type of gold</strong> you hold. Two investors could sell gold of identical value on the same day and face completely different tax treatment.</p>
+        <div class="split">
+          <div class="split__card split__card--exempt">
+            <div class="split__head"><span class="pill">£0 CGT</span> Exempt from CGT</div>
+            <p class="split__sub">UK Royal Mint legal tender coins &mdash; no limit on the gain.</p>
+            <ul>
+              <li><svg class="ic-yes" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> Gold Sovereigns (1837 onwards)</li>
+              <li><svg class="ic-yes" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> Gold Britannias (all sizes)</li>
+              <li><svg class="ic-yes" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> Queen's Beasts coins</li>
+              <li><svg class="ic-yes" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> Royal Tudor Beasts coins</li>
+              <li><svg class="ic-yes" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> Any Royal Mint coin with a sterling face value</li>
+            </ul>
+          </div>
+          <div class="split__card split__card--taxable">
+            <div class="split__head"><span class="pill">18&ndash;24%</span> Subject to CGT</div>
+            <p class="split__sub">Bullion and non-sterling coins are chargeable assets.</p>
+            <ul>
+              <li><svg class="ic-no" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Gold bars &mdash; all sizes &amp; refiners</li>
+              <li><svg class="ic-no" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Krugerrands (South Africa)</li>
+              <li><svg class="ic-no" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Canadian Maple Leafs</li>
+              <li><svg class="ic-no" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> American Eagles &amp; Buffalos</li>
+              <li><svg class="ic-no" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Gold ETFs / ETCs outside an ISA or SIPP</li>
+              <li><svg class="ic-no" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg> Gold jewellery sold over £6,000 per item</li>
+            </ul>
+          </div>
+        </div>
+        <h3>Why Royal Mint coins are CGT-exempt</h3>
+        <div class="callout callout--law">
+          <span class="callout__icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><path d="M5 7h14"/><path d="M5 7l-3 7h6z"/><path d="M19 7l-3 7h6z"/><path d="M8 21h8"/></svg></span>
+          <div class="callout__body">
+            <span class="callout__label">The legal basis</span>
+            <p>This exemption is not a loophole. It is grounded in primary legislation &mdash; the <strong>Taxation of Chargeable Gains Act 1992, s21(1)(b)</strong> &mdash; under which sterling currency is not a chargeable asset. Because Royal Mint gold coins are UK legal tender with a face value in pounds sterling, they fall outside the scope of CGT entirely.</p>
+          </div>
+        </div>
+        <p><strong>Practical implication:</strong> you could buy <span class="hl">£500,000</span> of Gold Sovereigns today, sell them in ten years for <span class="hl">£2,000,000</span>, and owe zero CGT on a <span class="hl">£1.5 million</span> profit &mdash; regardless of your income, tax band, or whether you have used your annual allowance.</p>
+        <h3>Which coins qualify for the CGT exemption?</h3>
+        <div class="table-wrap">
+          <div class="table-cap">CGT-exempt Royal Mint coins</div>
+          <div class="table-scroll">
+            <table class="dtable dtable--reflow">
+              <thead><tr><th>Coin</th><th>Purity</th><th>Face value</th><th>CGT exempt?</th><th>VAT exempt?</th></tr></thead>
+              <tbody>
+                <tr><td data-label="Coin"><strong>Gold Sovereign (1837+)</strong></td><td data-label="Purity">916.7 (22K)</td><td data-label="Face value" class="num">£1</td><td data-label="CGT exempt?"><span class="badge badge-yes">Yes</span></td><td data-label="VAT exempt?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr><td data-label="Coin"><strong>Half Sovereign</strong></td><td data-label="Purity">916.7 (22K)</td><td data-label="Face value" class="num">50p</td><td data-label="CGT exempt?"><span class="badge badge-yes">Yes</span></td><td data-label="VAT exempt?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr><td data-label="Coin"><strong>Gold Britannia 1oz (2026)</strong></td><td data-label="Purity">999.9 (24K)</td><td data-label="Face value" class="num">£100</td><td data-label="CGT exempt?"><span class="badge badge-yes">Yes</span></td><td data-label="VAT exempt?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr><td data-label="Coin"><strong>Gold Britannia ½oz</strong></td><td data-label="Purity">999.9 (24K)</td><td data-label="Face value" class="num">£50</td><td data-label="CGT exempt?"><span class="badge badge-yes">Yes</span></td><td data-label="VAT exempt?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr><td data-label="Coin"><strong>Gold Britannia ¼oz</strong></td><td data-label="Purity">999.9 (24K)</td><td data-label="Face value" class="num">£25</td><td data-label="CGT exempt?"><span class="badge badge-yes">Yes</span></td><td data-label="VAT exempt?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr><td data-label="Coin"><strong>Gold Britannia 1/10oz</strong></td><td data-label="Purity">999.9 (24K)</td><td data-label="Face value" class="num">£10</td><td data-label="CGT exempt?"><span class="badge badge-yes">Yes</span></td><td data-label="VAT exempt?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr><td data-label="Coin"><strong>Queen's Beasts</strong></td><td data-label="Purity">999.9 (24K)</td><td data-label="Face value">Varies</td><td data-label="CGT exempt?"><span class="badge badge-yes">Yes</span></td><td data-label="VAT exempt?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr><td data-label="Coin"><strong>Royal Tudor Beasts</strong></td><td data-label="Purity">999.9 (24K)</td><td data-label="Face value">Varies</td><td data-label="CGT exempt?"><span class="badge badge-yes">Yes</span></td><td data-label="VAT exempt?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr><td data-label="Coin"><strong>Other Royal Mint sterling coins</strong></td><td data-label="Purity">Varies</td><td data-label="Face value">Varies</td><td data-label="CGT exempt?"><span class="badge badge-yes">Yes</span></td><td data-label="VAT exempt?"><span class="badge badge-yes">Yes</span></td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="src-note">Sources: BullionByPost, BullionCompare, The Royal Mint, HMRC manuals CG76881 &amp; CG78305.</div>
+        </div>
+        <p>The key test is simple: <strong>was it struck by The Royal Mint, and does it carry a face value in sterling?</strong> If yes to both, it is CGT-exempt. Foreign gold coins are <em>not</em> exempt even though they may be legal tender in their own countries &mdash; HMRC is explicit that coins which are currency but not sterling remain chargeable assets for UK residents, so Krugerrands, Maple Leafs, Eagles, Buffalos and Kangaroos are all taxable on the gain.</p>
 
-    <h2>Practical Summary for UK Gold Investors</h2>
-    <p>The simplest CGT-efficient strategy is to hold <strong>Gold Sovereigns or Britannias for any amount where tax efficiency matters</strong>. For larger holdings, Royal Mint Vault storage (0.5% p.a.) maintains the coin's physical allocated ownership and CGT-exempt status without requiring home storage. For smaller sums or pension accounts, ISA-wrapped gold ETCs eliminate CGT at low annual cost (0.12% p.a. for iShares IGLN). Combining both approaches maximises tax efficiency as your gold holding grows.</p>
-    <div class="cta-box"><h3>Calculate Your Gold's Current Value</h3><p>Use GoldPriceTools' free live calculator to find the current melt value of Sovereigns, Britannias, and gold bars in GBP.</p><a href="/" class="cta-btn">Open Calculator &rarr;</a></div>
+        <h2 id="vat">VAT on Gold: A Separate (and Simpler) Question</h2>
+        <p>VAT is often confused with CGT by new investors. <strong>Investment-grade gold is VAT-exempt in the UK</strong> under HMRC VAT Notice 701/21A. To qualify, gold must:</p>
+        <ul>
+          <li>have a purity of at least <strong>995/1000</strong> (99.5% fine) for bars; or</li>
+          <li>for coins: be minted after 1800, be at least 900/1000 fine, and be (or have been) legal tender in its country of origin.</li>
+        </ul>
+        <p>This means most investment gold bars and bullion coins &mdash; including foreign coins like Krugerrands, Maples and Eagles &mdash; are VAT-free to buy. Silver, platinum and palladium bullion, by contrast, carry <strong>20% VAT</strong> in the UK &mdash; a key structural difference between the metals.</p>
+        <div class="callout">
+          <span class="callout__icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></span>
+          <div class="callout__body">
+            <span class="callout__label">The sweet spot</span>
+            <p>Britannias and Sovereigns are both CGT-exempt <em>and</em> VAT-exempt at the same time &mdash; making them uniquely tax-efficient among all investment assets available in the UK.</p>
+          </div>
+        </div>
+
+        <h2 id="calculate">How to Calculate CGT on Taxable Gold</h2>
+        <p>If you hold gold bars, Krugerrands, Maple Leafs or other taxable gold, here is exactly how CGT is worked out when you sell.</p>
+        <div class="steps">
+          <div class="step"><div class="step__n">1</div><div class="step__body"><strong>Calculate the gain</strong><p>Deduct what you paid and your allowable costs (purchase price, reasonable selling costs, and &mdash; arguably &mdash; directly associated insurance; seek advice) from the sale proceeds.</p><div class="formula">Gain = Sale proceeds &minus; Purchase price &minus; Allowable costs</div></div></div>
+          <div class="step"><div class="step__n">2</div><div class="step__body"><strong>Subtract the annual exemption</strong><p>Take off your £3,000 allowance if you have not already used it this tax year.</p><div class="formula">Taxable gain = Total gain &minus; £3,000</div></div></div>
+          <div class="step"><div class="step__n">3</div><div class="step__body"><strong>Apply your CGT rate</strong><p><strong>18%</strong> if your total income is below £50,270 (basic rate); <strong>24%</strong> if above it (higher or additional rate).</p></div></div>
+        </div>
+        <h3>Worked example: gold bars</h3>
+        <div class="calc-cards">
+          <div class="calc-card calc-card--nil">
+            <div class="calc-card__head">One 1oz bar<span>Bought £2,550 &middot; sold £3,650</span></div>
+            <div class="calc-card__rows">
+              <div class="calc-card__row"><span>Gain</span><span>+£1,100</span></div>
+              <div class="calc-card__row"><span>Less allowance</span><span>&minus;£3,000</span></div>
+              <div class="calc-card__row"><span>Taxable gain</span><span>£0</span></div>
+            </div>
+            <div class="calc-card__result"><span class="calc-card__result-label">CGT due</span><span class="calc-card__result-val">Nil</span></div>
+          </div>
+          <div class="calc-card calc-card--nil">
+            <div class="calc-card__head">Two 1oz bars<span>£1,100 gain on each</span></div>
+            <div class="calc-card__rows">
+              <div class="calc-card__row"><span>Total gain</span><span>+£2,200</span></div>
+              <div class="calc-card__row"><span>Less allowance</span><span>&minus;£3,000</span></div>
+              <div class="calc-card__row"><span>Taxable gain</span><span>£0</span></div>
+            </div>
+            <div class="calc-card__result"><span class="calc-card__result-label">CGT due</span><span class="calc-card__result-val">Nil</span></div>
+          </div>
+          <div class="calc-card calc-card--due">
+            <div class="calc-card__head">Ten 1oz bars<span>£1,100 gain each &middot; higher rate</span></div>
+            <div class="calc-card__rows">
+              <div class="calc-card__row"><span>Total gain</span><span>+£11,000</span></div>
+              <div class="calc-card__row"><span>Less allowance</span><span>&minus;£3,000</span></div>
+              <div class="calc-card__row"><span>Taxable gain</span><span>£8,000</span></div>
+              <div class="calc-card__row"><span>&times; 24% higher rate</span><span>£1,920</span></div>
+            </div>
+            <div class="calc-card__result"><span class="calc-card__result-label">CGT due</span><span class="calc-card__result-val">£1,920</span></div>
+          </div>
+        </div>
+        <p><strong>The takeaway:</strong> for modest holdings or gains below £3,000, CGT is nil. For larger holdings, the 18&ndash;24% tax on gains above the threshold becomes material &mdash; and this is precisely where switching to CGT-exempt coins becomes financially significant.</p>
+
+        <h2 id="chattel">Do Gold Bars Have a Chattel Exemption?</h2>
+        <p>A lesser-known relief is the <strong>chattel exemption</strong>: personal possessions ("chattels") sold for £6,000 or less are generally exempt from CGT. For gold investors this helps with smaller items &mdash; if a single small bar or piece of jewellery sells for £6,000 or less, no CGT arises on the disposal regardless of the gain.</p>
+        <p>However, HMRC looks at each item individually, and splitting a large holding into many small pieces does not create multiple £6,000 exemptions if HMRC treats them as a related "set". For items sold above £6,000, the chattel rules offer partial taper relief rather than full exemption.</p>
+
+        <h2 id="cgt-free">Is Gold CGT-Free in the UK? The Definitive Answer</h2>
+        <p>The honest answer to the most-searched question is: <strong>sometimes yes, sometimes no &mdash; and the difference matters enormously</strong>. This table is the quick reference.</p>
+        <div class="table-wrap">
+          <div class="table-cap">Is your gold CGT-free? VAT-free?</div>
+          <div class="table-scroll">
+            <table class="dtable dtable--reflow">
+              <thead><tr><th>Gold type</th><th>CGT free?</th><th>VAT free?</th></tr></thead>
+              <tbody>
+                <tr class="row-exempt"><td data-label="Gold type"><strong>Gold Sovereign</strong></td><td data-label="CGT free?"><span class="badge badge-yes">Yes</span> unlimited</td><td data-label="VAT free?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr class="row-exempt"><td data-label="Gold type"><strong>Gold Britannia</strong></td><td data-label="CGT free?"><span class="badge badge-yes">Yes</span> unlimited</td><td data-label="VAT free?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr class="row-exempt"><td data-label="Gold type"><strong>Other Royal Mint sterling coins</strong></td><td data-label="CGT free?"><span class="badge badge-yes">Yes</span> unlimited</td><td data-label="VAT free?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr class="row-tax"><td data-label="Gold type"><strong>Gold bars (any size/refiner)</strong></td><td data-label="CGT free?"><span class="badge badge-no">No</span> gains above £3k</td><td data-label="VAT free?"><span class="badge badge-yes">Yes</span> 99.5%+</td></tr>
+                <tr class="row-tax"><td data-label="Gold type"><strong>Gold Krugerrands</strong></td><td data-label="CGT free?"><span class="badge badge-no">No</span></td><td data-label="VAT free?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr class="row-tax"><td data-label="Gold type"><strong>Canadian Maple Leaf</strong></td><td data-label="CGT free?"><span class="badge badge-no">No</span></td><td data-label="VAT free?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr class="row-tax"><td data-label="Gold type"><strong>American Gold Eagle</strong></td><td data-label="CGT free?"><span class="badge badge-no">No</span></td><td data-label="VAT free?"><span class="badge badge-yes">Yes</span></td></tr>
+                <tr class="row-tax"><td data-label="Gold type"><strong>Gold ETF / ETC (outside ISA)</strong></td><td data-label="CGT free?"><span class="badge badge-no">No</span></td><td data-label="VAT free?"><span class="badge badge-na">N/A</span></td></tr>
+                <tr class="row-exempt"><td data-label="Gold type"><strong>Gold ETF / ETC (inside ISA)</strong></td><td data-label="CGT free?"><span class="badge badge-yes">Yes</span> unlimited</td><td data-label="VAT free?"><span class="badge badge-na">N/A</span></td></tr>
+                <tr class="row-exempt"><td data-label="Gold type"><strong>Gold in a SIPP</strong></td><td data-label="CGT free?"><span class="badge badge-yes">Yes</span> within wrapper</td><td data-label="VAT free?"><span class="badge badge-na">N/A</span></td></tr>
+                <tr class="row-exempt"><td data-label="Gold type"><strong>Gold jewellery (under £6,000)</strong></td><td data-label="CGT free?"><span class="badge badge-yes">Usually</span> chattel</td><td data-label="VAT free?"><span class="badge badge-no">20% VAT</span></td></tr>
+                <tr class="row-tax"><td data-label="Gold type"><strong>Gold jewellery (over £6,000)</strong></td><td data-label="CGT free?"><span class="badge badge-no">No</span> above allowance</td><td data-label="VAT free?"><span class="badge badge-no">20% VAT</span></td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <h2 id="bars">Are Gold Bars CGT-Exempt in the UK?</h2>
+        <p>No. Gold bars are <strong>not</strong> CGT-exempt &mdash; not even LBMA Good Delivery bars, not even Royal Mint gold bars. The CGT exemption applies exclusively to gold coins that qualify as UK legal tender, and bars, by definition, are not legal tender.</p>
+        <p>This trips up many investors who assume the investment-gold VAT exemption (which <em>does</em> apply to bars) and the CGT exemption are the same thing. They are not &mdash; they are completely separate rules, and only coins with a sterling face value qualify for the CGT exemption.</p>
+        <div class="callout">
+          <span class="callout__icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span>
+          <div class="callout__body">
+            <span class="callout__label">The £23,280 difference</span>
+            <p>A UK investor holding 10&nbsp;kg of gold bars who makes £100,000 profit could face a CGT bill of up to <strong>£23,280</strong> ((£100,000 &minus; £3,000) × 24%). The same investor holding 10&nbsp;kg of Gold Sovereigns with identical profit would owe <strong>nothing</strong>.</p>
+          </div>
+        </div>
+
+        <h2 id="sovereigns">CGT on Gold Sovereigns: A Special Case Worth Knowing</h2>
+        <p>Gold Sovereigns deserve particular attention: they are simultaneously one of the most liquid, most widely recognised and most tax-efficient gold investments available to UK investors.</p>
+        <p>Sovereigns have been minted continuously since 1817 (with minor interruptions), and all post-1837 Sovereigns carry a £1 face value, making them UK legal tender. Every gold Sovereign &mdash; a 2026 bullion Sovereign, a 1953 Elizabeth II, or a Victorian-era piece &mdash; is completely CGT-exempt when sold at a profit. A coin-of-the-realm is a coin-of-the-realm regardless of its date; the full, half, double and quintuple Sovereign all qualify.</p>
+        <div class="callout">
+          <span class="callout__icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89 17 22l-5-3-5 3 1.523-9.11"/></svg></span>
+          <div class="callout__body">
+            <span class="callout__label">The triple advantage</span>
+            <p>Combined with their VAT-exempt status, Sovereigns offer something almost unique in the UK tax system: <strong>no VAT on purchase, no CGT on sale, and no upper limit on tax-free gains.</strong></p>
+          </div>
+        </div>
+
+        <h2 id="avoid">How to Avoid CGT on Gold &mdash; 7 Legal Strategies</h2>
+        <p>For investors holding taxable gold (bars, foreign coins or unwrapped ETFs), there are several legitimate ways to reduce or eliminate the liability.</p>
+        <div class="strategy-grid">
+          <div class="strategy"><div class="strategy__n"></div><h3>Buy CGT-exempt coins, not bars</h3><p>The single most effective move. Choosing Sovereigns or Britannias over bars or Krugerrands eliminates CGT entirely. For new buyers there is almost always a compelling tax case for coins.</p></div>
+          <div class="strategy"><div class="strategy__n"></div><h3>Use your allowance every year</h3><p>The £3,000 exemption is use-it-or-lose-it. Stage sales to crystallise up to £3,000 of gains tax-free each tax year (5 April deadline).</p></div>
+          <div class="strategy"><div class="strategy__n"></div><h3>Split disposals across year-end</h3><p>Selling half a large gain in March and the rest in April (a new tax year) doubles the available allowance to £6,000 with no other change.</p></div>
+          <div class="strategy"><div class="strategy__n"></div><h3>Hold gold ETCs in a Stocks &amp; Shares ISA</h3><p>Physical metal can't go in an ISA, but gold ETCs can &mdash; and all gains inside the wrapper are CGT-free, whatever the amount. The 2026/27 ISA allowance is £20,000.</p><ul><li>iShares Physical Gold ETC (SGLN) &mdash; 0.12%</li><li>Invesco Physical Gold (SGLD) &mdash; 0.12%</li><li>WisdomTree Physical Gold (PHAU) &mdash; 0.15%</li></ul></div>
+          <div class="strategy"><div class="strategy__n"></div><h3>Hold physical gold ETCs in a SIPP</h3><p>A SIPP shelters gold ETCs from CGT, adds income-tax relief on contributions at your marginal rate, and allows a 25% tax-free lump sum. Trade-off: withdrawals above 25% are taxed as income and access is from age 57.</p></div>
+          <div class="strategy"><div class="strategy__n"></div><h3>Transfer to a spouse or civil partner</h3><p>Transfers between spouses or civil partners living together are "no gain, no loss", so a couple can combine two £3,000 allowances (£6,000) before a sale.</p></div>
+          <div class="strategy"><div class="strategy__n"></div><h3>Offset capital losses</h3><p>Losses on other assets (shares, funds, property) in the same year offset gains on taxable gold. A £5,000 stock loss cancels a £5,000 gold gain. Report losses to HMRC; they apply before the allowance.</p></div>
+        </div>
+
+        <h2 id="etfs">CGT on Gold ETFs in the UK</h2>
+        <p>Gold ETFs and ETCs held <strong>outside</strong> an ISA or SIPP are taxed exactly like gold bars &mdash; gains above the £3,000 allowance are taxed at 18% or 24%. <strong>Inside</strong> a Stocks &amp; Shares ISA or SIPP, gains are completely CGT-free, which makes the ISA wrapper especially well-suited to long-term accumulation in gold ETCs &mdash; particularly for investors drip-feeding smaller amounts, where physical coin premiums would otherwise bite. Unwrapped ETCs at least avoid the storage, insurance and buy/sell-spread complications of physical holdings &mdash; but the CGT position is identical to bars.</p>
+
+        <h2 id="physical-vs-etf">CGT on Physical Gold vs Gold ETFs</h2>
+        <div class="table-wrap">
+          <div class="table-cap">Physical gold vs gold ETFs &mdash; at a glance</div>
+          <div class="table-scroll">
+            <table class="dtable dtable--reflow">
+              <thead><tr><th>Factor</th><th>Coins (CGT-exempt)</th><th>Gold bars</th><th>ETC in ISA</th><th>ETC (no wrapper)</th></tr></thead>
+              <tbody>
+                <tr><td data-label="Factor"><strong>CGT on gains</strong></td><td data-label="Coins (exempt)">None &mdash; unlimited</td><td data-label="Gold bars">18&ndash;24% above £3k</td><td data-label="ETC in ISA">None &mdash; unlimited</td><td data-label="ETC (no wrapper)">18&ndash;24% above £3k</td></tr>
+                <tr><td data-label="Factor"><strong>VAT on purchase</strong></td><td data-label="Coins (exempt)">None</td><td data-label="Gold bars">None (99.5%+)</td><td data-label="ETC in ISA">N/A</td><td data-label="ETC (no wrapper)">N/A</td></tr>
+                <tr><td data-label="Factor"><strong>Annual cost</strong></td><td data-label="Coins (exempt)">Storage + insurance</td><td data-label="Gold bars">Storage + insurance</td><td data-label="ETC in ISA">0.12&ndash;0.15% TER</td><td data-label="ETC (no wrapper)">0.12&ndash;0.15% TER</td></tr>
+                <tr><td data-label="Factor"><strong>Physical possession</strong></td><td data-label="Coins (exempt)">Yes</td><td data-label="Gold bars">Yes</td><td data-label="ETC in ISA">No (vault-backed)</td><td data-label="ETC (no wrapper)">No (vault-backed)</td></tr>
+                <tr><td data-label="Factor"><strong>ISA-eligible</strong></td><td data-label="Coins (exempt)">No</td><td data-label="Gold bars">No</td><td data-label="ETC in ISA">Yes</td><td data-label="ETC (no wrapper)">Yes</td></tr>
+                <tr><td data-label="Factor"><strong>Liquidity</strong></td><td data-label="Coins (exempt)">Good via dealers</td><td data-label="Gold bars">Good via dealers</td><td data-label="ETC in ISA">Intraday exchange</td><td data-label="ETC (no wrapper)">Intraday exchange</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <h2 id="report">Do You Have to Report Gold Sales to HMRC?</h2>
+        <p>It depends on what you sold.</p>
+        <p><strong>CGT-exempt coins (Sovereigns, Britannias, Royal Mint legal tender):</strong> you do <strong>not</strong> need to report the disposal. Since there is no chargeable gain, there is nothing to declare.</p>
+        <p><strong>Taxable gold (bars, foreign coins, ETFs outside an ISA):</strong></p>
+        <ul>
+          <li>If total gains across all assets in the tax year are below £3,000, no report is required.</li>
+          <li>If total gains exceed £3,000 (or total disposal proceeds exceed four times the allowance &mdash; £12,000), you must report via Self Assessment.</li>
+          <li>CGT must be reported and paid by <strong>31 January</strong> following the end of the tax year.</li>
+        </ul>
+        <div class="callout">
+          <span class="callout__icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01"/><path d="M11 12h1v4h1"/></svg></span>
+          <div class="callout__body">
+            <span class="callout__label">Your responsibility</span>
+            <p>The duty to report and pay CGT lies with you, not the dealer. Bullion dealers do not report sales to HMRC &mdash; keeping accurate records and filing correctly is your personal responsibility.</p>
+          </div>
+        </div>
+
+        <h2 id="records">Record-Keeping for Gold CGT</h2>
+        <p>For any taxable gold, accurate records are essential. HMRC can investigate CGT up to four years back for innocent errors, and longer for deliberate omissions. Keep the following for at least seven years from the tax year in which the disposal occurred:</p>
+        <ul>
+          <li>Purchase receipts, invoices or contract notes showing the date, quantity, description and price paid;</li>
+          <li>Sale invoices confirming the sale date, quantity and proceeds received;</li>
+          <li>Storage or insurance costs potentially deductible against the gain (seek professional advice);</li>
+          <li>Bank statements confirming payment and receipt.</li>
+        </ul>
+
+        <h2 id="australia">Gold CGT in Australia: A Brief Note</h2>
+        <div class="aside-note">
+          <h3>For non-UK readers</h3>
+          <p>Australia taxes CGT on gold and precious metals similarly to the UK &mdash; gains are taxable &mdash; but residents who hold an asset for more than 12 months receive a <strong>50% CGT discount</strong>, effectively halving the taxable gain. There is no Australian equivalent of the UK's legal-tender coin exemption. Australian investors should consult the ATO's guidance on collectables and precious-metal assets.</p>
+        </div>
+
+        <h2 id="faq">Frequently Asked Questions</h2>
+        <div class="faq">
+          <details class="faq__item" open><summary class="faq__q">Is gold CGT free in the UK?</summary><div class="faq__a">It depends on the type of gold. Royal Mint legal tender gold coins &mdash; including Sovereigns and Britannias &mdash; are completely CGT-free with no limit on gains. Gold bars and foreign coins are subject to CGT on gains above the £3,000 annual allowance.</div></details>
+          <details class="faq__item"><summary class="faq__q">How much CGT do you pay on gold bars in the UK?</summary><div class="faq__a">For the 2026/27 tax year: <strong>18%</strong> if you are a basic-rate taxpayer and <strong>24%</strong> if you are a higher or additional-rate taxpayer, charged on gains above the £3,000 annual exemption.</div></details>
+          <details class="faq__item"><summary class="faq__q">Are gold bars CGT exempt in the UK?</summary><div class="faq__a">No. Gold bars are not CGT-exempt regardless of size, weight or refiner. The CGT exemption applies only to UK legal tender coins issued by The Royal Mint.</div></details>
+          <details class="faq__item"><summary class="faq__q">Which gold coins are CGT free in the UK?</summary><div class="faq__a">All Royal Mint coins that qualify as UK legal tender: Gold Sovereigns (all years from 1837), Gold Britannias (all sizes from 1987), and other Royal Mint coins with a sterling face value such as the Queen's Beasts and Royal Tudor Beasts.</div></details>
+          <details class="faq__item"><summary class="faq__q">Are Krugerrands CGT exempt in the UK?</summary><div class="faq__a">No. Krugerrands are South African legal tender but not UK legal tender, so they are chargeable assets and CGT applies to gains above the annual allowance.</div></details>
+          <details class="faq__item"><summary class="faq__q">Can you hold gold in an ISA?</summary><div class="faq__a">You cannot hold physical gold bars or coins directly in a UK ISA. However, you can hold gold ETCs (physically backed exchange-traded commodities) within a Stocks &amp; Shares ISA, and all gains on these are completely CGT-free. The annual ISA allowance for 2026/27 is £20,000.</div></details>
+          <details class="faq__item"><summary class="faq__q">What is the CGT annual allowance on gold for 2026/27?</summary><div class="faq__a">£3,000 for individuals and £1,500 for most trusts &mdash; confirmed unchanged from 2025/26.</div></details>
+          <details class="faq__item"><summary class="faq__q">What is the best CGT-free gold to buy in the UK?</summary><div class="faq__a">For most investors, <strong>Gold Sovereigns</strong> offer the best combination of CGT exemption, VAT exemption, dealer recognition and tight buy-sell spreads. Gold Britannias suit investors wanting a standard 1 troy ounce coin at 999.9 fineness.</div></details>
+          <details class="faq__item"><summary class="faq__q">Do I pay CGT on gold jewellery in the UK?</summary><div class="faq__a">Gold jewellery qualifies for the chattel exemption if sold for £6,000 or less per item, in which case no CGT applies. Sales above £6,000 per item are chargeable, with gains above the annual allowance taxed at 18&ndash;24%.</div></details>
+          <details class="faq__item"><summary class="faq__q">Does gold CGT apply to non-UK residents?</summary><div class="faq__a">Non-UK residents are generally not subject to UK CGT on the disposal of UK gold bullion, as it is a movable asset rather than UK property. Non-residents should take independent tax advice based on their country of residence.</div></details>
+        </div>
+
+        <div class="cta-box">
+          <h3>Know what your gold is worth before you sell</h3>
+          <p>Use the free GoldPriceTools live calculator to find the current value of your Sovereigns, Britannias and gold bars in GBP &mdash; the first step in any CGT calculation.</p>
+          <a href="/" class="cta-btn">Open the gold calculator &rarr;</a>
+        </div>
+
+        <p class="disclaimer">This guide is for informational purposes only and should not be treated as personal tax advice. Tax rules change and individual circumstances vary &mdash; always consult a qualified tax adviser or accountant for advice specific to your situation. The CGT rates, allowances and rules described reflect HMRC guidance and government legislation as of May 2026.</p>
+      </div>
+    </main>
+
+    <aside class="cgt-aside">
+      <nav class="toc" aria-label="Table of contents">
+        <div class="toc__title">On this page</div>
+        <ul class="toc__list">
+          <li><a href="#what-is-cgt">What is CGT on gold?</a></li>
+          <li><a href="#rates">Rates &amp; annual exemption</a></li>
+          <li><a href="#depends">What you own decides everything</a></li>
+          <li><a href="#vat">VAT on gold</a></li>
+          <li><a href="#calculate">How to calculate CGT</a></li>
+          <li><a href="#chattel">The chattel exemption</a></li>
+          <li><a href="#cgt-free">Is gold CGT-free? The verdict</a></li>
+          <li><a href="#bars">Are gold bars exempt?</a></li>
+          <li><a href="#sovereigns">Gold Sovereigns: a special case</a></li>
+          <li><a href="#avoid">7 ways to pay less CGT</a></li>
+          <li><a href="#etfs">CGT on gold ETFs</a></li>
+          <li><a href="#physical-vs-etf">Physical vs ETFs</a></li>
+          <li><a href="#report">Reporting to HMRC</a></li>
+          <li><a href="#records">Record-keeping</a></li>
+          <li><a href="#australia">CGT on gold in Australia</a></li>
+          <li><a href="#faq">FAQ</a></li>
+        </ul>
+      </nav>
+    </aside>
   </div>
-  
-<!-- FAQ Section -->
-<section style="padding:2rem 0 0;">
-  <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
-  <div class="faq-container">
-    <div class="faq-card">
-      <h3 class="faq-q">Which gold coins are CGT-exempt in the UK?</h3>
-      <p class="faq-answer">UK legal tender gold coins are exempt from Capital Gains Tax. This includes: Gold Britannia (all sizes from 1/10oz to 1oz), Gold Sovereign (full, half, quarter), and any other gold coin that is UK legal tender. Foreign coins — even popular bullion coins like the Canadian Maple Leaf or South African Krugerrand — are NOT CGT-exempt and gains are subject to standard CGT.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-q">What is the CGT rate on gold in the UK?</h3>
-      <p class="faq-answer">For gold assets that are not CGT-exempt (bars, foreign coins, ETFs outside an ISA), gains are taxed at 18% (basic rate taxpayers) or 24% (higher/additional rate taxpayers) as of 2024–25. You also have an annual CGT allowance (£3,000 for 2024–25) that can offset gains. Losses on gold can be offset against other capital gains.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-q">Is gold in an ISA CGT-free?</h3>
-      <p class="faq-answer">Yes. Gold ETCs (Exchange-Traded Commodities) held in a Stocks & Shares ISA are completely free of CGT regardless of gains. This makes ISA-held gold ETCs more tax-efficient than physical gold bars for most UK investors. The annual ISA allowance is £20,000.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-q">Do I need to declare gold sales to HMRC?</h3>
-      <p class="faq-answer">You must report gold sales on your Self Assessment tax return if: (1) your total gains exceed the annual CGT allowance (£3,000 for 2024–25), (2) your total proceeds from all asset sales exceed £50,000, or (3) you made a loss you want to carry forward. CGT-exempt coins (Britannias, Sovereigns) don't count toward these thresholds.</p>
-    </div>
-  </div>
-</section>
 
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
+  <section class="related-guides">
     <h2>Related Articles &amp; Guides</h2>
     <div class="related-guides-grid">
       <a href="/blog/how-to-buy-gold-royal-mint" class="related-card">
@@ -620,12 +1215,12 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <a href="/blog/gold-in-a-sipp-uk" class="related-card">
         <div class="related-card__tag">Article</div>
         <div class="related-card__title">Gold in a SIPP UK</div>
-        <div class="related-card__desc">Another CGT-free route to gold — holding ETCs inside a pension.</div>
+        <div class="related-card__desc">Another CGT-free route to gold &mdash; holding ETCs inside a pension.</div>
       </a>
       <a href="/guides/how-to-invest-in-gold" class="related-card">
         <div class="related-card__tag">Guide</div>
         <div class="related-card__title">How to Invest in Gold UK</div>
-        <div class="related-card__desc">All UK gold investment options — with tax efficiency considered.</div>
+        <div class="related-card__desc">All UK gold investment options &mdash; with tax efficiency considered.</div>
       </a>
       <a href="/blog/best-uk-gold-dealers-2026" class="related-card">
         <div class="related-card__tag">Article</div>
@@ -635,13 +1230,30 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <a href="/24k-gold-price-per-gram" class="related-card">
         <div class="related-card__tag">Live Price</div>
         <div class="related-card__title">Live Gold Price Today</div>
-        <div class="related-card__desc">Today's spot price — essential before calculating CGT on gold sales.</div>
+        <div class="related-card__desc">Today's spot price &mdash; essential before calculating CGT on gold sales.</div>
       </a>
     </div>
-  </div>
-</section>
+  </section>
 
 </article>
+<script>
+(function(){
+  var links=[].slice.call(document.querySelectorAll('.toc__list a'));
+  if(!links.length||!('IntersectionObserver' in window))return;
+  var map={};links.forEach(function(a){map[a.getAttribute('href').slice(1)]=a;});
+  var heads=[].slice.call(document.querySelectorAll('.prose h2[id]'));
+  if(!heads.length)return;
+  var io=new IntersectionObserver(function(entries){
+    entries.forEach(function(e){
+      if(e.isIntersecting){
+        links.forEach(function(l){l.classList.remove('is-active');});
+        var a=map[e.target.id];if(a)a.classList.add('is-active');
+      }
+    });
+  },{rootMargin:'-80px 0px -65% 0px'});
+  heads.forEach(function(h){io.observe(h);});
+})();
+</script>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">


### PR DESCRIPTION
## Summary

Rebuilds the body of `/blog/uk-gold-cgt-guide` (**Capital Gains Tax on Gold UK**) as a fully designed, mobile-first editorial article. The previous body relied on undefined classes (`.prose`, `.article-wrap`, `.breadcrumb` …) and rendered as near-unstyled prose; it has been replaced with a cohesive component system built on the site's existing design tokens, using the **ui-ux-pro-max** skill (Editorial/Magazine style + Comparison-Table pattern + Dark-OLED/gold).

### Standout components
- **Hero** — editorial Playfair Display headline, eyebrow badge, dek, byline, and a 4-up stat strip (18–24% · £3,000 · £0 · 0% VAT)
- **Key-point callouts** with a drop-cap lead paragraph
- **Exempt vs Taxable split** — green/red visual verdict that stacks on mobile
- **Allowance-erosion bar chart** (£12,300 → £3,000, current year highlighted)
- **Worked-example calc cards** — Nil (green) vs CGT-due (gold) results
- **Seven numbered strategy cards** (incl. the ISA ETC list)
- **Wide comparison tables** that reflow into labelled cards below 600px
- **Sticky table of contents** (desktop) + collapsible TOC (mobile) with scroll-spy
- **Native `<details>` FAQ accordion** (works without JS)

### Correctness / SEO / a11y
- Fixed a duplicate, incorrect breadcrumb ("Gold & Silver Price Outlook")
- Expanded `FAQPage` JSON-LD to match the 10 visible FAQs; bumped `dateModified`
- Loaded Inter / IBM Plex Sans / Playfair Display via the site's Google Fonts convention
- Darkened semantic green/red for light-mode contrast; preserved 44px targets and reduced-motion handling

## Verification
- JSON-LD validator passes (217 blocks across 82 files); HTML nesting is well-formed (0 issues)
- Rendered with headless Chromium and visually checked at **390px + 1280px** in **dark + light** themes — hero, split, bar chart, all four tables (reflow), calc cards, strategy grid, FAQ, and the sticky TOC all verified
- Only `blog/uk-gold-cgt-guide.html` changed

> Note: webfonts and the live price ticker were blocked during local rendering (network allowlist); headings fell back to Georgia. They will load normally in production.

## Test plan
- [ ] Confirm the page renders correctly in production with Playfair Display + live ticker
- [ ] Spot-check Rich Results for the updated FAQ schema
- [ ] Verify table reflow and sticky TOC on a real mobile device

https://claude.ai/code/session_01FibG2ubypbxcJe35XincAA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FibG2ubypbxcJe35XincAA)_