### PR TITLE
feat(blog): premium editorial redesign for Gold ETFs vs Physical Gold UK 2026

### DIFF
--- a/blog/gold-etf-vs-physical-gold-uk.html
+++ b/blog/gold-etf-vs-physical-gold-uk.html
@@ -6,9 +6,9 @@
 (function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
 </script>
     <meta name="cf-no-email-obfuscation"><meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold ETFs vs Physical Gold UK 2026 | GoldPriceTools</title>
+<title>Gold ETFs vs Physical Gold: UK Investor's Guide 2026 | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Gold ETFs vs physical gold coins and bars for UK investors in 2026. Covers costs, ISA eligibility, CGT treatment and the best strategy.">
+<meta name="description" content="Gold ETFs vs physical gold for UK investors in 2026. Compare SGLN, SGLP, PHAU and Royal Mint coins — costs, CGT, ISA eligibility, liquidity and risk explained.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/blog/gold-etf-vs-physical-gold-uk">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/blog/gold-etf-vs-physical-gold-uk">
@@ -17,7 +17,10 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
-<meta property="og:title" content="Gold ETFs vs Physical Gold UK 2026 | GoldPriceTools">><meta property="og:description" content="Gold ETFs vs physical gold coins and bars for UK investors in 2026. Covers costs, ISA eligibility, CGT treatment and the best strategy.">>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700;800&family=Inter:wght@300..700&family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+<meta property="og:title" content="Gold ETFs vs Physical Gold: UK Investor's Guide 2026 | GoldPriceTools"><meta property="og:description" content="Gold ETFs vs physical gold for UK investors in 2026. Compare SGLN, SGLP, PHAU and Royal Mint coins — costs, CGT, ISA eligibility, liquidity and risk explained.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://goldpricetools.com/blog/gold-etf-vs-physical-gold-uk">
 <meta property="og:site_name" content="GoldPriceTools">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
@@ -27,9 +30,9 @@
   "@context": "https://schema.org",
   "@type": "BlogPosting",
   "headline": "Gold ETFs vs Physical Gold: A UK Investor's Guide for 2026",
-  "description": "Compare gold ETFs (iShares IGLN, WisdomTree PHAU, Invesco SGLD) vs physical gold coins and bars. Covers costs, ISA eligibility, CGT treatment, and the best strategy for UK investors in 2026.",
+  "description": "Compare gold ETCs (iShares SGLN, Invesco SGLP, WisdomTree PHAU, Royal Mint RMAU) vs physical gold coins and bars. Costs, ISA eligibility, CGT treatment, allocation and the smartest strategy for UK investors in 2026.",
   "datePublished": "2026-05-03T08:00:00Z",
-  "dateModified": "2026-05-07T08:00:00Z",
+  "dateModified": "2026-06-03T08:00:00Z",
   "author": {
     "@type": "Organization",
     "name": "GoldPriceTools Editorial Team",
@@ -66,34 +69,66 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "What is a gold ETF?",
+      "name": "What is a gold ETF in the UK?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "A gold ETF (Exchange-Traded Fund) is a fund that tracks the gold price and trades on a stock exchange like a share. Most physically-backed gold ETFs hold actual gold bars in a vault. You get gold price exposure without storage, insurance or delivery logistics. UK examples include iShares Physical Gold ETC (SGLN) and Invesco Physical Gold ETC (SGLD)."
+        "text": "In the UK, what investors call a gold ETF is technically an Exchange Traded Commodity (ETC). UCITS rules prevent a fund from holding a single asset, so pure gold products are structured as debt securities collateralised by physical gold bars in London vaults. They trade on the LSE like ordinary shares. Major UK options include iShares SGLN, Invesco SGLP, WisdomTree PHAU and Royal Mint RMAU."
       }
     },
     {
       "@type": "Question",
-      "name": "Is physical gold or gold ETF better for UK investors?",
+      "name": "Is physical gold or a gold ETF better for UK investors in 2026?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "It depends on your goals. ETFs are cheaper to buy (no storage costs), more liquid, and easier to hold in an ISA or SIPP. Physical gold gives you direct ownership with no counterparty risk and is portable. For most UK investors holding under £50,000 in gold, ETFs in an ISA (no CGT) are the most practical and tax-efficient choice."
+        "text": "It depends on the size and purpose of your allocation. For most UK investors, a physically backed ETC like SGLN inside a Stocks & Shares ISA is the cheapest, most tax-efficient and most liquid option. Larger investors who want true wealth preservation and unlimited CGT exemption often combine ETCs with Royal Mint Britannias or Sovereigns, which are legal tender and entirely CGT-free."
       }
     },
     {
       "@type": "Question",
-      "name": "Can I hold gold ETFs in an ISA?",
+      "name": "Can I hold gold ETCs in an ISA or SIPP?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. UK gold ETCs (Exchange-Traded Commodities) like SGLN, SGLD and PHAU can be held in a Stocks & Shares ISA, making gains completely free of CGT and income tax. This is a significant advantage over physical gold (which is subject to CGT at 18% or 24% depending on your tax band)."
+        "text": "Yes. Physically backed gold ETCs such as SGLN, SGLP, PHAU and RMAU are eligible for both Stocks & Shares ISAs and SIPPs. Inside either wrapper, all gains are sheltered from CGT and income tax. The 2026/27 ISA allowance is £20,000 and the SIPP annual allowance is £60,000. Physical gold coins and bars cannot be held in an ISA or SIPP directly."
       }
     },
     {
       "@type": "Question",
-      "name": "What are the risks of gold ETFs vs physical?",
+      "name": "Are Britannia and Sovereign coins CGT exempt?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Gold ETF risks include: counterparty risk (the fund provider could fail, though gold-backed ETCs typically have segregated assets), tracking error, and annual management fees (typically 0.15–0.40%). Physical gold risks include storage, insurance costs, and the premium over spot when buying/selling. Neither form protects against gold price falls."
+        "text": "Yes. Britannias and Sovereigns are UK legal tender, so any capital gains on them are entirely exempt from CGT for UK residents — with no upper limit. This is unique to UK legal tender coins; foreign coins such as Krugerrands, Maple Leafs and American Eagles are not exempt, and gold bars and ETCs held outside an ISA/SIPP are also subject to CGT."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the TER of the cheapest UK gold ETC?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The two cheapest physically backed gold ETCs on the London Stock Exchange in 2026 are iShares Physical Gold ETC (SGLN) and Invesco Physical Gold ETC (SGLP), both with a Total Expense Ratio of 0.12% per year. WisdomTree PHAU charges 0.39% and Royal Mint RMAU charges 0.22%."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much gold should a UK investor hold?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most financial advisers and the World Gold Council suggest 5–15% of a portfolio in gold, with 10% widely cited as a benchmark. A 5–10% allocation has historically improved Sharpe ratios versus portfolios with zero gold. Conservative investors typically lean to 5–10%, balanced investors 7–12%, and growth investors can incorporate some gold miners ETF exposure on top of physical and ETC core positions."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do gold ETFs have counterparty risk?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — even physically backed gold ETCs involve multiple layers of counterparty exposure: the issuer, the custodian bank holding the gold, the brokerage, and exchange settlement. In normal markets these risks are very low and the underlying gold is segregated. In a systemic crisis, however, accessing the metal can be complicated, which is why some UK investors hold a portion of their gold in physical Britannias or Sovereigns at home or in a vault outside the banking system."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between a gold miners ETF and a physical gold ETC?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A physical gold ETC tracks the spot price of gold itself, while a gold miners ETF (such as VanEck GDGB) holds shares in companies that mine gold. Miners offer operating leverage to the gold price — in 2025 gold miners ETFs returned 96–110% while physical gold returned around 30% in GBP terms — but they also carry equity-level volatility, operational risk and geopolitical risk that pure gold does not."
       }
     }
   ]
@@ -116,26 +151,12 @@ window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#5a5852;--color-text-faint:#9c9b96;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-editorial:'Playfair Display',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#e8e7e4;--color-text-muted:#a8a7a3;--color-text-faint:#6a6967;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-/* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-
 
 html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
@@ -160,178 +181,10 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
 .ticker-label{color:var(--color-text-muted)}
 .ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
 .live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
 
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
-
-/* AD SLOTS */
-.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
-.ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
-
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
-
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
-
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
-
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
-
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
-
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
-
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
-
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
-
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
-
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
-
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
-
-#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-
-/* MEGA MENU */
+/* SITE NAV */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
@@ -385,27 +238,13 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
 .footer-brand-col{max-width:260px}
 .footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
 @media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
 @media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
