### PR TITLE
feat(10k-gold-price-per-gram): premium financial-dashboard redesign

### DIFF
--- a/10k-gold-price-per-gram.html
+++ b/10k-gold-price-per-gram.html
@@ -3,13 +3,13 @@
 <head>
 <meta charset="UTF-8">
   <script>
-(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>10K Gold Price Per Gram Today (Live UK) — 417 Hallmark Value | GoldPriceTools</title>
+<title>10K Gold Price Per Gram Today (Live US) — 417 Hallmark Value | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Live 10K gold price per gram in GBP and USD. 10 karat (417 hallmark) = 41.67% pure gold. The most durable everyday alloy. Free weight-to-value calculator. Updated every 60s.">
+<meta name="description" content="Live 10K gold price per gram in GBP, USD, EUR and INR. 10 karat (417 hallmark) = 41.67% pure gold — the US legal minimum. Calculator + dealer rates. Updated every 60s.">
 <meta name="robots" content="index, follow">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/10k-gold-price-per-gram">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/10k-gold-price-per-gram">
@@ -18,7 +18,7 @@
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"10K Gold Price Per Gram","item":"https://goldpricetools.com/10k-gold-price-per-gram"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the 10K gold price per gram today?","acceptedAnswer":{"@type":"Answer","text":"The 10K gold price per gram equals the 24K spot price per troy ounce divided by 31.1035, then multiplied by 0.4167 (10K purity). Our live calculator updates this every 60 seconds."}},{"@type":"Question","name":"Is 10K gold real gold?","acceptedAnswer":{"@type":"Answer","text":"Yes. 10K gold is real gold containing 41.67% pure gold (10 parts out of 24). It is the minimum legal standard for gold jewellery in the United States. The remaining 58.33% is alloy metals, making it harder and more durable than higher-karat gold."}},{"@type":"Question","name":"What is the hallmark for 10K gold?","acceptedAnswer":{"@type":"Answer","text":"10K gold is hallmarked 417 in Europe (41.7% fineness) or 10K / 10KT in the US. The 417 stamp is less common in UK jewellery as 9K (375) is the UK standard minimum."}},{"@type":"Question","name":"What does the 417 hallmark mean?","acceptedAnswer":{"@type":"Answer","text":"The 417 hallmark indicates 10K gold with 41.67% purity. In the UK, this stamp must be applied by an approved Assay Office under the Hallmarking Act 1973."}},{"@type":"Question","name":"How do I calculate the melt value of 10K gold?","acceptedAnswer":{"@type":"Answer","text":"Melt value = weight in grams × (spot price per troy oz ÷ 31.1035) × 0.4167. Use our live calculator above for an instant result."}}]}</script>
 <meta property="og:title" content="10K Gold Price Per Gram Today (Live)">
-<meta property="og:description" content="Real-time 10K gold price per gram in GBP and USD. 41.67% pure gold. Updated every 60 seconds.">
+<meta property="og:description" content="Real-time 10K gold price per gram in GBP, USD, EUR and INR. 41.67% pure gold — the US legal minimum. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/10k-gold-price-per-gram">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
@@ -42,9 +42,14 @@
   }
 });
 </script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link rel="manifest" href="/manifest.json">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
+<meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://api.gold-api.com" crossorigin>
+<link rel="preconnect" href="https://api.frankfurter.dev" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700;800&family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 
 /* ── Guides mega panel — category links ── */
@@ -56,26 +61,22 @@
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-
 :root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
 [data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
 .article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
 .article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
 .article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
 .article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
 .article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
 .article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
 .blog-preview-card:hover h3{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
-
 
 html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
@@ -89,190 +90,11 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 
-/* TICKER */
-.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
-.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
-.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
-.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
-.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
-.ticker:hover{animation-play-state:paused}
-@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
-.ticker-label{color:var(--color-text-muted)}
-.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
-.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+.live-dot{width:7px;height:7px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite;box-shadow:0 0 8px #4ade80}
 
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
-
-/* AD SLOTS */
-.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
-.ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
-
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
-
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
-
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
-
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
-
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
-
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
-
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
-
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
-
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
-
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
-
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
-
-#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-
-/* MEGA MENU */
-.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+/* NAV (shared) */
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
 .mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
@@ -325,120 +147,333 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
+/* BREADCRUMB */
+.breadcrumb-wrap{max-width:1100px;margin:0 auto;padding:var(--space-3) var(--space-4) 0}
+.breadcrumb{display:flex;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-xs);color:var(--color-text-faint)}
+.breadcrumb li+li::before{content:"\203A";margin-right:var(--space-1);color:var(--color-text-faint)}
+.breadcrumb a{color:var(--color-text-faint);text-decoration:none}
+.breadcrumb a:hover{color:var(--color-text-muted)}
+.breadcrumb [aria-current="page"]{color:var(--color-text-muted)}
 
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
-/* FOOTER */
-.footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
-.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+/* ═══════════════════════════════════════════════════════════════════════
+   10K GOLD PAGE — PREMIUM REDESIGN (mobile-first, fluid up to desktop)
+   ═══════════════════════════════════════════════════════════════════════ */
+.k10-page{max-width:1100px;margin:0 auto;padding:0 var(--space-4) var(--space-12)}
 
+/* ── HERO ──────────────────────────────────────────────────────────────── */
+.k10-hero{padding:var(--space-8) 0 var(--space-6);text-align:center}
+@media(min-width:768px){.k10-hero{padding:var(--space-12) 0 var(--space-6)}}
+.k10-hero__eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright);margin-bottom:var(--space-4);padding:6px 14px;background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,transparent);border-radius:var(--radius-full)}
+.k10-hero h1{font-family:var(--font-display);font-size:clamp(2rem,5.5vw,3.25rem);font-weight:800;line-height:1.05;letter-spacing:-.02em;color:var(--color-text);margin-bottom:var(--space-3);text-wrap:balance}
+.k10-hero h1 .gold{color:var(--color-gold-bright)}
+.k10-hero__sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:56ch;margin:0 auto var(--space-6);line-height:1.65}
 
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
+/* ── PRIMARY PRICE CARD ───────────────────────────────────────────────── */
+.k10-primary{position:relative;background:linear-gradient(180deg,var(--color-surface-2) 0%,var(--color-surface) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-md)}
+.k10-primary::before{content:'';position:absolute;inset:0;background:radial-gradient(ellipse at 50% 0%,color-mix(in oklch,var(--color-gold-bright) 14%,transparent) 0%,transparent 60%);pointer-events:none}
+.k10-primary__body{position:relative;z-index:1;padding:var(--space-6) var(--space-5) var(--space-5);text-align:center}
+@media(min-width:640px){.k10-primary__body{padding:var(--space-8) var(--space-6) var(--space-6)}}
+.k10-primary__label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.14em;color:var(--color-text-muted);margin-bottom:var(--space-3)}
+.k10-primary__number{font-family:var(--font-display);font-size:clamp(3.5rem,13vw,6.25rem);font-weight:300;color:var(--color-gold-bright);line-height:.95;letter-spacing:-.04em;font-variant-numeric:tabular-nums;text-shadow:0 0 30px color-mix(in oklch,var(--color-gold-bright) 35%,transparent);display:inline-flex;align-items:baseline;gap:var(--space-2)}
+.k10-primary__currency{font-family:var(--font-display);font-size:.42em;font-weight:400;color:var(--color-text-muted);letter-spacing:-.02em}
+.k10-primary__unit{font-size:var(--text-sm);color:var(--color-text-muted);margin-top:var(--space-2)}
+.k10-primary__secondary{display:flex;align-items:center;justify-content:center;gap:var(--space-2);margin-top:var(--space-3);font-size:var(--text-base);color:var(--color-text-muted);font-variant-numeric:tabular-nums}
+.k10-primary__secondary strong{color:var(--color-text);font-weight:600}
+.k10-primary__chips{display:flex;flex-wrap:wrap;justify-content:center;gap:var(--space-2);margin-top:var(--space-5)}
+.k10-chip{display:inline-flex;align-items:center;gap:6px;padding:5px 12px;border-radius:var(--radius-full);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;border:1px solid var(--color-border);background:var(--color-surface-offset);color:var(--color-text-muted)}
+.k10-chip--gold{border-color:color-mix(in oklch,var(--color-gold-bright) 38%,transparent);color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 8%,transparent)}
+.k10-chip--us{border-color:color-mix(in oklch,#3b82f6 38%,transparent);color:#60a5fa;background:color-mix(in oklch,#3b82f6 9%,transparent)}
+[data-theme="light"] .k10-chip--us{color:#1e40af}
+.k10-chip__dot{width:7px;height:7px;border-radius:50%;background:currentColor;box-shadow:0 0 6px currentColor}
 
+/* Spot tiles row */
+.k10-spot-tiles{display:grid;grid-template-columns:1fr 1fr;gap:1px;background:var(--color-border);border-top:1px solid var(--color-border)}
+.k10-spot-tile{padding:var(--space-4) var(--space-3);background:var(--color-surface);text-align:center}
+@media(min-width:640px){.k10-spot-tile{padding:var(--space-5) var(--space-4)}}
+.k10-spot-tile__label{display:flex;align-items:center;justify-content:center;gap:var(--space-2);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.k10-spot-tile__dot{width:8px;height:8px;border-radius:50%}
+.k10-spot-tile__dot--24k{background:var(--color-gold-bright);box-shadow:0 0 8px color-mix(in oklch,var(--color-gold-bright) 70%,transparent)}
+.k10-spot-tile__dot--10k{background:#d6a435;box-shadow:0 0 8px color-mix(in oklch,#d6a435 70%,transparent)}
+.k10-spot-tile__value{font-family:var(--font-display);font-size:clamp(1.25rem,4.5vw,1.75rem);font-weight:600;font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1.1;color:var(--color-text)}
+.k10-spot-tile__value--gold{color:var(--color-gold-bright)}
+.k10-spot-tile__sub{font-size:11px;color:var(--color-text-faint);margin-top:var(--space-1);font-variant-numeric:tabular-nums}
 
-/* ── Shared layout CSS ── */
-.breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"/";margin-right:var(--space-2);color:var(--color-text-faint)}
-.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
-.breadcrumb a:hover{color:var(--color-primary)}
-.breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.hero-tag{display:inline-block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-.hero-title{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero-title{font-size:var(--text-xl)}
-.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:72ch;line-height:1.7;margin-bottom:var(--space-6)}
-.price-card{display:inline-flex;flex-direction:column;gap:var(--space-1);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-2)}
-.price-card{width:100%}
-.price-label{font-size:var(--text-sm);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.price-value{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-gold-bright);font-weight:400;line-height:1}
-.price-usd{font-size:var(--text-base);color:var(--color-text-muted)}
-.price-purity{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-1)}
-.prose{max-width:72ch}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-1)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose{max-width:100%}
-.content{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
-.data-source{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.faq-answer-summary{font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4);cursor:pointer;list-style:none;background:var(--color-surface-offset);transition:background .15s}
-.faq-answer-summary:hover{background:var(--color-surface-dynamic)}
-.faq-answer-summary::marker,.faq-answer-summary::-webkit-details-marker{display:none}
-.faq-answer-summary::after{content:"＋";float:right;color:var(--color-text-faint)}
-.faq-answer-summary::after{content:"－"}
-.faq-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-4);border-top:1px solid var(--color-divider)}
+/* Source bar under price */
+.k10-source{display:flex;align-items:center;justify-content:center;gap:var(--space-3);flex-wrap:wrap;font-size:var(--text-xs);color:var(--color-text-faint);margin:var(--space-4) auto 0;text-align:center;line-height:1.5}
+.k10-source a{color:var(--color-text-muted);text-decoration:underline;text-decoration-color:transparent}
+.k10-source a:hover{text-decoration-color:currentColor;color:var(--color-text)}
+.k10-source__sep{color:var(--color-text-faint)}
 
-/* ── Hero left column ── */
-.hero-left{display:flex;flex-direction:column;justify-content:flex-start;gap:var(--space-3)}
-.hero-left .hero-title{margin-bottom:0}
-.hero-left .hero-tag{margin-bottom:var(--space-2)}
-@media(max-width:768px){.hero-left{margin-bottom:var(--space-4)}}
+/* ── PURITY VISUALIZATION ─────────────────────────────────────────────── */
+.k10-purity{margin-top:var(--space-8)}
+.k10-purity__card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6) var(--space-5);box-shadow:var(--shadow-sm)}
+@media(min-width:640px){.k10-purity__card{padding:var(--space-8) var(--space-6)}}
+.k10-purity__header{text-align:center;margin-bottom:var(--space-6)}
+.k10-purity__eyebrow{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.14em;color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.k10-purity__title{font-family:var(--font-display);font-size:clamp(1.25rem,2.6vw,1.75rem);font-weight:700;color:var(--color-text);margin:0;line-height:1.2}
+.k10-purity__grid{display:grid;grid-template-columns:1fr;gap:var(--space-6);align-items:center}
+@media(min-width:720px){.k10-purity__grid{grid-template-columns:240px 1fr;gap:var(--space-8)}}
+.k10-donut{position:relative;width:200px;height:200px;margin:0 auto}
+@media(min-width:720px){.k10-donut{width:220px;height:220px}}
+.k10-donut svg{width:100%;height:100%;transform:rotate(-90deg)}
+.k10-donut__center{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center}
+.k10-donut__hallmark{font-family:var(--font-display);font-size:clamp(2.5rem,7vw,3.25rem);font-weight:700;color:var(--color-gold-bright);line-height:.9;letter-spacing:-.02em}
+.k10-donut__pct{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-top:var(--space-1)}
+.k10-donut__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-top:2px}
+.k10-purity__breakdown{display:flex;flex-direction:column;gap:var(--space-4)}
+.k10-breakdown-row{display:grid;grid-template-columns:24px 1fr auto;gap:var(--space-3);align-items:center;padding:var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md)}
+.k10-breakdown-swatch{width:18px;height:18px;border-radius:6px;justify-self:start}
+.k10-breakdown-swatch--gold{background:linear-gradient(135deg,#e8af34,#b07a00);box-shadow:0 0 12px color-mix(in oklch,#e8af34 50%,transparent)}
+.k10-breakdown-swatch--alloy{background:linear-gradient(135deg,#9aa0a6,#5f6368)}
+.k10-breakdown-name{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.3}
+.k10-breakdown-sub{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4;margin-top:2px}
+.k10-breakdown-val{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
 
-/* ── Data Table ── */
-.data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
-.data-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-4) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.data-table td{padding:var(--space-3) var(--space-4) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.data-table td:first-child{color:var(--color-text);font-weight:500}
-.data-table td:not(:first-child){text-align:right;padding-right:0}
-.data-table th:not(:first-child){text-align:right;padding-right:0}
-.data-table tr:last-child td{border-bottom:none}
-.data-table tr:hover td{background:var(--color-surface)}
-.data-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border-radius:var(--radius-md)}
+/* ── SECTION HEADING (icon + text + divider) ──────────────────────────── */
+.k10-section-h{display:flex;align-items:center;gap:var(--space-3);margin-top:var(--space-10);margin-bottom:var(--space-4);padding-bottom:var(--space-3);border-bottom:1px solid var(--color-divider)}
+.k10-section-h__icon{display:inline-flex;align-items:center;justify-content:center;width:34px;height:34px;border-radius:var(--radius-sm);background:color-mix(in oklch,var(--color-gold-bright) 14%,transparent);color:var(--color-gold-bright);flex-shrink:0}
+.k10-section-h__text{font-size:clamp(1.25rem,2.4vw,1.625rem);font-weight:700;color:var(--color-text);line-height:1.2;margin:0;border:none;padding:0}
 
-/* ── Trust bar ── */
-.trust-bar{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset,var(--color-surface));border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.trust-bar a{color:var(--color-primary);text-decoration:none}
-.trust-bar a:hover{text-decoration:underline}
+/* ── CALCULATOR ───────────────────────────────────────────────────────── */
+.k10-calc{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm);margin-top:var(--space-4)}
+.k10-calc__header{padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3)}
+.k10-calc__title{font-size:var(--text-base);font-weight:700;color:var(--color-text);display:flex;align-items:center;gap:var(--space-2);margin:0}
+.k10-calc__title svg{color:var(--color-gold-bright);flex-shrink:0}
+.k10-currency-toggle{display:flex;background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);overflow:hidden}
+.k10-currency-toggle button{padding:7px 11px;font-size:11px;font-weight:700;letter-spacing:.04em;color:var(--color-text-muted);background:transparent;border:none;cursor:pointer;min-height:36px;transition:all var(--transition)}
+.k10-currency-toggle button:hover{color:var(--color-text)}
+.k10-currency-toggle button.active{background:var(--color-gold-bright);color:#0f0e0c}
+.k10-calc__body{padding:var(--space-5)}
+@media(min-width:640px){.k10-calc__body{padding:var(--space-6)}}
+.k10-calc__row{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:600px){.k10-calc__row{grid-template-columns:1fr 1fr}}
+.k10-field{display:flex;flex-direction:column;gap:var(--space-2);min-width:0}
+.k10-field__label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted)}
+.k10-field__group{display:flex;align-items:stretch;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);overflow:hidden;transition:border-color var(--transition),box-shadow var(--transition)}
+.k10-field__group:focus-within{border-color:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+.k10-field__input{flex:1;padding:var(--space-3) var(--space-4);background:transparent;border:none;font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;color:var(--color-text);min-width:0;width:100%;font-variant-numeric:tabular-nums;letter-spacing:-.01em;min-height:48px}
+.k10-field__input:focus{outline:none}
+.k10-field__select{flex:1;padding:0 var(--space-4);background:transparent;border:none;font-family:var(--font-body);font-size:var(--text-base);font-weight:600;color:var(--color-text);min-width:0;width:100%;min-height:48px;appearance:none;-webkit-appearance:none;cursor:pointer}
+.k10-field__select:focus{outline:none}
+.k10-field__suffix{display:flex;align-items:center;padding:0 var(--space-4);background:var(--color-surface);border-left:1px solid var(--color-border);font-size:11px;font-weight:700;color:var(--color-text-muted);letter-spacing:.06em;pointer-events:none}
+.k10-presets{display:flex;gap:var(--space-2);flex-wrap:wrap;margin-top:var(--space-5);padding-top:var(--space-5);border-top:1px solid var(--color-divider)}
+.k10-presets__label{width:100%;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-text-faint);margin-bottom:2px}
+.k10-preset{padding:7px 13px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);cursor:pointer;transition:all var(--transition);min-height:36px;display:inline-flex;align-items:center;font-variant-numeric:tabular-nums}
+.k10-preset:hover{border-color:var(--color-gold-bright);color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
 
-/* ── Share buttons ── */
-.share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) 0 var(--space-6);padding-top:var(--space-6);border-top:1px solid var(--color-border)}
-.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
-.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface)}
-.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset)}
-.share-buttons a svg{flex-shrink:0}
+/* Calc result */
+.k10-calc__result{margin-top:var(--space-5);padding:var(--space-5) var(--space-5);background:linear-gradient(180deg,color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset)) 0%,var(--color-surface-offset) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-radius:var(--radius-lg);text-align:center}
+.k10-calc__result-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.k10-calc__result-value{font-family:var(--font-display);font-size:clamp(2rem,6.5vw,3rem);font-weight:300;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;letter-spacing:-.02em}
+.k10-calc__result-sub{font-size:var(--text-sm);color:var(--color-text-muted);margin-top:var(--space-2)}
 
