### PR TITLE
Redesign 14K gold price page with premium editorial UI

### DIFF
--- a/14k-gold-price-per-gram.html
+++ b/14k-gold-price-per-gram.html
@@ -9,7 +9,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>14K Gold Price Per Gram Today (Live UK) — 585 Hallmark Value | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Live 14K gold price per gram in USD and GBP. 14 karat (585 hallmark) = 58.33% pure gold. Free calculator for rings, chains, and scrap. Updated every 60 seconds from LBMA.">
+<meta name="description" content="Live 14K gold price per gram in USD, GBP and INR. 14 karat (585 hallmark) = 58.33% pure gold. Free calculator for rings, chains, and scrap. Updated every 60 seconds from LBMA.">
 <meta name="robots" content="index, follow">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/14k-gold-price-per-gram">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/14k-gold-price-per-gram">
@@ -51,7 +51,9 @@
 <meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.gold-api.com">
+<link rel="preconnect" href="https://api.frankfurter.dev">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:wght@500;600;700;800&display=swap" rel="stylesheet">
 <style>
 
 /* ── Guides mega panel — category links ── */
@@ -64,8 +66,8 @@
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
 
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#5a5953;--color-text-faint:#8a8983;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#c08a00;--color-gold-deep:#8a5e00;--color-silver:#6b7280;--color-success:#0f7a3d;--color-danger:#b91c1c;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--shadow-gold:0 8px 32px -8px oklch(0.7 0.15 80/0.3);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--space-20:5rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--text-3xl:clamp(2.5rem,1.5rem + 4vw,5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-editorial:'Playfair Display',Georgia,serif;--transition:180ms cubic-bezier(0.16,1,0.3,1);--transition-slow:400ms cubic-bezier(0.16,1,0.3,1);--gradient-gold:linear-gradient(135deg,#d4a017 0%,#f4cc4b 35%,#b07a00 100%);--gradient-gold-soft:linear-gradient(135deg,oklch(0.7 0.13 80/0.18) 0%,oklch(0.6 0.12 80/0.06) 100%);--gold-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.7 0.15 80/0.12),transparent 60%)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#e8e6e0;--color-text-muted:#a09e98;--color-text-faint:#6a6864;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-gold-deep:#a87a1a;--color-silver:#9ca3af;--color-success:#4ade80;--color-danger:#f87171;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5);--shadow-gold:0 8px 32px -4px oklch(0.55 0.15 75/0.35);--gradient-gold:linear-gradient(135deg,#e8af34 0%,#f4cc4b 35%,#a87a1a 100%);--gradient-gold-soft:linear-gradient(135deg,oklch(0.6 0.13 80/0.18) 0%,oklch(0.4 0.08 80/0.04) 100%);--gold-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.6 0.15 75/0.15),transparent 60%)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 /* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
@@ -92,7 +94,7 @@ input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+:focus-visible{outline:2px solid var(--color-gold-bright);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 
@@ -107,9 +109,9 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
 .ticker-label{color:var(--color-text-muted)}
 .ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
-.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
+.ticker-change.up{color:var(--color-success)}
+.ticker-change.down{color:var(--color-danger)}
+.live-dot{width:6px;height:6px;border-radius:50%;background:var(--color-success);animation:pulse 2s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
 
 /* NAV */
@@ -139,142 +141,311 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 .ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
 .ad-slot-sidebar ins{display:block;width:100%}
 
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
+/* ────────────────────────────────────────────────────────────────
+   PREMIUM HERO — editorial luxury with live data tiles
+   ──────────────────────────────────────────────────────────────── */
+.hero-premium{position:relative;overflow:hidden;border-bottom:1px solid var(--color-border)}
+.hero-premium::before{content:'';position:absolute;inset:0;background:var(--gold-glow);pointer-events:none;z-index:0}
+.hero-premium__inner{position:relative;z-index:1;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-10)}
+@media(min-width:768px){.hero-premium__inner{padding:var(--space-12) var(--space-6) var(--space-12)}}
+@media(min-width:1024px){.hero-premium__inner{padding:var(--space-16) var(--space-8) var(--space-12)}}
 
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+.hero-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);padding:6px var(--space-3);background:var(--gradient-gold-soft);border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,transparent);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--color-gold-bright);margin-bottom:var(--space-5)}
+.hero-eyebrow svg{width:12px;height:12px}
+.hero-eyebrow__pulse{width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);box-shadow:0 0 8px var(--color-gold-bright);animation:pulse 2.4s ease-in-out infinite}
 
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+.hero-premium__title{font-family:var(--font-editorial);font-weight:600;color:var(--color-text);line-height:.98;letter-spacing:-.025em;margin-bottom:var(--space-5);font-size:clamp(2.5rem,1.5rem + 5.5vw,5.5rem)}
+.hero-premium__title-em{display:inline-block;background:var(--gradient-gold);-webkit-background-clip:text;background-clip:text;color:transparent;font-style:italic;font-weight:500}
+.hero-premium__sub{font-size:clamp(1rem,.95rem + .35vw,1.25rem);color:var(--color-text-muted);line-height:1.6;max-width:60ch;margin-bottom:var(--space-8)}
 