@@ -413,12 +252,379 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
+
+/* ════════════════════════════════════════════════════════════════
+   GOLD ETF vs PHYSICAL GOLD — PREMIUM EDITORIAL DESIGN
+   Mobile-first · dark/light adaptive · token-driven · a11y-first
+   Prefix: gpc- (Gold Physical Comparison)
+═════════════════════════════════════════════════════════════════ */
+:root{
+  --gpc-gold:var(--color-gold-bright);
+  --gpc-gold-deep:#b07a00;
+  --gpc-gold-ink:#7a5600;
+  --gpc-teal:var(--color-primary);
+  --gpc-teal-ink:#0c4e54;
+  --gpc-crimson:#b91c1c;
+  --gpc-emerald:#16a34a;
+  --gpc-amber:#d97706;
+  --gpc-royal:#7c3aed;
+  --gpc-award:#d4af37;
+  --gpc-maxw:1180px;
+  --gpc-read:760px;
+}
+[data-theme="dark"]{--gpc-gold-ink:#e8af34;--gpc-teal-ink:#6ab3be}
+
+/* READING PROGRESS BAR */
+#gpc-progress{position:fixed;top:0;left:0;height:3px;width:0;z-index:250;background:linear-gradient(90deg,var(--gpc-gold),var(--gpc-award),var(--gpc-teal));box-shadow:0 0 12px color-mix(in oklch,var(--gpc-gold) 50%,transparent);transition:width .12s linear}
+@media(prefers-reduced-motion:reduce){#gpc-progress{transition:none}}
+
+/* REVEAL ANIMATIONS */
+html.gpc-js .gpc-reveal{opacity:0;transform:translateY(18px)}
+html.gpc-js .gpc-reveal.is-in{opacity:1;transform:none;transition:opacity .6s ease-out,transform .7s cubic-bezier(.16,1,.3,1)}
+@media(prefers-reduced-motion:reduce){html.gpc-js .gpc-reveal{opacity:1!important;transform:none!important;transition:none!important}}
+
+/* ── BREADCRUMB ─────────────────────────────────────────── */
+.gpc-bc-wrap{max-width:var(--gpc-maxw);margin:0 auto;padding:var(--space-3) var(--space-4)}
+.gpc-bc{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
+.gpc-bc li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
+.gpc-bc a{color:var(--color-text-muted);text-decoration:none}
+.gpc-bc a:hover{color:var(--color-primary)}
+.gpc-bc li[aria-current="page"]{color:var(--color-text);font-weight:500}
+
+/* ── HERO ────────────────────────────────────────────────── */
+.gpc-hero{position:relative;overflow:hidden;border-bottom:1px solid var(--color-border);isolation:isolate}
+.gpc-hero__bg{position:absolute;inset:0;z-index:-1;pointer-events:none}
+.gpc-hero__bg::before,.gpc-hero__bg::after{content:"";position:absolute;width:62%;top:-25%;bottom:-25%;filter:blur(14px);opacity:.9}
+.gpc-hero__bg::before{left:-8%;background:radial-gradient(60% 60% at 30% 30%,color-mix(in oklch,var(--gpc-gold) 30%,transparent),transparent 70%)}
+.gpc-hero__bg::after{right:-8%;background:radial-gradient(60% 60% at 70% 70%,color-mix(in oklch,var(--gpc-teal) 22%,transparent),transparent 70%)}
+[data-theme="light"] .gpc-hero__bg::before{background:radial-gradient(60% 60% at 30% 30%,color-mix(in oklch,var(--gpc-gold) 16%,transparent),transparent 70%)}
+[data-theme="light"] .gpc-hero__bg::after{background:radial-gradient(60% 60% at 70% 70%,color-mix(in oklch,var(--gpc-teal) 12%,transparent),transparent 70%)}
+.gpc-hero__grid{position:absolute;inset:0;z-index:-1;background-image:linear-gradient(var(--color-border) 1px,transparent 1px),linear-gradient(90deg,var(--color-border) 1px,transparent 1px);background-size:72px 72px;-webkit-mask-image:radial-gradient(circle at 50% 25%,#000,transparent 75%);mask-image:radial-gradient(circle at 50% 25%,#000,transparent 75%);opacity:.10}
+.gpc-hero__inner{max-width:var(--gpc-maxw);margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-8);text-align:center;position:relative}
+.gpc-kicker{display:inline-flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.18em;color:var(--gpc-gold-ink);margin-bottom:var(--space-5)}
+.gpc-kicker::before,.gpc-kicker::after{content:"";width:24px;height:1px;background:currentColor;opacity:.5}
+.gpc-kicker__dot{width:6px;height:6px;border-radius:50%;background:var(--gpc-gold);box-shadow:0 0 8px var(--gpc-gold)}
+.gpc-hero h1{font-family:var(--font-editorial);font-weight:700;line-height:1.04;letter-spacing:-.02em;color:var(--color-text);font-size:clamp(2rem,1rem + 6vw,4.5rem);margin:0 auto var(--space-5);max-width:18ch;text-wrap:balance}
+.gpc-hero h1 .gpc-vs{color:var(--gpc-gold-ink);font-style:italic;font-weight:600;display:inline-block;margin:0 .1em;position:relative}
+.gpc-hero h1 .gpc-vs::before,.gpc-hero h1 .gpc-vs::after{content:"";display:inline-block;width:.45em;height:1px;background:currentColor;opacity:.6;vertical-align:middle;margin:0 .2em}
+.gpc-hero h1 .gpc-accent{color:var(--gpc-gold-ink);position:relative;white-space:nowrap}
+.gpc-hero h1 .gpc-accent::after{content:"";position:absolute;left:0;right:0;bottom:.06em;height:.10em;background:linear-gradient(90deg,transparent,var(--gpc-gold) 30%,var(--gpc-gold) 70%,transparent);opacity:.55}
+.gpc-hero__lead{font-family:var(--font-body);font-size:clamp(1rem,.95rem + .4vw,1.22rem);color:var(--color-text-muted);line-height:1.7;max-width:64ch;margin:0 auto var(--space-6)}
+.gpc-byline{display:flex;flex-wrap:wrap;justify-content:center;align-items:center;gap:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-8)}
+.gpc-byline a{color:var(--color-primary);font-weight:600;text-decoration:none}
+.gpc-byline a:hover{text-decoration:underline}
+.gpc-byline .dot{width:3px;height:3px;border-radius:50%;background:var(--color-text-faint)}
+.gpc-readtime{display:inline-flex;align-items:center;gap:5px;color:var(--color-text-muted)}
+.gpc-readtime svg{color:var(--gpc-gold)}
+
+/* HERO STAT CHIPS */
+.gpc-hero-stats{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);max-width:880px;margin:0 auto}
+@media(min-width:760px){.gpc-hero-stats{grid-template-columns:repeat(4,1fr)}}
+.gpc-hstat{background:color-mix(in oklch,var(--color-surface) 80%,transparent);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);text-align:left;position:relative;overflow:hidden;transition:border-color .2s,transform .2s,box-shadow .2s}
+.gpc-hstat:hover{border-color:color-mix(in oklch,var(--gpc-gold) 40%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.gpc-hstat::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--c,var(--gpc-gold))}
+.gpc-hstat--gold{--c:var(--gpc-gold)}
+.gpc-hstat--teal{--c:var(--gpc-teal)}
+.gpc-hstat--emerald{--c:var(--gpc-emerald)}
+.gpc-hstat--award{--c:var(--gpc-award)}
+.gpc-hstat__k{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1);display:flex;align-items:center;gap:6px}
+.gpc-hstat__k svg{flex-shrink:0;color:var(--c,var(--gpc-gold))}
+.gpc-hstat__v{font-family:var(--font-display);font-size:clamp(1.25rem,1rem + 1.2vw,1.75rem);font-weight:800;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1.1}
+.gpc-hstat__s{font-size:var(--text-xs);margin-top:4px;font-weight:500;color:var(--color-text-muted)}
+
+
+/* ── ARTICLE SHELL + STICKY TOC ──────────────────────────── */
+.gpc-shell{max-width:var(--gpc-maxw);margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-16)}
+.gpc-layout{display:block}
+.gpc-main{min-width:0;max-width:var(--gpc-read);margin:0 auto;width:100%}
+.gpc-main>*{margin-left:auto;margin-right:auto}
+
+@media(min-width:1080px){
+  .gpc-layout{display:grid;grid-template-columns:minmax(0,1fr) 240px;grid-template-areas:"main toc";gap:var(--space-10);align-items:start}
+  .gpc-main{grid-area:main;max-width:none;margin:0}
+  .gpc-toc{grid-area:toc;position:sticky;top:84px}
+}
+
+/* TOC */
+.gpc-toc{margin:0 0 var(--space-6)}
+.gpc-toc__box{border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface);overflow:hidden}
+.gpc-toc summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.gpc-toc summary::-webkit-details-marker{display:none}
+.gpc-toc summary svg{transition:transform .2s}
+.gpc-toc[open] summary svg{transform:rotate(180deg)}
+.gpc-toc nav{display:flex;flex-direction:column;padding:var(--space-2);border-top:1px solid var(--color-divider)}
+.gpc-toc a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:7px 10px;border-radius:var(--radius-sm);border-left:2px solid transparent;line-height:1.35;transition:color .15s,background .15s,border-color .15s}
+.gpc-toc a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.gpc-toc a.is-active{color:var(--gpc-gold-ink);border-left-color:var(--gpc-gold);background:color-mix(in oklch,var(--gpc-gold) 8%,transparent);font-weight:600}
+@media(min-width:1080px){.gpc-toc[open] summary svg,.gpc-toc summary svg{display:none}.gpc-toc nav{border-top:none}}
+
+/* ── PROSE ───────────────────────────────────────────────── */
+.gpc-prose{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.78}
+.gpc-prose p{margin:0 0 var(--space-5);text-wrap:pretty}
+.gpc-prose p.gpc-lead{font-family:var(--font-body);font-size:clamp(1.08rem,1rem + .5vw,1.32rem);color:var(--color-text);line-height:1.65;font-weight:400}
+.gpc-prose p.gpc-lead::first-letter{float:left;font-family:var(--font-editorial);font-weight:700;font-size:3.6em;line-height:.78;padding:.06em .12em .02em 0;color:var(--gpc-gold-ink);font-style:italic}
+.gpc-prose strong{color:var(--color-text);font-weight:700}
+.gpc-prose em{font-style:italic}
+.gpc-prose a{color:var(--color-primary);text-decoration:underline;text-underline-offset:2px;text-decoration-thickness:1px}
+.gpc-prose a:hover{color:var(--color-primary-hover);text-decoration-thickness:2px}
+.gpc-prose ul{list-style:none;padding:0;margin:0 0 var(--space-5)}
+.gpc-prose ul li{position:relative;padding-left:var(--space-6);margin-bottom:var(--space-3);line-height:1.7}
+.gpc-prose ul li::before{content:"";position:absolute;left:6px;top:.65em;width:7px;height:7px;border-radius:2px;transform:rotate(45deg);background:var(--gpc-gold)}
+.gpc-prose ol{padding-left:var(--space-6);margin:0 0 var(--space-5);counter-reset:nlist}
+.gpc-prose ol li{padding-left:var(--space-2);margin-bottom:var(--space-3);line-height:1.7;list-style:none;counter-increment:nlist;position:relative}
+.gpc-prose ol li::before{content:counter(nlist) ".";position:absolute;left:-1.6em;color:var(--gpc-gold-ink);font-weight:700;font-family:var(--font-display);width:1.4em;text-align:right}
+
+/* Reference superscript */
+.gpc-ref{display:inline-block;font-size:.72em;color:var(--gpc-gold-ink);font-weight:700;vertical-align:super;line-height:0;padding:0 1px;text-decoration:none}
+.gpc-ref:hover{color:var(--gpc-teal);text-decoration:underline}
+
+/* SECTION HEADERS */
+.gpc-sec{scroll-margin-top:84px;margin-top:var(--space-12)}
+.gpc-sec__kick{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-text-faint);margin-bottom:var(--space-2);display:flex;align-items:center;gap:8px}
+.gpc-sec__kick::before{content:"";width:22px;height:2px;border-radius:1px;background:var(--gpc-gold)}
+.gpc-sec h2{font-family:var(--font-editorial);font-weight:700;letter-spacing:-.01em;color:var(--color-text);font-size:clamp(1.6rem,1.15rem + 1.8vw,2.4rem);line-height:1.16;margin:0 0 var(--space-3)}
+.gpc-sec h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2);font-family:var(--font-display)}
+
+/* DIVIDER */
+.gpc-divider{display:flex;align-items:center;justify-content:center;gap:var(--space-3);margin:var(--space-12) 0;color:var(--color-text-faint)}
+.gpc-divider::before,.gpc-divider::after{content:"";height:1px;width:100px;background:linear-gradient(90deg,transparent,var(--color-divider),transparent)}
+.gpc-divider__dot{width:6px;height:6px;border-radius:50%;background:var(--gpc-gold);box-shadow:0 0 8px color-mix(in oklch,var(--gpc-gold) 60%,transparent)}
+
+/* ── ETC PRODUCT CARDS ──────────────────────────────────── */
+.gpc-etcs{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0}
+@media(min-width:680px){.gpc-etcs{grid-template-columns:repeat(2,1fr)}}
+.gpc-etc{position:relative;border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface);overflow:hidden;display:flex;flex-direction:column;transition:border-color .2s,transform .2s,box-shadow .2s}
+.gpc-etc:hover{border-color:color-mix(in oklch,var(--gpc-gold) 40%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-md)}
+.gpc-etc__top{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-4);background:linear-gradient(135deg,color-mix(in oklch,var(--gpc-gold) 10%,var(--color-surface-offset)),var(--color-surface-offset) 80%);border-bottom:1px solid var(--color-border)}
+.gpc-etc__ticker{display:flex;align-items:center;gap:var(--space-3);min-width:0}
+.gpc-etc__sym{font-family:var(--font-display);font-weight:800;font-size:1.25rem;color:var(--gpc-gold-ink);letter-spacing:.02em;line-height:1}
+.gpc-etc__brand{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.07em}
+.gpc-etc__ter{display:flex;flex-direction:column;align-items:flex-end;font-variant-numeric:tabular-nums}
+.gpc-etc__ter-v{font-family:var(--font-display);font-weight:800;font-size:1.5rem;color:var(--color-text);line-height:1;letter-spacing:-.02em}
+.gpc-etc__ter-l{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-top:2px}
+.gpc-etc__body{padding:var(--space-5);flex:1}
+.gpc-etc__name{font-family:var(--font-display);font-weight:700;font-size:var(--text-base);color:var(--color-text);margin-bottom:var(--space-3);line-height:1.3}
+.gpc-etc__name a{color:inherit;text-decoration:none;border-bottom:1px dashed transparent;transition:border-color .15s,color .15s}
+.gpc-etc__name a:hover{color:var(--gpc-gold-ink);border-bottom-color:var(--gpc-gold)}
+.gpc-etc__meta{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);padding:var(--space-3) 0;border-top:1px solid var(--color-divider)}
+.gpc-etc__mrow{display:flex;flex-direction:column;gap:2px}
+.gpc-etc__ml{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint)}
+.gpc-etc__mv{font-size:var(--text-sm);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+.gpc-etc__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin-top:var(--space-3)}
+.gpc-etc__desc strong{color:var(--color-text)}
+.gpc-etc__badges{display:flex;flex-wrap:wrap;gap:4px;margin-top:var(--space-3)}
+.gpc-pill{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:var(--radius-full);font-size:10px;font-weight:700;letter-spacing:.04em;line-height:1.3;text-transform:uppercase;border:1px solid transparent}
+.gpc-pill--gold{background:color-mix(in oklch,var(--gpc-gold) 12%,transparent);color:var(--gpc-gold-ink);border-color:color-mix(in oklch,var(--gpc-gold) 32%,transparent)}
+.gpc-pill--teal{background:color-mix(in oklch,var(--gpc-teal) 12%,transparent);color:var(--gpc-teal-ink);border-color:color-mix(in oklch,var(--gpc-teal) 32%,transparent)}
+.gpc-pill--emerald{background:color-mix(in oklch,var(--gpc-emerald) 12%,transparent);color:#0f6c34;border-color:color-mix(in oklch,var(--gpc-emerald) 32%,transparent)}
+[data-theme="dark"] .gpc-pill--emerald{color:#5cd699}
+.gpc-pill--royal{background:color-mix(in oklch,var(--gpc-royal) 12%,transparent);color:#5b21b6;border-color:color-mix(in oklch,var(--gpc-royal) 32%,transparent)}
+[data-theme="dark"] .gpc-pill--royal{color:#c4a8ff}
+.gpc-pill--amber{background:color-mix(in oklch,var(--gpc-amber) 12%,transparent);color:#92400e;border-color:color-mix(in oklch,var(--gpc-amber) 32%,transparent)}
+[data-theme="dark"] .gpc-pill--amber{color:#fbbf24}
+
+
+/* ── DUO COMPARISON (Physical vs ETC) ─────────────────────── */
+.gpc-duo{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0}
+@media(min-width:680px){.gpc-duo{grid-template-columns:1fr 1fr}}
+.gpc-duocard{border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);background:var(--color-surface);position:relative;overflow:hidden}
+.gpc-duocard--physical{border-top:4px solid var(--gpc-gold)}
+.gpc-duocard--etc{border-top:4px solid var(--gpc-teal)}
+.gpc-duocard__h{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4)}
+.gpc-duocard__ico{width:42px;height:42px;border-radius:var(--radius-md);display:flex;align-items:center;justify-content:center;flex-shrink:0}
+.gpc-duocard--physical .gpc-duocard__ico{background:color-mix(in oklch,var(--gpc-gold) 18%,transparent);color:var(--gpc-gold-ink)}
+.gpc-duocard--etc .gpc-duocard__ico{background:color-mix(in oklch,var(--gpc-teal) 18%,transparent);color:var(--gpc-teal-ink)}
+.gpc-duocard__title{font-family:var(--font-display);font-weight:800;color:var(--color-text);font-size:var(--text-lg);line-height:1.2;margin-bottom:2px}
+.gpc-duocard__sub{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+.gpc-duocard ul{list-style:none;padding:0;margin:0}
+.gpc-duocard ul li{position:relative;padding-left:24px;margin-bottom:10px;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55}
+.gpc-duocard ul li svg{position:absolute;left:0;top:.3em;width:14px;height:14px;flex-shrink:0}
+.gpc-duocard ul li.gpc-pro svg{color:var(--gpc-emerald)}
+.gpc-duocard ul li.gpc-con svg{color:var(--gpc-crimson)}
+.gpc-duocard ul li strong{color:var(--color-text)}
+
+/* ── CALLOUTS ───────────────────────────────────────────── */
+.gpc-callout{margin:var(--space-5) 0;padding:var(--space-4) var(--space-5);border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-surface-offset);display:flex;gap:var(--space-3);align-items:flex-start}
+.gpc-callout--gold{border-left:3px solid var(--gpc-gold);background:color-mix(in oklch,var(--gpc-gold) 6%,var(--color-surface-offset))}
+.gpc-callout--teal{border-left:3px solid var(--gpc-teal);background:color-mix(in oklch,var(--gpc-teal) 6%,var(--color-surface-offset))}
+.gpc-callout--warn{border-left:3px solid var(--gpc-amber);background:color-mix(in oklch,var(--gpc-amber) 6%,var(--color-surface-offset))}
+.gpc-callout--alert{border-left:3px solid var(--gpc-crimson);background:color-mix(in oklch,var(--gpc-crimson) 6%,var(--color-surface-offset))}
+.gpc-callout--emerald{border-left:3px solid var(--gpc-emerald);background:color-mix(in oklch,var(--gpc-emerald) 6%,var(--color-surface-offset))}
+.gpc-callout__icon{flex-shrink:0;width:24px;height:24px;margin-top:2px}
+.gpc-callout--gold .gpc-callout__icon{color:var(--gpc-gold-ink)}
+.gpc-callout--teal .gpc-callout__icon{color:var(--gpc-teal-ink)}
+.gpc-callout--warn .gpc-callout__icon{color:var(--gpc-amber)}
+.gpc-callout--alert .gpc-callout__icon{color:var(--gpc-crimson)}
+.gpc-callout--emerald .gpc-callout__icon{color:var(--gpc-emerald)}
+.gpc-callout__t{font-weight:700;color:var(--color-text);font-size:var(--text-xs);text-transform:uppercase;letter-spacing:.08em;margin-bottom:6px;display:block;font-family:var(--font-display)}
+.gpc-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
+.gpc-callout p+p{margin-top:8px}
+.gpc-callout p strong{color:var(--color-text)}
+
+/* ── TAX SPOTLIGHT BLOCK ────────────────────────────────── */
+.gpc-tax{margin:var(--space-8) 0;padding:var(--space-6) var(--space-5);border-radius:var(--radius-xl);position:relative;overflow:hidden;border:1px solid color-mix(in oklch,var(--gpc-gold) 30%,var(--color-border));background:linear-gradient(135deg,color-mix(in oklch,var(--gpc-gold) 10%,var(--color-surface)),var(--color-surface) 60%,color-mix(in oklch,var(--gpc-teal) 6%,var(--color-surface)))}
+@media(min-width:640px){.gpc-tax{padding:var(--space-8)}}
+.gpc-tax__icon{width:48px;height:48px;border-radius:var(--radius-md);background:color-mix(in oklch,var(--gpc-gold) 18%,transparent);color:var(--gpc-gold-ink);display:flex;align-items:center;justify-content:center;margin-bottom:var(--space-4)}
+.gpc-tax h3{font-family:var(--font-editorial);font-weight:700;font-size:clamp(1.4rem,1.1rem + 1.2vw,2rem);color:var(--color-text);margin:0 0 var(--space-2);line-height:1.2}
+.gpc-tax__lead{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin:0 0 var(--space-5);max-width:62ch}
+.gpc-tax__lead strong{color:var(--color-text)}
+
+/* ── COST COMPARISON CARDS ─────────────────────────────── */
+.gpc-cost{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0}
+@media(min-width:680px){.gpc-cost{grid-template-columns:repeat(2,1fr)}}
+.gpc-costcard{padding:var(--space-5);border-radius:var(--radius-lg);border:1px solid var(--color-border);background:var(--color-surface);position:relative;overflow:hidden}
+.gpc-costcard__type{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:var(--space-3)}
+.gpc-costcard--etc .gpc-costcard__type{color:var(--gpc-teal-ink)}
+.gpc-costcard--physical .gpc-costcard__type{color:var(--gpc-gold-ink)}
+.gpc-costcard__type::before{content:"";width:8px;height:8px;border-radius:50%;background:currentColor}
+.gpc-costcard__big{display:flex;align-items:baseline;gap:8px;margin-bottom:var(--space-4);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-divider)}
+.gpc-costcard__big-v{font-family:var(--font-display);font-weight:800;font-size:clamp(2rem,1.5rem + 2vw,2.6rem);color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1}
+.gpc-costcard--etc .gpc-costcard__big-v{color:var(--gpc-teal-ink)}
+.gpc-costcard--physical .gpc-costcard__big-v{color:var(--gpc-gold-ink)}
+.gpc-costcard__big-l{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.gpc-costcard__lines{display:flex;flex-direction:column;gap:var(--space-2)}
+.gpc-costcard__line{display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);font-size:var(--text-sm);padding:4px 0;border-bottom:1px dashed var(--color-divider)}
+.gpc-costcard__line:last-child{border-bottom:none}
+.gpc-costcard__line-l{color:var(--color-text-muted)}
+.gpc-costcard__line-v{font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;text-align:right}
+
+/* ── DECISION CARDS (Who Should Choose What) ──────────────── */
+.gpc-decision{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0}
+@media(min-width:680px){.gpc-decision{grid-template-columns:repeat(2,1fr)}}
+.gpc-dcard{padding:var(--space-5);border-radius:var(--radius-lg);border:1px solid var(--color-border);background:var(--color-surface);position:relative;overflow:hidden;display:flex;flex-direction:column}
+.gpc-dcard::before{content:"";position:absolute;left:0;top:0;right:0;height:4px;background:var(--dc,var(--gpc-gold))}
+.gpc-dcard--etc{--dc:var(--gpc-teal)}
+.gpc-dcard--bars{--dc:var(--gpc-amber)}
+.gpc-dcard--coins{--dc:var(--gpc-gold)}
+.gpc-dcard--miners{--dc:var(--gpc-emerald)}
+.gpc-dcard__pic{width:48px;height:48px;border-radius:var(--radius-md);background:color-mix(in oklch,var(--dc,var(--gpc-gold)) 16%,transparent);color:var(--dc,var(--gpc-gold));display:flex;align-items:center;justify-content:center;margin-bottom:var(--space-3);margin-top:var(--space-2)}
+.gpc-dcard--etc .gpc-dcard__pic{color:var(--gpc-teal-ink)}
+.gpc-dcard--coins .gpc-dcard__pic{color:var(--gpc-gold-ink)}
+.gpc-dcard__t{font-family:var(--font-display);font-weight:700;color:var(--color-text);font-size:var(--text-base);line-height:1.3;margin-bottom:var(--space-3)}
+.gpc-dcard__t span{display:block;font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);margin-bottom:4px}
+.gpc-dcard ul{list-style:none;padding:0;margin:0;flex:1}
+.gpc-dcard ul li{position:relative;padding-left:22px;margin-bottom:10px;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55}
+.gpc-dcard ul li::before{content:"";position:absolute;left:0;top:.55em;width:8px;height:8px;border-radius:50%;background:var(--dc,var(--gpc-gold))}
+.gpc-dcard ul li strong{color:var(--color-text)}
+
+
+/* ── COMPARISON TABLE ────────────────────────────────────── */
+.gpc-tablewrap{margin:var(--space-6) 0;border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;background:var(--color-surface)}
+.gpc-tablescroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+table.gpc-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:700px}
+table.gpc-table thead th{text-align:left;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);white-space:nowrap;position:sticky;top:0;font-family:var(--font-display)}
+table.gpc-table thead th.gpc-th-etc{color:var(--gpc-teal-ink);background:color-mix(in oklch,var(--gpc-teal) 8%,var(--color-surface-offset))}
+table.gpc-table thead th.gpc-th-bars{color:var(--gpc-gold-ink);background:color-mix(in oklch,var(--gpc-gold) 8%,var(--color-surface-offset))}
+table.gpc-table thead th.gpc-th-coins{color:var(--gpc-gold-ink);background:color-mix(in oklch,var(--gpc-award) 14%,var(--color-surface-offset))}
+table.gpc-table tbody td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text-muted);vertical-align:middle;line-height:1.45}
+table.gpc-table tbody tr:last-child td{border-bottom:none}
+table.gpc-table tbody tr{transition:background .15s}
+table.gpc-table tbody tr:hover{background:color-mix(in oklch,var(--gpc-gold) 5%,transparent)}
+table.gpc-table td:first-child{color:var(--color-text);font-weight:700;font-family:var(--font-display);font-size:var(--text-sm)}
+table.gpc-table .gpc-cell-pill{display:inline-flex;align-items:center;gap:4px;padding:3px 9px;border-radius:var(--radius-full);font-size:11px;font-weight:700;line-height:1.3;border:1px solid transparent}
+table.gpc-table .gpc-cell-pill--yes{background:color-mix(in oklch,var(--gpc-emerald) 14%,transparent);color:#0f6c34;border-color:color-mix(in oklch,var(--gpc-emerald) 32%,transparent)}
+[data-theme="dark"] table.gpc-table .gpc-cell-pill--yes{color:#5cd699}
+table.gpc-table .gpc-cell-pill--no{background:color-mix(in oklch,var(--gpc-crimson) 10%,transparent);color:#991b1b;border-color:color-mix(in oklch,var(--gpc-crimson) 28%,transparent)}
+[data-theme="dark"] table.gpc-table .gpc-cell-pill--no{color:#f87171}
+table.gpc-table .gpc-cell-pill--neutral{background:color-mix(in oklch,#94a3b8 14%,transparent);color:#475569;border-color:color-mix(in oklch,#94a3b8 32%,transparent)}
+[data-theme="dark"] table.gpc-table .gpc-cell-pill--neutral{color:#94a3b8}
+table.gpc-table .gpc-cell-pill--gold{background:color-mix(in oklch,var(--gpc-gold) 14%,transparent);color:var(--gpc-gold-ink);border-color:color-mix(in oklch,var(--gpc-gold) 32%,transparent);font-weight:800}
+.gpc-scrollhint{font-size:var(--text-xs);color:var(--color-text-faint);text-align:center;padding:var(--space-2);background:var(--color-surface-offset);border-top:1px solid var(--color-divider)}
+@media(min-width:760px){.gpc-scrollhint{display:none}}
+
+/* ── ALLOCATION CARDS ────────────────────────────────────── */
+.gpc-alloc{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-6) 0}
+@media(min-width:560px){.gpc-alloc{grid-template-columns:repeat(3,1fr)}}
+.gpc-allocard{padding:var(--space-5);border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface);position:relative;overflow:hidden;text-align:center}
+.gpc-allocard::after{content:"";position:absolute;left:0;right:0;top:0;height:3px;background:var(--ac,var(--gpc-gold))}
+.gpc-allocard--conservative{--ac:var(--gpc-teal)}
+.gpc-allocard--balanced{--ac:var(--gpc-gold)}
+.gpc-allocard--growth{--ac:var(--gpc-emerald)}
+.gpc-allocard__age{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);margin-bottom:var(--space-2)}
+.gpc-allocard__title{font-family:var(--font-display);font-weight:800;font-size:var(--text-base);color:var(--color-text);margin-bottom:var(--space-3);line-height:1.3}
+.gpc-allocard__big{font-family:var(--font-display);font-weight:800;font-size:clamp(2rem,1.6rem + 1.5vw,2.6rem);color:var(--ac,var(--gpc-gold));font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1;margin-bottom:var(--space-2)}
+.gpc-allocard--conservative .gpc-allocard__big{color:var(--gpc-teal-ink)}
+.gpc-allocard--balanced .gpc-allocard__big{color:var(--gpc-gold-ink)}
+.gpc-allocard__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55}
+
+/* ── STEPS ──────────────────────────────────────────────── */
+.gpc-steps{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-6) 0;counter-reset:gpc-step}
+.gpc-step{position:relative;display:grid;grid-template-columns:auto 1fr;gap:var(--space-4);padding:var(--space-4) var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);counter-increment:gpc-step;transition:border-color .2s,transform .2s}
+.gpc-step:hover{border-color:color-mix(in oklch,var(--gpc-gold) 35%,var(--color-border));transform:translateX(2px)}
+.gpc-step__num{flex-shrink:0;width:42px;height:42px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-weight:800;font-size:1.1rem;color:#fff;background:linear-gradient(135deg,var(--gpc-gold),var(--gpc-gold-deep));box-shadow:0 4px 12px color-mix(in oklch,var(--gpc-gold) 30%,transparent)}
+.gpc-step__num::before{content:counter(gpc-step)}
+.gpc-step__body{min-width:0}
+.gpc-step__t{font-family:var(--font-display);font-weight:700;color:var(--color-text);font-size:var(--text-base);margin:6px 0 4px;line-height:1.3}
+.gpc-step__d{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+.gpc-step__d a{color:var(--color-primary);text-decoration:underline;text-underline-offset:2px}
+.gpc-step__d strong{color:var(--color-text)}
+
+/* ── PRICE 2026 SECTION ─────────────────────────────────── */
+.gpc-prices{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) 0}
+@media(min-width:560px){.gpc-prices{grid-template-columns:repeat(3,1fr)}}
+.gpc-pricecard{padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);position:relative;overflow:hidden}
+.gpc-pricecard::after{content:"";position:absolute;inset:0 0 auto 0;height:3px;background:var(--pc,var(--gpc-gold))}
+.gpc-pricecard--ath{--pc:var(--gpc-gold)}
+.gpc-pricecard--target{--pc:var(--gpc-teal)}
+.gpc-pricecard--gbp{--pc:var(--gpc-emerald)}
+.gpc-pricecard__l{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-2)}
+.gpc-pricecard__v{font-family:var(--font-display);font-weight:800;font-size:clamp(1.5rem,1.2rem + 1.5vw,2rem);color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1.1;margin-bottom:var(--space-1)}
+.gpc-pricecard__v.gpc-up{color:var(--gpc-emerald)}
+.gpc-pricecard--ath .gpc-pricecard__v{color:var(--gpc-gold-ink)}
+.gpc-pricecard__d{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+
+/* ── FAQ ACCORDION ──────────────────────────────────────── */
+.gpc-faq{margin:var(--space-5) 0}
+.gpc-faqitem{border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface);margin-bottom:var(--space-3);overflow:hidden;transition:border-color .15s}
+.gpc-faqitem:hover{border-color:color-mix(in oklch,var(--gpc-gold) 30%,var(--color-border))}
+.gpc-faqitem[open]{border-color:color-mix(in oklch,var(--gpc-gold) 50%,var(--color-border));box-shadow:var(--shadow-sm)}
+.gpc-faqitem summary{list-style:none;cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-weight:700;color:var(--color-text);font-size:var(--text-base);line-height:1.35;font-family:var(--font-display)}
+.gpc-faqitem summary::-webkit-details-marker{display:none}
+.gpc-faqitem summary:hover{color:var(--gpc-gold-ink)}
+.gpc-faqitem summary .gpc-faqic{flex-shrink:0;width:22px;height:22px;color:var(--color-text-muted);transition:transform .25s;border-radius:50%;background:var(--color-surface-offset);padding:3px}
+.gpc-faqitem[open] summary .gpc-faqic{transform:rotate(45deg);color:var(--gpc-gold);background:color-mix(in oklch,var(--gpc-gold) 14%,transparent)}
+.gpc-faqitem__a{padding:0 var(--space-5) var(--space-4);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7}
+.gpc-faqitem__a strong{color:var(--color-text)}
+.gpc-faqitem__a a{color:var(--color-primary);text-decoration:underline;text-underline-offset:2px}
+
+/* ── CTA ─────────────────────────────────────────────────── */
+.gpc-cta{margin:var(--space-8) 0;border-radius:var(--radius-xl);padding:var(--space-8) var(--space-6);text-align:center;position:relative;overflow:hidden;border:1px solid color-mix(in oklch,var(--gpc-gold) 30%,var(--color-border));background:linear-gradient(135deg,color-mix(in oklch,var(--gpc-gold) 12%,var(--color-surface)),var(--color-surface) 60%,color-mix(in oklch,var(--gpc-teal) 8%,var(--color-surface)))}
+.gpc-cta::before{content:"";position:absolute;inset:0;background-image:radial-gradient(circle at 20% 30%,color-mix(in oklch,var(--gpc-gold) 12%,transparent),transparent 50%),radial-gradient(circle at 80% 70%,color-mix(in oklch,var(--gpc-teal) 10%,transparent),transparent 50%);pointer-events:none;z-index:0}
+.gpc-cta>*{position:relative;z-index:1}
+.gpc-cta__icon{width:54px;height:54px;border-radius:50%;background:linear-gradient(135deg,var(--gpc-gold),var(--gpc-gold-deep));color:#fff;display:flex;align-items:center;justify-content:center;margin:0 auto var(--space-3);box-shadow:0 8px 24px color-mix(in oklch,var(--gpc-gold) 30%,transparent)}
+.gpc-cta h3{font-family:var(--font-editorial);font-weight:700;font-size:clamp(1.3rem,1rem + 1vw,1.7rem);color:var(--color-text);margin:0 0 var(--space-2);line-height:1.2}
+.gpc-cta p{font-size:var(--text-sm);color:var(--color-text-muted);max-width:54ch;margin:0 auto var(--space-5);line-height:1.65}
+.gpc-ctabtn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-3) var(--space-6);background:var(--color-primary);color:#fff;border-radius:var(--radius-full);font-weight:700;font-size:var(--text-sm);text-decoration:none;box-shadow:var(--shadow-md);transition:background .15s,transform .15s,box-shadow .15s}
+.gpc-ctabtn:hover{background:var(--color-primary-hover);color:#fff;transform:translateY(-2px);box-shadow:var(--shadow-lg);text-decoration:none}
+.gpc-ctabtn svg{flex-shrink:0;width:16px;height:16px}
+
+/* ── SOURCES + DISCLAIMER ───────────────────────────────── */
+.gpc-sources{margin-top:var(--space-8);border-top:1px solid var(--color-border);padding-top:var(--space-5)}
+.gpc-sources h3{font-size:var(--text-base);font-family:var(--font-display);color:var(--color-text);margin:0 0 var(--space-3)}
+.gpc-sources ol{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.7;margin:0;padding-left:var(--space-5);counter-reset:src}
+.gpc-sources ol li{margin-bottom:6px;counter-increment:src;padding-left:4px;scroll-margin-top:84px}
+.gpc-sources ol li:target{background:color-mix(in oklch,var(--gpc-gold) 12%,transparent);border-radius:var(--radius-sm);padding:4px 6px}
+.gpc-sources a{color:var(--color-primary);text-decoration:underline;text-underline-offset:2px;word-break:break-word}
+.gpc-disclaimer{margin-top:var(--space-6);padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-border);font-size:var(--text-xs);color:var(--color-text-faint);line-height:1.7}
+.gpc-disclaimer strong{color:var(--color-text-muted)}
+
+/* ── RELATED ARTICLES ───────────────────────────────────── */
+.gpc-related{max-width:var(--gpc-maxw);margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-12);background:var(--color-surface-offset);border-top:1px solid var(--color-border)}
+.gpc-related-inner{max-width:var(--gpc-maxw);margin:0 auto}
+.gpc-related>h2,.gpc-related-inner>h2{font-family:var(--font-editorial);font-size:var(--text-xl);color:var(--color-text);margin:0 0 var(--space-6);font-weight:700}
+.gpc-related-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:560px){.gpc-related-grid{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:900px){.gpc-related-grid{grid-template-columns:repeat(3,1fr)}}
+.gpc-rcard{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,transform .15s,box-shadow .15s;color:var(--color-text)}
+.gpc-rcard:hover{border-color:var(--color-primary);transform:translateY(-2px);box-shadow:var(--shadow-md);text-decoration:none;color:var(--color-text)}
+.gpc-rcard__tag{display:inline-block;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--gpc-gold-ink);margin-bottom:var(--space-2);padding:3px 8px;background:color-mix(in oklch,var(--gpc-gold) 10%,transparent);border-radius:var(--radius-full)}
+.gpc-rcard__title{font-family:var(--font-display);font-weight:700;font-size:var(--text-base);color:var(--color-text);margin-bottom:var(--space-2);line-height:1.3}
+.gpc-rcard__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
+
+/* hide legacy article-wrap styles */
+.article-wrap.gpc-article{max-width:none;padding:0;margin:0}
 
 </style>
 <link rel="stylesheet" href="/assets/site.css">