-/* ── Related guides grid ── */
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin-top:var(--space-6)}
-.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface-offset,var(--color-surface));border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s;min-height:140px;color:var(--color-text)}
-.related-card:hover{border-color:var(--color-primary);box-shadow:var(--shadow-sm)}
+/* Buy-rate breakdown inside calculator */
+.k10-buyrates{margin-top:var(--space-5);padding-top:var(--space-5);border-top:1px solid var(--color-divider)}
+.k10-buyrates__title{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-text-faint);margin-bottom:var(--space-3)}
+.k10-buyrates__grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+@media(min-width:640px){.k10-buyrates__grid{grid-template-columns:repeat(4,1fr)}}
+.k10-buyrate{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-3);text-align:center;transition:border-color var(--transition)}
+.k10-buyrate:hover{border-color:var(--color-gold-bright)}
+.k10-buyrate__channel{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:var(--space-2);line-height:1.3}
+.k10-buyrate__value{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;line-height:1.1}
+.k10-buyrate__range{font-size:10px;color:var(--color-text-faint);margin-top:3px;font-variant-numeric:tabular-nums}
+
+/* ── WEIGHT TABLE ─────────────────────────────────────────────────────── */
+.k10-table-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm);margin-top:var(--space-4)}
+.k10-table-card__header{padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-border);background:var(--color-surface-offset)}
+.k10-table-card__title{font-size:var(--text-base);font-weight:700;color:var(--color-text);display:flex;align-items:center;gap:var(--space-2);margin:0}
+.k10-table-card__title svg{color:var(--color-gold-bright);flex-shrink:0}
+.k10-table-card__sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
+.k10-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.k10-data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:480px}
+.k10-data-table th{text-align:left;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);background:var(--color-surface)}
+.k10-data-table th:not(:first-child){text-align:right}
+.k10-data-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text-muted);font-variant-numeric:tabular-nums}
+.k10-data-table td:first-child{color:var(--color-text);font-weight:600}
+.k10-data-table td:not(:first-child){text-align:right;color:var(--color-gold-bright);font-weight:600}
+.k10-data-table tr:last-child td{border-bottom:none}
+.k10-data-table tr:hover td{background:var(--color-surface-offset)}
+.k10-data-table caption{padding:var(--space-3) var(--space-4);text-align:left;font-size:var(--text-xs);color:var(--color-text-faint);caption-side:bottom}
+.k10-data-table .row-highlight td{background:color-mix(in oklch,var(--color-gold-bright) 5%,transparent)}
+.k10-data-table .row-highlight td:first-child::after{content:" \2605";color:var(--color-gold-bright);font-size:.85em}
+
+/* ── KARAT COMPARISON ─────────────────────────────────────────────────── */
+.k10-karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
+.k10-karat{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);overflow:hidden;transition:border-color var(--transition),box-shadow var(--transition);text-decoration:none;color:inherit;display:block}
+.k10-karat:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-sm);transform:translateY(-1px)}
+.k10-karat::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:var(--karat-shade,var(--color-gold-bright));opacity:.8}
+.k10-karat--9k{--karat-shade:#c9962c}
+.k10-karat--10k{--karat-shade:#d6a435}
+.k10-karat--14k{--karat-shade:#e0b144}
+.k10-karat--18k{--karat-shade:#ecbe55}
+.k10-karat--22k{--karat-shade:#f5cc6a}
+.k10-karat--24k{--karat-shade:#f7d77d}
+.k10-karat.is-current{border-color:var(--color-gold-bright);box-shadow:0 0 0 2px color-mix(in oklch,var(--color-gold-bright) 22%,transparent)}
+.k10-karat.is-current::after{content:'YOU ARE HERE';position:absolute;top:8px;right:8px;font-size:9px;font-weight:700;letter-spacing:.08em;padding:3px 7px;border-radius:var(--radius-full);background:var(--color-gold-bright);color:#0f0e0c}
+.k10-karat__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);letter-spacing:-.01em}
+.k10-karat__hallmark{font-size:var(--text-xs);font-weight:700;color:var(--color-text-muted);letter-spacing:.08em;margin-top:2px}
+.k10-karat__bar{height:5px;background:var(--color-surface-offset);border-radius:var(--radius-full);margin:var(--space-3) 0;position:relative;overflow:hidden}
+.k10-karat__bar-fill{position:absolute;top:0;left:0;bottom:0;background:linear-gradient(90deg,var(--karat-shade,var(--color-gold-bright)) 0%,color-mix(in oklch,var(--karat-shade,var(--color-gold-bright)) 60%,white) 100%);border-radius:var(--radius-full)}
+.k10-karat__pct{font-size:11px;font-weight:600;color:var(--color-text-muted);font-variant-numeric:tabular-nums}
+.k10-karat__price{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-gold-bright);margin-top:var(--space-3);font-variant-numeric:tabular-nums}
+.k10-karat__use{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1);line-height:1.4}
+
+/* ── HISTORICAL CHART ─────────────────────────────────────────────────── */
+.k10-chart-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-4);box-shadow:var(--shadow-sm);margin-top:var(--space-4)}
+@media(min-width:640px){.k10-chart-card{padding:var(--space-6)}}
+.k10-chart-header{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3);margin-bottom:var(--space-5)}
+.k10-chart-title-wrap{display:flex;align-items:center;gap:var(--space-3);min-width:0}
+.k10-chart-title-wrap svg{color:var(--color-gold-bright);flex-shrink:0}
+.k10-chart-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0}
+.k10-chart-title-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:2px;display:block}
+.k10-chart-toggle{display:flex;gap:2px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:3px}
+.k10-chart-toggle button{padding:6px 14px;font-size:11px;font-weight:700;letter-spacing:.05em;color:var(--color-text-muted);background:transparent;border:none;border-radius:var(--radius-sm);cursor:pointer;min-height:32px;transition:all var(--transition)}
+.k10-chart-toggle button:hover{color:var(--color-text)}
+.k10-chart-toggle button.active{background:var(--color-gold-bright);color:#0f0e0c}
+.k10-chart-wrap{position:relative;height:260px}
+@media(min-width:640px){.k10-chart-wrap{height:340px}}
+.k10-chart-loader{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+.k10-chart-stats{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin-top:var(--space-5);padding-top:var(--space-5);border-top:1px solid var(--color-divider)}
+@media(min-width:640px){.k10-chart-stats{grid-template-columns:repeat(4,1fr);gap:var(--space-4)}}
+.k10-chart-stat{text-align:center;padding:var(--space-2) 0}
+.k10-chart-stat__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.k10-chart-stat__value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.01em;line-height:1.1}
+.k10-chart-stat__value.is-low{color:#4ade80}
+.k10-chart-stat__value.is-high{color:#f87171}
+
+/* ── EDITORIAL PROSE ──────────────────────────────────────────────────── */
+.k10-content{margin-top:var(--space-10);max-width:72ch;margin-left:auto;margin-right:auto}
+.k10-prose p{margin-bottom:var(--space-4);color:var(--color-text-muted);line-height:1.78;font-size:var(--text-base)}
+.k10-prose p strong{color:var(--color-text);font-weight:700}
+.k10-prose ul,.k10-prose ol{padding-left:var(--space-5);margin-bottom:var(--space-5);color:var(--color-text-muted);line-height:1.75}
+.k10-prose li{margin-bottom:var(--space-2);line-height:1.7}
+.k10-prose li::marker{color:var(--color-gold)}
+.k10-prose a{color:var(--color-primary);text-decoration:underline;text-decoration-color:transparent}
+.k10-prose a:hover{text-decoration-color:currentColor}
+.k10-prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-top:var(--space-6);margin-bottom:var(--space-3);line-height:1.3}
+.k10-prose blockquote{margin:var(--space-6) 0;padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border-left:3px solid var(--color-gold-bright);border-radius:0 var(--radius-md) var(--radius-md) 0;font-style:normal;color:var(--color-text)}
+.k10-prose blockquote strong{color:var(--color-gold-bright)}
+
+.k10-intro{font-size:clamp(1.0625rem,1.7vw,1.1875rem);color:var(--color-text);line-height:1.7;margin-bottom:var(--space-5)}
+.k10-intro::first-letter{font-family:var(--font-display);font-size:3.5em;font-weight:700;float:left;line-height:.85;margin:.08em .12em -.05em -.04em;color:var(--color-gold-bright)}
+
+.k10-pullquote{margin:var(--space-8) 0;padding:var(--space-5) var(--space-5) var(--space-5) var(--space-6);border-left:3px solid var(--color-gold-bright);font-family:var(--font-display);font-size:clamp(1.125rem,1.9vw,1.375rem);font-weight:500;color:var(--color-text);line-height:1.5;letter-spacing:-.01em;background:color-mix(in oklch,var(--color-gold-bright) 4%,transparent);border-radius:0 var(--radius-md) var(--radius-md) 0}
+.k10-pullquote cite{display:block;margin-top:var(--space-2);font-family:var(--font-body);font-size:var(--text-xs);font-style:normal;font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em}
+
+.k10-formula{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-5) 0;text-align:center}
+.k10-formula__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-text-muted);margin-bottom:var(--space-3)}
+.k10-formula__body{font-family:var(--font-display);font-size:clamp(.95rem,2vw,1.1875rem);color:var(--color-text);font-weight:500;line-height:1.5;letter-spacing:-.005em}
+.k10-formula__body em{color:var(--color-gold-bright);font-style:normal;font-weight:700}
+
+/* ── FTC LEGAL CALLOUT (10K-distinctive) ──────────────────────────────── */
+.k10-ftc{position:relative;padding:var(--space-5);background:linear-gradient(135deg,color-mix(in oklch,#3b82f6 10%,var(--color-surface)) 0%,var(--color-surface) 65%);border:1px solid color-mix(in oklch,#3b82f6 28%,var(--color-border));border-radius:var(--radius-lg);margin:var(--space-6) 0;overflow:hidden}
+.k10-ftc::before{content:'';position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#3b82f6 0%,#60a5fa 100%)}
+.k10-ftc__top{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap}
+.k10-ftc__icon{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-sm);background:color-mix(in oklch,#3b82f6 22%,transparent);color:#60a5fa;flex-shrink:0}
+.k10-ftc__title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0;line-height:1.3;flex:1;min-width:0}
+.k10-ftc__cite{font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:#60a5fa;padding:3px 8px;border:1px solid color-mix(in oklch,#3b82f6 35%,transparent);border-radius:var(--radius-full);background:color-mix(in oklch,#3b82f6 8%,transparent);white-space:nowrap}
+[data-theme="light"] .k10-ftc__cite,[data-theme="light"] .k10-ftc__icon{color:#1e40af}
+.k10-ftc__body{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0}
+.k10-ftc__body strong{color:var(--color-text);font-weight:700}
+.k10-ftc__body p+p{margin-top:var(--space-3)}
+
+/* ── VICKERS HARDNESS CHART (10K-distinctive horizontal bars) ─────────── */
+.k10-hardness{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);margin:var(--space-6) 0;box-shadow:var(--shadow-sm)}
+@media(min-width:640px){.k10-hardness{padding:var(--space-6)}}
+.k10-hardness__title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0 0 var(--space-1);display:flex;align-items:center;gap:var(--space-2)}
+.k10-hardness__title svg{color:var(--color-gold-bright);flex-shrink:0}
+.k10-hardness__sub{font-size:var(--text-xs);color:var(--color-text-muted);margin:0 0 var(--space-5)}
+.k10-hardness__list{display:flex;flex-direction:column;gap:var(--space-3)}
+.k10-hardness__row{display:grid;grid-template-columns:48px 1fr auto;gap:var(--space-3);align-items:center}
+.k10-hardness__karat{font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text);letter-spacing:.02em}
+.k10-hardness__bar{position:relative;height:24px;background:var(--color-surface-offset);border-radius:var(--radius-sm);overflow:hidden;border:1px solid var(--color-border)}
+.k10-hardness__bar-fill{position:absolute;top:0;left:0;bottom:0;background:linear-gradient(90deg,var(--hardness-shade,var(--color-gold-bright)) 0%,color-mix(in oklch,var(--hardness-shade,var(--color-gold-bright)) 70%,white) 100%);border-radius:var(--radius-sm)}
+.k10-hardness__bar-label{position:relative;z-index:1;display:flex;align-items:center;height:100%;padding:0 var(--space-2);font-size:11px;font-weight:700;color:#0f0e0c;font-variant-numeric:tabular-nums;letter-spacing:.02em}
+.k10-hardness__value{font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text-muted);font-variant-numeric:tabular-nums;text-align:right;min-width:72px}
+.k10-hardness__row--current .k10-hardness__karat{color:var(--color-gold-bright)}
+.k10-hardness__row--current .k10-hardness__value{color:var(--color-gold-bright)}
+.k10-hardness__legend{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2);margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-faint)}
+
+/* ── COMPARE CARDS (10K vs 9K, US vs UK) ──────────────────────────────── */
+.k10-compare-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:560px){.k10-compare-grid{grid-template-columns:1fr 1fr}}
+.k10-compare-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);position:relative;overflow:hidden}
+.k10-compare-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:var(--cmp-shade,var(--color-gold-bright))}
+.k10-compare-card--10k{--cmp-shade:linear-gradient(90deg,#3b82f6,#60a5fa)}
+.k10-compare-card--9k{--cmp-shade:linear-gradient(90deg,#c9962c,#e8af34)}
+.k10-compare-card--10k::before{background:linear-gradient(90deg,#3b82f6,#60a5fa)}
+.k10-compare-card--9k::before{background:linear-gradient(90deg,#c9962c,#e8af34)}
+.k10-compare-card__head{display:flex;align-items:baseline;justify-content:space-between;gap:var(--space-2);margin-bottom:var(--space-3)}
+.k10-compare-card__karat{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);letter-spacing:-.01em}
+.k10-compare-card__flag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
+.k10-compare-card--10k .k10-compare-card__flag{color:#60a5fa}
+.k10-compare-card--9k .k10-compare-card__flag{color:#e8af34}
+[data-theme="light"] .k10-compare-card--10k .k10-compare-card__flag{color:#1e40af}
+[data-theme="light"] .k10-compare-card--9k .k10-compare-card__flag{color:#b07a00}
+.k10-compare-card dl{display:grid;grid-template-columns:auto 1fr;gap:var(--space-2) var(--space-3);margin:0}
+.k10-compare-card dt{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;line-height:1.4}
+.k10-compare-card dd{font-size:var(--text-sm);color:var(--color-text);font-weight:600;margin:0;line-height:1.4}
+
+/* ── FAQ ACCORDION ────────────────────────────────────────────────────── */
+.k10-faq{display:flex;flex-direction:column;gap:var(--space-2);margin-top:var(--space-4)}
+.k10-faq details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.k10-faq details[open]{border-color:var(--color-gold-bright);box-shadow:var(--shadow-sm)}
+.k10-faq summary{padding:var(--space-4) var(--space-5);cursor:pointer;font-weight:600;font-size:var(--text-sm);color:var(--color-text);list-style:none;display:flex;justify-content:space-between;align-items:center;gap:var(--space-3);min-height:56px;line-height:1.4}
+.k10-faq summary::-webkit-details-marker{display:none}
+.k10-faq summary::after{content:'';width:10px;height:10px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:rotate(45deg);transition:transform .2s ease;flex-shrink:0;margin-top:-3px}
+.k10-faq details[open] summary::after{transform:rotate(-135deg);margin-top:3px;border-color:var(--color-gold-bright)}
+.k10-faq summary:hover{background:var(--color-surface-offset)}
+.k10-faq .faq-body{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7}
+.k10-faq .faq-body p{margin:0}
+.k10-faq .faq-body strong{color:var(--color-text)}
+
+/* ── DISCLAIMER ───────────────────────────────────────────────────────── */
+.k10-disclaimer{font-size:var(--text-xs);color:var(--color-text-faint);line-height:1.6;margin-top:var(--space-6);padding:var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-text-faint)}
+.k10-disclaimer strong{color:var(--color-text-muted)}
+
+/* ── SHARE BUTTONS ────────────────────────────────────────────────────── */
+.k10-share{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) auto var(--space-4);padding-top:var(--space-6);border-top:1px solid var(--color-border);max-width:72ch}
+.k10-share span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
+.k10-share a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface);min-height:36px}
+.k10-share a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset);text-decoration:none}
+.k10-share a svg{flex-shrink:0}
+
+/* ── REVEAL ON SCROLL ─────────────────────────────────────────────────── */
+.reveal{opacity:0;transform:translateY(16px);transition:opacity .6s cubic-bezier(.4,0,.2,1),transform .6s cubic-bezier(.4,0,.2,1)}
+.reveal.is-visible{opacity:1;transform:translateY(0)}
+@media(prefers-reduced-motion:reduce){.reveal{opacity:1;transform:none;transition:none}.live-dot,.k10-chip__dot,.k10-spot-tile__dot{animation:none!important}}
+
+/* ── RELATED GUIDES ───────────────────────────────────────────────────── */
+.related-guides{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-12) var(--space-4)}
+.container{max-width:1100px;margin:0 auto}
+.related-guides .container>h2{font-size:clamp(1.25rem,2vw,1.5rem);font-weight:700;margin-bottom:var(--space-6);color:var(--color-text)}
+.related-guides-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:560px){.related-guides-grid{grid-template-columns:1fr 1fr}}
+@media(min-width:900px){.related-guides-grid{grid-template-columns:repeat(3,1fr)}}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s;min-height:140px;color:var(--color-text)}
+.related-card:hover{border-color:var(--color-primary);box-shadow:var(--shadow-sm);text-decoration:none}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 .related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
 .related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin:var(--space-1) 0}
 .related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
 
-/* ── Prose spacing ── */
-.prose li{margin-bottom:var(--space-2);line-height:1.65}
-.prose h2{margin-top:var(--space-10);margin-bottom:var(--space-3)}
-.prose h3{margin-top:var(--space-6);margin-bottom:var(--space-2)}
+/* ── FOOTER (shared) ──────────────────────────────────────────────────── */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0 0}
+.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr;gap:var(--space-4)}}
+.footer-brand-col{max-width:260px}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
+.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col li{margin:0}
+.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
+.footer-col a:hover{color:var(--color-text)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
+
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
+
 </style>
 
 <script type="application/ld+json">
@@ -525,158 +560,595 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </div>
   </div>
 </nav>
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">10K Gold Price Per Gram</li></ol></div>
-<div class="hero">
-  <div class="hero-left">
-  <div class="hero-tag">Live Gold Price</div>
-  <h1 class="hero-title">10K Gold Price Per Gram Today</h1>
-  <p class="hero-sub">10 karat gold is 41.67% pure gold (417 hallmark). Live price updated every 60 seconds from LBMA spot market.</p>
-    </div>
-  <div class="price-card"><div class="price-label">10K Gold &mdash; Price Per Gram</div><div class="price-value" id="price-gbp" data-nosnippet>&mdash;</div><div class="price-usd" id="price-usd" data-nosnippet></div><div class="price-purity">10K = 41.67% pure gold (417 hallmark)</div></div>
+
+<div class="breadcrumb-wrap">
+  <ol class="breadcrumb" aria-label="Breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li aria-current="page">10K Gold Price Per Gram</li>
+  </ol>
 </div>
-<div class="content">
-  <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
-  <div class="prose">
-    <h2>What is 10K Gold?</h2>
-    <p>10K gold contains 10 parts gold out of 24, giving it a purity of <strong>41.67%</strong>. It is the minimum legal standard for gold jewellery in the United States. While it has a lower gold content than 14K or 18K, it is the most durable and scratch-resistant commonly available gold alloy. The European hallmark is <strong>417</strong>.</p>
-    <h2>10kt gold price per gram</h2>
-<p class="snippet-answer">The 10kt gold price per gram is determined by multiplying the live pure gold spot price by 0.4167. 10 karat gold contains 41.67% pure gold, making it the most durable and affordable gold alloy commonly used in jewelry. Use our calculator to find today's exact value.</p>
 
-<h2 id="q1-10K">How much is a gram of 10k gold worth?</h2>
-<p class="snippet-answer">10K gold is worth approximately <span id="snippet-price" data-nosnippet>[live value]</span> per gram in [currency] today. This is calculated by multiplying the live 24K spot price by 0.4167 — the gold purity ratio of 10 karat gold (10 parts gold out of 24). Use our calculator below for the exact live value.</p>
+<main class="k10-page">
+  <!-- ═══ HERO ═══ -->
+  <header class="k10-hero">
+    <span class="k10-hero__eyebrow"><span class="live-dot" aria-hidden="true"></span>Live Market Data &middot; LBMA Spot</span>
+    <h1>10K <span class="gold">Gold Price</span><br>Per Gram Today</h1>
+    <p class="k10-hero__sub">10 karat gold is <strong>41.67% pure</strong> &mdash; the United States' legal minimum, hallmarked <strong>417</strong>. The most durable everyday gold alloy. Live melt value updates every 60 seconds from the LBMA spot market.</p>
+  </header>
 
-<h2 id="q2-10K">What is 10k gold?</h2>
-<p class="snippet-answer">10K gold is a durable metal alloy containing 10 parts pure gold and 14 parts other metals. With a purity of 41.67%, it is the minimum legal standard for gold jewellery in the United States, offering excellent scratch resistance.</p>
-
-<h2 id="q3-10K">What is the hallmark for 10K gold?</h2>
-<p class="snippet-answer">The most common hallmark for 10K gold is 417, which represents its 41.7% gold fineness. In the United States, it is also frequently stamped as 10K or 10KT to indicate its karat rating.</p>
-
-<h2>10K Gold Price Table</h2>
-    <figure itemscope itemtype="https://schema.org/Table">
-      <figcaption>10K gold price per gram in GBP and USD — live, updated every 60 seconds</figcaption>
-      <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-      <div class="data-table-wrap"><table class="data-table" aria-label="10K gold price by weight">
-        <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th><th>INR (live)</th></tr></thead>
-        <tbody>
-          <tr><td>1g</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-usd" data-nosnippet>&mdash;</td><td id="t-1-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>5g</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-usd" data-nosnippet>&mdash;</td><td id="t-5-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>10g</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-usd" data-nosnippet>&mdash;</td><td id="t-10-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>20g</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-usd" data-nosnippet>&mdash;</td><td id="t-20-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>1 <a href="/how-many-grams-in-troy-ounce">troy oz</a> (31.1g)</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-usd" data-nosnippet>&mdash;</td><td id="t-31-inr" data-nosnippet>&mdash;</td></tr>
-        </tbody>
-      </table></div>
-    </figure>
-    <h2>Is 10K Gold Worth Buying?</h2>
-    <p>10K gold is an economical choice for everyday jewellery. Its high alloy content (copper, silver, zinc) makes it more resistant to scratches and tarnish than 14K or 18K. However, some people with sensitive skin may experience reactions to the higher base metal content. For investment purposes, 24K bullion offers a much higher gold content per pound spent.</p>
-    <h2>10K Purity Table</h2>
-<div class="data-table-wrap"><table class="data-table" aria-label="Karat purity and indicative prices">
-<thead><tr><th>Karat</th><th>Purity</th><th>GBP/gram</th><th>USD/gram</th></tr></thead>
-<tbody>
-<tr><td>24K</td><td>99.9%</td><td>--</td><td>--</td></tr>
-<tr><td>18K</td><td>75.0%</td><td>--</td><td>--</td></tr>
-<tr><td>14K</td><td>58.3%</td><td>--</td><td>--</td></tr>
-<tr><td>10K</td><td>41.7%</td><td>--</td><td>--</td></tr>
-<tr><td>9K</td><td>37.5%</td><td>--</td><td>--</td></tr>
-</tbody>
-</table></div>
-
-    
-    <h2>What is 10K Gold?</h2>
-    <p>10K gold contains 10 parts pure gold out of 24 parts, giving it a purity of <strong>41.67%</strong>. The hallmark stamp you will find on 10K items is <strong>417</strong>, which represents 41.7 parts per thousand of pure gold. 10K gold meets the US Federal Trade Commission's minimum gold content threshold. It is harder and more scratch-resistant than higher karats, making it popular for everyday wear.</p>
-    <p>10K gold is commonly used for US everyday jewellery, the legal minimum gold standard in the United States. When you buy or sell 10K rings and chains, the price you receive is calculated directly from the live gold spot price multiplied by the purity factor of 0.4167.</p>
-
-    <h2>How to Calculate the 10K Gold Price Per Gram</h2>
-    <p>The formula for the 10K gold price per gram is straightforward:</p>
-    <blockquote><strong>10K price per gram = (Spot price per troy oz ÷ 31.1035) × 0.4167</strong></blockquote>
-    <p>For example, if the gold spot price is $3,300 per troy ounce:</p>
-    <ul>
-      <li>Price per gram of pure gold = $3,300 ÷ 31.1035 = <strong>$106.10</strong></li>
-      <li>10K price per gram = $106.10 × 0.4167 = <strong>$44.21</strong></li>
-    </ul>
-    <p>This is the <em>melt value</em> — the intrinsic gold content value. Jewellers, dealers, and pawnbrokers typically pay between 70%–95% of melt value when buying, depending on condition and local market demand. When selling, retailers add a <em>premium</em> of 10%–30% above melt value.</p>
-
-    <h2>The 417 Hallmark Explained</h2>
-    <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices (London, Birmingham, Sheffield, or Edinburgh) under the Hallmarking Act 1973. The <strong>417 hallmark</strong> guarantees that the item contains at least 41.67% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
-    <p>On older or imported items, you may also see the hallmark written as <strong>.417</strong> or stamped alongside a date letter and assay office mark. When appraising estate jewellery, always check for the 417 stamp before calculating value.</p>
-
-    <h2>10K Gold and the FTC Legal Standard</h2>
-    <p>In the United States, the <strong>Federal Trade Commission (FTC)</strong> sets the legal minimum gold content for any item described or sold as "gold." Under the FTC's Jewelry Guides (16 CFR Part 23), no item may be labelled, advertised, or sold as "gold" jewellery unless it contains at least 10 karats (41.67%) of pure gold. Items below this threshold must be described as "gold-plated," "gold-filled," or "gold-tone."</p>
-    <p>This regulation is unique to the US market. In the <strong>United Kingdom</strong>, the legal minimum is <a href="/9k-gold-price-per-gram">9 karats (37.5%)</a>, established by the Hallmarking Act 1973. In many European countries, 8K (33.3%) is accepted. This means 10K gold falls in an interesting middle ground — it is legal to sell in the UK but is not a traditional UK standard, so you are less likely to find it in British high-street jewellers.</p>
-
-    <h2>Why 10K Gold Is the Most Durable Karat</h2>
-    <p>Gold in its pure form (24K) is remarkably soft — it can be scratched with a fingernail. The alloy metals added to create lower-karat gold dramatically increase hardness:</p>
-    <ul>
-      <li><strong>10K gold</strong> — Vickers hardness ~180–200 HV. The hardest standard gold alloy. Highly resistant to scratching, bending, and denting.</li>
-      <li><strong>14K gold</strong> — Vickers hardness ~150–180 HV. Good durability, the US standard for engagement rings.</li>
-      <li><strong>18K gold</strong> — Vickers hardness ~120–150 HV. Softer, more prone to surface scratches.</li>
-      <li><strong>24K gold</strong> — Vickers hardness ~25 HV. Too soft for everyday jewellery.</li>
-    </ul>
-    <p>This makes 10K the ideal choice for jewellery that takes daily abuse — <strong>class rings, chains worn under clothing, men's wedding bands for manual workers, and children's jewellery</strong> where durability matters more than gold content.</p>
-
-    <h2>10K Gold and Skin Sensitivity</h2>
-    <p>Because 10K gold contains <strong>58.33% alloy metals</strong> (more alloy than gold), it poses a higher risk of causing <strong>contact dermatitis</strong> in people with metal allergies — particularly nickel sensitivity. White 10K gold often contains nickel as a whitening agent, which is one of the most common jewellery allergens.</p>
-    <p>If you have sensitive skin, consider the following when buying 10K gold:</p>
-    <ul>
-      <li><strong>Choose yellow or rose 10K gold</strong> — These typically use copper and silver alloys, which cause fewer reactions than nickel.</li>
-      <li><strong>Ask for nickel-free alloys</strong> — Some manufacturers produce nickel-free 10K white gold using palladium instead.</li>
-      <li><strong>Consider a higher karat</strong> — <a href="/14k-gold-price-per-gram">14K</a> or <a href="/18k-gold-price-per-gram">18K</a> gold has less alloy content and is gentler on sensitive skin.</li>
-      <li><strong>Apply clear nail polish</strong> — A coat of clear polish on the inside of a ring creates a barrier, though this is a temporary fix that wears off.</li>
-    </ul>
-
-    <h2>Where 10K Gold Is Most Popular</h2>
-    <p>10K gold has distinct regional popularity patterns that differ from other karats:</p>
-    <ul>
-      <li><strong>United States</strong> — 10K is widely available for budget-conscious buyers. It is the most common karat for <strong>class rings, initial pendants, basic chains, and affordable earrings</strong>. Retailers like Walmart, Kay Jewelers, and Zales stock extensive 10K ranges.</li>
-      <li><strong>Canada</strong> — Similar to the US, 10K is the entry-level gold standard.</li>
-      <li><strong>United Kingdom</strong> — 10K is rare. The UK market jumps from <a href="/9k-gold-price-per-gram">9K (375)</a> directly to <a href="/14k-gold-price-per-gram">14K (585)</a>. If you encounter 10K gold in the UK, it is almost certainly an import.</li>
-      <li><strong>India and Middle East</strong> — 10K is virtually unheard of. These markets strongly prefer <a href="/22k-gold-price-per-gram">22K</a> and <a href="/24k-gold-price-per-gram">24K</a> for its higher gold content and deeper colour.</li>
-    </ul>
-
-    <h2>10K Gold Scrap Value: What Dealers Actually Pay</h2>
-    <p>10K gold scrap commands the <strong>lowest per-gram price</strong> of any standard karat because of its 41.67% gold content. When selling 10K scrap, keep these realities in mind:</p>
-    <ul>
-      <li><strong>Refiners prefer large lots</strong> — A single 2g ring is less attractive to a refiner than a 50g bag of mixed 10K scrap. You may get 5–10% better rates by accumulating scrap before selling.</li>
-      <li><strong>The "refining cost" discount</strong> — Refiners deduct a processing fee to extract the gold from the alloy. Because 10K has more alloy to remove, this fee is proportionally higher than for 18K or 22K scrap.</li>
-      <li><strong>Online vs local</strong> — Online gold buyers (who ship directly to refineries) typically offer 80–90% of melt value for 10K. High-street pawnbrokers may offer as low as 50–65%.</li>
-    </ul>
-    <p>Use our <a href="/scrap-gold-calculator">scrap gold calculator</a> to check the current melt value before approaching any buyer.</p>
-
-    <h2>Frequently Asked Questions</h2>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">How do I convert the 10K gold price from troy ounces to grams?</h3>
-      <p class="faq-answer">There are 31.1035 grams in one troy ounce. Divide the spot price (in any currency) by 31.1035 to get the price per gram of pure gold, then multiply by 0.4167 to get the 10K price per gram. Our live calculator above does this automatically.</p>
+  <!-- ═══ PRIMARY PRICE CARD ═══ -->
+  <section class="k10-primary" aria-label="Live 10K gold price per gram">
+    <div class="k10-primary__body">
+      <div class="k10-primary__label">10K Gold &mdash; Per Gram</div>
+      <div class="k10-primary__number" aria-live="polite">
+        <span id="price-gbp" data-nosnippet>&mdash;</span>
+      </div>
+      <p class="k10-primary__unit">Live melt value &middot; per gram</p>
+      <div class="k10-primary__secondary">
+        <span>USD</span>
+        <strong id="price-usd" data-nosnippet>&mdash;</strong>
+      </div>
+      <div class="k10-primary__chips">
+        <span class="k10-chip k10-chip--gold"><span class="k10-chip__dot" aria-hidden="true"></span>10K &middot; 41.67% Pure</span>
+        <span class="k10-chip">Hallmark 417</span>
+        <span class="k10-chip k10-chip--us"><span class="k10-chip__dot" aria-hidden="true"></span>US Legal Min</span>
+        <span class="k10-chip" id="last-updated">Updating&hellip;</span>
+      </div>
     </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">What is the difference between 10K gold and gold-filled or gold-plated?</h3>
-      <p class="faq-answer">Solid 10K gold contains 41.67% pure gold throughout the item. Gold-filled has a layer of 10K gold mechanically bonded to a base metal core — it contains far less gold by weight. Gold-plated items have only a thin electroplated layer of gold, typically less than 0.05% of the item's total weight. Only solid 10K gold carries the 417 hallmark and has significant melt value.</p>
+    <div class="k10-spot-tiles" role="group" aria-label="Reference spot prices">
+      <div class="k10-spot-tile">
+        <div class="k10-spot-tile__label"><span class="k10-spot-tile__dot k10-spot-tile__dot--24k" aria-hidden="true"></span>24K Spot</div>
+        <div id="spot-24k-display" class="k10-spot-tile__value k10-spot-tile__value--gold">&mdash;</div>
+        <div class="k10-spot-tile__sub">per troy ounce &middot; USD</div>
+      </div>
+      <div class="k10-spot-tile">
+        <div class="k10-spot-tile__label"><span class="k10-spot-tile__dot k10-spot-tile__dot--10k" aria-hidden="true"></span>10K Conversion</div>
+        <div id="spot-10k-display" class="k10-spot-tile__value">&times;0.4167</div>
+        <div class="k10-spot-tile__sub">10 parts gold &divide; 24</div>
+      </div>
     </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Why does the 10K gold price per gram vary between different websites?</h3>
-      <p class="faq-answer">Small differences between sites reflect the timing of their data feed, the spot price source used (LBMA, COMEX, or OTC), and whether they include the GBP/USD exchange rate at slightly different timestamps. GoldPriceTools fetches live prices from gold-api.com and currency rates from the Frankfurter API, both updated every 60 seconds.</p>
-    </div>
+  </section>
 
-    <div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative melt values only. Dealer buy prices are typically 70&ndash;90% of melt value. Not financial advice.</div>
+  <p class="k10-source">
+    <span>Prices sourced from LBMA via gold-api.com</span>
+    <span class="k10-source__sep">&middot;</span>
+    <span>FX via Frankfurter</span>
+    <span class="k10-source__sep">&middot;</span>
+    <a href="/about">About our data</a>
+  </p>
+
+  <!-- ═══ PURITY VISUALIZATION ═══ -->
+  <section class="k10-purity reveal" aria-label="10K gold purity breakdown">
+    <div class="k10-purity__card">
+      <div class="k10-purity__header">
+        <div class="k10-purity__eyebrow">Composition</div>
+        <h2 class="k10-purity__title">What's Inside 1 Gram of 10K Gold?</h2>
+      </div>
+      <div class="k10-purity__grid">
+        <div class="k10-donut" role="img" aria-label="10K gold purity ring: 41.67 percent pure gold, 58.33 percent alloy metals">
+          <svg viewBox="0 0 100 100" aria-hidden="true">
+            <circle cx="50" cy="50" r="42" fill="none" stroke="var(--color-surface-offset)" stroke-width="14"/>
+            <circle cx="50" cy="50" r="42" fill="none" stroke="url(#k10-grad)" stroke-width="14" stroke-dasharray="109.94 263.89" stroke-dashoffset="0" stroke-linecap="butt"/>
+            <defs>
+              <linearGradient id="k10-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#e8af34"/>
+                <stop offset="100%" stop-color="#b07a00"/>
+              </linearGradient>
+            </defs>
+          </svg>
+          <div class="k10-donut__center">
+            <div class="k10-donut__hallmark">417</div>
+            <div class="k10-donut__pct">41.67% pure</div>
+            <div class="k10-donut__label">US Hallmark</div>
+          </div>
+        </div>
+        <div class="k10-purity__breakdown">
+          <div class="k10-breakdown-row">
+            <span class="k10-breakdown-swatch k10-breakdown-swatch--gold" aria-hidden="true"></span>
+            <div>
+              <div class="k10-breakdown-name">Pure gold (Au)</div>
+              <div class="k10-breakdown-sub">10 parts out of 24 &middot; spot-priced</div>
+            </div>
+            <div class="k10-breakdown-val">0.4167 g</div>
+          </div>
+          <div class="k10-breakdown-row">
+            <span class="k10-breakdown-swatch k10-breakdown-swatch--alloy" aria-hidden="true"></span>
+            <div>
+              <div class="k10-breakdown-name">Alloy metals</div>
+              <div class="k10-breakdown-sub">Copper, silver, zinc &middot; for hardness</div>
+            </div>
+            <div class="k10-breakdown-val">0.5833 g</div>
+          </div>
+          <div class="k10-breakdown-row">
+            <span style="width:18px;height:18px;border-radius:6px;background:linear-gradient(135deg,#4ade80,#16a34a);box-shadow:0 0 12px color-mix(in oklch,#4ade80 50%,transparent)" aria-hidden="true"></span>
+            <div>
+              <div class="k10-breakdown-name">Pure gold value</div>
+              <div class="k10-breakdown-sub">Melt value of the gold content only</div>
+            </div>
+            <div class="k10-breakdown-val" id="purity-pure-value">&mdash;</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ CALCULATOR ═══ -->
+  <div class="k10-section-h" id="calculator">
+    <span class="k10-section-h__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="8" y1="6" x2="16" y2="6"/><line x1="8" y1="10" x2="16" y2="10"/><line x1="8" y1="14" x2="16" y2="14"/><line x1="8" y1="18" x2="16" y2="18"/></svg>
+    </span>
+    <h2 class="k10-section-h__text">10K Gold Melt Value Calculator</h2>
   </div>
-</div>
-<div class="content" style="padding-bottom:1.5rem">
-<!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
-  <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/10k-gold-price-per-gram&text=10K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
-  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/10k-gold-price-per-gram&title=10K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=10K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F10k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
-</div>
-</div>
+  <section class="k10-calc reveal" aria-label="10K gold melt value calculator">
+    <div class="k10-calc__header">
+      <h3 class="k10-calc__title">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+        Enter weight to get instant value
+      </h3>
+      <div id="k10-currency-toggle" class="k10-currency-toggle" role="group" aria-label="Currency selector">
+        <button type="button" data-currency="USD" class="active">USD</button>
+        <button type="button" data-currency="GBP">GBP</button>
+        <button type="button" data-currency="EUR">EUR</button>
+        <button type="button" data-currency="INR">INR</button>
+      </div>
+    </div>
+    <div class="k10-calc__body">
+      <div class="k10-calc__row">
+        <div class="k10-field">
+          <label class="k10-field__label" for="k10-input-weight">Weight</label>
+          <div class="k10-field__group">
+            <input type="number" id="k10-input-weight" class="k10-field__input" value="10" min="0" step="0.1" inputmode="decimal" aria-label="Item weight">
+            <span class="k10-field__suffix" id="k10-unit-suffix">G</span>
+          </div>
+        </div>
+        <div class="k10-field">
+          <label class="k10-field__label" for="k10-input-unit">Unit</label>
+          <div class="k10-field__group">
+            <select id="k10-input-unit" class="k10-field__select" aria-label="Weight unit">
+              <option value="g">Grams (g)</option>
+              <option value="oz">Troy ounce (oz)</option>
+              <option value="dwt">Pennyweight (dwt)</option>
+            </select>
+          </div>
+        </div>
+      </div>
 
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
+      <div class="k10-calc__result" role="status" aria-live="polite">
+        <div class="k10-calc__result-label">Estimated Melt Value</div>
+        <div class="k10-calc__result-value" id="k10-result">&mdash;</div>
+        <div class="k10-calc__result-sub" id="k10-result-sub">Enter weight above to calculate.</div>
+      </div>
+
+      <div class="k10-presets" role="group" aria-label="Quick weight presets">
+        <span class="k10-presets__label">Quick presets &middot; typical 10K jewellery</span>
+        <button type="button" class="k10-preset" data-w="2">Charm &middot; 2 g</button>
+        <button type="button" class="k10-preset" data-w="4">Class ring &middot; 4 g</button>
+        <button type="button" class="k10-preset" data-w="7">Wedding band &middot; 7 g</button>
+        <button type="button" class="k10-preset" data-w="15">Curb chain &middot; 15 g</button>
+        <button type="button" class="k10-preset" data-w="30">Heavy chain &middot; 30 g</button>
+        <button type="button" class="k10-preset" data-w="100">100 g lot</button>
+      </div>
+
+      <div class="k10-buyrates" aria-label="Dealer buy-rate breakdown">
+        <div class="k10-buyrates__title">What dealers typically pay <span style="color:var(--color-text-faint);font-weight:600">(% of melt)</span></div>
+        <div class="k10-buyrates__grid">
+          <div class="k10-buyrate">
+            <div class="k10-buyrate__channel">Online specialist</div>
+            <div class="k10-buyrate__value" id="br-online">&mdash;</div>
+            <div class="k10-buyrate__range">80&ndash;90%</div>
+          </div>
+          <div class="k10-buyrate">
+            <div class="k10-buyrate__channel">High-street jeweller</div>
+            <div class="k10-buyrate__value" id="br-jeweller">&mdash;</div>
+            <div class="k10-buyrate__range">65&ndash;80%</div>
+          </div>
+          <div class="k10-buyrate">
+            <div class="k10-buyrate__channel">Pawnbroker</div>
+            <div class="k10-buyrate__value" id="br-pawn">&mdash;</div>
+            <div class="k10-buyrate__range">50&ndash;65%</div>
+          </div>
+          <div class="k10-buyrate">
+            <div class="k10-buyrate__channel">Mail-in service</div>
+            <div class="k10-buyrate__value" id="br-postal">&mdash;</div>
+            <div class="k10-buyrate__range">35&ndash;60%</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ LIVE WEIGHT TABLE ═══ -->
+  <div class="k10-section-h">
+    <span class="k10-section-h__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="3" x2="9" y2="21"/><line x1="15" y1="3" x2="15" y2="21"/></svg>
+    </span>
+    <h2 class="k10-section-h__text">10K Gold Price by Weight</h2>
+  </div>
+  <section class="k10-table-card reveal" aria-label="10K gold price table">
+    <div class="k10-table-card__header">
+      <h3 class="k10-table-card__title">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        Live values across common weights
+      </h3>
+      <div class="k10-table-card__sub">Updated every 60 seconds &middot; melt value only</div>
+    </div>
+    <div class="k10-table-wrap">
+      <figure itemscope itemtype="https://schema.org/Table" style="margin:0">
+        <table class="k10-data-table" aria-label="10K gold price by weight in multiple currencies">
+          <caption>10K gold price per gram in USD, GBP, EUR, and INR &mdash; live, updated every 60 seconds</caption>
+          <thead><tr><th scope="col">Weight</th><th scope="col">USD</th><th scope="col">GBP</th><th scope="col">EUR</th><th scope="col">INR</th></tr></thead>
+          <tbody>
+            <tr><td>0.5 g</td><td id="t-0-5-usd" data-nosnippet>&mdash;</td><td id="t-0-5-gbp" data-nosnippet>&mdash;</td><td id="t-0-5-eur" data-nosnippet>&mdash;</td><td id="t-0-5-inr" data-nosnippet>&mdash;</td></tr>
+            <tr class="row-highlight"><td>1 g</td><td id="t-1-usd" data-nosnippet>&mdash;</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-eur" data-nosnippet>&mdash;</td><td id="t-1-inr" data-nosnippet>&mdash;</td></tr>
+            <tr><td>2 g</td><td id="t-2-usd" data-nosnippet>&mdash;</td><td id="t-2-gbp" data-nosnippet>&mdash;</td><td id="t-2-eur" data-nosnippet>&mdash;</td><td id="t-2-inr" data-nosnippet>&mdash;</td></tr>
+            <tr><td>5 g</td><td id="t-5-usd" data-nosnippet>&mdash;</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-eur" data-nosnippet>&mdash;</td><td id="t-5-inr" data-nosnippet>&mdash;</td></tr>
+            <tr><td>10 g</td><td id="t-10-usd" data-nosnippet>&mdash;</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-eur" data-nosnippet>&mdash;</td><td id="t-10-inr" data-nosnippet>&mdash;</td></tr>
+            <tr><td>20 g</td><td id="t-20-usd" data-nosnippet>&mdash;</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-eur" data-nosnippet>&mdash;</td><td id="t-20-inr" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1 <a href="/how-many-grams-in-troy-ounce">troy oz</a> (31.1 g)</td><td id="t-31-usd" data-nosnippet>&mdash;</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-eur" data-nosnippet>&mdash;</td><td id="t-31-inr" data-nosnippet>&mdash;</td></tr>
+          </tbody>
+        </table>
+      </figure>
+    </div>
+  </section>
+
+  <!-- ═══ KARAT COMPARISON ═══ -->
+  <div class="k10-section-h">
+    <span class="k10-section-h__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+    </span>
+    <h2 class="k10-section-h__text">10K Against Other Karats</h2>
+  </div>
+  <section class="reveal" aria-label="Karat comparison">
+    <p style="font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch">Each karat is a different gold content. Higher karat = more gold, higher price, lower durability. Live prices below.</p>
+    <div class="k10-karat-grid">
+      <a href="/9k-gold-price-per-gram" class="k10-karat k10-karat--9k">
+        <div class="k10-karat__title">9K</div>
+        <div class="k10-karat__hallmark">Hallmark 375</div>
+        <div class="k10-karat__bar"><div class="k10-karat__bar-fill" style="width:37.5%"></div></div>
+        <div class="k10-karat__pct">37.5% pure</div>
+        <div class="k10-karat__price" id="karat-9k-price">&mdash;</div>
+        <div class="k10-karat__use">UK everyday jewellery</div>
+      </a>
+      <a href="/10k-gold-price-per-gram" class="k10-karat k10-karat--10k is-current" aria-current="page">
+        <div class="k10-karat__title">10K</div>
+        <div class="k10-karat__hallmark">Hallmark 417</div>
+        <div class="k10-karat__bar"><div class="k10-karat__bar-fill" style="width:41.7%"></div></div>
+        <div class="k10-karat__pct">41.7% pure</div>
+        <div class="k10-karat__price" id="karat-10k-price">&mdash;</div>
+        <div class="k10-karat__use">US minimum standard</div>
+      </a>
+      <a href="/14k-gold-price-per-gram" class="k10-karat k10-karat--14k">
+        <div class="k10-karat__title">14K</div>
+        <div class="k10-karat__hallmark">Hallmark 585</div>
+        <div class="k10-karat__bar"><div class="k10-karat__bar-fill" style="width:58.3%"></div></div>
+        <div class="k10-karat__pct">58.3% pure</div>
+        <div class="k10-karat__price" id="karat-14k-price">&mdash;</div>
+        <div class="k10-karat__use">US engagement rings</div>
+      </a>
+      <a href="/18k-gold-price-per-gram" class="k10-karat k10-karat--18k">
+        <div class="k10-karat__title">18K</div>
+        <div class="k10-karat__hallmark">Hallmark 750</div>
+        <div class="k10-karat__bar"><div class="k10-karat__bar-fill" style="width:75%"></div></div>
+        <div class="k10-karat__pct">75% pure</div>
+        <div class="k10-karat__price" id="karat-18k-price">&mdash;</div>
+        <div class="k10-karat__use">Fine jewellery</div>
+      </a>
+      <a href="/22k-gold-price-per-gram" class="k10-karat k10-karat--22k">
+        <div class="k10-karat__title">22K</div>
+        <div class="k10-karat__hallmark">Hallmark 916</div>
+        <div class="k10-karat__bar"><div class="k10-karat__bar-fill" style="width:91.7%"></div></div>
+        <div class="k10-karat__pct">91.7% pure</div>
+        <div class="k10-karat__price" id="karat-22k-price">&mdash;</div>
+        <div class="k10-karat__use">South Asian bridal</div>
+      </a>
+      <a href="/24k-gold-price-per-gram" class="k10-karat k10-karat--24k">
+        <div class="k10-karat__title">24K</div>
+        <div class="k10-karat__hallmark">Hallmark 999</div>
+        <div class="k10-karat__bar"><div class="k10-karat__bar-fill" style="width:99.9%"></div></div>
+        <div class="k10-karat__pct">99.9% pure</div>
+        <div class="k10-karat__price" id="karat-24k-price">&mdash;</div>
+        <div class="k10-karat__use">Bullion bars &amp; coins</div>
+      </a>
+    </div>
+  </section>
+
+  <!-- ═══ HISTORICAL CHART ═══ -->
+  <div class="k10-section-h">
+    <span class="k10-section-h__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 21H4.6a.6.6 0 0 1-.6-.6V3"/><path d="M7 14l4-4 4 4 5-5"/></svg>
+    </span>
+    <h2 class="k10-section-h__text">10K Price History</h2>
+  </div>
+  <section class="k10-chart-card reveal" aria-label="10K gold price historical chart">
+    <div class="k10-chart-header">
+      <div class="k10-chart-title-wrap">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 17 9 11 13 15 21 7"/><polyline points="14 7 21 7 21 14"/></svg>
+        <div>
+          <h3 class="k10-chart-title">10K Gold &mdash; Per Gram (USD)</h3>
+          <span class="k10-chart-title-sub" id="k10-chart-range-label">Computed from XAU spot &times; 0.4167 &divide; 31.1035</span>
+        </div>
+      </div>
+      <div id="k10-chart-toggle" class="k10-chart-toggle" role="group" aria-label="Time range">
+        <button type="button" data-range="1M">1M</button>
+        <button type="button" data-range="3M">3M</button>
+        <button type="button" data-range="1Y" class="active">1Y</button>
+        <button type="button" data-range="5Y">5Y</button>
+        <button type="button" data-range="10Y">10Y</button>
+      </div>
+    </div>
+    <div class="k10-chart-wrap">
+      <canvas id="k10-chart" aria-label="10K gold price per gram historical line chart"></canvas>
+      <div id="k10-chart-loader" class="k10-chart-loader">Loading historical data&hellip;</div>
+    </div>
+    <div class="k10-chart-stats">
+      <div class="k10-chart-stat"><div class="k10-chart-stat__label">Period Low</div><div id="k10-stat-low" class="k10-chart-stat__value is-low">&mdash;</div></div>
+      <div class="k10-chart-stat"><div class="k10-chart-stat__label">Period High</div><div id="k10-stat-high" class="k10-chart-stat__value is-high">&mdash;</div></div>
+      <div class="k10-chart-stat"><div class="k10-chart-stat__label">Period Average</div><div id="k10-stat-avg" class="k10-chart-stat__value">&mdash;</div></div>
+      <div class="k10-chart-stat"><div class="k10-chart-stat__label">Today vs Avg</div><div id="k10-stat-delta" class="k10-chart-stat__value">&mdash;</div></div>
+    </div>
+  </section>
+
+  <!-- ═══ EDITORIAL PROSE ═══ -->
+  <article class="k10-content">
+    <div class="k10-prose">
+
+      <div class="k10-section-h" style="margin-top:var(--space-8)">
+        <span class="k10-section-h__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+        </span>
+        <h2 class="k10-section-h__text">What Is 10K Gold?</h2>
+      </div>
+
+      <p class="k10-intro">10K gold contains <strong>10 parts pure gold out of 24</strong> &mdash; a purity of <strong>41.67%</strong>. It is the United States' minimum legal gold standard, codified by the FTC's Jewelry Guides under <strong>16 CFR Part 23</strong>. On US and European pieces it is stamped <strong>417</strong>; on US pieces, also <strong>10K</strong> or <strong>10KT</strong>. The remaining 58.33% is an alloy of copper, silver and zinc &mdash; the trade-off that makes 10K harder, more scratch-resistant, and less expensive than 14K or 18K.</p>
+
+      <p class="snippet-answer">10K gold is worth approximately <span id="snippet-price" data-nosnippet>the live price shown above</span> per gram today. This value is calculated by multiplying the live 24K spot price by 0.4167, which represents the 41.67% gold purity of 10 karat gold. Dealers typically pay <strong>65&ndash;90%</strong> of this melt value when buying scrap, depending on the channel.</p>
+
+      <blockquote class="k10-pullquote">
+        &ldquo;10K is the legal floor for gold in the United States. Anything below 41.67% pure cannot be sold as &lsquo;gold&rsquo; under federal law.&rdquo;
+        <cite>&mdash; FTC Jewelry Guides, 16 CFR Part 23</cite>
+      </blockquote>
+
+      <div class="k10-section-h">
+        <span class="k10-section-h__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+        </span>
+        <h2 class="k10-section-h__text">How the 10K Price Is Calculated</h2>
+      </div>
+      <p>10K gold has no spot market of its own &mdash; only pure (24K) gold trades on the LBMA. The per-gram value is derived from the 24K spot price using a simple formula:</p>
+
+      <div class="k10-formula">
+        <div class="k10-formula__label">Formula</div>
+        <div class="k10-formula__body">10K price/g <em>=</em> spot $/oz <em>&divide;</em> 31.1035 <em>&times;</em> 0.4167</div>
+      </div>
+
+      <p>The two constants are fixed: <strong>31.1035 g</strong> per troy ounce, <strong>0.4167</strong> for 41.67% purity. Only the spot price changes. We fetch it every 60 seconds from <strong>gold-api.com</strong>, then convert to GBP, EUR and INR using live FX from the <strong>Frankfurter</strong> rate API.</p>
+
+      <p>Example at <strong>$3,300/oz spot</strong>:</p>
+      <ul>
+        <li>Pure gold per gram = $3,300 &divide; 31.1035 = <strong>$106.10/g</strong></li>
+        <li>10K per gram = $106.10 &times; 0.4167 = <strong>$44.21/g</strong></li>
+        <li>That is the <em>melt value</em>. Dealers pay a percentage of it (see calculator above).</li>
+      </ul>
+
+      <div class="k10-section-h">
+        <span class="k10-section-h__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        </span>
+        <h2 class="k10-section-h__text">The 417 Hallmark</h2>
+      </div>
+      <p>In US jewellery, 10K is most commonly stamped <strong>10K</strong> or <strong>10KT</strong>. In Europe and on import-ready pieces, the same metal is marked <strong>417</strong> &mdash; the millesimal fineness (417 parts pure gold per 1000). Both marks describe the same alloy; only the convention differs by market.</p>
+      <p>In the UK, where 9K (375) is the local minimum, any 10K piece sold over <strong>1 g</strong> must still pass through an approved Assay Office &mdash; London, Birmingham, Sheffield or Edinburgh &mdash; under the Hallmarking Act 1973. When appraising estate or imported jewellery, look for the 417 stamp before relying on a value calculation.</p>
+
+      <aside class="k10-ftc" role="note" aria-label="US legal threshold note">
+        <div class="k10-ftc__top">
+          <span class="k10-ftc__icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><polyline points="9 12 11 14 15 10"/></svg>
+          </span>
+          <h3 class="k10-ftc__title">FTC Legal Threshold &mdash; The US Floor for "Gold"</h3>
+          <span class="k10-ftc__cite">16 CFR Part 23</span>
+        </div>
+        <div class="k10-ftc__body">
+          <p>Under the <strong>Federal Trade Commission's Jewelry Guides</strong>, no item may be labelled, advertised or sold as &ldquo;gold&rdquo; in the United States unless it contains at least <strong>10 karats (41.67%)</strong> of pure gold. Items below this threshold must be sold as &ldquo;gold-plated&rdquo;, &ldquo;gold-filled&rdquo;, or &ldquo;gold-tone&rdquo;.</p>
+          <p>This is a stricter floor than the United Kingdom (<strong>9K / 375</strong>) but more permissive than France and Italy (<strong>18K / 750</strong>). It explains why 10K is the dominant entry-tier gold across North American retail &mdash; Walmart, Kay, Zales, JCPenney and Macy's all stock extensive 10K ranges.</p>
+        </div>
+      </aside>
+
+      <div class="k10-section-h">
+        <span class="k10-section-h__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+        </span>
+        <h2 class="k10-section-h__text">Why 10K Is the Most Durable Karat</h2>
+      </div>
+      <p>Pure 24K gold is remarkably soft &mdash; it can be marked with a fingernail. Alloy metals dramatically increase hardness. On the Vickers (HV) scale, 10K sits at the top of the standard gold-alloy range, making it the natural choice for jewellery that takes daily abuse: class rings, men's wedding bands, working chains, and children's pieces.</p>
+
+      <div class="k10-hardness" aria-label="Vickers hardness comparison across karats">
+        <h3 class="k10-hardness__title">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+          Vickers Hardness by Karat
+        </h3>
+        <p class="k10-hardness__sub">Lower karat = more alloy = harder &amp; more scratch-resistant. Typical values for yellow gold.</p>
+        <div class="k10-hardness__list">
+          <div class="k10-hardness__row k10-hardness__row--current" style="--hardness-shade:#d6a435">
+            <div class="k10-hardness__karat">10K</div>
+            <div class="k10-hardness__bar"><div class="k10-hardness__bar-fill" style="width:92%"><span class="k10-hardness__bar-label">Hardest</span></div></div>
+            <div class="k10-hardness__value">180&ndash;200 HV</div>
+          </div>
+          <div class="k10-hardness__row" style="--hardness-shade:#c9962c">
+            <div class="k10-hardness__karat">9K</div>
+            <div class="k10-hardness__bar"><div class="k10-hardness__bar-fill" style="width:88%"><span class="k10-hardness__bar-label">Very hard</span></div></div>
+            <div class="k10-hardness__value">160&ndash;180 HV</div>
+          </div>
+          <div class="k10-hardness__row" style="--hardness-shade:#e0b144">
+            <div class="k10-hardness__karat">14K</div>
+            <div class="k10-hardness__bar"><div class="k10-hardness__bar-fill" style="width:78%"><span class="k10-hardness__bar-label">Hard</span></div></div>
+            <div class="k10-hardness__value">150&ndash;180 HV</div>
+          </div>
+          <div class="k10-hardness__row" style="--hardness-shade:#ecbe55">
+            <div class="k10-hardness__karat">18K</div>
+            <div class="k10-hardness__bar"><div class="k10-hardness__bar-fill" style="width:62%"><span class="k10-hardness__bar-label">Medium</span></div></div>
+            <div class="k10-hardness__value">120&ndash;150 HV</div>
+          </div>
+          <div class="k10-hardness__row" style="--hardness-shade:#f5cc6a">
+            <div class="k10-hardness__karat">22K</div>
+            <div class="k10-hardness__bar"><div class="k10-hardness__bar-fill" style="width:30%"><span class="k10-hardness__bar-label">Soft</span></div></div>
+            <div class="k10-hardness__value">52&ndash;75 HV</div>
+          </div>
+          <div class="k10-hardness__row" style="--hardness-shade:#f7d77d">
+            <div class="k10-hardness__karat">24K</div>
+            <div class="k10-hardness__bar"><div class="k10-hardness__bar-fill" style="width:12%"><span class="k10-hardness__bar-label">Very soft</span></div></div>
+            <div class="k10-hardness__value">~25 HV</div>
+          </div>
+        </div>
+        <div class="k10-hardness__legend">
+          <span>Most durable</span>
+          <span>Vickers HV scale</span>
+          <span>Softest</span>
+        </div>
+      </div>
+
+      <p>This makes 10K the ideal choice for jewellery that needs to survive daily wear &mdash; <strong>class rings, chains worn under clothing, men's wedding bands for manual workers, and children's pieces</strong> where durability matters more than gold content.</p>
+
+      <div class="k10-section-h">
+        <span class="k10-section-h__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+        </span>
+        <h2 class="k10-section-h__text">10K Gold and Skin Sensitivity</h2>
+      </div>
+      <p>Because 10K contains <strong>58.33% alloy metals</strong> (more alloy than gold), it carries a higher risk of <strong>contact dermatitis</strong> than 14K or 18K &mdash; particularly for people with <strong>nickel sensitivity</strong>. White 10K gold historically uses nickel as a whitening agent, one of the most common jewellery allergens. If you have sensitive skin:</p>
+      <ul>
+        <li><strong>Choose yellow or rose 10K</strong> &mdash; typically uses copper and silver, which trigger fewer reactions than nickel.</li>
+        <li><strong>Ask for nickel-free alloys</strong> &mdash; some US manufacturers offer palladium-whitened 10K.</li>
+        <li><strong>Step up to <a href="/14k-gold-price-per-gram">14K</a> or <a href="/18k-gold-price-per-gram">18K</a></strong> &mdash; less alloy content, gentler on the skin.</li>
+        <li><strong>Clear nail polish</strong> on the inside of a ring is a short-term barrier &mdash; effective for hours, not days.</li>
+      </ul>
+
+      <div class="k10-section-h">
+        <span class="k10-section-h__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        </span>
+        <h2 class="k10-section-h__text">10K vs 9K &mdash; US vs UK</h2>
+      </div>
+      <p>10K (US) and <a href="/9k-gold-price-per-gram">9K</a> (UK) both serve as entry-level gold &mdash; but they sit on opposite sides of the Atlantic legal divide. The 4.2 percentage-point gap in purity has real consequences for value, resale and reach.</p>
+
+      <div class="k10-compare-grid">
+        <div class="k10-compare-card k10-compare-card--10k">
+          <div class="k10-compare-card__head">
+            <div class="k10-compare-card__karat">10K</div>
+            <div class="k10-compare-card__flag">US Standard</div>
+          </div>
+          <dl>
+            <dt>Purity</dt><dd>41.67%</dd>
+            <dt>Hallmark</dt><dd>417 / 10K / 10KT</dd>
+            <dt>Legal floor</dt><dd>US, Canada</dd>
+            <dt>Typical use</dt><dd>Class rings, chains, men's bands</dd>
+            <dt>Hardness</dt><dd>Hardest standard gold alloy</dd>
+            <dt>Per-gram value</dt><dd>~11% more than 9K</dd>
+          </dl>
+        </div>
+        <div class="k10-compare-card k10-compare-card--9k">
+          <div class="k10-compare-card__head">
+            <div class="k10-compare-card__karat">9K</div>
+            <div class="k10-compare-card__flag">UK Standard</div>
+          </div>
+          <dl>
+            <dt>Purity</dt><dd>37.50%</dd>
+            <dt>Hallmark</dt><dd>375</dd>
+            <dt>Legal floor</dt><dd>UK, IE, AU, NZ</dd>
+            <dt>Typical use</dt><dd>British high-street jewellery</dd>
+            <dt>Hardness</dt><dd>Slightly softer than 10K</dd>
+            <dt>Per-gram value</dt><dd>Roughly 90% of 10K's melt</dd>
+          </dl>
+        </div>
+      </div>
+
+      <p><strong>Resale in the US:</strong> 10K resells freely because dealers expect it &mdash; you're paid on weight and purity regardless. <strong>In the UK</strong>, 10K is rare on the high street (9K dominates the entry tier and 14K covers the mid range), but reputable scrap buyers will still test and pay melt-percentage. <strong>In France or Italy</strong>, neither 9K nor 10K legally qualifies as &ldquo;gold&rdquo; &mdash; sales are restricted to 18K (750) and above.</p>
+
+      <div class="k10-section-h">
+        <span class="k10-section-h__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L5 6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+        </span>
+        <h2 class="k10-section-h__text">Selling 10K Scrap</h2>
+      </div>
+      <p>10K dominates the US <strong>scrap gold</strong> market for the same reasons it dominates the high street. But the economics differ from higher karats:</p>
+      <ul>
+        <li><strong>Lower per-gram value.</strong> A gram of 10K is worth roughly half a gram of <a href="/18k-gold-price-per-gram">18K</a>. A typical 15&ndash;25 g 10K chain has a melt value of <strong>several hundred dollars</strong> at current spot prices &mdash; use the calculator above for the exact figure.</li>
+        <li><strong>Higher refining cost.</strong> Refiners must process more alloy per gram of recovered gold, so the buy-rate (% of melt) on 10K is typically 3&ndash;5 percentage points below 18K or 22K.</li>
+        <li><strong>Wide channel spread.</strong> The best and worst quotes on the same lot can differ by <strong>30%+</strong>. Always get at least three quotes &mdash; the calculator above sets your floor.</li>
+        <li><strong>Bulk matters.</strong> A 50 g+ lot is far more attractive to refiners than a single 2 g ring &mdash; accumulating scrap can lift the rate 5&ndash;10%.</li>
+      </ul>
+      <p>Use our <a href="/scrap-gold-calculator">scrap gold calculator</a> to compute melt across mixed-karat lots, or read our guide on <a href="/guides/how-to-sell-gold-jewellery">how to sell gold jewellery</a> for negotiation tactics.</p>
+
+      <!-- FAQ -->
+      <div class="k10-section-h">
+        <span class="k10-section-h__icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        </span>
+        <h2 class="k10-section-h__text">Frequently Asked Questions</h2>
+      </div>
+
+      <div class="k10-faq">
+        <details>
+          <summary>What is the 10K gold price per gram today?</summary>
+          <div class="faq-body faq-answer"><p>The live 10K gold price per gram is shown at the top of this page &mdash; calculated by multiplying the current 24K spot price per troy ounce by <strong>0.4167</strong> (10K purity) and dividing by <strong>31.1035</strong> (grams per troy ounce). It refreshes every 60 seconds.</p></div>
+        </details>
+        <details>
+          <summary>Is 10K gold real gold?</summary>
+          <div class="faq-body faq-answer"><p>Yes. 10K gold is real gold &mdash; it contains <strong>41.67% pure gold</strong> (10 parts gold out of 24), alloyed with copper, silver and sometimes zinc or nickel for strength and durability. It is the legal minimum standard for gold jewellery in the United States.</p></div>
+        </details>
+        <details>
+          <summary>What does the 417 hallmark mean?</summary>
+          <div class="faq-body faq-answer"><p>The <strong>417</strong> hallmark indicates 10K gold with <strong>41.67% purity</strong> (417 parts pure gold per 1000). In the UK this stamp must be applied by an approved Assay Office under the Hallmarking Act 1973. In the US, the same alloy is more commonly stamped <strong>10K</strong> or <strong>10KT</strong>.</p></div>
+        </details>
+        <details>
+          <summary>How do I calculate the melt value of my 10K gold?</summary>
+          <div class="faq-body faq-answer"><p>Melt value = weight in grams &times; (spot price per troy oz &divide; 31.1035) &times; 0.4167. Or use the calculator above &mdash; enter the weight and your currency, and it returns the live melt value plus the typical dealer buy-rates as a percentage.</p></div>
+        </details>
+        <details>
+          <summary>What percentage of melt value do dealers actually pay for 10K?</summary>
+          <div class="faq-body faq-answer"><p>Online specialist gold buyers typically pay <strong>80&ndash;90%</strong> of melt; high-street jewellers <strong>65&ndash;80%</strong>; pawnbrokers <strong>50&ndash;65%</strong>; postal/mail-in gold-buying services <strong>35&ndash;60%</strong>. Always get three quotes &mdash; the spread can exceed 30% on the same item.</p></div>
+        </details>
+        <details>
+          <summary>Why does the 10K gold price per gram vary between different websites?</summary>
+          <div class="faq-body faq-answer"><p>Small differences reflect the timing of the data feed, the spot source (LBMA, COMEX or OTC), and which FX rate is applied. GoldPriceTools fetches gold from <strong>gold-api.com</strong> and currency from <strong>Frankfurter</strong>, both every 60 seconds.</p></div>
+        </details>
+        <details>
+          <summary>What is the difference between 10K solid gold, gold-filled and gold-plated?</summary>
+          <div class="faq-body faq-answer"><p>Solid 10K contains <strong>41.67% pure gold</strong> throughout the item. <strong>Gold-filled</strong> bonds a 10K layer to a base-metal core &mdash; far less gold by weight. <strong>Gold-plated</strong> has only a thin electroplated gold layer (often &lt;0.05% of total weight) and effectively no melt value. Only solid 10K carries the 417 hallmark and has meaningful scrap value.</p></div>
+        </details>
+        <details>
+          <summary>How do I convert the 10K gold price from troy ounces to grams?</summary>
+          <div class="faq-body faq-answer"><p>There are <strong>31.1035 grams</strong> in one troy ounce. Divide the per-troy-oz price by 31.1035 to get per-gram pure gold, then multiply by 0.4167 for 10K. See our <a href="/how-many-grams-in-troy-ounce">troy ounce converter</a> for instant conversions.</p></div>
+        </details>
+      </div>
+
+      <div class="k10-disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Dealer buy prices are typically 65&ndash;90% of melt value depending on channel and item condition. Always verify with your dealer before selling.</div>
+
+      <!-- Share buttons -->
+      <div class="k10-share">
+        <span>Share:</span>
+        <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/10k-gold-price-per-gram&amp;text=10K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+        <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/10k-gold-price-per-gram&amp;title=10K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+        <a href="https://api.whatsapp.com/send?text=10K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F10k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+      </div>
+
+    </div>
+  </article>
+</main>
+
+<!-- Related Guides -->
+<section class="related-guides">
+  <div class="container">
     <h2>Related Gold &amp; Silver Guides</h2>
     <div class="related-guides-grid">
+      <a href="/9k-gold-price-per-gram" class="related-card">
+        <div class="related-card__tag">Live Price</div>
+        <div class="related-card__title">9K Gold Price Per Gram</div>
+        <div class="related-card__desc">Today's 9K gold price &mdash; the UK equivalent of 10K, both are entry-level jewellery gold.</div>
+      </a>
       <a href="/14k-gold-price-per-gram" class="related-card">
         <div class="related-card__tag">Live Price</div>
         <div class="related-card__title">14K Gold Price Per Gram</div>
-        <div class="related-card__desc">Live 14K gold price per gram — the most widely traded karat for jewellery in the US.</div>
+        <div class="related-card__desc">Live 14K gold price per gram &mdash; the most widely traded karat for jewellery in the US.</div>
       </a>
       <a href="/18k-gold-price-per-gram" class="related-card">
         <div class="related-card__tag">Live Price</div>
@@ -686,27 +1158,17 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <a href="/scrap-gold-calculator" class="related-card">
         <div class="related-card__tag">Tool</div>
         <div class="related-card__title">Scrap Gold Calculator</div>
-        <div class="related-card__desc">Calculate the melt value of 10K scrap gold using today's live spot price.</div>
+        <div class="related-card__desc">Calculate the melt value of mixed-karat scrap including 10K at today's live spot price.</div>
       </a>
       <a href="/guides/gold-hallmarks-explained" class="related-card">
         <div class="related-card__tag">Guide</div>
         <div class="related-card__title">Gold Hallmarks Explained</div>
-        <div class="related-card__desc">Understand what hallmarks mean on your 10K gold pieces — 375, 417 and more.</div>
+        <div class="related-card__desc">Understand what hallmarks mean on your 10K gold pieces &mdash; 375, 417, 585 and more.</div>
       </a>
       <a href="/guides/how-to-sell-gold-jewellery" class="related-card">
         <div class="related-card__tag">Guide</div>
         <div class="related-card__title">How to Sell Gold Jewellery</div>
-        <div class="related-card__desc">How to get the best price for your 10K gold pieces.</div>
-      </a>
-      <a href="/guides/gold-purity-guide" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold Purity Guide</div>
-        <div class="related-card__desc">Understand gold hallmarks, karats and millesimal fineness — 375, 585, 750 and 999 explained.</div>
-      </a>
-      <a href="/gold-price-today-10k" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">Gold Price Today 10K</div>
-        <div class="related-card__desc">Today's live 10 karat gold value in USD, GBP and EUR — updated every 60 seconds.</div>
+        <div class="related-card__desc">How to get the best price for your 10K gold pieces and avoid common pitfalls.</div>
       </a>
     </div>
   </div>
@@ -719,7 +1181,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
       <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
@@ -732,7 +1194,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -788,17 +1249,370 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
   </div>
 </footer>
+
 <script>
-async function fetchFx(){try{const r=await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,INR',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.rates.GBP||0.79;window._usdinr=d.rates.INR||83.5;}catch{window._gbpusd=0.79;}}
-async function fetchSpot(){const PURITY=0.4167;try{const r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();const spotUSD=d.price;const pgUSD=spotUSD/31.1035*PURITY;const pgGBP=pgUSD*(window._gbpusd||0.79);
-    const pgINR=pgUSD*(window._usdinr||83.5);document.getElementById('price-gbp').textContent='£'+pgGBP.toFixed(2)+'/g';document.getElementById('price-usd').textContent='$'+pgUSD.toFixed(2)+'/g USD';
-    const snippetEl = document.getElementById('snippet-price');
-    if(snippetEl) snippetEl.textContent='£'+pgGBP.toFixed(2)+' ($'+pgUSD.toFixed(2)+' USD)';[[1,'1'],[5,'5'],[10,'10'],[20,'20'],[31.1035,'31']].forEach(([w,id])=>{const g=document.getElementById('t-'+id+'-gbp');const u=document.getElementById('t-'+id+'-usd');if(g)g.textContent='£'+(pgGBP*w).toFixed(2);if(u)u.textContent='$'+(pgUSD*w).toFixed(2);
-      const inrEl=document.getElementById('t-'+ids[i]+'-inr');
-      if(inrEl)inrEl.textContent='₹'+(pgINR*w).toFixed(2);});}catch(e){console.warn('Price fetch failed',e);}}
-Promise.all([fetchFx(),fetchSpot()]);setInterval(fetchSpot,60000);
+(function(){
+  /* ── 10K Page state ─────────────────────────────────────────────────── */
+  const PURITY = 0.4167;
+  const G_PER_OZ = 31.1035;
+  const G_PER_DWT = 1.55517384;
+  const KARATS = [
+    { id: '9k',  pct: 0.375  },
+    { id: '10k', pct: 0.4167 },
+    { id: '14k', pct: 0.5833 },
+    { id: '18k', pct: 0.7500 },
+    { id: '22k', pct: 0.9167 },
+    { id: '24k', pct: 0.9990 }
+  ];
+  const state = {
+    spotUSD: 0,
+    pgUSD: 0,
+    currency: 'USD',
+    fx: { USD: 1, GBP: 0.79, EUR: 0.92, INR: 83.5 },
+    historyRange: '1Y',
+    chart: null
+  };
+  const $ = id => document.getElementById(id);
+  const CURRENCY_SYMBOL = { USD:'$', GBP:'£', EUR:'€', INR:'₹' };
+  const fmtMoney = (v, cur) => {
+    if (!isFinite(v)) return CURRENCY_SYMBOL[cur] + '0.00';
+    const opts = (cur === 'INR' && v >= 100)
+      ? { minimumFractionDigits: 0, maximumFractionDigits: 0 }
+      : { minimumFractionDigits: 2, maximumFractionDigits: 2 };
+    return CURRENCY_SYMBOL[cur] + v.toLocaleString('en-US', opts);
+  };
+  const fmtSpot = (v) => '$' + v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  /* ── Live FX ──────────────────────────────────────────────────────── */
+  async function fetchFX() {
+    try {
+      const r = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR', { cache: 'no-store' });
+      if (!r.ok) throw new Error();
+      const d = await r.json();
+      if (d && d.rates) {
+        state.fx.GBP = d.rates.GBP || state.fx.GBP;
+        state.fx.EUR = d.rates.EUR || state.fx.EUR;
+        state.fx.INR = d.rates.INR || state.fx.INR;
+      }
+    } catch (e) { /* keep fallbacks */ }
+  }
+
+  /* ── Live spot ────────────────────────────────────────────────────── */
+  async function fetchSpot() {
+    try {
+      const r = await fetch('https://api.gold-api.com/price/XAU', { cache: 'no-store' });
+      if (!r.ok) throw new Error();
+      const d = await r.json();
+      state.spotUSD = d.price;
+      state.pgUSD = (state.spotUSD / G_PER_OZ) * PURITY;
+      renderAll();
+      if (typeof gtag === 'function') gtag('event', 'price_view', { metal: 'gold', karat: '10K' });
+    } catch (e) {
+      console.warn('Price fetch failed', e);
+    }
+  }
+
+  /* ── Render: hero, spot tiles, snippet ───────────────────────────── */
+  function renderHero() {
+    if (!state.pgUSD) return;
+    const pgGBP = state.pgUSD * state.fx.GBP;
+
+    /* Primary hero shows USD big + GBP secondary (US-first for 10K) */
+    const heroEl = $('price-gbp'); // ID retained for backward compatibility
+    if (heroEl) heroEl.innerHTML = '$' + state.pgUSD.toFixed(2) + '<span class="k10-primary__currency">/g</span>';
+    const usdEl = $('price-usd'); // ID retained; now displays GBP secondary
+    if (usdEl) usdEl.textContent = '£' + pgGBP.toFixed(2) + '/g';
+
+    /* Snippet for the SEO answer block */
+    const snippet = $('snippet-price');
+    if (snippet) snippet.textContent = '$' + state.pgUSD.toFixed(2) + ' (£' + pgGBP.toFixed(2) + ' GBP)';
+
+    /* Spot tiles */
+    const t24 = $('spot-24k-display');
+    if (t24) t24.textContent = fmtSpot(state.spotUSD);
+
+    /* Last updated chip */
+    const lu = $('last-updated');
+    if (lu) {
+      const now = new Date();
+      const t = now.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+      lu.textContent = 'Updated ' + t;
+    }
+
+    /* Purity donut "pure value" line — value of the 0.4167g pure gold in 1g of 10K */
+    const pure = $('purity-pure-value');
+    if (pure) pure.textContent = fmtMoney(PURITY * (state.spotUSD / G_PER_OZ), 'USD');
+  }
+
+  function renderTable() {
+    if (!state.pgUSD) return;
+    const pgGBP = state.pgUSD * state.fx.GBP;
+    const pgEUR = state.pgUSD * state.fx.EUR;
+    const pgINR = state.pgUSD * state.fx.INR;
+    const weights = [0.5, 1, 2, 5, 10, 20, G_PER_OZ];
+    const ids = ['0-5','1','2','5','10','20','31'];
+    weights.forEach((w, i) => {
+      const set = (suffix, val) => {
+        const el = $('t-' + ids[i] + '-' + suffix);
+        if (el) el.textContent = val;
+      };
+      set('usd', '$' + (state.pgUSD * w).toFixed(2));
+      set('gbp', '£' + (pgGBP * w).toFixed(2));
+      set('eur', '€' + (pgEUR * w).toFixed(2));
+      set('inr', '₹' + (pgINR * w).toLocaleString('en-US', { maximumFractionDigits: 0 }));
+    });
+  }
+
+  function renderKarats() {
+    if (!state.spotUSD) return;
+    KARATS.forEach(k => {
+      const el = $('karat-' + k.id + '-price');
+      if (!el) return;
+      const pgUSDk = (state.spotUSD / G_PER_OZ) * k.pct;
+      el.textContent = '$' + pgUSDk.toFixed(2) + '/g';
+    });
+  }
+
+  /* ── Calculator ───────────────────────────────────────────────────── */
+  const weightInput = $('k10-input-weight');
+  const unitSel = $('k10-input-unit');
+  const unitSuffix = $('k10-unit-suffix');
+  const resultEl = $('k10-result');
+  const resultSubEl = $('k10-result-sub');
+
+  function weightInGrams() {
+    const v = parseFloat(weightInput.value) || 0;
+    const u = unitSel.value;
+    if (u === 'oz') return v * G_PER_OZ;
+    if (u === 'dwt') return v * G_PER_DWT;
+    return v;
+  }
+
+  function renderCalc() {
+    if (!state.pgUSD) {
+      resultEl.textContent = '—';
+      resultSubEl.textContent = 'Waiting for live spot price…';
+      return;
+    }
+    const w = weightInGrams();
+    const cur = state.currency;
+    const fx = state.fx[cur] || 1;
+    const meltUSD = w * state.pgUSD;
+    const melt = meltUSD * fx;
+    resultEl.textContent = fmtMoney(melt, cur);
+    const u = unitSel.value;
+    const wDisp = (parseFloat(weightInput.value) || 0).toLocaleString('en-US', { maximumFractionDigits: 3 });
+    const unitName = u === 'oz' ? 'troy oz' : u === 'dwt' ? 'pennyweight' : 'g';
+    resultSubEl.innerHTML = wDisp + ' ' + unitName + ' &times; <strong>10K (41.67%) melt</strong> at live spot';
+
+    /* Buy-rate breakdown — show midpoints of the typical ranges */
+    const setBR = (id, lo, hi) => {
+      const el = $(id);
+      if (!el) return;
+      const mid = melt * ((lo + hi) / 2);
+      el.textContent = fmtMoney(mid, cur);
+    };
+    setBR('br-online',   0.80, 0.90);
+    setBR('br-jeweller', 0.65, 0.80);
+    setBR('br-pawn',     0.50, 0.65);
+    setBR('br-postal',   0.35, 0.60);
+  }
+
+  function syncUnitSuffix() {
+    const u = unitSel.value;
+    unitSuffix.textContent = u === 'oz' ? 'OZ' : u === 'dwt' ? 'DWT' : 'G';
+  }
+
+  weightInput.addEventListener('input', renderCalc);
+  unitSel.addEventListener('change', () => { syncUnitSuffix(); renderCalc(); });
+  document.querySelectorAll('.k10-preset').forEach(btn => {
+    btn.addEventListener('click', () => {
+      weightInput.value = btn.dataset.w;
+      unitSel.value = 'g';
+      syncUnitSuffix();
+      renderCalc();
+    });
+  });
+  document.querySelectorAll('#k10-currency-toggle button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#k10-currency-toggle button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      state.currency = btn.dataset.currency;
+      renderCalc();
+    });
+  });
+
+  function renderAll() {
+    renderHero();
+    renderTable();
+    renderKarats();
+    renderCalc();
+  }
+
+  /* ── Historical chart (lazy-loaded) ──────────────────────────────── */
+  let chartJSPromise = null;
+  function loadChartJS() {
+    if (chartJSPromise) return chartJSPromise;
+    chartJSPromise = new Promise((resolve, reject) => {
+      const s = document.createElement('script');
+      s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js';
+      s.onload = resolve;
+      s.onerror = reject;
+      document.head.appendChild(s);
+    });
+    return chartJSPromise;
+  }
+
+  const RANGE_LABEL = {
+    '1M': 'Last 30 days · daily XAU spot × 0.4167 ÷ 31.1035',
+    '3M': 'Last 90 days · weekly XAU spot × 0.4167 ÷ 31.1035',
+    '1Y': 'Last 12 months · weekly XAU spot × 0.4167 ÷ 31.1035',
+    '5Y': 'Last 5 years · monthly XAU spot × 0.4167 ÷ 31.1035',
+    '10Y':'Last 10 years · monthly XAU spot × 0.4167 ÷ 31.1035'
+  };
+
+  async function loadHistory(range) {
+    const loader = $('k10-chart-loader');
+    if (loader) { loader.style.display = 'flex'; loader.textContent = 'Loading historical data…'; }
+    try {
+      const r = await fetch('/chart-data/XAU-' + range + '.json');
+      if (!r.ok) throw new Error();
+      const j = await r.json();
+      const labels = j.labels;
+      const data = j.data.map(v => (v / G_PER_OZ) * PURITY); // convert spot/oz to 10K per gram (USD)
+      await loadChartJS();
+      drawChart(labels, data);
+      updateChartStats(data);
+      const lbl = $('k10-chart-range-label');
+      if (lbl) lbl.textContent = RANGE_LABEL[range] || RANGE_LABEL['1Y'];
+      if (loader) loader.style.display = 'none';
+    } catch (e) {
+      console.warn('History load failed', e);
+      if (loader) loader.textContent = 'Historical data unavailable';
+    }
+  }
+
+  function drawChart(labels, data) {
+    const canvas = $('k10-chart');
+    if (!canvas) return;
+    const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+    const gold = '#e8af34';
+    const textMuted = '#7a7974';
+    const grid = isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.06)';
+    if (state.chart) state.chart.destroy();
+    state.chart = new Chart(canvas, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          data,
+          borderColor: gold,
+          borderWidth: 2,
+          fill: true,
+          backgroundColor: function(c) {
+            const g = c.chart.ctx.createLinearGradient(0, 0, 0, 340);
+            g.addColorStop(0, gold + '55');
+            g.addColorStop(1, gold + '00');
+            return g;
+          },
+          pointRadius: 0,
+          pointHitRadius: 14,
+          tension: 0.32
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            backgroundColor: 'rgba(15,14,12,0.92)',
+            titleColor: '#fff',
+            bodyColor: '#fff',
+            padding: 10,
+            displayColors: false,
+            callbacks: { label: ctx => ' 10K: $' + ctx.parsed.y.toFixed(2) + '/g' }
+          }
+        },
+        scales: {
+          x: { ticks: { color: textMuted, font: { size: 11 }, maxTicksLimit: 6 }, grid: { color: grid, drawTicks: false } },
+          y: { ticks: { color: textMuted, font: { size: 11 }, callback: v => '$' + v.toFixed(0) }, grid: { color: grid }, position: 'right' }
+        },
+        interaction: { mode: 'index', intersect: false }
+      }
+    });
+  }
+
+  function updateChartStats(arr) {
+    if (!arr.length) return;
+    const min = Math.min.apply(null, arr);
+    const max = Math.max.apply(null, arr);
+    const avg = arr.reduce((a, b) => a + b, 0) / arr.length;
+    const setStat = (id, v) => { const el = $(id); if (el) el.textContent = '$' + v.toFixed(2); };
+    setStat('k10-stat-low',  min);
+    setStat('k10-stat-high', max);
+    setStat('k10-stat-avg',  avg);
+    if (state.pgUSD) {
+      const delta = state.pgUSD - avg;
+      const el = $('k10-stat-delta');
+      if (el) {
+        const sign = delta >= 0 ? '+' : '';
+        el.textContent = sign + '$' + delta.toFixed(2);
+        el.className = 'k10-chart-stat__value ' + (delta > avg*0.05 ? 'is-high' : delta < -avg*0.05 ? 'is-low' : '');
+      }
+    }
+  }
+
+  document.querySelectorAll('#k10-chart-toggle button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('#k10-chart-toggle button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      state.historyRange = btn.dataset.range;
+      loadHistory(state.historyRange);
+    });
+  });
+
+  /* ── Scroll reveal ───────────────────────────────────────────────── */
+  if ('IntersectionObserver' in window) {
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('is-visible'); io.unobserve(e.target); } });
+    }, { rootMargin: '0px 0px -60px 0px', threshold: 0.05 });
+    document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+
+    const chartEl = document.querySelector('.k10-chart-wrap');
+    if (chartEl) {
+      const chartIO = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting) {
+          loadHistory(state.historyRange);
+          chartIO.disconnect();
+        }
+      }, { rootMargin: '200px' });
+      chartIO.observe(chartEl);
+    }
+  } else {
+    document.querySelectorAll('.reveal').forEach(el => el.classList.add('is-visible'));
+    loadHistory(state.historyRange);
+  }
+
+  /* ── Init ─────────────────────────────────────────────────────────── */
+  syncUnitSuffix();
+  fetchFX().then(() => fetchSpot());
+  setInterval(fetchSpot, 60000);
+})();
 </script>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+<script>(function(){
+  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
+  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+  root.setAttribute('data-theme',theme);
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);try{localStorage.setItem('gpt-theme',theme);}catch(e){}themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
+  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
+  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
+  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
+  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
+})();</script>
 <script>
 let _deepReadFired = false;
 window.addEventListener('scroll', () => {


### PR DESCRIPTION
## Summary

Full redesign of `/10k-gold-price-per-gram` to match the premium financial-dashboard template introduced for the 9K page (#376), adapted for 10K-specific framing.

**Distinctive 10K elements vs the sibling pattern:**
- **US Legal Min chip** in the price card (blue-tinted) alongside the 417 hallmark chip
- **FTC Legal Threshold callout** (blue government-style aside citing 16 CFR Part 23)
- **Vickers hardness comparison chart** — horizontal bars showing 10K = hardest standard alloy (180–200 HV), with the 10K row highlighted
- **US vs UK compare cards** — 10K (US Standard) vs 9K (UK Standard) side-by-side
- **Hero leads in USD** (matches the US audience for 10K) while still surfacing GBP and the multi-currency table

**Sections (mobile-first, scales to 1100px max-width):**
1. Hero with eyebrow live-dot chip
2. Primary price card — massive numeric, USD + GBP, chips for purity/hallmark/US-min/last-updated
3. Spot tiles — 24K reference + ×0.4167 conversion factor
4. Source bar (LBMA via gold-api.com + FX via Frankfurter + link to /about)
5. Purity donut — 41.67% gold arc + composition breakdown (Au / alloys / pure gold value)
6. Calculator — currency toggle (USD/GBP/EUR/INR), unit toggle (g/oz/dwt), jewellery weight presets, dealer buy-rate breakdown
7. Live multi-currency weight table (0.5g → 1 troy oz)
8. Karat comparison grid (10K marked "YOU ARE HERE")
9. Historical chart (1M/3M/1Y/5Y/10Y, lazy-loaded Chart.js)
10. Editorial prose with drop-cap intro, pullquote, formula block, FTC callout, Vickers chart, compare cards
11. FAQ accordion, disclaimer, share buttons, related guides

## Live data accuracy

Identical contract to sibling karat pages:
- `XAU` spot from `api.gold-api.com/price/XAU`
- FX from `api.frankfurter.dev` (`USD → GBP, EUR, INR`)
- `PURITY = 0.4167`, `G_PER_OZ = 31.1035`
- `setInterval(fetchSpot, 60000)` — 60-second refresh
- Historical data from `/chart-data/XAU-{1M,3M,1Y,5Y,10Y}.json`, converted to 10K per-gram USD client-side

Also fixes a latent bug in the previous version where the table-update `forEach` referenced an undefined `ids[i]` (INR row never populated).

## SEO / structured data

All preserved and updated:
- FAQPage schema, BreadcrumbList schema, WebPage + Speakable schema
- Canonical URL, hreflang `en-gb`/`en-us`/`x-default`
- Updated `<title>` and meta description to reflect the new multi-currency + US-min framing

## Test plan

- [ ] Run `python3 tools/playwright_audit.py https://goldpricetools.com/10k-gold-price-per-gram` after deploy (per DEVELOPMENT_RULES.md Rule 3)
- [ ] Verify hero price renders (USD large, GBP secondary) within 2s of load
- [ ] Verify weight table populates all 4 currency columns across all 7 rows
- [ ] Verify karat comparison grid shows current 10K with "YOU ARE HERE" badge
- [ ] Verify calculator: change weight → result updates; change unit g→oz→dwt → result + suffix update; click preset → weight + result update; switch currency → result + buy-rates update
- [ ] Verify chart loads on scroll, range buttons swap data + label, stats (low/high/avg/delta) update
- [ ] Verify FAQ details elements expand/collapse, theme toggle persists, mobile menu opens
- [ ] Visual sweep at 375px (iPhone), 768px (tablet), 1024px, 1440px (desktop) — both dark and light themes
- [ ] Spot-check axe-style accessibility: aria-labels on icon buttons, focus rings, 44×44 tap targets


---
_Generated by [Claude Code](https://claude.ai/code/session_01TqTukw4Fv41gs3yZ7aYUFY)_