-/* SCRAP TABLE */
+/* Price tiles — 3-currency live display */
+.price-tiles{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-6)}
+@media(min-width:560px){.price-tiles{grid-template-columns:repeat(3,1fr);gap:var(--space-3)}}
+@media(min-width:1024px){.price-tiles{gap:var(--space-4)}}
+
+.price-tile{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.price-tile::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,transparent,var(--color-gold-bright),transparent);opacity:.6}
+.price-tile:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-gold)}
+.price-tile--primary{background:linear-gradient(135deg,var(--color-surface) 0%,var(--color-surface-offset) 100%);border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border))}
+.price-tile--primary::before{background:var(--gradient-gold);opacity:1;height:4px}
+
+.price-tile__head{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-3)}
+.price-tile__label{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--color-text-muted)}
+.price-tile__flag{display:inline-flex;align-items:center;gap:6px;font-size:11px;color:var(--color-text-faint);font-weight:600}
+.price-tile__value{font-family:var(--font-display);font-size:clamp(1.75rem,1.2rem + 2.2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.02em;line-height:1;font-variant-numeric:tabular-nums;margin-bottom:var(--space-2)}
+.price-tile--primary .price-tile__value{color:var(--color-gold-bright)}
+.price-tile__sub{font-size:var(--text-xs);color:var(--color-text-muted);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.price-tile__purity-dot{width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);flex-shrink:0}
+
+/* Live status bar */
+.live-status{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2) var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted)}
+.live-status__dot{width:8px;height:8px;border-radius:50%;background:var(--color-success);box-shadow:0 0 8px color-mix(in oklch,var(--color-success) 80%,transparent);animation:pulse 2s ease-in-out infinite;flex-shrink:0}
+.live-status__label{font-weight:600;color:var(--color-text)}
+.live-status__divider{color:var(--color-text-faint);user-select:none}
+.live-status__meta{font-variant-numeric:tabular-nums}
+.live-status__meta strong{color:var(--color-gold-bright);font-weight:600}
+.live-status__cta{margin-left:auto;display:inline-flex;align-items:center;gap:6px;padding:6px var(--space-3);background:var(--gradient-gold);color:#1a1410;border-radius:var(--radius-md);font-weight:700;font-size:11px;letter-spacing:.06em;text-transform:uppercase;text-decoration:none}
+.live-status__cta:hover{filter:brightness(1.1);text-decoration:none;color:#1a1410}
+
+/* Trust strip */
+.trust-strip{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4);display:flex;flex-wrap:wrap;gap:var(--space-3);align-items:center;border-bottom:1px solid var(--color-divider)}
+.trust-strip__item{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+.trust-strip__item svg{width:14px;height:14px;color:var(--color-gold-bright);flex-shrink:0}
+.trust-strip__item--link{margin-left:auto;color:var(--color-primary);font-weight:600}
+.trust-strip__item--link:hover{color:var(--color-primary-hover);text-decoration:underline}
+@media(max-width:540px){.trust-strip__item--link{margin-left:0}}
+
+/* ────────────────────────────────────────────────────────────────
+   LIVE CALCULATOR — flagship interactive component
+   ──────────────────────────────────────────────────────────────── */
+.calc-pro{max-width:1200px;margin:var(--space-10) auto;padding:0 var(--space-4)}
+@media(min-width:768px){.calc-pro{margin:var(--space-12) auto}}
+
+.calc-pro__card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden;box-shadow:var(--shadow-md)}
+.calc-pro__card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-gold-bright) 30%,var(--color-gold-bright) 70%,transparent 100%);opacity:.5}
+
+.calc-pro__head{padding:var(--space-6) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-4);flex-wrap:wrap}
+@media(min-width:768px){.calc-pro__head{padding:var(--space-8) var(--space-8) var(--space-5)}}
+.calc-pro__head-left{flex:1;min-width:200px}
+.calc-pro__title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);display:flex;align-items:center;gap:var(--space-2)}
+.calc-pro__title-icon{width:24px;height:24px;color:var(--color-gold-bright);flex-shrink:0}
+.calc-pro__sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;max-width:50ch}
+.calc-pro__head-badge{display:inline-flex;align-items:center;gap:6px;padding:6px var(--space-3);background:color-mix(in oklch,var(--color-success) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-success) 30%,transparent);color:var(--color-success);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase}
+
+.calc-pro__body{padding:var(--space-5)}
+@media(min-width:768px){.calc-pro__body{padding:var(--space-6) var(--space-8) var(--space-8)}}
+
+.calc-pro__row{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-4)}
+@media(min-width:560px){.calc-pro__row{grid-template-columns:2fr 1fr;gap:var(--space-4)}}
+
+.calc-pro__field{display:flex;flex-direction:column;gap:var(--space-2)}
+.calc-pro__field-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__input,.calc-pro__select{width:100%;min-height:48px;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none;transition:border-color var(--transition),background var(--transition),box-shadow var(--transition)}
+.calc-pro__input:focus,.calc-pro__select:focus{border-color:var(--color-gold-bright);background:var(--color-surface);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent);outline:none}
+.calc-pro__input{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;font-variant-numeric:tabular-nums}
+.calc-pro__select-wrap{position:relative}
+.calc-pro__select-wrap::after{content:'';position:absolute;right:var(--space-4);top:50%;width:8px;height:8px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:translateY(-70%) rotate(45deg);pointer-events:none}
+
+/* Quick weight chips */
+.calc-pro__chips{display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-5);align-items:center}
+.calc-pro__chips-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-right:var(--space-2);width:100%}
+@media(min-width:560px){.calc-pro__chips-label{width:auto;margin-right:var(--space-1)}}
+.calc-chip{min-height:36px;padding:6px var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);cursor:pointer;transition:all var(--transition);white-space:nowrap}
+.calc-chip:hover{border-color:var(--color-gold-bright);color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset))}
+.calc-chip:focus-visible{outline:2px solid var(--color-gold-bright);outline-offset:2px}
+.calc-chip.active{background:var(--gradient-gold);color:#1a1410;border-color:transparent}
+
+/* Result block */
+.calc-pro__result{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface)) 0%,var(--color-surface) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-5);position:relative;overflow:hidden}
+.calc-pro__result::before{content:'';position:absolute;top:-50%;right:-20%;width:280px;height:280px;background:radial-gradient(circle,color-mix(in oklch,var(--color-gold-bright) 18%,transparent) 0%,transparent 60%);pointer-events:none}
+
+.calc-pro__result-primary{position:relative;display:flex;align-items:baseline;justify-content:space-between;padding-bottom:var(--space-4);margin-bottom:var(--space-4);border-bottom:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));flex-wrap:wrap;gap:var(--space-2)}
+.calc-pro__result-label{font-size:var(--text-xs);font-weight:700;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.1em}
+.calc-pro__result-label-main{font-size:var(--text-sm);font-weight:700;color:var(--color-text);text-transform:uppercase;letter-spacing:.08em}
+.calc-pro__result-main{font-family:var(--font-display);font-size:clamp(2rem,1.5rem + 2vw,3rem);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.025em;line-height:1}
+
+.calc-pro__result-grid{position:relative;display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3) var(--space-4)}
+@media(min-width:560px){.calc-pro__result-grid{grid-template-columns:1fr 1fr}}
+.calc-pro__result-item{display:flex;flex-direction:column;gap:var(--space-1)}
+.calc-pro__result-item-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__result-item-value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+.calc-pro__hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-4);line-height:1.6;max-width:62ch}
+.calc-pro__hint code{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;background:var(--color-surface-offset-2);padding:2px 6px;border-radius:4px;color:var(--color-gold-bright);border:1px solid var(--color-divider)}
+
+/* ────────────────────────────────────────────────────────────────
+   STAT CARDS — highlight key facts
+   ──────────────────────────────────────────────────────────────── */
+.stat-cards{max-width:1200px;margin:0 auto var(--space-12);padding:0 var(--space-4);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+@media(min-width:768px){.stat-cards{grid-template-columns:repeat(4,1fr);gap:var(--space-4)}}
+
+.stat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);position:relative;overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.stat-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));transform:translateY(-2px)}
+.stat-card__icon{width:32px;height:32px;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.stat-card__value{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);letter-spacing:-.02em;line-height:1;margin-bottom:var(--space-2);font-variant-numeric:tabular-nums}
+.stat-card__label{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.4}
+
+/* ────────────────────────────────────────────────────────────────
+   SECTION COMMON — content sections
+   ──────────────────────────────────────────────────────────────── */
+.section{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
+.section--narrow{max-width:920px}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:var(--space-5);flex-wrap:wrap;gap:var(--space-3)}
+.section-head__left{flex:1;min-width:200px}
+.section-eyebrow{display:inline-block;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.section-title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);line-height:1.2;margin-bottom:var(--space-2);letter-spacing:-.015em}
+.section-sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;max-width:60ch}
+
+/* ────────────────────────────────────────────────────────────────
+   PRICE TABLE — enhanced with currency selector
+   ──────────────────────────────────────────────────────────────── */
+.price-table-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.price-table-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden}
+.price-table-card__head{padding:var(--space-5) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3)}
+@media(min-width:768px){.price-table-card__head{padding:var(--space-6) var(--space-8) var(--space-5)}}
+.price-table-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1)}
+.price-table-card__sub{font-size:var(--text-xs);color:var(--color-text-muted)}
+.price-table-card__sub strong{color:var(--color-success);font-weight:700}
+
+.currency-switch{display:inline-flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px;gap:2px}
+.currency-switch__btn{min-height:32px;padding:6px var(--space-3);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);border-radius:var(--radius-full);cursor:pointer;transition:all var(--transition);letter-spacing:.04em}
+.currency-switch__btn:hover{color:var(--color-text)}
+.currency-switch__btn.active{background:var(--gradient-gold);color:#1a1410}
+
+.price-table-card__body{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.price-table-pro{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}
+.price-table-pro th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-5);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);white-space:nowrap}
+.price-table-pro th:not(:first-child){text-align:right}
+.price-table-pro td{padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.price-table-pro td:first-child{color:var(--color-text);font-weight:600;font-family:var(--font-display)}
+.price-table-pro td:not(:first-child){text-align:right;color:var(--color-text);font-weight:500}
+.price-table-pro td.price-table-pro__primary{color:var(--color-gold-bright);font-weight:700}
+.price-table-pro tr:last-child td{border-bottom:none}
+.price-table-pro tr:hover td{background:color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface))}
+.price-table-pro .weight-label-sub{color:var(--color-text-faint);font-size:11px;font-weight:400;display:block;margin-top:2px}
+
+/* ────────────────────────────────────────────────────────────────
+   KARAT COMPARISON — bento cards
+   ──────────────────────────────────────────────────────────────── */
+.karat-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.karat-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:560px){.karat-cards{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:900px){.karat-cards{grid-template-columns:repeat(5,1fr);gap:var(--space-3)}}
+
+.karat-pro-card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4);text-decoration:none;transition:all var(--transition);overflow:hidden;display:flex;flex-direction:column;gap:var(--space-2);color:var(--color-text)}
+.karat-pro-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 50%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-md);color:var(--color-text);text-decoration:none}
+.karat-pro-card--current{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface)) 0%,var(--color-surface) 100%);border-color:var(--color-gold-bright);box-shadow:0 0 0 1px var(--color-gold-bright),var(--shadow-gold)}
+.karat-pro-card--current::before{content:'YOU ARE HERE';position:absolute;top:8px;right:8px;font-size:9px;font-weight:700;letter-spacing:.1em;color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 14%,transparent);padding:2px 6px;border-radius:4px}
+
+.karat-pro-card__karat{font-family:var(--font-editorial);font-size:clamp(2rem,1.4rem + 2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.025em;line-height:1}
+.karat-pro-card--current .karat-pro-card__karat{color:var(--color-gold-bright);font-style:italic}
+.karat-pro-card__purity{font-size:var(--text-sm);color:var(--color-gold-bright);font-weight:700;font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+.karat-pro-card__hallmark{font-size:11px;font-weight:600;color:var(--color-text-faint);font-family:'IBM Plex Mono',ui-monospace,monospace;letter-spacing:.1em;text-transform:uppercase}
+.karat-pro-card__price{font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;padding-top:var(--space-2);border-top:1px solid var(--color-divider);margin-top:auto}
+.karat-pro-card__price-label{display:block;font-size:10px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-bottom:2px}
+.karat-pro-card__use{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+
+/* ────────────────────────────────────────────────────────────────
+   FORMULA BLOCK — featured calculation showcase
+   ──────────────────────────────────────────────────────────────── */
+.formula-block{max-width:920px;margin:var(--space-10) auto var(--space-8);padding:0 var(--space-4)}
+.formula-card{background:linear-gradient(180deg,var(--color-surface-offset) 0%,var(--color-surface) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6) var(--space-5);position:relative;overflow:hidden}
+@media(min-width:768px){.formula-card{padding:var(--space-8)}}
+.formula-card__eyebrow{font-size:11px;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.12em;margin-bottom:var(--space-3)}
+.formula-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-4)}
+.formula-card__equation{font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:clamp(.875rem,.8rem + .5vw,1.125rem);color:var(--color-text);background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);overflow-x:auto;-webkit-overflow-scrolling:touch;white-space:nowrap;font-variant-numeric:tabular-nums;line-height:1.6}
+.formula-card__equation .op{color:var(--color-gold-bright);font-weight:600}
+.formula-card__equation .var{color:var(--color-primary);font-weight:600}
+.formula-card__steps{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:768px){.formula-card__steps{grid-template-columns:repeat(3,1fr)}}
+.formula-step{display:flex;gap:var(--space-3);padding:var(--space-3);background:var(--color-surface);border:1px solid var(--color-divider);border-radius:var(--radius-md)}
+.formula-step__num{flex-shrink:0;width:28px;height:28px;border-radius:50%;background:var(--gradient-gold);color:#1a1410;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
+.formula-step__text{font-size:var(--text-sm);color:var(--color-text);line-height:1.5}
+.formula-step__text strong{color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* ────────────────────────────────────────────────────────────────
+   COLOR SWATCHES — 14K Yellow/White/Rose
+   ──────────────────────────────────────────────────────────────── */
+.swatch-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-5) 0}
+@media(min-width:560px){.swatch-grid{grid-template-columns:repeat(3,1fr)}}
+.swatch-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden}
+.swatch-card__color{height:120px;position:relative;display:flex;align-items:flex-end;justify-content:flex-start;padding:var(--space-3)}
+.swatch-card__color--yellow{background:linear-gradient(135deg,#f4cc4b 0%,#e8af34 40%,#b07a00 100%)}
+.swatch-card__color--white{background:linear-gradient(135deg,#f5f5f5 0%,#dcdcdc 40%,#a8a8a8 100%)}
+.swatch-card__color--rose{background:linear-gradient(135deg,#f4b09a 0%,#e89478 40%,#b86848 100%)}
+.swatch-card__color::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 30% 30%,rgba(255,255,255,.4),transparent 50%);pointer-events:none}
+.swatch-card__hallmark{position:relative;font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:11px;font-weight:700;color:#1a1410;background:rgba(255,255,255,.8);padding:3px 8px;border-radius:4px;letter-spacing:.08em;backdrop-filter:blur(4px)}
+.swatch-card__body{padding:var(--space-4)}
+.swatch-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1)}
+.swatch-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.55}
+
+/* ────────────────────────────────────────────────────────────────
+   ASSAY OFFICES (Hallmark info)
+   ──────────────────────────────────────────────────────────────── */
+.assay-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:560px){.assay-grid{grid-template-columns:repeat(4,1fr)}}
+.assay-card{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.assay-card__mark{display:flex;align-items:center;justify-content:center;width:40px;height:40px;margin:0 auto var(--space-2);color:var(--color-gold-bright)}
+.assay-card__mark svg{width:32px;height:32px}
+.assay-card__name{font-size:var(--text-xs);font-weight:700;color:var(--color-text);font-family:var(--font-display)}
+.assay-card__est{font-size:10px;color:var(--color-text-faint);margin-top:2px}
+
+/* ────────────────────────────────────────────────────────────────
+   PROSE — editorial content styling
+   ──────────────────────────────────────────────────────────────── */
+.content-section{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-12)}
+.prose-pro{max-width:760px;margin:0 auto}
+.prose-pro h2{font-family:var(--font-display);font-size:clamp(1.5rem,1.1rem + 1.5vw,2rem);font-weight:700;color:var(--color-text);margin:var(--space-12) 0 var(--space-4);line-height:1.2;letter-spacing:-.015em;position:relative;padding-top:var(--space-3)}
+.prose-pro h2::before{content:'';position:absolute;top:0;left:0;width:48px;height:3px;background:var(--gradient-gold);border-radius:2px}
+.prose-pro h2:first-child{margin-top:0}
+.prose-pro h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-8) 0 var(--space-3);letter-spacing:-.01em}
+.prose-pro p{font-size:var(--text-base);color:var(--color-text);line-height:1.75;margin-bottom:var(--space-4)}
+.prose-pro ul,.prose-pro ol{padding-left:var(--space-5);margin-bottom:var(--space-5)}
+.prose-pro li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:var(--space-2)}
+.prose-pro li::marker{color:var(--color-gold-bright)}
+.prose-pro strong{color:var(--color-text);font-weight:700}
+.prose-pro a{color:var(--color-primary);text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;transition:color var(--transition)}
+.prose-pro a:hover{color:var(--color-primary-hover);text-decoration-thickness:2px}
+
+.prose-pro blockquote{margin:var(--space-5) 0;padding:var(--space-4) var(--space-5);background:var(--color-surface);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-md);font-family:var(--font-editorial);font-size:var(--text-lg);font-style:italic;color:var(--color-text);font-weight:500;line-height:1.5}
+.prose-pro blockquote strong{font-style:normal;font-family:'IBM Plex Mono',ui-monospace,monospace;color:var(--color-gold-bright);font-size:var(--text-base);font-weight:600}
+
+.snippet-answer{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);margin:var(--space-4) 0;font-size:var(--text-base);color:var(--color-text);line-height:1.7}
+.snippet-answer strong{color:var(--color-gold-bright)}
+
+.callout{background:var(--gradient-gold-soft);border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-5) 0;display:flex;gap:var(--space-3);align-items:flex-start}
+.callout__icon{flex-shrink:0;width:32px;height:32px;color:var(--color-gold-bright);margin-top:2px}
+.callout__title{font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);font-family:var(--font-display)}
+.callout__body{font-size:var(--text-sm);color:var(--color-text);line-height:1.6}
+
+/* ────────────────────────────────────────────────────────────────
+   FAQ ACCORDION
+   ──────────────────────────────────────────────────────────────── */
+.faq-pro{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+.faq-pro__item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.faq-pro__item:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border))}
+.faq-pro__item[open]{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border))}
+.faq-pro__summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;min-height:60px}
+.faq-pro__summary::-webkit-details-marker{display:none}
+.faq-pro__summary:hover{background:var(--color-surface-offset)}
+.faq-pro__summary:focus-visible{outline:2px solid var(--color-gold-bright);outline-offset:-2px}
+.faq-pro__plus{flex-shrink:0;width:24px;height:24px;border:1px solid var(--color-border);border-radius:50%;display:flex;align-items:center;justify-content:center;position:relative;transition:transform var(--transition),border-color var(--transition),background var(--transition)}
+.faq-pro__plus::before,.faq-pro__plus::after{content:'';position:absolute;background:var(--color-text-muted);transition:transform var(--transition),background var(--transition)}
+.faq-pro__plus::before{width:10px;height:2px}
+.faq-pro__plus::after{width:2px;height:10px}
+.faq-pro__item[open] .faq-pro__plus{background:var(--color-gold-bright);border-color:var(--color-gold-bright);transform:rotate(45deg)}
+.faq-pro__item[open] .faq-pro__plus::before,.faq-pro__item[open] .faq-pro__plus::after{background:#1a1410}
+.faq-pro__body{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;border-top:1px solid var(--color-divider);padding-top:var(--space-4)}
+.faq-pro__body strong{color:var(--color-text)}
+
+/* ────────────────────────────────────────────────────────────────
+   STICKY MOBILE PRICE BAR
+   ──────────────────────────────────────────────────────────────── */
+.sticky-price{position:fixed;bottom:0;left:0;right:0;background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-3) var(--space-4);z-index:80;display:none;align-items:center;gap:var(--space-3);box-shadow:0 -8px 24px rgba(0,0,0,.2);backdrop-filter:blur(12px);transform:translateY(100%);transition:transform .3s ease-out;padding-bottom:max(var(--space-3),env(safe-area-inset-bottom))}
+.sticky-price.visible{transform:translateY(0)}
+@media(max-width:768px){.sticky-price{display:flex}body{padding-bottom:80px}}
+.sticky-price__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.sticky-price__value{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.1}
+.sticky-price__info{flex:1;min-width:0}
+.sticky-price__cta{display:inline-flex;align-items:center;gap:6px;padding:10px var(--space-4);background:var(--gradient-gold);color:#1a1410;border-radius:var(--radius-md);font-size:var(--text-xs);font-weight:700;text-decoration:none;letter-spacing:.04em;text-transform:uppercase;min-height:44px;white-space:nowrap}
+.sticky-price__cta:hover{filter:brightness(1.1);color:#1a1410;text-decoration:none}
+
+/* SCRAP TABLE legacy */
 .scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
 .scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
 .scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
 .scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
 .scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
 @media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
-
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
-
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
-
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
 
 /* CHART */
 .chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
 .chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
 .chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
 
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
-
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
-
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+/* DISCLAIMER */
+.disclaimer{margin-top:var(--space-8);padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--color-text-faint);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+.disclaimer strong{color:var(--color-text)}
 
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
@@ -332,22 +503,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
 .footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
@@ -357,16 +512,10 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
+footer{background:var(--color-surface);border-top:1px solid var(--color-border)}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
-
-
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
-
 
 /* ── Shared layout CSS ── */
 .breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
@@ -375,78 +524,26 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .breadcrumb a{color:var(--color-text-muted);text-decoration:none}
 .breadcrumb a:hover{color:var(--color-primary)}
 .breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.hero-tag{display:inline-block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-.hero-title{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero-title{font-size:var(--text-xl)}
-.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:72ch;line-height:1.7;margin-bottom:var(--space-6)}
-.price-card{display:inline-flex;flex-direction:column;gap:var(--space-1);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-2)}
-.price-card{width:100%}
-.price-label{font-size:var(--text-sm);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.price-value{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-gold-bright);font-weight:400;line-height:1}
-.price-usd{font-size:var(--text-base);color:var(--color-text-muted)}
-.price-purity{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-1)}
-.prose{max-width:72ch}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-1)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose{max-width:100%}
-.content{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
-.data-source{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.faq-answer-summary{font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4);cursor:pointer;list-style:none;background:var(--color-surface-offset);transition:background .15s}
-.faq-answer-summary:hover{background:var(--color-surface-dynamic)}
-.faq-answer-summary::marker,.faq-answer-summary::-webkit-details-marker{display:none}
-.faq-answer-summary::after{content:"＋";float:right;color:var(--color-text-faint)}
-.faq-answer-summary::after{content:"－"}
-.faq-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-4);border-top:1px solid var(--color-divider)}
-
-/* ── Hero left column ── */
-.hero-left{display:flex;flex-direction:column;justify-content:flex-start;gap:var(--space-3)}
-.hero-left .hero-title{margin-bottom:0}
-.hero-left .hero-tag{margin-bottom:var(--space-2)}
-@media(max-width:768px){.hero-left{margin-bottom:var(--space-4)}}
-
-/* ── Data Table ── */
-.data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
-.data-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-4) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.data-table td{padding:var(--space-3) var(--space-4) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.data-table td:first-child{color:var(--color-text);font-weight:500}
-.data-table td:not(:first-child){text-align:right;padding-right:0}
-.data-table th:not(:first-child){text-align:right;padding-right:0}
-.data-table tr:last-child td{border-bottom:none}
-.data-table tr:hover td{background:var(--color-surface)}
-.data-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border-radius:var(--radius-md)}
-
-/* ── Trust bar ── */
-.trust-bar{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset,var(--color-surface));border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.trust-bar a{color:var(--color-primary);text-decoration:none}
-.trust-bar a:hover{text-decoration:underline}
 
 /* ── Share buttons ── */
 .share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) 0 var(--space-6);padding-top:var(--space-6);border-top:1px solid var(--color-border)}
 .share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