@@ -517,131 +723,937 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </div>
 </nav>
 
-<div class="breadcrumb-wrap">
-  <ol class="breadcrumb" aria-label="Breadcrumb">
+<!-- Reading progress bar -->
+<div id="gpc-progress" aria-hidden="true"></div>
+
+<!-- SVG icon sprite -->
+<svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false">
+  <defs>
+    <symbol id="gpc-i-coin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v10M9 9.5h4.5a2.5 2.5 0 010 5h-3a2.5 2.5 0 000 5H15"/></symbol>
+    <symbol id="gpc-i-bar" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9l3-3h10l3 3v9H4z"/><path d="M4 9h16"/><path d="M8 13h8"/></symbol>
+    <symbol id="gpc-i-chart" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="20" x2="21" y2="20"/><polyline points="5 17 9 11 13 14 19 6"/><circle cx="19" cy="6" r="1.5"/></symbol>
+    <symbol id="gpc-i-vault" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="12" cy="12" r="3"/><line x1="12" y1="9" x2="12" y2="7"/><line x1="12" y1="17" x2="12" y2="15"/><line x1="9" y1="12" x2="7" y2="12"/><line x1="17" y1="12" x2="15" y2="12"/></symbol>
+    <symbol id="gpc-i-shield" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></symbol>
+    <symbol id="gpc-i-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></symbol>
+    <symbol id="gpc-i-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></symbol>
+    <symbol id="gpc-i-clock" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></symbol>
+    <symbol id="gpc-i-tag" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.59 13.41l-7.17 7.17a2 2 0 01-2.83 0L2 12V2h10l8.59 8.59a2 2 0 010 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></symbol>
+    <symbol id="gpc-i-trending" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></symbol>
+    <symbol id="gpc-i-info" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></symbol>
+    <symbol id="gpc-i-alert" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></symbol>
+    <symbol id="gpc-i-plus" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></symbol>
+    <symbol id="gpc-i-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></symbol>
+    <symbol id="gpc-i-pound" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 7c0-3-2-5-5-5s-5 2-5 5v2c0 4-2 5-2 5h12"/><line x1="6" y1="14" x2="18" y2="14"/><line x1="6" y1="20" x2="18" y2="20"/></symbol>
+    <symbol id="gpc-i-bag" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6L18 2z"/><line x1="3" y1="6" x2="21" y2="6"/><path d="M16 10a4 4 0 01-8 0"/></symbol>
+    <symbol id="gpc-i-scale" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><path d="M5 21h14"/><circle cx="6" cy="9" r="3"/><circle cx="18" cy="9" r="3"/><path d="M6 3l-3 6h6z"/><path d="M18 3l3 6h-6z"/></symbol>
+    <symbol id="gpc-i-zap" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></symbol>
+    <symbol id="gpc-i-lock" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></symbol>
+    <symbol id="gpc-i-target" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></symbol>
+    <symbol id="gpc-i-globe" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></symbol>
+    <symbol id="gpc-i-pie" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.21 15.89A10 10 0 118 2.83"/><path d="M22 12A10 10 0 0012 2v10z"/></symbol>
+    <symbol id="gpc-i-chev" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="2 4 6 8 10 4"/></symbol>
+  </defs>
+</svg>
+
+<nav class="gpc-bc-wrap" aria-label="Breadcrumb">
+  <ol class="gpc-bc">
     <li><a href="/">Home</a></li>
     <li><a href="/blog/">Blog</a></li>
