### PR TITLE
fix(gold-silver-ratio): gauge tick labels colliding with zone legend

### DIFF
--- a/gold-silver-ratio.html
+++ b/gold-silver-ratio.html
@@ -618,20 +618,20 @@ details[open] .faq-answer-summary::after{content:"▼"}
 .gauge-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);display:flex;align-items:center;gap:var(--space-2)}
 .gauge-title svg{color:var(--color-gold-bright);flex-shrink:0}
 .gauge-meta{font-size:var(--text-xs);color:var(--color-text-muted)}
-.gauge-track-wrap{position:relative;padding:36px 0 56px;margin:0 12px}
+.gauge-track-wrap{position:relative;padding:36px 12px 12px}
 .gauge-track{position:relative;height:10px;background:linear-gradient(90deg,#4ade80 0%,#4ade80 28%,#fbbf24 34%,#fbbf24 58%,#f87171 66%,#f87171 100%);border-radius:var(--radius-full);box-shadow:inset 0 1px 2px oklch(0 0 0/.3)}
 .gauge-marker{position:absolute;top:50%;width:22px;height:22px;border-radius:50%;background:var(--color-text);border:3px solid var(--color-surface);box-shadow:0 0 0 2px var(--color-text),0 0 18px color-mix(in oklch,var(--color-gold-bright) 70%,transparent);transform:translate(-50%,-50%);transition:left .9s cubic-bezier(.4,0,.2,1);z-index:3;left:50%}
 .gauge-marker__pulse{position:absolute;inset:-6px;border-radius:50%;background:color-mix(in oklch,var(--color-gold-bright) 45%,transparent);animation:gauge-pulse 2s ease-out infinite;z-index:-1}
 @keyframes gauge-pulse{0%{transform:scale(1);opacity:1}100%{transform:scale(2.5);opacity:0}}
 .gauge-marker__label{position:absolute;left:50%;top:-32px;transform:translateX(-50%);font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text);background:var(--color-surface-2);padding:3px 9px;border-radius:var(--radius-sm);border:1px solid var(--color-border);white-space:nowrap;font-variant-numeric:tabular-nums;box-shadow:var(--shadow-sm)}
 .gauge-marker__label::after{content:'';position:absolute;left:50%;bottom:-4px;transform:translateX(-50%) rotate(45deg);width:6px;height:6px;background:var(--color-surface-2);border-right:1px solid var(--color-border);border-bottom:1px solid var(--color-border)}
-.gauge-ticks{position:absolute;left:0;right:0;top:calc(100% + 10px);height:30px}
-.gauge-tick{position:absolute;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center}
+.gauge-ticks{position:relative;height:34px;margin-top:10px}
+.gauge-tick{position:absolute;top:0;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center}
 .gauge-tick::before{content:'';width:1px;height:6px;background:var(--color-border);margin-bottom:3px}
 .gauge-tick__value{font-size:11px;font-weight:600;font-variant-numeric:tabular-nums;color:var(--color-text-muted);line-height:1}
-.gauge-tick__label{font-size:10px;color:var(--color-text-faint);margin-top:2px;text-align:center;white-space:nowrap;line-height:1}
-.gauge-zones{display:flex;gap:var(--space-3) var(--space-4);margin-top:var(--space-2);padding-top:var(--space-4);border-top:1px solid var(--color-divider);flex-wrap:wrap;justify-content:center}
-.gauge-zone{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);color:var(--color-text-muted)}
+.gauge-tick__label{font-size:10px;color:var(--color-text-faint);margin-top:3px;text-align:center;white-space:nowrap;line-height:1}
+.gauge-zones{display:flex;gap:var(--space-3) var(--space-5);margin-top:var(--space-3);padding-top:var(--space-4);border-top:1px solid var(--color-divider);flex-wrap:wrap;justify-content:center}
+.gauge-zone{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.3}
 .gauge-zone__chip{width:12px;height:12px;border-radius:3px;flex-shrink:0}
 .gauge-zone__chip--low{background:#4ade80}
 .gauge-zone__chip--normal{background:#fbbf24}
@@ -767,8 +767,8 @@ details[open] .faq-answer-summary::after{content:"▼"}
 .reveal.is-visible{opacity:1;transform:translateY(0)}
 @media(prefers-reduced-motion:reduce){.reveal{opacity:1;transform:none;transition:none}.gauge-marker__pulse,.live-dot,.spot-tile__dot,.ratio-primary__signal-dot{animation:none!important}.gauge-marker{transition:none!important}}
 
-/* Hide redundant nav-only links on tiny screens already covered by mobile menu */
-@media(max-width:380px){.gauge-tick__label{display:none}}
+/* Hide context labels on small phones — tick numbers remain visible */
+@media(max-width:480px){.gauge-tick__label{display:none}.gauge-ticks{height:18px}}
 </style>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
@@ -869,12 +869,12 @@ details[open] .faq-answer-summary::after{content:"▼"}
     <div class="spot-tiles">
       <div class="spot-tile">
         <div class="spot-tile__label"><span class="spot-tile__dot spot-tile__dot--gold" aria-hidden="true"></span>Gold Spot</div>
-        <div id="gold-spot-display" class="spot-tile__value spot-tile__value--gold">$0.00</div>
+        <div id="gold-spot-display" class="spot-tile__value spot-tile__value--gold">&mdash;</div>
         <div class="spot-tile__sub">per troy ounce &middot; USD</div>
       </div>
       <div class="spot-tile">
         <div class="spot-tile__label"><span class="spot-tile__dot spot-tile__dot--silver" aria-hidden="true"></span>Silver Spot</div>
-        <div id="silver-spot-display" class="spot-tile__value spot-tile__value--silver">$0.00</div>
+        <div id="silver-spot-display" class="spot-tile__value spot-tile__value--silver">&mdash;</div>
         <div class="spot-tile__sub">per troy ounce &middot; USD</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

The "Where Today's Ratio Sits Historically" gauge had its tick labels (47, 60, 80 with context labels "20C avg", "Long-run", "High line") visually overlapping the zone legend chips ("Below 50 — Gold relatively cheap" / "50–80 — Long-run normal band" / "Above 80 — Silver relatively cheap") below it.

**Root cause:** `.gauge-ticks` used `position: absolute` with `top: calc(100% + 10px)` relative to `.gauge-track-wrap`. The wrap is ~102px tall (padding-top 36 + track 10 + padding-bottom 56), so `100% + 10px` placed the ticks at 112px from the wrap top — past the wrap entirely, landing on top of the zone legend row.

**Fix:** switch `.gauge-ticks` to `position: relative` with `margin-top: 10px` so it flows naturally below the track. Child `.gauge-tick` elements remain absolutely positioned within the now-relative ticks container, preserving their horizontal `%` offsets. Track-wrap padding adjusted accordingly (36px top for marker label, 12px sides, 12px bottom).

## Also in this PR

- Bumped tick-label hide breakpoint from 380px → 480px so the contextual labels never crowd on phones; tick numbers (14/47/60/80/124) always remain visible
- Zone legend spacing increased (`gap` 5, `padding-top` 4, `margin-top` 3) for cleaner separation
- Initial spot-price placeholders changed from `"$0.00"` to `"—"` so users don't briefly see fake zeros before the API responds

## Live API verification

The live integration was already correct — verified end-to-end:
- `fetchSpot()` polls `api.gold-api.com/price/XAU` and `XAG` every 60s
- `state.ratio = goldUSD / silverUSD` drives the gauge marker, ratio number, signal badge, signal cards, and calculator
- The 60.9 ratio shown in the user's screenshot matches current spot prices (~$4700 gold / ~$77 silver = ~61) — confirming live data is flowing correctly

## Test plan

- [ ] Run `python3 tools/playwright_audit.py https://goldpricetools.com/gold-silver-ratio` after deploy
- [ ] Visual check: desktop (1440px), tablet (768px), iPhone 14 Pro (390px), small phone (375px)
- [ ] Verify gauge tick labels (47/60/80 with context labels) sit clearly above the zone legend with no overlap
- [ ] Verify zone legend chips wrap cleanly without bleeding into the gauge area
- [ ] Verify spot tiles show "—" briefly then populate with live USD prices
- [ ] Verify ratio number updates and gauge marker animates to position

https://claude.ai/code/session_01GwRr8rq4MZDNcuFAuVGZki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwRr8rq4MZDNcuFAuVGZki)_