-.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface)}
-.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset)}
+.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface);min-height:44px}
+.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset);text-decoration:none}
 .share-buttons a svg{flex-shrink:0}
 
 /* ── Related guides grid ── */
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin-top:var(--space-6)}
-.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface-offset,var(--color-surface));border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s;min-height:140px;color:var(--color-text)}
-.related-card:hover{border-color:var(--color-primary);box-shadow:var(--shadow-sm)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin:var(--space-1) 0}
+.related-guides{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.related-guides-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.related-guides-grid{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:900px){.related-guides-grid{grid-template-columns:repeat(4,1fr)}}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,transform .15s,box-shadow .15s;color:var(--color-text)}
+.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);transform:translateY(-2px);text-decoration:none;color:var(--color-text)}
+.related-card:hover .related-card__title{color:var(--color-gold-bright)}
+.related-card__tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);align-self:flex-start;padding:2px 8px;background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border-radius:99px}
+.related-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0;line-height:1.3;transition:color var(--transition)}
 .related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
 
-/* ── Prose spacing ── */
-.prose p{margin-bottom:var(--space-4);line-height:1.7}
-.prose li{margin-bottom:var(--space-2);line-height:1.65}
-.prose h2{margin-top:var(--space-10);margin-bottom:var(--space-3)}
-.prose h3{margin-top:var(--space-6);margin-bottom:var(--space-2)}
 </style>
 
 <script type="application/ld+json">
@@ -457,7 +554,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   "url": "https://goldpricetools.com/14k-gold-price-per-gram",
   "speakable": {
     "@type": "SpeakableSpecification",
-    "cssSelector": [".snippet-answer", ".faq-answer"]
+    "cssSelector": [".snippet-answer", ".faq-pro__body"]
   }
 }
 </script>
@@ -533,125 +630,389 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </div>
   </div>
 </nav>
+
 <div class="breadcrumb-wrap">
   <ol class="breadcrumb" aria-label="Breadcrumb">
     <li><a href="/">Home</a></li>
+    <li><a href="/gold-price-per-gram">Gold Per Gram</a></li>
     <li aria-current="page">14K Gold Price Per Gram</li>
   </ol>
 </div>
 
-<div class="hero">
-  <div class="hero-left">
-<div class="hero-tag">Live Gold Price</div>
-  <h1 class="hero-title">14K Gold Price Per Gram Today</h1>
-  <p class="hero-sub">14 karat gold is 58.33% pure gold. Live price updated every 60 seconds from LBMA spot market.</p>
+<!-- ═══════════════════════════════════════════════════════════════
+     PREMIUM HERO — editorial typography + live 3-currency tiles
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="hero-premium" aria-labelledby="hero-title">
+  <div class="hero-premium__inner">
+    <div class="hero-eyebrow">
+      <span class="hero-eyebrow__pulse" aria-hidden="true"></span>
+      <span>Live · LBMA Spot Market</span>
     </div>