-    <li aria-current="page">Gold &amp; Silver Price Outlook</li>
+    <li aria-current="page">Gold ETFs vs Physical Gold: UK Investor's Guide 2026</li>
   </ol>
-</div>
+</nav>
 
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb">
-<li><a href="/">Home</a></li><li><a href="/blog/">Blog</a></li><li aria-current="page">Gold ETFs vs Physical Gold: A UK Investor's Guide for 2026</li>
-</ol></div>
-<article class="article-wrap" itemscope itemtype="https://schema.org/BlogPosting">
-  <div class="article-tag">Investment Guide</div>
-  <h1 class="article-title" itemprop="headline">Gold ETFs vs Physical Gold: A UK Investor's Guide for 2026</h1>
-  <div class="article-byline">
-    By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a>
-    &middot; <time datetime="2026-06-03" itemprop="datePublished">2026-05-03</time>
-    &middot; <span style="font-size:0.8em;color:var(--color-text-faint)">Last updated: 3 May 2026</span>
-  </div>
-  <div class="prose">
-    <p>When UK investors decide to add gold to their portfolio, they immediately face a choice: buy the physical metal — coins, bars, something tangible — or buy a gold ETC that trades on the London Stock Exchange like a share. Both routes give you exposure to the gold price, but they are very different products with different tax treatments, costs, and risk profiles. This guide walks through both options so you can make an informed decision for 2026.</p>
 
-    <h2>Physical Gold: What You Are Actually Buying</h2>
-    <p>Physical gold means owning the metal itself: coins, bars, or an allocated account where a specific quantity of metal is held in your name in a vault. The main physical formats available to UK retail investors are Gold Sovereigns (22-carat, 7.32g pure gold) and Gold Britannias (999.9 fine, 1 troy oz) from the Royal Mint, both CGT-exempt as UK legal tender; gold bars from 1g retail to 400 troy oz LBMA Good Delivery; and allocated digital accounts such as Royal Mint DigiGold or BullionVault, which give fractional ownership of physically allocated gold from as little as £25.</p>
-    <p>The advantages of physical gold include direct ownership with no counterparty risk if you hold it personally, CGT exemption on qualifying coins, and a tangible asset that survives financial system disruption. The drawbacks are storage and insurance costs, wider dealer spreads (typically 1–3% on coins), relative illiquidity compared to exchange-traded products, and the logistical complexity of large bars.</p>
+<article class="article-wrap gpc-article" itemscope itemtype="https://schema.org/BlogPosting">
 
-    <h2>Gold ETCs: The Exchange-Traded Alternative</h2>
-    <p>Gold exchange-traded commodities (ETCs) — loosely called "gold ETFs" — are debt instruments backed by physical gold held in a custodian vault. They trade on the LSE during market hours and track the gold spot price minus a small annual fee. The major options for UK investors in 2026:</p>
-    <ul>
-      <li><strong>iShares Physical Gold ETC (IGLN / SGLN)</strong> — TER 0.12% p.a., AUM over £25bn. Backed by LBMA Good Delivery bars at JPMorgan Chase in London. The largest and most liquid gold ETC in Europe.</li>
-      <li><strong>Invesco Physical Gold ETC (SGLD)</strong> — TER 0.12% p.a., AUM over £21bn. Very similar in structure and cost to IGLN.</li>
-      <li><strong>WisdomTree Physical Gold (PHAU)</strong> — TER 0.39% p.a., AUM £5.7bn. One of the oldest European gold ETCs (launched 2007). Higher ongoing charge than the iShares and Invesco products.</li>
-      <li><strong>Gold Bullion Securities (GBS)</strong> — TER 0.40% p.a., AUM £3.3bn. The original European gold ETC, launched 2003.</li>
-    </ul>
-    <p>The advantages of gold ETCs include ISA and SIPP eligibility (unlike physical gold), very tight bid-ask spreads on the exchange (0.05–0.10%), no storage or insurance to arrange, and easy purchase through any UK stockbroker. The drawbacks are no CGT exemption (unlike Sovereigns and Britannias), a small ongoing annual TER, and the fact that you technically own a debt instrument rather than gold itself — though physical backing strongly mitigates the counterparty risk.</p>
-
-    <h2>ISA Eligibility: The Crucial Difference</h2>
-    <p>Physical gold coins and bars <strong>cannot be held inside a Stocks &amp; Shares ISA</strong>. The ISA rules require assets to be exchange-listed securities or cash equivalents. Physical metal does not qualify. Gold ETCs, on the other hand, are exchange-listed securities and are fully ISA-eligible. Inside an ISA, all gains from a gold ETC are permanently free from CGT and income tax, with no annual reporting. The annual ISA allowance is £20,000 per person. This is one of the most compelling reasons for many UK investors to prefer ETCs for their initial gold allocation.</p>
-
-    <h2>Cost Comparison: 5-Year Worked Example</h2>
-    <p>Suppose you invest £10,000 in gold for five years. The cost profile for each route:</p>
-    <ul>
-      <li><strong>1 oz Gold Britannia (Royal Mint, Vault storage):</strong> ~2–4% initial premium over spot at purchase. Royal Mint Vault storage: 0.5% p.a. Total 5-year holding cost: approximately 4.5–6.5% of value.</li>
-      <li><strong>iShares Physical Gold ETC (IGLN) in ISA:</strong> ~0.07% bid-ask spread at purchase. TER 0.12% p.a. No storage or insurance. Total 5-year holding cost: approximately 0.7–1% of value.</li>
-    </ul>
-    <p>On pure cost, the ISA-wrapped ETC wins easily for most holding periods. Physical coins become more competitive when CGT exemption on large gains matters — particularly as holdings grow beyond ISA limits.</p>
-
-    <h2>Full Tax Comparison</h2>
-    <table class="data-table" aria-label="Gold investment tax comparison">
-      <thead><tr><th>Asset</th><th>CGT?</th><th>ISA-eligible?</th><th>SIPP-eligible?</th><th>VAT?</th></tr></thead>
-      <tbody>
-        <tr><td>Gold Sovereigns / Britannias</td><td>Exempt (legal tender)</td><td>No</td><td>Yes (HMRC-approved)</td><td>No (investment gold)</td></tr>
-        <tr><td>Gold bars (LBMA ≥99.5%)</td><td>Yes — CGT applies</td><td>No</td><td>Yes</td><td>No (investment gold)</td></tr>
-        <tr><td>Gold ETCs (IGLN, SGLD, PHAU)</td><td>Yes — unless in ISA/SIPP</td><td>Yes</td><td>Yes</td><td>No</td></tr>
-      </tbody>
-    </table>
-
-    <h2>Which Is Right for You?</h2>
-    <p>As a practical framework: for a first gold investment under £20,000, an ISA-wrapped gold ETC (IGLN at 0.12% TER) offers simplicity, low cost, and a complete CGT shelter. For larger sums where CGT exemption on unlimited gains matters more than annual fees, Gold Sovereigns and Britannias offer unbeatable tax efficiency. For the most comprehensive approach, combine both: ETCs in an ISA for the first £20,000 annually, then CGT-exempt coins for everything beyond the ISA limit. Gold ETCs or LBMA bars inside a SIPP are optimal for pension investors who want tax relief on contributions combined with CGT-free growth.</p>
-    <div class="cta-box"><h3>See Live Gold Prices in GBP</h3><p>Track 24K, 18K, 9K gold and silver prices live. Use GoldPriceTools' free calculator to value any holding before you invest.</p><a href="/" class="cta-btn">Open Live Calculator &rarr;</a></div>
-  </div>
-  
-<!-- FAQ Section -->
-<section style="padding:2rem 0 0;">
-  <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
-  <div class="faq-container">
-    <div class="faq-card">
-      <h3 class="faq-q">What is a gold ETF?</h3>
-      <p class="faq-answer">A gold ETF (Exchange-Traded Fund) is a fund that tracks the gold price and trades on a stock exchange like a share. Most physically-backed gold ETFs hold actual gold bars in a vault. You get gold price exposure without storage, insurance or delivery logistics. UK examples include iShares Physical Gold ETC (SGLN) and Invesco Physical Gold ETC (SGLD).</p>
+  <!-- ═══════════════ HERO ═══════════════ -->
+  <header class="gpc-hero">
+    <div class="gpc-hero__bg" aria-hidden="true"></div>
+    <div class="gpc-hero__grid" aria-hidden="true"></div>
+    <div class="gpc-hero__inner">
+      <span class="gpc-kicker"><span class="gpc-kicker__dot" aria-hidden="true"></span>Investment Guide · 2026 Edition</span>
+      <h1 itemprop="headline">Gold <span class="gpc-accent">ETFs</span> <span class="gpc-vs">vs</span> <span class="gpc-accent">Physical Gold</span></h1>
+      <p class="gpc-hero__lead">A UK investor's complete guide for 2026 — costs, taxes, liquidity, custody and the smartest blend of SGLN, SGLP, Britannias and Sovereigns for every kind of investor.</p>
+      <div class="gpc-byline">
+        By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a>
+        <span class="dot" aria-hidden="true"></span>
+        <span itemprop="datePublished" content="2026-05-03">Published 3 May 2026</span>
+        <span class="dot" aria-hidden="true"></span>
+        <time datetime="2026-06-03" itemprop="dateModified" style="color:var(--color-text-faint)">Updated 3 June 2026</time>
+        <span class="dot" aria-hidden="true"></span>
+        <span class="gpc-readtime"><svg width="13" height="13"><use href="#gpc-i-clock"/></svg> 18 min read</span>
+      </div>
+      <div class="gpc-hero-stats">
+        <div class="gpc-hstat gpc-hstat--gold gpc-reveal">
+          <div class="gpc-hstat__k"><svg width="13" height="13"><use href="#gpc-i-trending"/></svg>Gold Spot (Jan 2026)</div>
+          <div class="gpc-hstat__v">$5,100+</div>
+          <div class="gpc-hstat__s">+18% in weeks</div>
+        </div>
+        <div class="gpc-hstat gpc-hstat--teal gpc-reveal">
+          <div class="gpc-hstat__k"><svg width="13" height="13"><use href="#gpc-i-tag"/></svg>Lowest UK ETC TER</div>
+          <div class="gpc-hstat__v">0.12%</div>
+          <div class="gpc-hstat__s">SGLN &amp; SGLP per year</div>
+        </div>
+        <div class="gpc-hstat gpc-hstat--emerald gpc-reveal">
+          <div class="gpc-hstat__k"><svg width="13" height="13"><use href="#gpc-i-shield"/></svg>CGT on Britannias</div>
+          <div class="gpc-hstat__v">0%</div>
+          <div class="gpc-hstat__s">UK legal tender exempt</div>
+        </div>
+        <div class="gpc-hstat gpc-hstat--award gpc-reveal">
+          <div class="gpc-hstat__k"><svg width="13" height="13"><use href="#gpc-i-pound"/></svg>2026/27 ISA Limit</div>
+          <div class="gpc-hstat__v">£20,000</div>
+          <div class="gpc-hstat__s">Per person, tax-free</div>
+        </div>
+      </div>
     </div>
-    <div class="faq-card">
-      <h3 class="faq-q">Is physical gold or gold ETF better for UK investors?</h3>
-      <p class="faq-answer">It depends on your goals. ETFs are cheaper to buy (no storage costs), more liquid, and easier to hold in an ISA or SIPP. Physical gold gives you direct ownership with no counterparty risk and is portable. For most UK investors holding under £50,000 in gold, ETFs in an ISA (no CGT) are the most practical and tax-efficient choice.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-q">Can I hold gold ETFs in an ISA?</h3>
-      <p class="faq-answer">Yes. UK gold ETCs (Exchange-Traded Commodities) like SGLN, SGLD and PHAU can be held in a Stocks & Shares ISA, making gains completely free of CGT and income tax. This is a significant advantage over physical gold (which is subject to CGT at 18% or 24% depending on your tax band).</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-q">What are the risks of gold ETFs vs physical?</h3>
-      <p class="faq-answer">Gold ETF risks include: counterparty risk (the fund provider could fail, though gold-backed ETCs typically have segregated assets), tracking error, and annual management fees (typically 0.15–0.40%). Physical gold risks include storage, insurance costs, and the premium over spot when buying/selling. Neither form protects against gold price falls.</p>
-    </div>
-  </div>
-</section>
+  </header>
 
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
-    <h2>Related Articles &amp; Guides</h2>
-    <div class="related-guides-grid">
-      <a href="/guides/how-to-invest-in-gold" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">How to Invest in Gold UK</div>
-        <div class="related-card__desc">From ETFs to bullion coins — a complete guide to gold investment in the UK.</div>
-      </a>
-      <a href="/blog/uk-gold-cgt-guide" class="related-card">
-        <div class="related-card__tag">Article</div>
-        <div class="related-card__title">UK Gold CGT Guide</div>
-        <div class="related-card__desc">CGT treatment of gold ETFs, coins and bars — how to invest tax-efficiently.</div>
-      </a>
-      <a href="/blog/gold-in-a-sipp-uk" class="related-card">
-        <div class="related-card__tag">Article</div>
-        <div class="related-card__title">Gold in a SIPP UK</div>
-        <div class="related-card__desc">Can you hold gold ETFs or physical gold in your pension? What the rules say.</div>
-      </a>
-      <a href="/guides/gold-vs-silver-investment" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold vs Silver Investment</div>
-        <div class="related-card__desc">Compare the case for gold vs silver in a UK investment portfolio.</div>
-      </a>
-      <a href="/guides/gold-price-history" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold Price History</div>
-        <div class="related-card__desc">Long-term gold price chart — essential context for any gold investment decision.</div>
-      </a>
-      <a href="/gold-silver-ratio" class="related-card">
-        <div class="related-card__tag">Live Tool</div>
-        <div class="related-card__title">Gold-Silver Ratio</div>
-        <div class="related-card__desc">Track the live gold-silver ratio alongside your ETF research.</div>
-      </a>
+  <!-- ═══════════════ MAIN SHELL ═══════════════ -->
+  <div class="gpc-shell">
+    <div class="gpc-layout">
+
+      <!-- TOC sidebar (desktop) -->
+      <aside class="gpc-toc">
+        <details class="gpc-toc__box" open>
+          <summary>On this page<svg width="14" height="14"><use href="#gpc-i-chev"/></svg></summary>
+          <nav aria-label="Article sections">
+            <a href="#what-is-etf">What is a Gold ETF?</a>
+            <a href="#etcs">UK gold ETC options</a>
+            <a href="#what-is-physical">What is physical gold?</a>
+            <a href="#price-gap">Why prices can differ</a>
+            <a href="#tax">Tax picture in 2026</a>
+            <a href="#costs">Cost comparison</a>
+            <a href="#liquidity">Liquidity</a>
+            <a href="#counterparty">Counterparty risk</a>
+            <a href="#miners">Gold miners ETFs</a>
+            <a href="#leveraged">Leveraged / inverse</a>
+            <a href="#price-2026">Gold price in 2026</a>
+            <a href="#allocation">How much to hold</a>
+            <a href="#head-to-head">Head-to-head</a>
+            <a href="#who-should">Who should choose what</a>
+            <a href="#next-steps">Next steps</a>
+            <a href="#faq">FAQ</a>
+          </nav>
+        </details>
+      </aside>
+
+      <!-- Main article -->
+      <div class="gpc-main">
+
+        <!-- INTRO -->
+        <div class="gpc-prose">
+          <p class="gpc-lead">Gold is having a moment. After surpassing $5,100 per troy ounce in early 2026 — a gain of nearly 18% in a matter of weeks — the precious metal has firmly cemented itself as one of the standout asset classes of recent years. For UK investors wondering how best to get involved, the central question is almost always the same: should you buy physical gold, or is a gold ETF (technically an ETC in the UK) the smarter move?<a class="gpc-ref" href="#src-1">[1]</a></p>
+          <p>The honest answer is that it depends on who you are and what you want from gold. This guide breaks down every meaningful difference between the two approaches — costs, taxes, liquidity, risk, and how each fits into a modern UK portfolio — so you can make an informed decision in 2026.</p>
+        </div>
+
+
+        <!-- ═══════════════ WHAT IS A GOLD ETF ═══════════════ -->
+        <section class="gpc-sec" id="what-is-etf">
+          <div class="gpc-sec__kick">Defining the product</div>
+          <h2>What Is a Gold ETF (or ETC)?</h2>
+          <div class="gpc-prose">
+            <p>In the UK, what most investors call a "gold ETF" is, technically speaking, an <strong>Exchange Traded Commodity (ETC)</strong> rather than a fund. Under EU-derived UCITS regulations still applicable in Britain, a fund cannot hold a single underlying asset — which means a pure gold product must be structured as a certificate rather than a traditional fund. The practical difference for investors is minimal, but it's worth knowing the correct terminology.<a class="gpc-ref" href="#src-2">[2]</a></p>
+            <p>A physically backed gold ETC is a debt security issued by a financial institution and collateralised with real gold bars stored in secure vaults — typically in London. When you buy shares in one, you are not purchasing gold itself, but a financial instrument whose value is pegged to the spot price of gold. These products trade on the London Stock Exchange just like ordinary shares, meaning you can buy and sell during market hours through any standard brokerage account or Stocks and Shares ISA.<a class="gpc-ref" href="#src-3">[3]</a></p>
+            <p>The most widely held gold ETCs in the UK include the four products profiled below — all physically backed, all valued daily at the London PM fixing price, all tracking spot gold closely minus the management fee.<a class="gpc-ref" href="#src-6">[6]</a></p>
+          </div>
+
+          <!-- ETC product cards -->
+          <div class="gpc-etcs" id="etcs">
+            <div class="gpc-etc gpc-reveal">
+              <div class="gpc-etc__top">
+                <div class="gpc-etc__ticker">
+                  <div>
+                    <div class="gpc-etc__sym">SGLN</div>
+                    <div class="gpc-etc__brand">iShares · BlackRock</div>
+                  </div>
+                </div>
+                <div class="gpc-etc__ter">
+                  <span class="gpc-etc__ter-v">0.12%</span>
+                  <span class="gpc-etc__ter-l">TER per year</span>
+                </div>
+              </div>
+              <div class="gpc-etc__body">
+                <div class="gpc-etc__name">iShares Physical Gold ETC</div>
+                <div class="gpc-etc__meta">
+                  <div class="gpc-etc__mrow"><span class="gpc-etc__ml">AUM</span><span class="gpc-etc__mv">£27.6 bn+</span></div>
+                  <div class="gpc-etc__mrow"><span class="gpc-etc__ml">Custodian</span><span class="gpc-etc__mv">JP Morgan, London</span></div>
+                </div>
+                <p class="gpc-etc__desc">Europe's largest physically backed gold ETC and the lowest-cost option for UK investors.<a class="gpc-ref" href="#src-4">[4]</a> The default choice for most ISA-wrapped allocations.</p>
+                <div class="gpc-etc__badges">
+                  <span class="gpc-pill gpc-pill--emerald">ISA / SIPP eligible</span>
+                  <span class="gpc-pill gpc-pill--gold">Cheapest TER</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="gpc-etc gpc-reveal">
+              <div class="gpc-etc__top">
+                <div class="gpc-etc__ticker">
+                  <div>
+                    <div class="gpc-etc__sym">SGLP</div>
+                    <div class="gpc-etc__brand">Invesco</div>
+                  </div>
+                </div>
+                <div class="gpc-etc__ter">
+                  <span class="gpc-etc__ter-v">0.12%</span>
+                  <span class="gpc-etc__ter-l">TER per year</span>
+                </div>
+              </div>
+              <div class="gpc-etc__body">
+                <div class="gpc-etc__name">Invesco Physical Gold ETC</div>
+                <div class="gpc-etc__meta">
+                  <div class="gpc-etc__mrow"><span class="gpc-etc__ml">AUM</span><span class="gpc-etc__mv">£21.6 bn+</span></div>
+                  <div class="gpc-etc__mrow"><span class="gpc-etc__ml">Custodian</span><span class="gpc-etc__mv">JP Morgan, London</span></div>
+                </div>
+                <p class="gpc-etc__desc">Tied with SGLN on cost at 0.12% TER and backed by gold stored in JP Morgan Chase Bank's London vaults.<a class="gpc-ref" href="#src-5">[5]</a><a class="gpc-ref" href="#src-6">[6]</a></p>
+                <div class="gpc-etc__badges">
+                  <span class="gpc-pill gpc-pill--emerald">ISA / SIPP eligible</span>
+                  <span class="gpc-pill gpc-pill--gold">Cheapest TER</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="gpc-etc gpc-reveal">
+              <div class="gpc-etc__top">
+                <div class="gpc-etc__ticker">
+                  <div>
+                    <div class="gpc-etc__sym">PHAU</div>
+                    <div class="gpc-etc__brand">WisdomTree · Est. 2007</div>
+                  </div>
+                </div>
+                <div class="gpc-etc__ter">
+                  <span class="gpc-etc__ter-v">0.39%</span>
+                  <span class="gpc-etc__ter-l">TER per year</span>
+                </div>
+              </div>
+              <div class="gpc-etc__body">
+                <div class="gpc-etc__name">WisdomTree Physical Gold ETC</div>
+                <div class="gpc-etc__meta">
+                  <div class="gpc-etc__mrow"><span class="gpc-etc__ml">Launched</span><span class="gpc-etc__mv">2007</span></div>
+                  <div class="gpc-etc__mrow"><span class="gpc-etc__ml">Variant</span><span class="gpc-etc__mv">PHGP (GBP-hedged)</span></div>
+                </div>
+                <p class="gpc-etc__desc">One of the oldest European gold ETCs.<a class="gpc-ref" href="#src-7">[7]</a> Higher TER reflects its longer track record and currency-hedged sister class.</p>
+                <div class="gpc-etc__badges">
+                  <span class="gpc-pill gpc-pill--emerald">ISA / SIPP eligible</span>
+                  <span class="gpc-pill gpc-pill--teal">GBP-hedged available</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="gpc-etc gpc-reveal">
+              <div class="gpc-etc__top">
+                <div class="gpc-etc__ticker">
+                  <div>
+                    <div class="gpc-etc__sym">RMAU</div>
+                    <div class="gpc-etc__brand">Royal Mint · HanETF</div>
+                  </div>
+                </div>
+                <div class="gpc-etc__ter">
+                  <span class="gpc-etc__ter-v">0.22%</span>
+                  <span class="gpc-etc__ter-l">TER per year</span>
+                </div>
+              </div>
+              <div class="gpc-etc__body">
+                <div class="gpc-etc__name">Royal Mint Responsibly Sourced Physical Gold</div>
+                <div class="gpc-etc__meta">
+                  <div class="gpc-etc__mrow"><span class="gpc-etc__ml">Custodian</span><span class="gpc-etc__mv">Llantrisant, Wales</span></div>
+                  <div class="gpc-etc__mrow"><span class="gpc-etc__ml">Backing</span><span class="gpc-etc__mv">100% physical</span></div>
+                </div>
+                <p class="gpc-etc__desc">Custodied outside the London banking system in a high-security vault in Wales.<a class="gpc-ref" href="#src-8">[8]</a><a class="gpc-ref" href="#src-9">[9]</a> Backed by responsibly sourced bars.</p>
+                <div class="gpc-etc__badges">
+                  <span class="gpc-pill gpc-pill--emerald">ISA / SIPP eligible</span>
+                  <span class="gpc-pill gpc-pill--royal">Sovereign vault</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+
+        <!-- ═══════════════ WHAT IS PHYSICAL GOLD ═══════════════ -->
+        <section class="gpc-sec" id="what-is-physical">
+          <div class="gpc-sec__kick">The tangible alternative</div>
+          <h2>What Is Physical Gold?</h2>
+          <div class="gpc-prose">
+            <p>Physical gold means exactly what it sounds like — gold you can hold in your hands. In the UK, that typically means:</p>
+            <ul>
+              <li><strong>Gold bars</strong>, ranging from small 1g bars up to the institutional 400oz (12.5kg) good delivery bar</li>
+              <li><strong>Gold coins</strong>, most notably the British Britannia and the Sovereign, both struck by the Royal Mint</li>
+            </ul>
+            <p>The Royal Mint itself sells coins and bars ranging from around £100 to over £130,000, with insured UK delivery and optional secure vault storage. Other major UK bullion dealers include BullionByPost, Sharps Pixley, and Tavex.<a class="gpc-ref" href="#src-10">[10]</a></p>
+            <p>The key attraction of physical gold is absolute ownership. When you hold a gold coin or bar, there is no counterparty, no fund manager, no custodian bank that could fail. The gold is yours, outright, and its value does not depend on anyone else's promises being kept.<a class="gpc-ref" href="#src-11">[11]</a><a class="gpc-ref" href="#src-12">[12]</a></p>
+          </div>
+
+          <!-- Side-by-side comparison cards -->
+          <div class="gpc-duo">
+            <div class="gpc-duocard gpc-duocard--physical gpc-reveal">
+              <div class="gpc-duocard__h">
+                <div class="gpc-duocard__ico"><svg width="22" height="22"><use href="#gpc-i-coin"/></svg></div>
+                <div>
+                  <div class="gpc-duocard__title">Physical Gold</div>
+                  <div class="gpc-duocard__sub">Coins, bars &amp; allocated metal</div>
+                </div>
+              </div>
+              <ul>
+                <li class="gpc-pro"><svg><use href="#gpc-i-check"/></svg><strong>Absolute ownership</strong> — no counterparty, no custodian bank</li>
+                <li class="gpc-pro"><svg><use href="#gpc-i-check"/></svg><strong>CGT-free for legal tender coins</strong> with no upper limit</li>
+                <li class="gpc-pro"><svg><use href="#gpc-i-check"/></svg>Crisis-proof — survives banking system disruption</li>
+                <li class="gpc-pro"><svg><use href="#gpc-i-check"/></svg>Tangible, divisible, internationally portable</li>
+                <li class="gpc-con"><svg><use href="#gpc-i-x"/></svg>Storage and insurance costs (0.5–2% p.a.)</li>
+                <li class="gpc-con"><svg><use href="#gpc-i-x"/></svg>Cannot be held in an ISA or SIPP</li>
+                <li class="gpc-con"><svg><use href="#gpc-i-x"/></svg>Wider buy/sell spreads than ETCs</li>
+              </ul>
+            </div>
+
+            <div class="gpc-duocard gpc-duocard--etc gpc-reveal">
+              <div class="gpc-duocard__h">
+                <div class="gpc-duocard__ico"><svg width="22" height="22"><use href="#gpc-i-chart"/></svg></div>
+                <div>
+                  <div class="gpc-duocard__title">Gold ETC</div>
+                  <div class="gpc-duocard__sub">Exchange-traded commodity</div>
+                </div>
+              </div>
+              <ul>
+                <li class="gpc-pro"><svg><use href="#gpc-i-check"/></svg><strong>ISA &amp; SIPP eligible</strong> — completely tax-free wrapper</li>
+                <li class="gpc-pro"><svg><use href="#gpc-i-check"/></svg>Cheapest TER from 0.12% p.a. (SGLN, SGLP)</li>
+                <li class="gpc-pro"><svg><use href="#gpc-i-check"/></svg>Instant liquidity — sell in seconds during market hours</li>
+                <li class="gpc-pro"><svg><use href="#gpc-i-check"/></svg>Tight bid-ask spreads, no storage to arrange</li>
+                <li class="gpc-con"><svg><use href="#gpc-i-x"/></svg><strong>Counterparty risk</strong> — issuer, custodian, broker</li>
+                <li class="gpc-con"><svg><use href="#gpc-i-x"/></svg>Subject to CGT outside an ISA / SIPP</li>
+                <li class="gpc-con"><svg><use href="#gpc-i-x"/></svg>You own a debt security, not the metal itself</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <!-- ═══════════════ WHY PRICES DIFFER ═══════════════ -->
+        <section class="gpc-sec" id="price-gap">
+          <div class="gpc-sec__kick">Tracking mechanics</div>
+          <h2>Why the Gold Price vs Gold ETF Price Can Differ</h2>
+          <div class="gpc-prose">
+            <p>One of the most common questions from newcomers is why there sometimes appears to be a gap between the gold spot price and the price of a gold ETC. There are a few reasons for this:</p>
+            <ol>
+              <li><strong>The management fee drag:</strong> Every day, a tiny fraction of your ETC's gold entitlement is deducted to pay the fund's running costs (the TER). Over time, this means each unit represents slightly less gold than it did when you bought it.<a class="gpc-ref" href="#src-3">[3]</a></li>
+              <li><strong>Currency effects:</strong> Most gold ETCs are priced in US dollars at the underlying level. UK investors see the price expressed in pounds, so the GBP/USD exchange rate also influences what you observe day to day.</li>
+              <li><strong>Bid-ask spreads:</strong> On any given day, you will pay slightly more to buy units than you receive when you sell them. For large, liquid ETCs like SGLN, this spread is extremely narrow.<a class="gpc-ref" href="#src-13">[13]</a></li>
+              <li><strong>Tracking error:</strong> Minor operational factors can cause a small, temporary divergence between an ETC's net asset value and the gold price it is meant to track.<a class="gpc-ref" href="#src-14">[14]</a></li>
+            </ol>
+            <p>In practice, for the physically backed ETCs from major providers like iShares, Invesco, and WisdomTree, tracking is extremely tight and the price difference from gold itself is negligible for everyday investors.</p>
+          </div>
+
+          <div class="gpc-callout gpc-callout--teal">
+            <svg class="gpc-callout__icon"><use href="#gpc-i-info"/></svg>
+            <div>
+              <span class="gpc-callout__t">Practical takeaway</span>
+              <p>For a £10,000 holding in SGLN, the daily fee drag is approximately <strong>£0.03</strong>. Over a full year, total tracking deviation against spot gold typically stays inside <strong>0.15%</strong> — effectively indistinguishable from owning the metal directly.</p>
+            </div>
+          </div>
+        </section>
+
+
+        <!-- ═══════════════ TAX PICTURE ═══════════════ -->
+        <section class="gpc-sec" id="tax">
+          <div class="gpc-sec__kick">The decisive factor</div>
+          <h2>Gold ETFs vs Physical Gold: The Tax Picture in 2026</h2>
+          <div class="gpc-prose">
+            <p>This is where the two approaches diverge most meaningfully for UK investors, and it is arguably the single most important factor in making a decision.</p>
+            <h3>Capital Gains Tax (CGT)</h3>
+            <p>For the 2026/27 tax year, the CGT annual exempt amount stands at just <strong>£3,000</strong> — down sharply from £12,300 in 2022/23. CGT rates are <strong>18% for basic rate taxpayers</strong> and <strong>24% for higher and additional rate taxpayers</strong> on investment gains.<a class="gpc-ref" href="#src-15">[15]</a></p>
+            <p><strong>Physical gold bars</strong> are fully subject to CGT when sold at a profit above the annual allowance. So are <strong>foreign bullion coins</strong> (Krugerrands, Maple Leafs, American Eagles) and most gold jewellery held as an investment.<a class="gpc-ref" href="#src-16">[16]</a></p>
+            <p><strong>Gold ETCs</strong> held outside a tax wrapper are also subject to CGT in the same way.<a class="gpc-ref" href="#src-17">[17]</a></p>
+          </div>
+
+          <!-- CGT Spotlight -->
+          <div class="gpc-tax gpc-reveal">
+            <div class="gpc-tax__icon"><svg width="26" height="26"><use href="#gpc-i-shield"/></svg></div>
+            <h3>The Britannia &amp; Sovereign exemption</h3>
+            <p class="gpc-tax__lead"><strong>UK legal tender gold coins — principally the Britannia and the Sovereign — are entirely exempt from CGT.</strong> Because these coins carry a sterling face value, HMRC cannot tax the movement of legal currency. This exemption has no annual cap — whether you make £5,000 or £500,000 in gains, there is no CGT liability on Britannias or Sovereigns sold by UK residents.<a class="gpc-ref" href="#src-18">[18]</a><a class="gpc-ref" href="#src-19">[19]</a><a class="gpc-ref" href="#src-20">[20]</a></p>
+            <p class="gpc-tax__lead" style="margin:0">Gold bars, ETCs, and all other coins do not share this exemption.</p>
+          </div>
+
+          <div class="gpc-prose">
+            <h3>VAT</h3>
+            <p>Investment gold in the UK is VAT-exempt, and this applies to both physical gold (bars and qualifying coins) and gold ETCs alike. Silver, by contrast, is subject to 20% VAT — an important distinction if you are considering a mixed precious metals strategy.<a class="gpc-ref" href="#src-21">[21]</a><a class="gpc-ref" href="#src-22">[22]</a></p>
+            <h3>The ISA and SIPP Advantage</h3>
+            <p>For most UK investors, the most powerful tool available is wrapping a gold ETC inside a <strong>Stocks and Shares ISA</strong> or a <strong>SIPP</strong>. Inside either wrapper, all gains and income are completely sheltered from CGT and income tax.<a class="gpc-ref" href="#src-23">[23]</a></p>
+            <p>For the 2026/27 tax year, the ISA allowance remains at <strong>£20,000</strong> and the SIPP annual allowance at <strong>£60,000</strong>. A basic rate taxpayer contributing to a SIPP receives 20% tax relief — meaning a £100 contribution effectively costs £80 — while a higher rate taxpayer can claim 40% relief.<a class="gpc-ref" href="#src-24">[24]</a><a class="gpc-ref" href="#src-25">[25]</a><a class="gpc-ref" href="#src-15">[15]</a></p>
+            <p>You cannot hold physical gold coins or bars inside an ISA or SIPP. This is a significant structural advantage for ETCs over physical gold for investors who are not buying UK legal tender coins.</p>
+          </div>
+
+          <div class="gpc-callout gpc-callout--emerald">
+            <svg class="gpc-callout__icon"><use href="#gpc-i-zap"/></svg>
+            <div>
+              <span class="gpc-callout__t">Worked example</span>
+              <p>If you invest <strong>£20,000</strong> in SGLN inside a Stocks and Shares ISA at the start of the tax year and the gold price doubles over five years, you pay <strong>zero CGT</strong> on the entire gain. The same investment held in a General Investment Account would leave you with a potentially large CGT bill.<a class="gpc-ref" href="#src-26">[26]</a><a class="gpc-ref" href="#src-23">[23]</a></p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ═══════════════ COSTS ═══════════════ -->
+        <section class="gpc-sec" id="costs">
+          <div class="gpc-sec__kick">Total cost of ownership</div>
+          <h2>Cost Comparison: What You Actually Pay</h2>
+
+          <div class="gpc-cost">
+            <div class="gpc-costcard gpc-costcard--etc gpc-reveal">
+              <div class="gpc-costcard__type">Gold ETC costs</div>
+              <div class="gpc-costcard__big">
+                <span class="gpc-costcard__big-v">0.27–0.84%</span>
+                <span class="gpc-costcard__big-l">total p.a. (£10k)</span>
+              </div>
+              <div class="gpc-costcard__lines">
+                <div class="gpc-costcard__line"><span class="gpc-costcard__line-l">Management fee (TER)</span><span class="gpc-costcard__line-v">0.12–0.39%</span></div>
+                <div class="gpc-costcard__line"><span class="gpc-costcard__line-l">Platform fee</span><span class="gpc-costcard__line-v">0.15–0.45%</span></div>
+                <div class="gpc-costcard__line"><span class="gpc-costcard__line-l">Trading commission</span><span class="gpc-costcard__line-v">£0–£10</span></div>
+                <div class="gpc-costcard__line"><span class="gpc-costcard__line-l">Storage / insurance</span><span class="gpc-costcard__line-v">Included</span></div>
+              </div>
+            </div>
+
+            <div class="gpc-costcard gpc-costcard--physical gpc-reveal">
+              <div class="gpc-costcard__type">Physical gold costs</div>
+              <div class="gpc-costcard__big">
+                <span class="gpc-costcard__big-v">2.5–7%+</span>
+                <span class="gpc-costcard__big-l">Year-1 effective</span>
+              </div>
+              <div class="gpc-costcard__lines">
+                <div class="gpc-costcard__line"><span class="gpc-costcard__line-l">Purchase premium (1oz Britannia)</span><span class="gpc-costcard__line-v">2–5%</span></div>
+                <div class="gpc-costcard__line"><span class="gpc-costcard__line-l">Vault storage</span><span class="gpc-costcard__line-v">£50–£200+ p.a.</span></div>
+                <div class="gpc-costcard__line"><span class="gpc-costcard__line-l">Home insurance</span><span class="gpc-costcard__line-v">1–2% p.a.</span></div>
+                <div class="gpc-costcard__line"><span class="gpc-costcard__line-l">Selling spread</span><span class="gpc-costcard__line-v">~1–2%</span></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="gpc-prose">
+            <h3>Gold ETC costs</h3>
+            <p>The total cost of holding a gold ETC typically includes the annual management fee (TER), platform fees (most ISA and SIPP platforms charge 0.15%–0.45% per year to hold ETFs/ETCs), and trading commissions (often zero on modern platforms, though some charge a flat fee per trade).<a class="gpc-ref" href="#src-13">[13]</a><a class="gpc-ref" href="#src-7">[7]</a><a class="gpc-ref" href="#src-5">[5]</a></p>
+            <p>For a £10,000 investment in SGLN, the annual management fee is just <strong>£12</strong> — genuinely minimal.</p>
+            <h3>Physical gold costs</h3>
+            <p>Physical gold carries a different set of costs. For popular items like the 1oz Britannia, premiums typically run 2–5% above spot.<a class="gpc-ref" href="#src-19">[19]</a> Home storage is free but risky; a bank safe deposit box or professional vault typically costs £50–£200+ per year; third-party insurance for gold stored at home generally runs 1–2% of the gold's value annually.<a class="gpc-ref" href="#src-27">[27]</a><a class="gpc-ref" href="#src-28">[28]</a> Dealers typically buy back at a small discount to spot.</p>
+            <p>For a £10,000 physical gold holding stored in a professional vault with insurance, you might realistically pay 0.5–2% per year in combined storage and insurance costs — comparable to or slightly above ETC fees for smaller holdings, but with different ownership characteristics.</p>
+          </div>
+
+          <div class="gpc-callout gpc-callout--gold">
+            <svg class="gpc-callout__icon"><use href="#gpc-i-info"/></svg>
+            <div>
+              <span class="gpc-callout__t">Often overlooked</span>
+              <p>Physically backed ETCs are also insured and stored by the fund. The difference is <strong>who bears those costs and who controls the gold</strong> — not whether they exist at all.</p>
+            </div>
+          </div>
+        </section>
+
+
+        <!-- ═══════════════ LIQUIDITY ═══════════════ -->
+        <section class="gpc-sec" id="liquidity">
+          <div class="gpc-sec__kick">Time to cash</div>
+          <h2>Liquidity: How Quickly Can You Access Your Money?</h2>
+          <div class="gpc-prose">
+            <p>This is a clear win for gold ETCs. You can sell SGLN, SGLP, or any of the major ETCs during London Stock Exchange hours and have the cash proceeds in your account within the standard T+2 settlement window — just like selling any share.<a class="gpc-ref" href="#src-29">[29]</a></p>
+            <p>Selling physical gold is more involved. You need to contact a bullion dealer, arrange for secure delivery or collection, wait for the price to be agreed, and wait for the funds to transfer. For large holdings, this can take days. In a genuine financial emergency, that delay matters.</p>
+            <p>That said, physical gold stored with providers like BullionVault or directly through the Royal Mint's vault service can be sold relatively quickly, though still not as instantaneously as clicking "sell" on a brokerage platform.</p>
+          </div>
+        </section>
+
+        <!-- ═══════════════ COUNTERPARTY RISK ═══════════════ -->
+        <section class="gpc-sec" id="counterparty">
+          <div class="gpc-sec__kick">Trust &amp; control</div>
+          <h2>Counterparty Risk: The Argument for Real Gold</h2>
+          <div class="gpc-prose">
+            <p>Here is where physical gold's advocates make their strongest case. Gold ETCs, despite being "physically backed," involve multiple layers of counterparty exposure:</p>
+            <ul>
+              <li>The ETF/ETC issuer (e.g., BlackRock, Invesco, WisdomTree)</li>
+              <li>The custodian bank holding the gold (e.g., JP Morgan Chase for SGLP)</li>
+              <li>Your brokerage or platform</li>
+              <li>The exchange settlement infrastructure</li>
+            </ul>
+            <p>If any of these parties were to fail in extreme circumstances, recovery could be complicated and time-consuming. The gold exists, but accessing it in a systemic crisis — the very scenario some gold investors are preparing for — is not straightforward.<a class="gpc-ref" href="#src-30">[30]</a><a class="gpc-ref" href="#src-3">[3]</a></p>
+            <p>Physical gold in your possession involves none of this. A gold Sovereign in a home safe is yours without qualification, regardless of what happens to any bank, broker, or fund.<a class="gpc-ref" href="#src-11">[11]</a></p>
+          </div>
+
+          <div class="gpc-callout gpc-callout--warn">
+            <svg class="gpc-callout__icon"><use href="#gpc-i-alert"/></svg>
+            <div>
+              <span class="gpc-callout__t">Why central banks are doing the same</span>
+              <p>This is not merely theoretical. It is the reason central banks globally have been steadily moving gold reserves back to domestic vaults and away from custodians in other countries. The same logic — at a retail level — leads some UK investors to maintain a portion of their gold in physical form even if they hold the majority via ETCs.</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ═══════════════ MINING ETFs ═══════════════ -->
+        <section class="gpc-sec" id="miners">
+          <div class="gpc-sec__kick">Leveraged exposure</div>
+          <h2>Gold Mining ETFs: A Different Proposition Entirely</h2>
+          <div class="gpc-prose">
+            <p>Beyond physically backed ETCs, UK investors can also access <strong>gold miners ETFs</strong> — funds that hold shares in companies that extract gold from the ground rather than the metal itself.</p>
+            <p>The leading option for UK investors is the <strong>VanEck Gold Miners UCITS ETF (GDGB)</strong>, which tracks major miners including Newmont, Agnico Eagle, and Barrick Mining, and carries a TER of 0.53% and over £2.6 billion in assets. The iShares Gold Producers ETF follows a similar approach.<a class="gpc-ref" href="#src-31">[31]</a></p>
+            <p>These are fundamentally different investments from a physical gold ETC. Their performance in 2025 illustrates this vividly: gold mining ETFs returned approximately <strong>96–110%</strong> while physical gold ETCs returned around <strong>30%</strong> in sterling terms. The amplification works in both directions — miners fell much harder than gold in down years like 2023.<a class="gpc-ref" href="#src-32">[32]</a></p>
+            <p>The reason for this disparity is that mining companies have operating leverage. When the gold price rises, revenue rises while fixed costs remain broadly stable, making profitability expand at a higher rate than gold itself. They also carry risks entirely absent from owning gold: operational risk, geopolitical risk in mining jurisdictions, management decisions, environmental liabilities, and currency exposure from mining in multiple countries.</p>
+            <p>Mining ETFs are appropriate for investors who want leveraged exposure to the gold price and are comfortable with equity-level volatility. They also offer potential dividend income, which physical gold and ETCs do not. For pure gold price exposure and portfolio diversification, physically backed ETCs remain the cleaner choice.<a class="gpc-ref" href="#src-32">[32]</a></p>
+          </div>
+
+          <div class="gpc-callout gpc-callout--teal">
+            <svg class="gpc-callout__icon"><use href="#gpc-i-trending"/></svg>
+            <div>
+              <span class="gpc-callout__t">2025 performance gap</span>
+              <p>Gold miners returned <strong>96–110%</strong> in 2025 against <strong>~30%</strong> for physical gold ETCs in GBP terms. The same leverage works in reverse in down years — miners are <em>not</em> a substitute for a core gold allocation, they're an amplified satellite position.</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ═══════════════ LEVERAGED / INVERSE ═══════════════ -->
+        <section class="gpc-sec" id="leveraged">
+          <div class="gpc-sec__kick">Specialist instruments</div>
+          <h2>Leveraged and Inverse Gold ETFs: Specialist Tools Only</h2>
+          <div class="gpc-prose">
+            <p>Completeness requires a mention of <strong>leveraged gold ETFs</strong> (such as the WisdomTree Gold 2x Daily Leveraged ETC, LBUL, with a TER of 0.98%) and <strong>inverse gold ETFs</strong> — products designed to deliver a multiple of gold's daily return, or to profit when gold falls.<a class="gpc-ref" href="#src-33">[33]</a></p>
+            <p>These are sophisticated instruments built for short-term trading, not long-term investment. An inverse gold ETC profits when gold falls; a 2x leveraged ETC attempts to deliver twice gold's daily return. Both use derivatives rather than physical gold.<a class="gpc-ref" href="#src-34">[34]</a><a class="gpc-ref" href="#src-33">[33]</a></p>
+          </div>
+
+          <div class="gpc-callout gpc-callout--alert">
+            <svg class="gpc-callout__icon"><use href="#gpc-i-alert"/></svg>
+            <div>
+              <span class="gpc-callout__t">The daily reset trap</span>
+              <p>Because leveraged and inverse products rebalance <strong>daily</strong>, the compounding effect in volatile markets means their actual returns over weeks or months can diverge significantly from the multiple of gold's return over that period — and not in your favour. <strong>These products are not suitable for long-term investors</strong> and carry significantly higher risk than either physical gold or standard ETCs.<a class="gpc-ref" href="#src-34">[34]</a></p>
+            </div>
+          </div>
+        </section>
+
+
+        <!-- ═══════════════ PRICE IN 2026 ═══════════════ -->
+        <section class="gpc-sec" id="price-2026">
+          <div class="gpc-sec__kick">Macro backdrop</div>
+          <h2>What the Gold Price Is Doing in 2026</h2>
+          <div class="gpc-prose">
+            <p>No guide for UK investors in 2026 would be complete without acknowledging the macro backdrop. Gold has been one of the strongest performing assets of the past two years. Spot gold crossed $5,100 per ounce in January 2026, with the rally driven by a combination of central bank buying, geopolitical uncertainty, a weaker US dollar, and record ETF inflows.<a class="gpc-ref" href="#src-1">[1]</a></p>
+          </div>
+
+          <div class="gpc-prices">
+            <div class="gpc-pricecard gpc-pricecard--ath gpc-reveal">
+              <div class="gpc-pricecard__l">Gold Spot (Jan 2026)</div>
+              <div class="gpc-pricecard__v">$5,100+</div>
+              <p class="gpc-pricecard__d">Per troy ounce — a new all-time high amid record central bank demand.</p>
+            </div>
+            <div class="gpc-pricecard gpc-pricecard--target gpc-reveal">
+              <div class="gpc-pricecard__l">JPM Forecast EOY 2026</div>
+              <div class="gpc-pricecard__v">$5,000–6,300</div>
+              <p class="gpc-pricecard__d">Base case $5,000–5,400; bull scenario $6,000–6,300 per oz.<a class="gpc-ref" href="#src-1">[1]</a></p>
+            </div>
+            <div class="gpc-pricecard gpc-pricecard--gbp gpc-reveal">
+              <div class="gpc-pricecard__l">PHAU YTD (GBP, mid-2025)</div>
+              <div class="gpc-pricecard__v gpc-up">+28.51%</div>
+              <p class="gpc-pricecard__d">Sterling weakness amplified the dollar-denominated gold gain.<a class="gpc-ref" href="#src-7">[7]</a></p>
+            </div>
+          </div>
+
+          <div class="gpc-prose">
+            <p>Global gold ETF assets under management doubled to an all-time high of <strong>$559 billion</strong> in 2025, with physical holdings reaching <strong>4,025 tonnes</strong>. J.P. Morgan Research forecasts gold could push toward $5,000–$5,400 per ounce by the end of 2026 and potentially $6,000–$6,300 in a bull scenario.<a class="gpc-ref" href="#src-35">[35]</a><a class="gpc-ref" href="#src-36">[36]</a><a class="gpc-ref" href="#src-1">[1]</a></p>
+            <p>In sterling terms, this has been even more pronounced for UK investors, since a weak pound has amplified dollar-denominated gold gains. The WisdomTree Physical Gold ETC showed a year-to-date return of 28.51% in GBP terms as of mid-2025.<a class="gpc-ref" href="#src-7">[7]</a></p>
+            <p>Whether this rally continues depends on factors including Federal Reserve policy, the direction of the US dollar, geopolitical developments, and whether central bank demand — running at roughly 585 tonnes per quarter — is sustained.<a class="gpc-ref" href="#src-35">[35]</a></p>
+          </div>
+        </section>
+
+        <!-- ═══════════════ ALLOCATION ═══════════════ -->
+        <section class="gpc-sec" id="allocation">
+          <div class="gpc-sec__kick">Portfolio sizing</div>
+          <h2>Gold Allocation: How Much Should You Hold?</h2>
+          <div class="gpc-prose">
+            <p>Whether you choose ETCs, physical gold, or a combination, the question of how much gold to hold is equally important.</p>
+            <p>Most financial advisors and institutional analysts recommend <strong>5% to 15% of a portfolio in gold</strong>, with 10% serving as a widely cited benchmark. World Gold Council research shows that a 5–10% gold allocation historically improved Sharpe ratios — meaning better risk-adjusted returns — compared to portfolios with no gold exposure.<a class="gpc-ref" href="#src-37">[37]</a></p>
+          </div>
+
+          <div class="gpc-alloc">
+            <div class="gpc-allocard gpc-allocard--conservative gpc-reveal">
+              <div class="gpc-allocard__age">55+ · Capital preservation</div>
+              <div class="gpc-allocard__title">Conservative</div>
+              <div class="gpc-allocard__big">5–10%</div>
+              <p class="gpc-allocard__desc">Predominantly physical or ISA-wrapped ETCs. Stability over leverage.</p>
+            </div>
+            <div class="gpc-allocard gpc-allocard--balanced gpc-reveal">
+              <div class="gpc-allocard__age">35–55 · Moderate risk</div>
+              <div class="gpc-allocard__title">Balanced</div>
+              <div class="gpc-allocard__big">7–12%</div>
+              <p class="gpc-allocard__desc">Core ETC inside ISA, topped up with CGT-exempt coins as size grows.</p>
+            </div>
+            <div class="gpc-allocard gpc-allocard--growth gpc-reveal">
+              <div class="gpc-allocard__age">Under 35 · Growth focus</div>
+              <div class="gpc-allocard__title">Growth</div>
+              <div class="gpc-allocard__big">10–15%</div>
+              <p class="gpc-allocard__desc">Physical ETC core with a satellite gold miners ETF for amplified upside.<a class="gpc-ref" href="#src-38">[38]</a></p>
+            </div>
+          </div>
+
+          <div class="gpc-prose">
+            <p>Most experienced investors settle on a blend — holding a core physical position for genuine crisis protection and ISA-wrapped ETCs for liquidity, cost efficiency, and tax-free growth.</p>
+          </div>
+        </section>
+
+        <!-- ═══════════════ HEAD TO HEAD ═══════════════ -->
+        <section class="gpc-sec" id="head-to-head">
+          <div class="gpc-sec__kick">At a glance</div>
+          <h2>Head-to-Head: Gold ETF vs Physical Gold</h2>
+          <div class="gpc-prose">
+            <p>Every factor that matters to a UK investor in 2026 — compared across the three meaningful routes to gold ownership.</p>
+          </div>
+
+          <div class="gpc-tablewrap">
+            <div class="gpc-tablescroll">
+              <table class="gpc-table" aria-label="Gold ETF vs physical gold UK comparison 2026">
+                <thead>
+                  <tr>
+                    <th scope="col">Factor</th>
+                    <th scope="col" class="gpc-th-etc">Gold ETC (SGLN, SGLP&nbsp;etc.)</th>
+                    <th scope="col" class="gpc-th-bars">Physical Gold (Bars)</th>
+                    <th scope="col" class="gpc-th-coins">UK Legal Tender Coins</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Ownership</td>
+                    <td>Financial instrument (debt security)</td>
+                    <td>Direct ownership</td>
+                    <td>Direct ownership</td>
+                  </tr>
+                  <tr>
+                    <td>VAT</td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">None</span></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">None</span></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">None<a class="gpc-ref" href="#src-21">[21]</a></span></td>
+                  </tr>
+                  <tr>
+                    <td>Capital Gains Tax</td>
+                    <td>Yes (outside ISA/SIPP)</td>
+                    <td>Yes<a class="gpc-ref" href="#src-16">[16]</a></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--gold">Fully exempt<a class="gpc-ref" href="#src-18">[18]</a><a class="gpc-ref" href="#src-20">[20]</a></span></td>
+                  </tr>
+                  <tr>
+                    <td>ISA eligible</td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">Yes<a class="gpc-ref" href="#src-23">[23]</a></span></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--no">No</span></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--no">No</span></td>
+                  </tr>
+                  <tr>
+                    <td>SIPP eligible</td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">Yes</span></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--no">No</span></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--no">No</span></td>
+                  </tr>
+                  <tr>
+                    <td>Annual cost</td>
+                    <td>0.12–0.39% TER<a class="gpc-ref" href="#src-13">[13]</a><a class="gpc-ref" href="#src-5">[5]</a></td>
+                    <td>Storage/insurance ~0.5–2%<a class="gpc-ref" href="#src-27">[27]</a></td>
+                    <td>Storage/insurance ~0.5–2%</td>
+                  </tr>
+                  <tr>
+                    <td>Liquidity</td>
+                    <td>Very high (exchange hours)<a class="gpc-ref" href="#src-29">[29]</a></td>
+                    <td>Moderate</td>
+                    <td>Moderate to high</td>
+                  </tr>
+                  <tr>
+                    <td>Counterparty risk</td>
+                    <td>Present (issuer, custodian)<a class="gpc-ref" href="#src-30">[30]</a></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">None</span></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">None</span></td>
+                  </tr>
+                  <tr>
+                    <td>Minimum investment</td>
+                    <td>Any amount (fractional)</td>
+                    <td>~£50+ for small bars</td>
+                    <td>~£400+ for 1/10oz Sovereign</td>
+                  </tr>
+                  <tr>
+                    <td>Tracking gold price</td>
+                    <td>Extremely close</td>
+                    <td>Exact</td>
+                    <td>Exact</td>
+                  </tr>
+                  <tr>
+                    <td>Inflation hedge</td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">Yes</span></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">Yes</span></td>
+                    <td><span class="gpc-cell-pill gpc-cell-pill--yes">Yes</span></td>
+                  </tr>
+                  <tr>
+                    <td>Crisis insurance</td>
+                    <td>Partial (paper claim)</td>
+                    <td>Strong (physical ownership)</td>
+                    <td>Strong (physical ownership)</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="gpc-scrollhint">← Scroll horizontally to compare →</div>
+          </div>
+        </section>
+
+
+        <!-- ═══════════════ WHO SHOULD CHOOSE WHAT ═══════════════ -->
+        <section class="gpc-sec" id="who-should">
+          <div class="gpc-sec__kick">The decision framework</div>
+          <h2>Who Should Choose What in 2026?</h2>
+
+          <div class="gpc-decision">
+            <div class="gpc-dcard gpc-dcard--etc gpc-reveal">
+              <div class="gpc-dcard__pic"><svg width="26" height="26"><use href="#gpc-i-chart"/></svg></div>
+              <div class="gpc-dcard__t"><span>Choose if</span>Physically backed gold ETC (SGLN, SGLP, RMAU)</div>
+              <ul>
+                <li>You want the <strong>cheapest, most convenient</strong> route to gold price exposure</li>
+                <li>You plan to hold inside an <strong>ISA or SIPP</strong> for tax-free growth</li>
+                <li>You are investing smaller amounts where physical storage costs would be proportionally high</li>
+                <li>You value simplicity and the ability to <strong>sell instantly</strong></li>
+              </ul>
+            </div>
+
+            <div class="gpc-dcard gpc-dcard--bars gpc-reveal">
+              <div class="gpc-dcard__pic"><svg width="26" height="26"><use href="#gpc-i-bar"/></svg></div>
+              <div class="gpc-dcard__t"><span>Choose if</span>Physical gold bars</div>
+              <ul>
+                <li>You are investing <strong>large sums</strong> where the CGT-free coin exemption is not sufficient</li>
+                <li>You want to hold gold <strong>outside the banking system</strong> entirely</li>
+                <li>You are thinking in <strong>decades, not years</strong> — true wealth preservation</li>
+                <li>You are comfortable with storage and insurance arrangements</li>
+              </ul>
+            </div>
+
+            <div class="gpc-dcard gpc-dcard--coins gpc-reveal">
+              <div class="gpc-dcard__pic"><svg width="26" height="26"><use href="#gpc-i-coin"/></svg></div>
+              <div class="gpc-dcard__t"><span>Choose if</span>UK legal tender coins (Britannia / Sovereign)</div>
+              <ul>
+                <li>You want the <strong>best of both worlds</strong> — physical ownership + complete CGT exemption</li>
+                <li>You are a larger investor for whom avoiding CGT outweighs the purchase premium</li>
+                <li>You want the option to access your gold <strong>physically in any scenario</strong></li>
+              </ul>
+            </div>
+
+            <div class="gpc-dcard gpc-dcard--miners gpc-reveal">
+              <div class="gpc-dcard__pic"><svg width="26" height="26"><use href="#gpc-i-trending"/></svg></div>
+              <div class="gpc-dcard__t"><span>Choose if</span>Gold miners ETF (GDGB)</div>
+              <ul>
+                <li>You want <strong>amplified exposure</strong> to a rising gold price</li>
+                <li>You are comfortable with <strong>equity-level volatility</strong> and want dividend income</li>
+                <li>Gold forms part of a broader, actively managed equities sleeve rather than a pure hedge</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="gpc-callout gpc-callout--gold">
+            <svg class="gpc-callout__icon"><use href="#gpc-i-target"/></svg>
+            <div>
+              <span class="gpc-callout__t">The practical answer for most investors</span>
+              <p>For most UK investors in 2026, the practical answer is <strong>a combination</strong>: a core position in a physically backed ETC inside an ISA (for cost efficiency and tax freedom), topped up over time with CGT-exempt Britannias or Sovereigns for those who want genuine physical ownership that no counterparty can ever compromise.</p>
+            </div>
+          </div>
+        </section>
+
+        <!-- ═══════════════ NEXT STEPS ═══════════════ -->
+        <section class="gpc-sec" id="next-steps">
+          <div class="gpc-sec__kick">From plan to action</div>
+          <h2>Practical Next Steps for UK Investors</h2>
+          <div class="gpc-prose">
+            <p>Getting started is straightforward:</p>
+          </div>
+
+          <div class="gpc-steps">
+            <div class="gpc-step gpc-reveal">
+              <div class="gpc-step__num" aria-hidden="true"></div>
+              <div class="gpc-step__body">
+                <h3 class="gpc-step__t">For gold ETCs</h3>
+                <p class="gpc-step__d">Open or use a <strong>Stocks and Shares ISA</strong> with any major UK platform (Hargreaves Lansdown, AJ Bell, Interactive Investor, InvestEngine, Vanguard). Search for <strong>SGLN</strong>, <strong>SGLP</strong>, or <strong>RMAU</strong>. You can invest from as little as £1 on some platforms.</p>
+              </div>
+            </div>
+            <div class="gpc-step gpc-reveal">
+              <div class="gpc-step__num" aria-hidden="true"></div>
+              <div class="gpc-step__body">
+                <h3 class="gpc-step__t">For physical gold</h3>
+                <p class="gpc-step__d">The <strong>Royal Mint</strong> is the most trusted source for UK investors, offering both coins and bars with secure vault storage options. <a href="/blog/best-uk-gold-dealers-2026">BullionByPost and Sharps Pixley</a> are reputable alternatives.<a class="gpc-ref" href="#src-39">[39]</a></p>
+              </div>
+            </div>
+            <div class="gpc-step gpc-reveal">
+              <div class="gpc-step__num" aria-hidden="true"></div>
+              <div class="gpc-step__body">
+                <h3 class="gpc-step__t">Tax planning</h3>
+                <p class="gpc-step__d">If you are a higher-rate taxpayer with significant gold holdings outside a wrapper, consider the <strong>"bed and ISA"</strong> strategy — selling holdings to crystallise gains within your annual CGT allowance and repurchasing inside an ISA each tax year.<a class="gpc-ref" href="#src-15">[15]</a></p>
+              </div>
+            </div>
+            <div class="gpc-step gpc-reveal">
+              <div class="gpc-step__num" aria-hidden="true"></div>
+              <div class="gpc-step__body">
+                <h3 class="gpc-step__t">Portfolio sizing</h3>
+                <p class="gpc-step__d">Start with a target allocation of <strong>5–10%</strong> of your total investable assets. Build the position gradually rather than all at once, particularly given gold's strong run in 2025–2026.<a class="gpc-ref" href="#src-37">[37]</a></p>
+              </div>
+            </div>
+          </div>
+
+          <!-- CTA -->
+          <div class="gpc-cta gpc-reveal">
+            <div class="gpc-cta__icon"><svg width="26" height="26"><use href="#gpc-i-pound"/></svg></div>
+            <h3>See live gold prices in GBP, USD &amp; per gram</h3>
+            <p>Before you buy a single ETC unit or coin, check the live spot price. GoldPriceTools updates every 60 seconds from LBMA data — across every karat, ounce, gram and kilo measurement.</p>
+            <a href="/" class="gpc-ctabtn">Open live calculator <svg><use href="#gpc-i-arrow"/></svg></a>
+          </div>
+        </section>
+
+
+        <!-- ═══════════════ FAQ ═══════════════ -->
+        <section class="gpc-sec" id="faq">
+          <div class="gpc-sec__kick">Common questions</div>
+          <h2>Frequently Asked Questions</h2>
+
+          <div class="gpc-faq">
+            <details class="gpc-faqitem gpc-reveal">
+              <summary>What is a gold ETF in the UK?<svg class="gpc-faqic"><use href="#gpc-i-plus"/></svg></summary>
+              <div class="gpc-faqitem__a">
+                <p>In the UK, what investors call a "gold ETF" is technically an <strong>Exchange Traded Commodity (ETC)</strong>. UCITS rules prevent a fund from holding a single asset, so pure gold products are structured as debt securities collateralised by physical gold bars in London vaults. They trade on the LSE like ordinary shares. Major UK options include iShares SGLN, Invesco SGLP, WisdomTree PHAU and Royal Mint RMAU.</p>
+              </div>
+            </details>
+
+            <details class="gpc-faqitem gpc-reveal">
+              <summary>Is physical gold or a gold ETF better for UK investors in 2026?<svg class="gpc-faqic"><use href="#gpc-i-plus"/></svg></summary>
+              <div class="gpc-faqitem__a">
+                <p>It depends on the size and purpose of your allocation. For most UK investors, a physically backed ETC like <strong>SGLN inside a Stocks &amp; Shares ISA</strong> is the cheapest, most tax-efficient and most liquid option. Larger investors who want true wealth preservation and unlimited CGT exemption often combine ETCs with Royal Mint <strong>Britannias or Sovereigns</strong>, which are legal tender and entirely CGT-free.</p>
+              </div>
+            </details>
+
+            <details class="gpc-faqitem gpc-reveal">
+              <summary>Can I hold gold ETCs in an ISA or SIPP?<svg class="gpc-faqic"><use href="#gpc-i-plus"/></svg></summary>
+              <div class="gpc-faqitem__a">
+                <p>Yes. Physically backed gold ETCs such as SGLN, SGLP, PHAU and RMAU are eligible for both <strong>Stocks &amp; Shares ISAs and SIPPs</strong>. Inside either wrapper, all gains are sheltered from CGT and income tax. The 2026/27 ISA allowance is £20,000 and the SIPP annual allowance is £60,000. Physical gold coins and bars cannot be held in an ISA or SIPP directly.</p>
+              </div>
+            </details>
+
+            <details class="gpc-faqitem gpc-reveal">
+              <summary>Are Britannia and Sovereign coins really CGT exempt?<svg class="gpc-faqic"><use href="#gpc-i-plus"/></svg></summary>
+              <div class="gpc-faqitem__a">
+                <p>Yes. Britannias and Sovereigns are UK legal tender, so any capital gains on them are <strong>entirely exempt from CGT</strong> for UK residents — with no upper limit. This is unique to UK legal tender coins; foreign coins such as Krugerrands, Maple Leafs and American Eagles are not exempt, and gold bars and ETCs held outside an ISA/SIPP are also subject to CGT.</p>
+              </div>
+            </details>
+
+            <details class="gpc-faqitem gpc-reveal">
+              <summary>What is the TER of the cheapest UK gold ETC?<svg class="gpc-faqic"><use href="#gpc-i-plus"/></svg></summary>
+              <div class="gpc-faqitem__a">
+                <p>The two cheapest physically backed gold ETCs on the London Stock Exchange in 2026 are <strong>iShares Physical Gold ETC (SGLN)</strong> and <strong>Invesco Physical Gold ETC (SGLP)</strong>, both with a Total Expense Ratio of <strong>0.12% per year</strong>. WisdomTree PHAU charges 0.39% and Royal Mint RMAU charges 0.22%.</p>
+              </div>
+            </details>
+
+            <details class="gpc-faqitem gpc-reveal">
+              <summary>How much gold should a UK investor hold?<svg class="gpc-faqic"><use href="#gpc-i-plus"/></svg></summary>
+              <div class="gpc-faqitem__a">
+                <p>Most financial advisers and the World Gold Council suggest <strong>5–15% of a portfolio in gold</strong>, with 10% widely cited as a benchmark. A 5–10% allocation has historically improved Sharpe ratios versus portfolios with zero gold. Conservative investors typically lean to 5–10%, balanced investors 7–12%, and growth investors can incorporate some gold miners ETF exposure on top of physical and ETC core positions.</p>
+              </div>
+            </details>
+
+            <details class="gpc-faqitem gpc-reveal">
+              <summary>Do gold ETFs have counterparty risk?<svg class="gpc-faqic"><use href="#gpc-i-plus"/></svg></summary>
+              <div class="gpc-faqitem__a">
+                <p>Yes — even physically backed gold ETCs involve multiple layers of counterparty exposure: the <strong>issuer</strong>, the <strong>custodian bank</strong> holding the gold, the <strong>brokerage</strong>, and <strong>exchange settlement</strong>. In normal markets these risks are very low and the underlying gold is segregated. In a systemic crisis, however, accessing the metal can be complicated, which is why some UK investors hold a portion of their gold in physical Britannias or Sovereigns at home or in a vault outside the banking system.</p>
+              </div>
+            </details>
+
+            <details class="gpc-faqitem gpc-reveal">
+              <summary>What is the difference between a gold miners ETF and a physical gold ETC?<svg class="gpc-faqic"><use href="#gpc-i-plus"/></svg></summary>
+              <div class="gpc-faqitem__a">
+                <p>A physical gold ETC tracks the spot price of gold itself, while a gold miners ETF (such as VanEck GDGB) holds shares in companies that mine gold. Miners offer operating leverage to the gold price — in 2025 gold miners ETFs returned <strong>96–110%</strong> while physical gold returned around <strong>30%</strong> in GBP terms — but they also carry equity-level volatility, operational risk and geopolitical risk that pure gold does not.</p>
+              </div>
+            </details>
+          </div>
+        </section>
+
+        <!-- ═══════════════ SOURCES ═══════════════ -->
+        <div class="gpc-sources">
+          <h3>Sources &amp; references</h3>
+          <ol>
+            <li id="src-1">J.P. Morgan Research — Gold price outlook 2026; gold spot price data, January 2026.</li>
+            <li id="src-2">UCITS Directive — single-asset fund restrictions and UK ETC structure rules.</li>
+            <li id="src-3">London Stock Exchange — physically backed ETCs trading mechanism and management fee mechanics.</li>
+            <li id="src-4">iShares — <a href="https://www.ishares.com/uk/individual/en/products/258441/" rel="nofollow noopener">Physical Gold ETC (SGLN)</a> factsheet, AUM and TER, 2026.</li>
+            <li id="src-5">Invesco — <a href="https://etf.invesco.com/gb/private/en/product/invesco-physical-gold-etc" rel="nofollow noopener">Physical Gold ETC (SGLP)</a> factsheet, AUM and TER, 2026.</li>
+            <li id="src-6">London PM fixing — daily gold price benchmark methodology (LBMA).</li>
+            <li id="src-7">WisdomTree — <a href="https://www.wisdomtree.eu/en-gb/etfs/commodities/wisdomtree-physical-gold" rel="nofollow noopener">Physical Gold ETC (PHAU/PHGP)</a> factsheet, GBP YTD returns mid-2025.</li>
+            <li id="src-8">HANetf / Royal Mint — Royal Mint Responsibly Sourced Physical Gold ETC (RMAU) factsheet, 2026.</li>
+            <li id="src-9">Royal Mint — Llantrisant vault custody overview.</li>
+            <li id="src-10"><a href="https://www.royalmint.com/invest/" rel="nofollow noopener">Royal Mint</a>, BullionByPost, Sharps Pixley, Tavex — UK retail bullion dealer ranges.</li>
+            <li id="src-11">World Gold Council — Direct ownership and counterparty risk principles.</li>
+            <li id="src-12">Bank of England — Counterparty exposure in custodial bullion arrangements.</li>
+            <li id="src-13">iShares SGLN factsheet — bid-ask spread and tracking data, 2026.</li>
+            <li id="src-14">FCA — UCITS tracking error disclosure requirements.</li>
+            <li id="src-15">HMRC — Capital Gains Tax rates, allowances and "bed and ISA" guidance, 2026/27 tax year.</li>
+            <li id="src-16">HMRC CG78305 — CGT treatment of gold bars and foreign bullion coins.</li>
+            <li id="src-17">HMRC — CGT treatment of exchange-traded commodities held outside ISA/SIPP.</li>
+            <li id="src-18">HMRC CG78308 — UK legal tender coins, capital gains tax exemption.</li>
+            <li id="src-19">Royal Mint Britannia — coin specifications, premium guidance and CGT treatment.</li>
+            <li id="src-20">HMRC — Britannia and Sovereign capital gains exemption (no upper limit).</li>
+            <li id="src-21">HMRC Notice 701/21A — Investment gold VAT exemption.</li>
+            <li id="src-22">HMRC — VAT treatment of silver bullion (20% standard rate).</li>
+            <li id="src-23">HMRC ISA Manual — Stocks &amp; Shares ISA eligible investments, including ETCs.</li>
+            <li id="src-24">HMRC ISA Allowance 2026/27 — £20,000 annual subscription limit.</li>
+            <li id="src-25">HMRC — SIPP annual allowance £60,000 and tax relief structure 2026/27.</li>
+            <li id="src-26">GoldPriceTools — ISA-wrapped ETC compounding worked example.</li>
+            <li id="src-27">UK vault providers (Royal Mint, BullionVault, Brink's) — storage and insurance fee schedules.</li>
+            <li id="src-28">Specialist home insurance providers — typical premium rates for stored gold.</li>
+            <li id="src-29">London Stock Exchange — T+2 settlement window for ETC trades.</li>
+            <li id="src-30">FCA — Counterparty risk disclosure for physically backed ETCs.</li>
+            <li id="src-31">VanEck — <a href="https://www.vaneck.com/ucits/etf/equity/gdgb/" rel="nofollow noopener">Gold Miners UCITS ETF (GDGB)</a> factsheet, holdings and TER 2026.</li>
+            <li id="src-32">Performance data — gold miners ETFs vs physical gold ETCs GBP returns 2023–2025.</li>
+            <li id="src-33">WisdomTree Gold 2x Daily Leveraged ETC (LBUL) — factsheet and TER.</li>
+            <li id="src-34">FCA / WisdomTree — Daily reset mechanism and compounding risk for leveraged ETPs.</li>
+            <li id="src-35">World Gold Council — Q4 2025 Gold Demand Trends, central bank purchases ~585 tonnes/quarter.</li>
+            <li id="src-36">World Gold Council — Global gold ETF AUM and physical holdings 2025.</li>
+            <li id="src-37">World Gold Council — Strategic portfolio research; 5–10% allocation Sharpe ratio improvement.</li>
+            <li id="src-38">GoldPriceTools — Investor-profile-based allocation framework.</li>
+            <li id="src-39">GoldPriceTools — <a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers 2026</a> editorial review.</li>
+          </ol>
+        </div>
+
+        <div class="gpc-disclaimer">
+          <strong>Disclaimer.</strong> The information in this article is for educational purposes and does not constitute financial advice. Gold investments can fall as well as rise in value. UK tax rules may change. Tax treatment is based on HMRC rules current as of June 2026 and may change. Consult a qualified financial adviser before making investment decisions.
+        </div>
+
+      </div><!-- /gpc-main -->
+    </div><!-- /gpc-layout -->
+  </div><!-- /gpc-shell -->
+
+  <!-- ═══════════════ RELATED ═══════════════ -->
+  <section class="gpc-related">
+    <div class="gpc-related-inner">
+      <h2>Related articles &amp; guides</h2>
+      <div class="gpc-related-grid">
+        <a href="/blog/uk-gold-cgt-guide" class="gpc-rcard">
+          <div class="gpc-rcard__tag">Article</div>
+          <div class="gpc-rcard__title">UK Gold CGT Guide</div>
+          <div class="gpc-rcard__desc">Which gold coins are CGT-exempt, how HMRC taxes bars and ETFs, and the £3,000 annual allowance explained.</div>
+        </a>
+        <a href="/blog/gold-in-a-sipp-uk" class="gpc-rcard">
+          <div class="gpc-rcard__tag">Article</div>
+          <div class="gpc-rcard__title">Gold in a SIPP UK</div>
+          <div class="gpc-rcard__desc">Can you hold gold ETFs or physical gold in your pension? What the HMRC rules say.</div>
+        </a>
+        <a href="/blog/best-uk-gold-dealers-2026" class="gpc-rcard">
+          <div class="gpc-rcard__tag">Editorial</div>
+          <div class="gpc-rcard__title">Best UK Gold Dealers 2026</div>
+          <div class="gpc-rcard__desc">Nine of Britain's most trusted bullion dealers ranked on premium, service and BNTA status.</div>
+        </a>
+        <a href="/guides/how-to-invest-in-gold" class="gpc-rcard">
+          <div class="gpc-rcard__tag">Guide</div>
+          <div class="gpc-rcard__title">How to Invest in Gold UK</div>
+          <div class="gpc-rcard__desc">A beginner's framework — ETFs, bullion, coins, SIPPs, ISAs — every route to gold in the UK.</div>
+        </a>
+        <a href="/blog/is-gold-overpriced-2026" class="gpc-rcard">
+          <div class="gpc-rcard__tag">Analysis</div>
+          <div class="gpc-rcard__title">Is Gold Overpriced in 2026?</div>
+          <div class="gpc-rcard__desc">Spot, ATH and 2026 forecasts — what the data says about whether gold is too expensive.</div>
+        </a>
+        <a href="/24k-gold-price-per-gram" class="gpc-rcard">
+          <div class="gpc-rcard__tag">Live Tool</div>
+          <div class="gpc-rcard__title">Live Gold Price Per Gram</div>
+          <div class="gpc-rcard__desc">Track today's spot gold in GBP, USD and EUR per gram, ounce, and kilo. Updates every 60 seconds.</div>
+        </a>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
 </article>
+
+
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">
@@ -662,7 +1674,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -736,5 +1747,80 @@ async function loadTicker(){
   }catch(e){}
 }
 loadTicker();setInterval(loadTicker,60000);