-  <div class="price-card">
-    <div class="price-label">14K Gold &mdash; Price Per Gram</div>
-    <div class="price-value" id="price-gbp" data-nosnippet>&mdash;</div>
-    <div class="price-usd" id="price-usd" data-nosnippet></div>
-    <div class="price-purity">14K = 58.33% pure gold (585 hallmark)</div>
+    <h1 class="hero-premium__title" id="hero-title">
+      14K Gold <span class="hero-premium__title-em">price per gram</span> today
+    </h1>
+    <p class="hero-premium__sub">Real-time 14&nbsp;karat (585 hallmark) gold valuation in USD, GBP and INR — refreshed every 60 seconds direct from LBMA spot data. 58.33% pure gold, the world's most popular ring alloy.</p>
+
+    <!-- 3-currency live price tiles -->
+    <div class="price-tiles" role="region" aria-label="Live 14K gold prices">
+      <article class="price-tile price-tile--primary">
+        <div class="price-tile__head">
+          <span class="price-tile__label">USD / gram</span>
+          <span class="price-tile__flag">US</span>
+        </div>
+        <div class="price-tile__value" id="hero-usd" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>14K · 58.33% purity · 585 hallmark</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">GBP / gram</span>
+          <span class="price-tile__flag">UK</span>
+        </div>
+        <div class="price-tile__value" id="hero-gbp" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>14K · UK hallmark 585</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">INR / gram</span>
+          <span class="price-tile__flag">IN</span>
+        </div>
+        <div class="price-tile__value" id="hero-inr" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>14K · Indian retail base</div>
+      </article>
+    </div>
+
+    <!-- Live status bar -->
+    <div class="live-status" role="status" aria-live="polite">
+      <span class="live-status__dot" aria-hidden="true"></span>
+      <span class="live-status__label">Live</span>
+      <span class="live-status__divider" aria-hidden="true">·</span>
+      <span class="live-status__meta">24K spot: <strong id="spot-usd" data-nosnippet>&mdash;</strong></span>
+      <span class="live-status__divider" aria-hidden="true">·</span>
+      <span class="live-status__meta">Updated <span id="updated-time">just now</span></span>
+      <span class="live-status__divider" aria-hidden="true">·</span>
+      <span class="live-status__meta">Refresh in <span id="refresh-counter">60s</span></span>
+      <a href="#calculator" class="live-status__cta">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>
+        Calculate
+      </a>
+    </div>
   </div>
+</section>
+
+<!-- Trust strip -->
+<div class="trust-strip">
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    LBMA-sourced spot data
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+    60-second refresh
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/><circle cx="12" cy="12" r="10"/></svg>
+    USD · GBP · INR · EUR
+  </span>
+  <a href="/about" class="trust-strip__item trust-strip__item--link">About our data &rarr;</a>
 </div>
 
-<div class="content">
-  <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
+<!-- ═══════════════════════════════════════════════════════════════
+     LIVE CALCULATOR — flagship interactive tool
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="calc-pro" id="calculator" aria-labelledby="calc-title">
+  <div class="calc-pro__card">
+    <div class="calc-pro__head">
+      <div class="calc-pro__head-left">
+        <h2 class="calc-pro__title" id="calc-title">
+          <svg class="calc-pro__title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M12 14h.01M16 14h.01M8 18h2M12 18h.01M16 18h.01"/></svg>
+          14K Gold Calculator
+        </h2>
+        <p class="calc-pro__sub">Enter your weight — get live melt value, dealer payout estimate, and retail price for any 14K (585) item.</p>
+      </div>
+      <span class="calc-pro__head-badge">
+        <span class="live-dot" aria-hidden="true"></span>
+        Live · 60s refresh
+      </span>
+    </div>
 
-  <div class="prose">
-    <h2>What is 14K Gold?</h2>
-    <p>14K gold contains 14 parts gold out of 24 &mdash; a purity of <strong>58.33%</strong>. It is the most popular gold alloy for jewellery in the United States and is widely used for engagement rings and wedding bands. The hallmark you will see on European and UK pieces is <strong>585</strong>. On American pieces you will see <strong>14K</strong> or <strong>14KT</strong>.</p>
+    <div class="calc-pro__body">
+      <div class="calc-pro__row">
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-weight">Weight (grams)</label>
+          <input class="calc-pro__input" type="number" id="calc-weight" inputmode="decimal" placeholder="e.g. 3.5" min="0" step="0.01" value="1" aria-label="Weight in grams">
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-currency">Currency</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-currency" aria-label="Display currency">
+              <option value="USD">USD ($)</option>
+              <option value="GBP">GBP (£)</option>
+              <option value="INR">INR (₹)</option>
+            </select>
+          </div>
+        </div>
+      </div>
 
+      <div class="calc-pro__chips" role="group" aria-label="Quick weight presets">
+        <span class="calc-pro__chips-label">Quick weights:</span>
+        <button class="calc-chip" type="button" data-weight="1">1g</button>
+        <button class="calc-chip" type="button" data-weight="3.5">Wedding ring · 3.5g</button>
+        <button class="calc-chip" type="button" data-weight="5">5g</button>
+        <button class="calc-chip" type="button" data-weight="10">10g</button>
+        <button class="calc-chip" type="button" data-weight="15">Chain · 15g</button>
+        <button class="calc-chip" type="button" data-weight="31.1035">1 troy oz</button>
+      </div>
+
+      <div class="calc-pro__result">
+        <div class="calc-pro__result-primary">
+          <span class="calc-pro__result-label-main">Melt value</span>
+          <span class="calc-pro__result-main" id="calc-melt" data-nosnippet>&mdash;</span>
+        </div>
+        <div class="calc-pro__result-grid">
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Dealer pays (~85%)</span>
+            <span class="calc-pro__result-item-value" id="calc-dealer" data-nosnippet>&mdash;</span>
+          </div>
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Retail price (~+25%)</span>
+            <span class="calc-pro__result-item-value" id="calc-retail" data-nosnippet>&mdash;</span>
+          </div>
+        </div>
+      </div>
+      <p class="calc-pro__hint">Formula: <code>weight × (spot ÷ 31.1035) × 0.5833</code>. Dealer payouts (70–95% of melt) and retail premiums (10–30%) vary by dealer, item condition, brand and market. <a href="/where-to-sell-gold-silver">Find the best dealers&nbsp;&rarr;</a></p>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     STAT CARDS — key 14K facts at a glance
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="stat-cards" aria-label="14K gold key facts">
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+    <div class="stat-card__value">58.33%</div>
+    <div class="stat-card__label">Pure gold content in 14K alloy</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 12a8 8 0 11-16 0 8 8 0 0116 0z"/><path d="M12 8v4l3 2"/></svg>
+    <div class="stat-card__value">70%</div>
+    <div class="stat-card__label">US engagement rings set in 14K</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    <div class="stat-card__value">585</div>
+    <div class="stat-card__label">European hallmark for 14K gold</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 3h18v18H3z"/><path d="M9 9h6v6H9z"/></svg>
+    <div class="stat-card__value">150–180 HV</div>
+    <div class="stat-card__label">Vickers hardness, ideal for rings</div>
+  </article>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     LIVE PRICE TABLE — by weight, currency switcher
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="price-table-section" aria-labelledby="price-table-title">
+  <div class="price-table-card">
+    <div class="price-table-card__head">
+      <div>
+        <h2 class="price-table-card__title" id="price-table-title">14K Gold Price by Weight</h2>
+        <p class="price-table-card__sub"><strong>Live</strong> · Updated every 60s · 0.5g to 1 troy oz</p>
+      </div>
+      <div class="currency-switch" role="tablist" aria-label="Choose currency to highlight">
+        <button class="currency-switch__btn active" role="tab" data-currency="USD" aria-selected="true">USD</button>
+        <button class="currency-switch__btn" role="tab" data-currency="GBP" aria-selected="false">GBP</button>
+        <button class="currency-switch__btn" role="tab" data-currency="INR" aria-selected="false">INR</button>
+      </div>
+    </div>
+    <div class="price-table-card__body">
+      <figure itemscope itemtype="https://schema.org/Table" style="margin:0">
+        <figcaption class="sr-only">14K gold price per gram in USD, GBP, and INR — live, updated every 60 seconds</figcaption>
+        <table class="price-table-pro" aria-label="14K gold price by weight">
+          <thead><tr><th>Weight</th><th data-col="USD">USD</th><th data-col="GBP">GBP</th><th data-col="INR">INR</th></tr></thead>
+          <tbody>
+            <tr><td>0.5g <span class="weight-label-sub">Small stud / pendant</span></td><td id="t-0-5-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-0-5-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-0-5-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1g <span class="weight-label-sub">Light chain link</span></td><td id="t-1-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-1-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-1-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>2g <span class="weight-label-sub">Pendant / earring</span></td><td id="t-2-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-2-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-2-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>5g <span class="weight-label-sub">Engagement ring</span></td><td id="t-5-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-5-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-5-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>10g <span class="weight-label-sub">Heavy bangle</span></td><td id="t-10-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-10-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-10-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>20g <span class="weight-label-sub">Thick chain</span></td><td id="t-20-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-20-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-20-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1 <a href="/how-many-grams-in-troy-ounce">troy oz</a> <span class="weight-label-sub">31.1035g</span></td><td id="t-31-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-31-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-31-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+          </tbody>
+        </table>
+      </figure>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     KARAT COMPARISON — bento cards (14K highlighted)
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="karat-section" aria-labelledby="karat-section-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Compare</span>
+      <h2 class="section-title" id="karat-section-title">14K vs Other Karats</h2>
+      <p class="section-sub">Compare live prices, purity and typical uses across every common gold purity — from 9K UK everyday wear to 24K bullion.</p>
+    </div>
+  </div>
+  <div class="karat-cards">
+    <a href="/9k-gold-price-per-gram" class="karat-pro-card">
+      <div class="karat-pro-card__karat">9K</div>
+      <div class="karat-pro-card__purity">37.5% pure</div>
+      <div class="karat-pro-card__hallmark">375</div>
+      <div class="karat-pro-card__use">UK everyday jewellery</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-9-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <div class="karat-pro-card karat-pro-card--current">
+      <div class="karat-pro-card__karat">14K</div>
+      <div class="karat-pro-card__purity">58.33% pure</div>
+      <div class="karat-pro-card__hallmark">585</div>
+      <div class="karat-pro-card__use">US engagement rings &amp; wedding bands</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-14-usd" data-nosnippet>&mdash;</span></div>
+    </div>
+    <a href="/18k-gold-price-per-gram" class="karat-pro-card">
+      <div class="karat-pro-card__karat">18K</div>
+      <div class="karat-pro-card__purity">75.0% pure</div>
+      <div class="karat-pro-card__hallmark">750</div>
+      <div class="karat-pro-card__use">Fine jewellery, luxury watches</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-18-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/22k-gold-price-per-gram" class="karat-pro-card">
+      <div class="karat-pro-card__karat">22K</div>
+      <div class="karat-pro-card__purity">91.67% pure</div>
+      <div class="karat-pro-card__hallmark">916</div>
+      <div class="karat-pro-card__use">South Asian bridal gold</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-22-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/24k-gold-price-per-gram" class="karat-pro-card">
+      <div class="karat-pro-card__karat">24K</div>
+      <div class="karat-pro-card__purity">99.9% pure</div>
+      <div class="karat-pro-card__hallmark">999</div>
+      <div class="karat-pro-card__use">Bullion coins and bars</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-24-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     FORMULA BLOCK — how the price is calculated
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="formula-block" aria-labelledby="formula-title">
+  <div class="formula-card">
+    <div class="formula-card__eyebrow">The Math</div>
+    <h2 class="formula-card__title" id="formula-title">How the 14K gold price is calculated</h2>
+    <p style="color:var(--color-text-muted);font-size:var(--text-sm);margin-bottom:var(--space-4);line-height:1.7">The 14K gold price per gram is derived from the 24K (pure) spot price set twice daily by the LBMA. Our calculator fetches this in real time and applies the 14K purity factor of 0.5833.</p>
+    <div class="formula-card__equation"><span class="var">14K price/g</span> <span class="op">=</span> (<span class="var">spot USD/oz</span> <span class="op">÷</span> 31.1035) <span class="op">×</span> 0.5833</div>
+    <div class="formula-card__steps">
+      <div class="formula-step">
+        <div class="formula-step__num">1</div>
+        <div class="formula-step__text">Take the live LBMA spot price (<strong>USD per troy oz</strong> for 24K pure gold)</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">2</div>
+        <div class="formula-step__text">Divide by <strong>31.1035</strong> grams in a troy oz to get the per-gram pure-gold price</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">3</div>
+        <div class="formula-step__text">Multiply by <strong>0.5833</strong> — the 14K purity ratio (14 ÷ 24)</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     EDITORIAL CONTENT — long-form, premium typography
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="content-section">
+  <article class="prose-pro">
     <h2 id="14k-gold-per-gram">How much is a gram of 14K gold worth?</h2>
-<p class="snippet-answer">14K gold is worth approximately <span id="snippet-price" data-nosnippet>[live value]</span> per gram in [currency] today. This is calculated by multiplying the live 24K spot price by 0.5833 — the gold purity ratio of 14 karat gold (14 parts gold out of 24). Use our calculator below for the exact live value.</p>
+    <div class="snippet-answer">14K gold is worth approximately <strong><span id="snippet-price" data-nosnippet>[live value]</span> per gram</strong> today. This is calculated by multiplying the live 24K spot price by 0.5833 — the gold purity ratio of 14 karat gold (14 parts gold out of 24). Use our live calculator above for the exact value for any weight.</div>
 
-<h2 id="q2-14K">What is 14k gold?</h2>
-<p class="snippet-answer">14K gold is an alloy containing 14 parts pure gold out of 24, giving it a purity of 58.33%. It is the most popular gold alloy for jewellery in the United States, offering a great balance of durability, beautiful colour, and lasting value.</p>
+    <h2 id="q2-14K">What is 14K gold?</h2>
+    <div class="snippet-answer">14K gold is an alloy containing <strong>14 parts pure gold out of 24</strong>, giving it a purity of <strong>58.33%</strong>. It is the most popular gold alloy for jewellery in the United States, offering a great balance of durability, beautiful colour, and lasting value. The remaining 41.67% is typically copper, silver, palladium or zinc — the choice of alloy metals determines whether the resulting gold is yellow, white or rose.</div>
 
-<h2 id="q3-14K">What does 585 mean on gold?</h2>
-<p class="snippet-answer">The 585 hallmark on gold indicates that the item is made of 14 karat gold. The number represents the gold's purity, showing it contains 585 parts pure gold per 1000, which equals 58.5% (or 58.33% standard). This is the common European hallmark for 14K.</p>
+    <h2 id="q3-14K">What does the 585 hallmark mean?</h2>
+    <div class="snippet-answer">The <strong>585 hallmark</strong> indicates an item is made of 14 karat gold. The number represents parts pure gold per thousand — 585 parts of every 1,000 are pure gold, or 58.5% (58.33% standard). This is the universal European hallmark for 14K, while US pieces are typically stamped <strong>14K</strong> or <strong>14KT</strong> instead.</div>
 
-<h2>14K Gold Price Table</h2>
-    <figure itemscope itemtype="https://schema.org/Table">
-      <figcaption>14K gold price per gram in USD and GBP — live, updated every 60 seconds</figcaption>
-      <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-      <div class="data-table-wrap"><table class="data-table" aria-label="14K gold price by weight">
-        <thead><tr><th>Weight</th><th>USD (live)</th><th>GBP (live)</th><th>INR (live)</th></tr></thead>
-        <tbody>
-          <tr><td>0.5g</td><td id="t-0-5-usd" data-nosnippet>&mdash;</td><td id="t-0-5-gbp" data-nosnippet>&mdash;</td><td id="t-0-5-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>1g</td><td id="t-1-usd" data-nosnippet>&mdash;</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>2g</td><td id="t-2-usd" data-nosnippet>&mdash;</td><td id="t-2-gbp" data-nosnippet>&mdash;</td><td id="t-2-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>5g</td><td id="t-5-usd" data-nosnippet>&mdash;</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>10g</td><td id="t-10-usd" data-nosnippet>&mdash;</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>20g</td><td id="t-20-usd" data-nosnippet>&mdash;</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>1 <a href="/how-many-grams-in-troy-ounce">troy oz</a> (31.1g)</td><td id="t-31-usd" data-nosnippet>&mdash;</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-inr" data-nosnippet>&mdash;</td></tr>
-        </tbody>
-      </table></div>
-    </figure>
+    <h2>The 585 hallmark explained</h2>
+    <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices under the Hallmarking Act 1973. The <strong>585 hallmark</strong> guarantees that the item contains at least 58.33% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
 
-    <h2>How Is the 14K Gold Price Calculated?</h2>
-    <p>The 14K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>14K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 0.5833</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
+    <div class="assay-grid">
+      <div class="assay-card">
+        <div class="assay-card__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8c-3.5 0-6 2-6 5 0 2 1 3.5 2.5 4.5C11 18 9 19 9 22h14c0-3-2-4-3.5-4.5C21 16.5 22 15 22 13c0-3-2.5-5-6-5z"/><circle cx="13" cy="13" r=".8" fill="currentColor"/><circle cx="19" cy="13" r=".8" fill="currentColor"/><path d="M14 17h4"/></svg>
+        </div>
+        <div class="assay-card__name">London</div>
+        <div class="assay-card__est">Leopard's head · 1300</div>
+      </div>
+      <div class="assay-card">
+        <div class="assay-card__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16 6v18M10 8h12M9 18c0 4 3 7 7 7s7-3 7-7"/><circle cx="16" cy="6" r="2"/></svg>
+        </div>
+        <div class="assay-card__name">Birmingham</div>
+        <div class="assay-card__est">Anchor · 1773</div>
+      </div>
+      <div class="assay-card">
+        <div class="assay-card__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="16" cy="16" r="3"/><path d="M16 5c-2 3-2 6 0 8M16 27c-2-3-2-6 0-8M5 16c3-2 6-2 8 0M27 16c-3-2-6-2-8 0M9 9c2 1 3 3 4 5M23 23c-2-1-3-3-4-5M9 23c2-1 3-3 4-5M23 9c-2 1-3 3-4 5"/></svg>
+        </div>
+        <div class="assay-card__name">Sheffield</div>
+        <div class="assay-card__est">Tudor rose · 1773</div>
+      </div>
+      <div class="assay-card">
+        <div class="assay-card__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M6 26V14l4-3v3l3-2 3 2v-3l3 2 3-2v3l4 3v12z"/><path d="M13 26v-6h6v6"/><path d="M8 14V9M12 11V8M20 11V8M24 14V9"/></svg>
+        </div>
+        <div class="assay-card__name">Edinburgh</div>
+        <div class="assay-card__est">Castle · 1457</div>
+      </div>
+    </div>
 
-    <h2>14K vs Other Karats</h2>
-    <figure itemscope itemtype="https://schema.org/Table">
-      <figcaption>Gold karat comparison — purity, hallmark, and typical use</figcaption>
-      <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-      <div class="data-table-wrap"><table class="data-table" aria-label="Gold karat comparison">
-        <thead><tr><th>Karat</th><th>Purity</th><th>Hallmark</th><th>Typical Use</th></tr></thead>
-        <tbody>
-          <tr><td>9K</td><td>37.5%</td><td>375</td><td>UK everyday jewellery</td></tr>
-          <tr><td><strong>14K</strong></td><td><strong>58.33%</strong></td><td><strong>585</strong></td><td><strong>US engagement rings (most popular)</strong></td></tr>
-          <tr><td>18K</td><td>75.0%</td><td>750</td><td>Fine jewellery, luxury watches</td></tr>
-          <tr><td>22K</td><td>91.67%</td><td>916</td><td>South Asian bridal gold</td></tr>
-          <tr><td>24K</td><td>99.9%</td><td>999</td><td>Bullion coins and bars</td></tr>
-        </tbody>
-      </table></div>
-    </figure>
-
-    <h2>14K Purity Table</h2>
-<div class="data-table-wrap"><table class="data-table" aria-label="Karat purity and indicative prices">
-<thead><tr><th>Karat</th><th>Purity</th><th>USD/gram</th><th>GBP/gram</th></tr></thead>
-<tbody>
-<tr><td>24K</td><td>99.9%</td><td>--</td><td>--</td></tr>
-<tr><td>18K</td><td>75.0%</td><td>--</td><td>--</td></tr>
-<tr><td>14K</td><td>58.3%</td><td>--</td><td>--</td></tr>
-<tr><td>10K</td><td>41.7%</td><td>--</td><td>--</td></tr>
-<tr><td>9K</td><td>37.5%</td><td>--</td><td>--</td></tr>
-</tbody>
-</table></div>
-
-    
-    <h2>What is 14K Gold?</h2>
-    <p>14K gold contains 14 parts pure gold out of 24 parts, giving it a purity of <strong>58.33%</strong>. The hallmark stamp you will find on 14K items is <strong>585</strong>, which represents 58.3 parts per thousand of pure gold. 14K gold balances durability with a warm gold colour. In the United States it is the most popular karat for engagement and wedding rings.</p>
-    <p>14K gold is commonly used for US and international fine jewellery, especially engagement rings. When you buy or sell 14K jewellery, the price you receive is calculated directly from the live gold spot price multiplied by the purity factor of 0.5833.</p>
-
-    <h2>How to Calculate the 14K Gold Price Per Gram</h2>
-    <p>The formula for the 14K gold price per gram is straightforward:</p>
-    <blockquote><strong>14K price per gram = (Spot price per troy oz ÷ 31.1035) × 0.5833</strong></blockquote>
-    <p>For example, if the gold spot price is $3,300 per troy ounce:</p>
-    <ul>
-      <li>Price per gram of pure gold = $3,300 ÷ 31.1035 = <strong>$106.10</strong></li>
-      <li>14K price per gram = $106.10 × 0.5833 = <strong>$61.89</strong></li>
-    </ul>
-    <p>This is the <em>melt value</em> — the intrinsic gold content value. Jewellers, dealers, and pawnbrokers typically pay between 70%–95% of melt value when buying, depending on condition and local market demand. When selling, retailers add a <em>premium</em> of 10%–30% above melt value.</p>
-
-    <h2>The 585 Hallmark Explained</h2>
-    <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices (London, Birmingham, Sheffield, or Edinburgh) under the Hallmarking Act 1973. The <strong>585 hallmark</strong> guarantees that the item contains at least 58.33% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
     <p>On older or imported items, you may also see the hallmark written as <strong>.585</strong> or stamped alongside a date letter and assay office mark. When appraising estate jewellery, always check for the 585 stamp before calculating value.</p>
 