+</script>
+<script>
+/* Gold ETFs vs Physical Gold — interactivity */
+(function(){
+  document.documentElement.classList.add('gpc-js');
+  var bar=document.getElementById('gpc-progress');
+  var article=document.querySelector('.gpc-article');
+  function prog(){
+    if(!bar||!article)return;
+    var rect=article.getBoundingClientRect();
+    var total=article.offsetHeight-window.innerHeight;
+    var passed=Math.min(Math.max(-rect.top,0),total>0?total:0);
+    bar.style.width=(total>0?(passed/total)*100:0)+'%';
+  }
+  window.addEventListener('scroll',prog,{passive:true});
+  window.addEventListener('resize',prog,{passive:true});
+  prog();
+
+  /* Reveal on scroll */
+  var anims=document.querySelectorAll('.gpc-reveal');
+  if('IntersectionObserver' in window){
+    var io=new IntersectionObserver(function(es){
+      es.forEach(function(e){if(e.isIntersecting){e.target.classList.add('is-in');io.unobserve(e.target);}});
+    },{rootMargin:'0px 0px -8% 0px',threshold:0.08});
+    anims.forEach(function(el){io.observe(el);});
+  }else{anims.forEach(function(el){el.classList.add('is-in');});}
+
+  /* TOC active state */
+  var links=[].slice.call(document.querySelectorAll('.gpc-toc a'));
+  var map={},secs=[];
+  links.forEach(function(a){var id=a.getAttribute('href').slice(1);var s=document.getElementById(id);if(s){map[id]=a;secs.push(s);}});
+  if('IntersectionObserver' in window && secs.length){
+    var cur=null;
+    var so=new IntersectionObserver(function(es){
+      es.forEach(function(e){
+        if(e.isIntersecting){
+          if(cur)cur.classList.remove('is-active');
+          cur=map[e.target.id];
+          if(cur)cur.classList.add('is-active');
+        }
+      });
+    },{rootMargin:'-20% 0px -70% 0px',threshold:0});
+    secs.forEach(function(s){so.observe(s);});
+  }
+
+  /* Mobile menu toggle */
+  var ham=document.getElementById('hamburger');
+  var menu=document.getElementById('mobileMenu');
+  if(ham&&menu){
+    ham.addEventListener('click',function(){
+      var open=menu.classList.toggle('open');
+      ham.setAttribute('aria-expanded',open?'true':'false');
+    });
+  }
+  var msToggles=document.querySelectorAll('.mobile-section__toggle');
+  msToggles.forEach(function(t){
+    t.addEventListener('click',function(){
+      var panel=t.nextElementSibling;
+      var open=panel.classList.toggle('open');
+      t.setAttribute('aria-expanded',open?'true':'false');
+    });
+  });
+
+  /* Theme toggle */
+  var tt=document.querySelector('[data-theme-toggle]');
+  if(tt){
+    tt.addEventListener('click',function(){
+      var root=document.documentElement;
+      var cur=root.getAttribute('data-theme');
+      var nx=cur==='dark'?'light':'dark';
+      root.setAttribute('data-theme',nx);
+      try{localStorage.setItem('gpt-theme',nx);}catch(e){}
+    });
+  }
+})();
 </script>
 </body></html>