-    <h2>Why 14K Dominates the US Engagement Ring Market</h2>
+    <h2>Why 14K dominates the US engagement ring market</h2>
     <p>According to the Jewelers of America, roughly <strong>70% of all engagement rings</strong> sold in the United States are set in 14K gold. The reason is practical: 14K offers the ideal balance between gold content and structural integrity. An engagement ring must withstand decades of daily wear — washing hands, gripping objects, and accidental knocks. Higher-karat alloys like 18K (75% gold) are noticeably softer and more prone to scratching, bending, and losing prong settings that hold diamonds.</p>
-    <p>The alloy metals in 14K gold — typically copper, silver, and zinc — give it a <strong>Vickers hardness of approximately 150–180 HV</strong>, compared to around 120–150 HV for 18K and just 25 HV for pure 24K gold. This hardness directly translates to better prong retention for gemstones and greater scratch resistance for bands.</p>
-    <p>Iconic jewellers such as <strong>Tiffany & Co.</strong> and <strong>Blue Nile</strong> use 14K as their standard setting for diamond solitaires. Many designer brands offer 14K alongside 18K, with the price difference typically running 20–30% for the same design — driven entirely by the gold content difference (58.33% vs 75%).</p>
 
-    <h2>14K Gold Colour Differences: Yellow, White, and Rose</h2>
-    <p>The alloy composition of 14K gold varies depending on the colour:</p>
-    <ul>
-      <li><strong>14K Yellow Gold</strong> — Alloyed primarily with copper and silver. Produces a warm, classic gold tone that is slightly less saturated than 18K yellow due to the lower gold content. This is the traditional choice for wedding bands.</li>
-      <li><strong>14K White Gold</strong> — Alloyed with palladium, nickel, or manganese to create a silvery-white appearance. Almost all 14K white gold is <strong>rhodium-plated</strong> — a thin layer of rhodium (a platinum-group metal) applied to the surface for a bright, reflective finish. This plating wears away over 12–18 months of daily wear and needs periodic re-plating, typically costing £25–£50 at a jeweller.</li>
-      <li><strong>14K Rose Gold</strong> — Alloyed with a higher proportion of copper (typically 33.3% copper, 8.33% silver). The result is a distinctive pink-gold hue that has grown significantly in popularity since 2015. Rose gold does not require plating and develops a subtle patina over time.</li>
-    </ul>
+    <div class="callout">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+      <div>
+        <div class="callout__title">Hardness comparison</div>
+        <div class="callout__body">14K gold: ~150–180 HV (Vickers). 18K gold: ~120–150 HV. Pure 24K: ~25 HV. Higher hardness = better prong retention, less scratching, longer life on daily-worn pieces.</div>
+      </div>
+    </div>
 
-    <h2>Selling 14K Gold Engagement Rings and Jewellery</h2>
+    <p>The alloy metals in 14K gold — typically copper, silver, and zinc — give it superior scratch resistance and prong retention compared to higher-karat alternatives. Iconic jewellers such as <strong>Tiffany &amp; Co.</strong> and <strong>Blue Nile</strong> use 14K as their standard setting for diamond solitaires. Many designer brands offer 14K alongside 18K, with the price difference typically running 20–30% for the same design — driven entirely by the gold content difference (58.33% vs 75%).</p>
+
+    <h2>14K gold colours: Yellow, White and Rose</h2>
+    <p>The alloy composition of 14K gold varies depending on the colour. All three carry the same 585 hallmark and contain 58.33% pure gold — the difference is the other 41.67%.</p>
+
+    <div class="swatch-grid">
+      <div class="swatch-card">
+        <div class="swatch-card__color swatch-card__color--yellow"><span class="swatch-card__hallmark">585 · 14K</span></div>
+        <div class="swatch-card__body">
+          <div class="swatch-card__title">14K Yellow Gold</div>
+          <div class="swatch-card__desc">Alloyed with copper and silver. Warm, classic gold tone — the traditional choice for wedding bands.</div>
+        </div>
+      </div>
+      <div class="swatch-card">
+        <div class="swatch-card__color swatch-card__color--white"><span class="swatch-card__hallmark">585 · 14K</span></div>
+        <div class="swatch-card__body">
+          <div class="swatch-card__title">14K White Gold</div>
+          <div class="swatch-card__desc">Alloyed with palladium or nickel, then rhodium-plated. Needs re-plating every 12–18 months (£25–£50).</div>
+        </div>
+      </div>
+      <div class="swatch-card">
+        <div class="swatch-card__color swatch-card__color--rose"><span class="swatch-card__hallmark">585 · 14K</span></div>
+        <div class="swatch-card__body">
+          <div class="swatch-card__title">14K Rose Gold</div>
+          <div class="swatch-card__desc">Higher copper content (~33%). Distinctive pink hue, no plating required, develops a subtle patina over time.</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Selling 14K gold: what to expect</h2>
     <p>14K gold jewellery occupies a unique position in the resale market. Unlike 9K or 10K gold — which many buyers consider "scrap only" — 14K pieces can sometimes command a premium above melt value if the design, brand, or gemstones add collectible value. A Tiffany 14K ring, for example, may sell for 40–60% above its raw gold weight on secondary markets like eBay or Vestiaire Collective.</p>
     <p>For plain 14K gold without brand or gemstone value, you should expect to receive <strong>75–90% of melt value</strong> from reputable dealers. The key factors that affect your 14K offer price:</p>
     <ul>
@@ -660,10 +1021,10 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       <li><strong>Gemstone content</strong> — Most scrap buyers pay nothing for small diamonds or gemstones under 0.25ct. Larger stones should be sold separately through a diamond dealer.</li>
       <li><strong>White gold premium</strong> — Some refiners pay slightly more for white 14K gold due to the palladium or nickel alloy content, which has independent value.</li>
     </ul>
-    <p>For the best price, get at least three quotes and use our live calculator to know your baseline melt value before negotiating.</p>
+    <p>For the best price, get at least three quotes and use our live calculator above to know your baseline melt value before negotiating. See our guide on <a href="/where-to-sell-gold-silver">where to sell gold safely</a> for vetted dealer recommendations.</p>
 
-    <h2>14K vs 18K: Which Should You Choose?</h2>
-    <p>The choice between 14K and 18K gold is one of the most common questions in jewellery buying. Here is a practical comparison:</p>
+    <h2>14K vs 18K: Which should you choose?</h2>
+    <p>The choice between 14K and <a href="/18k-gold-price-per-gram">18K gold</a> is one of the most common questions in jewellery buying. Here is a practical comparison:</p>
     <ul>
       <li><strong>Price difference</strong> — 18K gold contains 28.6% more pure gold than 14K (75% vs 58.33%), so it costs roughly 25–30% more per gram at current spot prices. For a typical 5g engagement ring, the gold content difference is around £80–£120 at today's prices.</li>
       <li><strong>Colour</strong> — 18K yellow gold has a richer, deeper golden hue. The difference is subtle but noticeable side by side. In white gold, the difference is hidden by rhodium plating.</li>
@@ -673,27 +1034,52 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </ul>
     <p>For engagement rings and daily-wear jewellery in the US or UK, 14K remains the pragmatic choice. For luxury pieces, European heritage jewellery, or items intended for the international resale market, 18K is the standard.</p>
 
-    <h2>Frequently Asked Questions</h2>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">How do I convert the 14K gold price from troy ounces to grams?</h3>
-      <p class="faq-answer">There are 31.1035 grams in one troy ounce. Divide the spot price (in any currency) by 31.1035 to get the price per gram of pure gold, then multiply by 0.5833 to get the 14K price per gram. Our live calculator above does this automatically.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">What is the difference between 14K gold and gold-filled or gold-plated?</h3>
-      <p class="faq-answer">Solid 14K gold contains 58.33% pure gold throughout the item. Gold-filled has a layer of 14K gold mechanically bonded to a base metal core — it contains far less gold by weight. Gold-plated items have only a thin electroplated layer of gold, typically less than 0.05% of the item's total weight. Only solid 14K gold carries the 585 hallmark and has significant melt value.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Why does the 14K gold price per gram vary between different websites?</h3>
-      <p class="faq-answer">Small differences between sites reflect the timing of their data feed, the spot price source used (LBMA, COMEX, or OTC), and whether they include the GBP/USD exchange rate at slightly different timestamps. GoldPriceTools fetches live prices from gold-api.com and currency rates from the Frankfurter API, both updated every 60 seconds.</p>
+    <h2>Frequently asked questions</h2>
+    <div class="faq-pro">
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How do I convert the 14K gold price from troy ounces to grams?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">There are <strong>31.1035 grams in one troy ounce</strong>. Divide the spot price (in any currency) by 31.1035 to get the price per gram of pure gold, then multiply by 0.5833 to get the 14K price per gram. Our live calculator above does this automatically using real-time LBMA spot data.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What is the difference between 14K solid, gold-filled and gold-plated?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body"><strong>Solid 14K gold</strong> contains 58.33% pure gold throughout the item. <strong>Gold-filled</strong> has a layer of 14K gold mechanically bonded to a base metal core — it contains far less gold by weight (typically 5%). <strong>Gold-plated</strong> items have only a thin electroplated layer of gold, usually less than 0.05% of the item's total weight. Only solid 14K gold carries the 585 hallmark and has significant melt value.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Why do 14K gold prices vary between different websites?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Small differences between sites reflect the timing of their data feed, the spot price source used (LBMA, COMEX, or OTC), and whether they include the GBP/USD exchange rate at slightly different timestamps. GoldPriceTools fetches live prices from <strong>gold-api.com</strong> (LBMA-sourced) and currency rates from the <strong>Frankfurter API</strong>, both updated every 60 seconds.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Is 14K gold real gold?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Yes. 14K gold is real gold — it contains <strong>58.33% pure gold</strong> (14 parts gold out of 24), alloyed with metals such as copper, silver, palladium or zinc for strength and durability. It is hallmarked 585 in Europe/UK and 14K or 14KT in the US.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How accurate are these live prices?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Spot prices on this page come direct from the LBMA via gold-api.com and refresh every 60 seconds. Currency conversion to GBP and INR uses the Frankfurter API live rates. These are the <em>melt values</em> — what the raw gold content is worth. Dealer buy prices are typically 70–95% of melt, retail prices include a 10–30% premium.</div>
+      </details>
     </div>
 