### PR DESCRIPTION
## Summary

Full rebuild of `/blog/gold-etf-vs-physical-gold-uk` (`Gold ETFs vs Physical Gold: A UK Investor's Guide for 2026`) using the **UI/UX Pro Max** skill at maximum capability. Mobile-first, dual-theme, token-driven editorial design with a `gpc-` prefix.

## What's new

**Layout & navigation**
- Full-bleed hero with radial-gradient background, grid pattern, kicker label, editorial Playfair Display title with gold `ETFs` / `Physical Gold` accents and "vs" connector
- 4 hero stat chips (spot, lowest TER, CGT on Britannias, ISA limit) with colored side accents
- Sticky TOC sidebar (desktop ≥1080px) with intersection-observer active-section highlighting; collapsible details disclosure on mobile
- Top reading-progress bar tied to article scroll position
- Section dividers and section kickers with gold accent rule

**Article components**
- Drop-cap lead paragraph (Playfair italic)
- 4 ETC product cards — SGLN, SGLP, PHAU, RMAU — with ticker, brand, TER, AUM, custodian and ISA/SIPP pill badges
- Side-by-side Physical vs ETC duo cards with ✅ pro / ❌ con lists
- CGT/VAT/ISA tax spotlight block with gradient gold/teal background
- Cost comparison cards (ETC: 0.27–0.84%/yr · Physical: 2.5–7%/yr) with itemised lines
- 4-card decision matrix ("Who should choose what")
- 3-card portfolio allocation framework (conservative · balanced · growth)
- 12-row head-to-head table with sticky headers, pill cells, sticky-key column and mobile scroll hint
- 4-step practical-next-steps numbered cards
- Premium CTA block for the live calculator
- 8-item FAQ accordion (matching FAQPage JSON-LD)
- 39 numbered source references with deep links and target-highlight on click
- Disclaimer block + 6-card related-articles grid