-    <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Dealer buy prices are typically 70&ndash;90% of melt value. Always verify with your dealer before selling.</div>
-  </div>
+    <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Dealer buy prices are typically 70–90% of melt value. Always verify with your dealer before selling or buying.</div>
+  </article>
 </div>
 
-<div class="content" style="padding-bottom:1.5rem">
-<!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
+<!-- Social share buttons -->
+<div class="content-section" style="padding-top:0;padding-bottom:1.5rem">
+<div class="share-buttons" style="max-width:760px;margin:0 auto">
   <span>Share:</span>
   <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/14k-gold-price-per-gram&text=14K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
   <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/14k-gold-price-per-gram&title=14K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
@@ -701,54 +1087,69 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 </div>
 </div>
 
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
-    <h2>Related Gold &amp; Silver Guides</h2>
-    <div class="related-guides-grid">
-      <a href="/10k-gold-price-per-gram" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">10K Gold Price Per Gram</div>
-        <div class="related-card__desc">Today's 10K gold price per gram — ideal for US jewellery and scrap gold.</div>
-      </a>
-      <a href="/18k-gold-price-per-gram" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">18K Gold Price Per Gram</div>
-        <div class="related-card__desc">Live 18K gold price per gram — commonly used in European and Middle Eastern jewellery.</div>
-      </a>
-      <a href="/scrap-gold-calculator" class="related-card">
-        <div class="related-card__tag">Tool</div>
-        <div class="related-card__title">Scrap Gold Calculator</div>
-        <div class="related-card__desc">Calculate the melt value of your 14K gold jewellery using today's live spot price.</div>
-      </a>
-      <a href="/guides/what-is-14k-gold" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">What is 14K Gold?</div>
-        <div class="related-card__desc">Understand 14K gold alloy composition, hallmarks, and why it's the most popular karat in the US.</div>
-      </a>
-      <a href="/guides/gold-hallmarks-explained" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold Hallmarks Explained</div>
-        <div class="related-card__desc">Understand what hallmarks mean on your 14K gold pieces — 585 fineness and more.</div>
-      </a>
-      <a href="/guides/how-to-sell-gold-jewellery" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">How to Sell Gold Jewellery</div>
-        <div class="related-card__desc">Get the best price for your gold — what dealers look for and how to avoid being underpaid.</div>
-      </a>
-      <a href="/gold-price-today-14k" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">Gold Price Today 14K</div>
-        <div class="related-card__desc">Today's live 14 karat gold value in USD, GBP and EUR — updated every 60 seconds.</div>
-      </a>
-      <a href="/14k-gold-price-in-usd" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">14K Gold Price in USD</div>
-        <div class="related-card__desc">Live 14 karat gold price in US dollars per gram, troy ounce and kilogram.</div>
-      </a>
+<!-- Related Guides -->
+<section class="related-guides" aria-labelledby="related-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Keep reading</span>
+      <h2 class="section-title" id="related-title">Related Gold &amp; Silver Guides</h2>
     </div>
   </div>
+  <div class="related-guides-grid">
+    <a href="/10k-gold-price-per-gram" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">10K Gold Price Per Gram</div>
+      <div class="related-card__desc">Today's 10K gold price per gram — ideal for US jewellery and scrap gold.</div>
+    </a>
+    <a href="/18k-gold-price-per-gram" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">18K Gold Price Per Gram</div>
+      <div class="related-card__desc">Live 18K gold price per gram — commonly used in European and Middle Eastern jewellery.</div>
+    </a>
+    <a href="/scrap-gold-calculator" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">Scrap Gold Calculator</div>
+      <div class="related-card__desc">Calculate the melt value of your 14K gold jewellery using today's live spot price.</div>
+    </a>
+    <a href="/guides/what-is-14k-gold" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">What is 14K Gold?</div>
+      <div class="related-card__desc">Understand 14K gold alloy composition, hallmarks, and why it's the most popular karat in the US.</div>
+    </a>
+    <a href="/guides/gold-hallmarks-explained" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Gold Hallmarks Explained</div>
+      <div class="related-card__desc">Understand what hallmarks mean on your 14K gold pieces — 585 fineness and more.</div>
+    </a>
+    <a href="/guides/how-to-sell-gold-jewellery" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">How to Sell Gold Jewellery</div>
+      <div class="related-card__desc">Get the best price for your gold — what dealers look for and how to avoid being underpaid.</div>
+    </a>
+    <a href="/gold-price-today-14k" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">Gold Price Today 14K</div>
+      <div class="related-card__desc">Today's live 14 karat gold value in USD, GBP and EUR — updated every 60 seconds.</div>
+    </a>
+    <a href="/14k-gold-price-in-usd" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">14K Gold Price in USD</div>
+      <div class="related-card__desc">Live 14 karat gold price in US dollars per gram, troy ounce and kilogram.</div>
+    </a>
+  </div>
 </section>
+
+<!-- Sticky mobile price bar -->
+<div class="sticky-price" id="stickyPrice" role="complementary" aria-label="Live price quick access">
+  <div class="sticky-price__info">
+    <div class="sticky-price__label">14K · USD/g</div>
+    <div class="sticky-price__value" id="sticky-usd">&mdash;</div>
+  </div>
+  <a href="#calculator" class="sticky-price__cta">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M8 18h2"/></svg>
+    Calculate
+  </a>
+</div>
 
 <footer>
   <div class="footer-inner">
@@ -770,7 +1171,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -828,46 +1228,254 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 </footer>
 
 <script>
-async function fetchFx(){
-  try{
-    const r=await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,INR',{cache:'no-store'});
-    if(!r.ok)throw new Error();
-    const d=await r.json();
-    window._gbpusd=d.rates.GBP||0.79;window._usdinr=d.rates.INR||83.5;
-  }catch{window._gbpusd=0.79;}
-}
-async function fetchSpot(){
-  const PURITY=0.5833;
-  try{
-    const r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
-    if(!r.ok)throw new Error();
-    const d=await r.json();
-    const spotUSD=d.price;
-    const pgUSD=spotUSD/31.1035*PURITY;
-    const pgGBP=pgUSD*(window._gbpusd||0.79);
-    const pgINR=pgUSD*(window._usdinr||83.5);
-    document.getElementById('price-gbp').textContent='$'+pgUSD.toFixed(2)+'/g';
-    document.getElementById('price-usd').textContent='£'+pgGBP.toFixed(2)+'/g GBP';
-    const snippetEl = document.getElementById('snippet-price');
-    if(snippetEl) snippetEl.textContent='$'+pgUSD.toFixed(2)+' USD (£'+pgGBP.toFixed(2)+' GBP)';
-    const weights=[0.5,1,2,5,10,20,31.1035];
-    const ids=['0-5','1','2','5','10','20','31'];
-    weights.forEach((w,i)=>{
-      const g=document.getElementById('t-'+ids[i]+'-gbp');
-      const u=document.getElementById('t-'+ids[i]+'-usd');
-      if(g)g.textContent='£'+(pgGBP*w).toFixed(2);
-      if(u)u.textContent='$'+(pgUSD*w).toFixed(2);
-      const inrEl=document.getElementById('t-'+ids[i]+'-inr');
-      if(inrEl)inrEl.textContent='₹'+(pgINR*w).toFixed(2);
-    });
-    gtag('event','price_view',{metal:'gold',karat:'14K'});
-  }catch(e){
-    console.warn('Price fetch failed',e);
+/* ───────── Live price engine — preserves API contract ─────────
+   Sources:
+     • Gold spot:  https://api.gold-api.com/price/XAU  (LBMA-derived USD/oz)
+     • FX rates:   https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,INR
+   Refresh: 60s — DO NOT change interval (keeps cross-page consistency)
+*/
+(function(){
+  const PURITY_14K = 0.5833;
+  const PURITY_KARATS = {9:0.375, 10:0.4167, 14:0.5833, 18:0.75, 22:0.9167, 24:0.999};
+  const G_PER_OZ = 31.1035;
+  const REFRESH_MS = 60000;
+  let lastFetchTs = 0;
+  let countdownTimer = null;
+
+  // Currency formatters
+  const fmtUSD = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
+  const fmtGBP = new Intl.NumberFormat('en-GB',{style:'currency',currency:'GBP',maximumFractionDigits:2});
+  const fmtINR = new Intl.NumberFormat('en-IN',{style:'currency',currency:'INR',maximumFractionDigits:0});
+  const fmtSpot = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
+
+  function $(id){return document.getElementById(id);}
+
+  async function fetchFx(){
+    try{
+      const r = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,INR',{cache:'no-store'});
+      if(!r.ok) throw new Error('FX fetch failed');
+      const d = await r.json();
+      window._gbpusd = d.rates.GBP || 0.79;
+      window._usdinr = d.rates.INR || 83.5;
+    }catch(e){
+      console.warn('FX fallback used',e);
+      window._gbpusd = window._gbpusd || 0.79;
+      window._usdinr = window._usdinr || 83.5;
+    }
   }
-}
-Promise.all([fetchFx(),fetchSpot()]);
-setInterval(fetchSpot,60000);
+
+  async function fetchSpot(){
+    try{
+      const r = await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
+      if(!r.ok) throw new Error('Spot fetch failed');
+      const d = await r.json();
+      const spotUSD = d.price;
+      window._spotUSD = spotUSD;
+      lastFetchTs = Date.now();
+      render(spotUSD);
+      gtag('event','price_view',{metal:'gold',karat:'14K'});
+    }catch(e){
+      console.warn('Spot fetch failed',e);
+    }
+  }
+
+  function render(spotUSD){
+    const gbp = window._gbpusd || 0.79;
+    const inr = window._usdinr || 83.5;
+    const pg14USD = (spotUSD / G_PER_OZ) * PURITY_14K;
+    const pg14GBP = pg14USD * gbp;
+    const pg14INR = pg14USD * inr;
+
+    // Hero tiles
+    const usdEl = $('hero-usd');
+    const gbpEl = $('hero-gbp');
+    const inrEl = $('hero-inr');
+    if(usdEl) usdEl.textContent = fmtUSD.format(pg14USD);
+    if(gbpEl) gbpEl.textContent = fmtGBP.format(pg14GBP);
+    if(inrEl) inrEl.textContent = fmtINR.format(pg14INR);
+
+    // Sticky mobile bar
+    const stickyEl = $('sticky-usd');
+    if(stickyEl) stickyEl.textContent = fmtUSD.format(pg14USD);
+
+    // Spot reference
+    const spotEl = $('spot-usd');
+    if(spotEl) spotEl.textContent = fmtSpot.format(spotUSD) + ' /oz';
+
+    // Snippet inline price
+    const snippetEl = $('snippet-price');
+    if(snippetEl) snippetEl.textContent = fmtUSD.format(pg14USD) + ' (' + fmtGBP.format(pg14GBP) + ')';
+
+    // Weight table — preserves original IDs (t-0-5, t-1, t-2, t-5, t-10, t-20, t-31)
+    const weights = [0.5, 1, 2, 5, 10, 20, G_PER_OZ];
+    const ids =    ['0-5','1','2','5','10','20','31'];
+    weights.forEach((w,i) => {
+      const u = $('t-'+ids[i]+'-usd');
+      const g = $('t-'+ids[i]+'-gbp');
+      const n = $('t-'+ids[i]+'-inr');
+      if(u) u.textContent = fmtUSD.format(pg14USD * w);
+      if(g) g.textContent = fmtGBP.format(pg14GBP * w);
+      if(n) n.textContent = fmtINR.format(pg14INR * w);
+    });
+
+    // Karat comparison cards
+    Object.keys(PURITY_KARATS).forEach(k => {
+      const el = $('karat-'+k+'-usd');
+      if(el){
+        const p = PURITY_KARATS[k];
+        el.textContent = fmtUSD.format((spotUSD / G_PER_OZ) * p);
+      }
+    });
+
+    // Calculator — update live
+    updateCalculator();
+
+    // Update timestamp
+    updateTimestamp();
+    startCountdown();
+  }
+
+  function updateTimestamp(){
+    const el = $('updated-time');
+    if(!el) return;
+    el.textContent = 'just now';
+  }
+
+  function startCountdown(){
+    if(countdownTimer) clearInterval(countdownTimer);
+    const counterEl = $('refresh-counter');
+    const updatedEl = $('updated-time');
+    countdownTimer = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - lastFetchTs) / 1000);
+      const remaining = Math.max(0, 60 - elapsed);
+      if(counterEl) counterEl.textContent = remaining + 's';
+      if(updatedEl){
+        if(elapsed < 10) updatedEl.textContent = 'just now';
+        else if(elapsed < 60) updatedEl.textContent = elapsed + 's ago';
+        else updatedEl.textContent = Math.floor(elapsed/60) + 'm ago';
+      }
+    }, 1000);
+  }
+
+  // ───────── Calculator interaction ─────────
+  function updateCalculator(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD) return;
+    const weightEl = $('calc-weight');
+    const currencyEl = $('calc-currency');
+    if(!weightEl || !currencyEl) return;
+    const weight = parseFloat(weightEl.value) || 0;
+    const currency = currencyEl.value;
+
+    const pg14USD = (spotUSD / G_PER_OZ) * PURITY_14K;
+    let pricePerGram, fmt;
+    if(currency === 'GBP'){
+      pricePerGram = pg14USD * (window._gbpusd || 0.79);
+      fmt = fmtGBP;
+    }else if(currency === 'INR'){
+      pricePerGram = pg14USD * (window._usdinr || 83.5);
+      fmt = fmtINR;
+    }else{
+      pricePerGram = pg14USD;
+      fmt = fmtUSD;
+    }
+
+    const melt = pricePerGram * weight;
+    const dealer = melt * 0.85;
+    const retail = melt * 1.25;
+
+    const meltEl = $('calc-melt');
+    const dealerEl = $('calc-dealer');
+    const retailEl = $('calc-retail');
+    if(meltEl) meltEl.textContent = fmt.format(melt);
+    if(dealerEl) dealerEl.textContent = fmt.format(dealer);
+    if(retailEl) retailEl.textContent = fmt.format(retail);
+  }
+
+  // Calculator listeners
+  function bindCalculator(){
+    const weightEl = $('calc-weight');
+    const currencyEl = $('calc-currency');
+    if(weightEl) weightEl.addEventListener('input', updateCalculator);
+    if(currencyEl) currencyEl.addEventListener('change', updateCalculator);
+    document.querySelectorAll('.calc-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const w = chip.getAttribute('data-weight');
+        if(weightEl){
+          weightEl.value = w;
+          updateCalculator();
+        }
+        document.querySelectorAll('.calc-chip').forEach(c => c.classList.remove('active'));
+        chip.classList.add('active');
+        gtag('event','calc_chip_click',{weight:w});
+      });
+    });
+  }
+
+  // Currency switch (highlights column in price table)
+  function bindCurrencySwitch(){
+    const btns = document.querySelectorAll('.currency-switch__btn');
+    btns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const cur = btn.getAttribute('data-currency');
+        btns.forEach(b => {
+          b.classList.toggle('active', b === btn);
+          b.setAttribute('aria-selected', b === btn ? 'true' : 'false');
+        });
+        // Highlight column
+        document.querySelectorAll('.price-table-pro td, .price-table-pro th').forEach(c => {
+          c.classList.toggle('price-table-pro__primary', c.getAttribute('data-col') === cur);
+        });
+        // Also reflect in calculator dropdown for convenience
+        const calcCur = $('calc-currency');
+        if(calcCur && calcCur.value !== cur){
+          calcCur.value = cur;
+          updateCalculator();
+        }
+      });
+    });
+    // Set initial highlight
+    document.querySelectorAll('.price-table-pro td[data-col="USD"], .price-table-pro th[data-col="USD"]').forEach(c => c.classList.add('price-table-pro__primary'));
+  }
+
+  // Sticky mobile bar — show after scroll past hero
+  function bindStickyBar(){
+    const bar = $('stickyPrice');
+    if(!bar) return;
+    let visible = false;
+    window.addEventListener('scroll', () => {
+      const show = window.scrollY > 400;
+      if(show !== visible){
+        bar.classList.toggle('visible', show);
+        visible = show;
+      }
+    }, {passive: true});
+  }
+
+  // Init
+  document.addEventListener('DOMContentLoaded', () => {
+    bindCalculator();
+    bindCurrencySwitch();
+    bindStickyBar();
+  });
+
+  // Boot
+  Promise.all([fetchFx(), fetchSpot()]).catch(e => console.warn('init',e));
+  setInterval(fetchSpot, REFRESH_MS);
+})();
 </script>
+<script>(function(){
+  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
+  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+  root.setAttribute('data-theme',theme);
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);try{localStorage.setItem('gpt-theme',theme);}catch(e){}themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
+  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
+  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
+  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
+  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
+})();</script>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>
 let _deepReadFired = false;


### PR DESCRIPTION
## Summary

Mobile-first premium redesign of `/14k-gold-price-per-gram` using the ui-ux-pro-max design system (Editorial Premium + Trust & Authority pattern). The page previously claimed "use our calculator above" but had no calculator — this PR adds one, plus a 3-currency live price tile hero, bento karat comparison, formula breakdown, color swatches, and a sticky mobile bottom bar.

## What's new

**Premium hero** — Editorial Playfair Display title with gold gradient accent, three live-price tiles (USD/GBP/INR), live pulse indicator, 24K spot price reference, refresh countdown timer, and a trust strip.

**Live calculator (NEW)** — Weight input with quick-weight chips (Wedding ring 3.5g, Chain 15g, 5g, 10g, 1 troy oz), currency selector, melt value display + dealer payout estimate (~85%) and retail premium (~+25%) — all live, updates with the spot price.

**Price-by-weight table** — Preserves every original `t-*-usd/gbp/inr` ID. New currency segmented control highlights the selected column. Sub-labels per weight (Wedding ring, Engagement ring, Heavy bangle, etc.).

**Karat comparison bento** — Live-priced cards for 9K / 14K / 18K / 22K / 24K, with 14K marked "you are here" and gold-glow border.

**Editorial polish** — Formula block with step-by-step numbered breakdown, 14K color swatches (yellow/white/rose) with photorealistic gradients, four UK assay office cards with hand-drawn SVG marks (Leopard's head, Anchor, Tudor rose, Castle — historically accurate), accordion FAQ with smooth animation, stat cards (58.33% / 70% / 585 / 150-180 HV).

**Mobile-first** — Sticky bottom price bar with live USD/g + jump-to-calculator CTA. All touch targets ≥44px, `dvh` units, no horizontal scroll, smooth scroll with proper scroll-padding.

## Live data integrity

The 60-second refresh contract is preserved exactly:
- Gold spot: `https://api.gold-api.com/price/XAU` (LBMA-derived USD/oz) — unchanged endpoint
- FX rates: `https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,INR` — unchanged endpoint
- Refresh interval: 60000ms — unchanged
- Purity factor: 0.5833 — unchanged
- Conversion math: `(spot USD/oz ÷ 31.1035) × 0.5833` — unchanged

Karat comparison cards derive prices from the same single spot fetch using `{9: 0.375, 10: 0.4167, 14: 0.5833, 18: 0.75, 22: 0.9167, 24: 0.999}` — guaranteed cross-page consistency.

## Bug fixes included

- Removed duplicate "What is 14K Gold?" H2 (was rendered twice)
- Replaced the static "14K Purity Table" that had hard-coded `--` placeholders that never updated with the live bento karat cards
- Wired the shared nav JS (hamburger, theme toggle, mega-nav, mobile sections) which was missing from the page — the navigation now actually works on this page
- Fixed assay office symbol assignments (the previous Unicode characters had London and Birmingham swapped)
- Improved colour contrast in light mode: `--color-text-muted` darkened from `#7a7974` to `#5a5953` (WCAG AA)

## Test plan

- [ ] Verify USD/GBP/INR live prices populate in hero tiles on page load and refresh every 60s
- [ ] Verify calculator updates instantly on weight change, currency change, and chip click
- [ ] Verify weight table all 7 rows × 3 currencies populate live
- [ ] Verify karat comparison cards show live USD/g for each karat
- [ ] Verify sticky mobile bar appears below 400px scroll
- [ ] Verify currency segmented control highlights the correct column
- [ ] Verify FAQ accordion expand/collapse with smooth animation
- [ ] Verify navigation (hamburger, theme toggle, mega-nav) all work
- [ ] Run `python3 tools/playwright_audit.py https://goldpricetools.com/14k-gold-price-per-gram` per `DEVELOPMENT_RULES.md`
- [ ] Cross-check 14K price matches `/gold-price-today-14k` and `/14k-gold-price-in-usd` exactly

https://claude.ai/code/session_01F6Kv39kkTeszbaEVpeouV6

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6Kv39kkTeszbaEVpeouV6)_