**Design system & a11y**
- Light + dark theme parity (improved contrast: muted text from #7a7974 → #a8a7a3 in dark, #5a5852 in light)
- All callouts in 5 semantic flavours (gold · teal · emerald · warn · alert)
- 24-symbol SVG sprite (no emoji icons)
- Reveal-on-scroll animations with `prefers-reduced-motion` respected
- Mobile-first responsive breakpoints at 375/560/680/760/900/1080/1440px
- ARIA labels on all interactive nav and accordion controls
- Tab order and focus-visible outlines preserved

**SEO**
- Updated `<title>`, meta description, OG tags
- Refreshed `BlogPosting` JSON-LD (`dateModified` 2026-06-03, new description)
- Rewrote `FAQPage` JSON-LD with 8 Q&As matching the on-page accordion

## Test plan

- [ ] Open `/blog/gold-etf-vs-physical-gold-uk` and verify hero renders without horizontal scroll at 375px
- [ ] Tap theme toggle — verify light + dark both render with sufficient contrast across cards, callouts and table
- [ ] Scroll the article — verify reading-progress bar fills, TOC links highlight active section on desktop ≥1080px
- [ ] Open FAQ accordion items — verify open/close animation and accessibility
- [ ] Horizontally scroll the comparison table on mobile
- [ ] Click any superscript reference `[n]` and confirm scroll-target highlight on the source list
- [ ] Verify ticker continues animating and theme toggle persists across reload

https://claude.ai/code/session_01QhH8P2YKhMsakx8kriuaMv

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhH8P2YKhMsakx8kriuaMv)_