### PR TITLE
Redesign 24K gold price page with premium editorial bullion UI

### DIFF
--- a/24k-gold-price-per-gram.html
+++ b/24k-gold-price-per-gram.html
@@ -7,35 +7,33 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>24K Gold Price Per Gram Today | Live Calculator | GoldPriceTools</title>
+<title>24K Gold Price Per Gram Today (Live USD) — 999 Pure Gold | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Live 24K gold price per gram in USD, GBP, EUR and more. Pure gold (99.9%) calculator updated every 60 seconds. Free scrap gold value tool.">
+<meta name="description" content="Live 24K gold price per gram in USD, INR, GBP and EUR. Pure gold (99.9%, 999 hallmark) — the LBMA benchmark from which every karat is derived. Free calculator, updated every 60 seconds.">
 <meta name="robots" content="index, follow">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/24k-gold-price-per-gram">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/24k-gold-price-per-gram">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/24k-gold-price-per-gram">
 <link rel="canonical" href="https://goldpricetools.com/24k-gold-price-per-gram">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"24K Gold Price Per Gram","item":"https://goldpricetools.com/24k-gold-price-per-gram"}]}</script>
-<meta property="og:title" content="24K Gold Price Per Gram Today (Live)">
-<meta property="og:description" content="Real-time 24K gold price per gram in USD, GBP, EUR. 99.9% pure gold. Updated every 60 seconds.">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Gold Per Gram","item":"https://goldpricetools.com/gold-price-per-gram"},{"@type":"ListItem","position":3,"name":"24K Gold Price Per Gram","item":"https://goldpricetools.com/24k-gold-price-per-gram"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the 24K gold price per gram today?","acceptedAnswer":{"@type":"Answer","text":"The live 24K gold price per gram is calculated by dividing the current LBMA gold spot price (USD per troy ounce) by 31.1035 grams per troy ounce, then multiplying by 0.999 (24K purity). USD is the primary currency on this page; live INR, GBP and EUR conversions use ECB reference rates. The value updates every 60 seconds."}},{"@type":"Question","name":"Is 24K gold real gold?","acceptedAnswer":{"@type":"Answer","text":"Yes. 24K gold is the purest commercially available gold — 99.9% pure, hallmarked 999. It is the LBMA bullion standard used for investment bars, sovereign coins (Britannia, Maple Leaf, Buffalo) and central bank reserves. Because it is so soft, it is rarely used for everyday jewellery in Western markets."}},{"@type":"Question","name":"What does the 999 hallmark mean?","acceptedAnswer":{"@type":"Answer","text":"The 999 hallmark indicates 24 karat gold at 99.9% purity — 999 parts pure gold per 1,000. In the UK this stamp is enforced by the four Assay Offices under the Hallmarking Act 1973. LBMA Good Delivery bars must meet a minimum 995 fineness; modern retail bullion from PAMP, Valcambi and the Royal Mint is typically 999 or 9999 (four-nines)."}},{"@type":"Question","name":"How do I calculate the 24K gold price per gram?","acceptedAnswer":{"@type":"Answer","text":"24K price per gram = (Spot price USD per troy oz ÷ 31.1035) × 0.999. For example, at a $3,300/oz spot, a gram of 24K gold = $3,300 ÷ 31.1035 × 0.999 = approximately $105.99. Use our live calculator for an instant melt value in USD, INR, GBP or EUR."}},{"@type":"Question","name":"Is 24K gold a good investment?","acceptedAnswer":{"@type":"Answer","text":"24K gold is the only purity used for investment-grade bullion. UK Gold Britannia coins (24K, 1oz) are CGT and VAT exempt as legal tender. LBMA-accredited bars from PAMP, Valcambi or the Royal Mint carry the lowest premiums over spot. For US investors, 24K bullion qualifies for Gold IRA inclusion."}},{"@type":"Question","name":"How accurate are these live prices?","acceptedAnswer":{"@type":"Answer","text":"Spot prices come direct from the LBMA via gold-api.com and refresh every 60 seconds. Currency conversion from USD to INR, GBP and EUR uses the Frankfurter API (ECB reference rates). These are melt values — dealer payouts for 24K bullion are typically 95–99% of spot; retail bullion premiums add 2–8% depending on size and product."}}]}</script>
+<meta property="og:title" content="24K Gold Price Per Gram Today (Live USD)">
+<meta property="og:description" content="Real-time 24K gold price per gram in USD, INR, GBP, EUR. 99.9% pure gold &middot; 999 hallmark &middot; the LBMA benchmark. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/24k-gold-price-per-gram">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the 24K gold price per gram today?","acceptedAnswer":{"@type":"Answer","text":"The live 24K gold price per gram is calculated by multiplying the current gold spot price per troy ounce by 1.0 (24K purity) and dividing by 31.1035 (grams per troy ounce). This value updates every 60 seconds on Gold Price Tools."}},{"@type":"Question","name":"How much is 24K gold worth per gram in GBP?","acceptedAnswer":{"@type":"Answer","text":"The 24K gold price per gram in GBP is calculated from the live USD spot price converted at the current USD/GBP exchange rate, then multiplied by 1.0 (24K purity) and divided by 31.1035 (grams per troy ounce). The live GBP price is shown on this page."}},{"@type":"Question","name":"Is 24K gold real gold?","acceptedAnswer":{"@type":"Answer","text":"Yes. 24K gold is the realest form of gold — it is pure gold (99.9%), not alloyed with other metals. Because it is pure, it is very soft and rarely used for everyday jewellery."}},{"@type":"Question","name":"How do I calculate 24K gold value?","acceptedAnswer":{"@type":"Answer","text":"To calculate: 1) Find the current gold spot price per troy ounce. 2) Divide by 31.1035 to get the price per gram of pure gold. 3) Multiply by 1.0 (24K purity). 4) Multiply by the weight of your item in grams. Use our live calculator above for instant results."}},{"@type":"Question","name":"What does the 999 hallmark mean?","acceptedAnswer":{"@type":"Answer","text":"The 999 hallmark indicates 24K gold with 99.90% purity. In the UK, this stamp must be applied by an approved Assay Office under the Hallmarking Act 1973."}},{"@type":"Question","name":"How do I calculate the melt value of 24K gold?","acceptedAnswer":{"@type":"Answer","text":"Melt value = weight in grams × (spot price per troy oz ÷ 31.1035) × 0.999. Use our live calculator above for an instant result."}}]}</script>
 <script>
   window.dataLayer=window.dataLayer||[];
   function gtag(){dataLayer.push(arguments);}
   gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
 </script>
-<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
 <script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
 <script>
 (adsbygoogle = window.adsbygoogle || []).push({
   google_ad_client: "ca-pub-8849494330640880",
@@ -51,9 +49,10 @@
 <meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.gold-api.com">
+<link rel="preconnect" href="https://api.frankfurter.dev">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:wght@500;600;700;800&display=swap" rel="stylesheet">
 <style>
-
 /* ── Guides mega panel — category links ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
@@ -63,28 +62,22 @@
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#5a5953;--color-text-faint:#8a8983;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#c08a00;--color-gold-deep:#8a5e00;--color-gold-luxe:#d4a017;--color-saffron:#c97812;--color-silver:#6b7280;--color-success:#0f7a3d;--color-danger:#b91c1c;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--shadow-gold:0 8px 32px -8px oklch(0.7 0.15 80/0.3);--shadow-luxe:0 20px 50px -20px oklch(0.7 0.15 80/0.35);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--space-20:5rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--text-3xl:clamp(2.5rem,1.5rem + 4vw,5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-editorial:'Playfair Display',Georgia,serif;--font-mono:'IBM Plex Mono',ui-monospace,monospace;--transition:180ms cubic-bezier(0.16,1,0.3,1);--transition-slow:400ms cubic-bezier(0.16,1,0.3,1);--gradient-gold:linear-gradient(135deg,#d4a017 0%,#f4cc4b 35%,#b07a00 100%);--gradient-gold-luxe:linear-gradient(135deg,#e8af34 0%,#f6d97a 25%,#d4a017 55%,#a87a1a 100%);--gradient-gold-deep:linear-gradient(135deg,#f4cc4b 0%,#e8af34 30%,#a87a1a 70%,#8a5e00 100%);--gradient-gold-soft:linear-gradient(135deg,oklch(0.7 0.13 80/0.18) 0%,oklch(0.6 0.12 80/0.06) 100%);--gradient-bullion:linear-gradient(135deg,#fbe084 0%,#f4cc4b 20%,#e8af34 50%,#a87a1a 85%,#5e4000 100%);--gold-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.7 0.15 80/0.14),transparent 60%);--gold-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.7 0.16 78/0.22),transparent 65%)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#e8e6e0;--color-text-muted:#a09e98;--color-text-faint:#6a6864;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-gold-deep:#a87a1a;--color-gold-luxe:#f4cc4b;--color-saffron:#e89432;--color-silver:#9ca3af;--color-success:#4ade80;--color-danger:#f87171;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5);--shadow-gold:0 8px 32px -4px oklch(0.55 0.15 75/0.35);--shadow-luxe:0 30px 60px -20px oklch(0.55 0.18 75/0.4);--gradient-gold:linear-gradient(135deg,#e8af34 0%,#f4cc4b 35%,#a87a1a 100%);--gradient-gold-luxe:linear-gradient(135deg,#f4cc4b 0%,#fbe084 30%,#e8af34 55%,#a87a1a 100%);--gradient-gold-deep:linear-gradient(135deg,#fbe084 0%,#f4cc4b 25%,#e8af34 55%,#a87a1a 100%);--gradient-gold-soft:linear-gradient(135deg,oklch(0.6 0.13 80/0.18) 0%,oklch(0.4 0.08 80/0.04) 100%);--gradient-bullion:linear-gradient(135deg,#fbe084 0%,#f4cc4b 25%,#e8af34 55%,#a87a1a 85%,#5e4000 100%);--gold-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.6 0.15 75/0.18),transparent 60%);--gold-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.65 0.16 78/0.22),transparent 70%)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-/* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
 .article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
 .article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
 .article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
 .article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
 .article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
 .article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
 .blog-preview-card:hover h3{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
-
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:calc(var(--space-16) + var(--space-2))}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
@@ -92,194 +85,318 @@ input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+:focus-visible{outline:2px solid var(--color-gold-bright);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-
-/* TICKER */
-.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
-.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
-.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
-.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
-.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
-.ticker:hover{animation-play-state:paused}
-@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
-.ticker-label{color:var(--color-text-muted)}
-.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
-.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
-@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
-
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
 
 /* AD SLOTS */
 .ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
 .ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
 
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
+/* PREMIUM HERO */
+.hero-premium{position:relative;overflow:hidden;border-bottom:1px solid var(--color-border)}
+.hero-premium::before{content:'';position:absolute;inset:0;background:var(--gold-glow-deep);pointer-events:none;z-index:0}
+.hero-premium::after{content:'';position:absolute;top:-20%;right:-10%;width:60%;height:140%;background:radial-gradient(ellipse 50% 70% at 30% 30%,oklch(0.6 0.18 75/0.1),transparent 60%);pointer-events:none;z-index:0}
+.hero-premium__inner{position:relative;z-index:1;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-10)}
+@media(min-width:768px){.hero-premium__inner{padding:var(--space-12) var(--space-6) var(--space-12)}}
+@media(min-width:1024px){.hero-premium__inner{padding:var(--space-16) var(--space-8) var(--space-12)}}
+.hero-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);padding:6px var(--space-3);background:var(--gradient-gold-soft);border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,transparent);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--color-gold-bright);margin-bottom:var(--space-5)}
+.hero-eyebrow__pulse{width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);box-shadow:0 0 8px var(--color-gold-bright);animation:heroPulse 2.4s ease-in-out infinite}
+@keyframes heroPulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+.hero-premium__title{font-family:var(--font-editorial);font-weight:600;color:var(--color-text);line-height:.98;letter-spacing:-.025em;margin-bottom:var(--space-5);font-size:clamp(2.5rem,1.5rem + 5.5vw,5.5rem)}
+.hero-premium__title-em{display:inline-block;background:var(--gradient-gold-deep);-webkit-background-clip:text;background-clip:text;color:transparent;font-style:italic;font-weight:500}
+.hero-premium__sub{font-size:clamp(1rem,.95rem + .35vw,1.25rem);color:var(--color-text-muted);line-height:1.6;max-width:62ch;margin-bottom:var(--space-8)}
+.hero-premium__sub strong{color:var(--color-gold-bright);font-weight:600}
 
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+/* PRICE TILES */
+.price-tiles{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-6)}
+@media(min-width:560px){.price-tiles{grid-template-columns:repeat(3,1fr);gap:var(--space-3)}}
+@media(min-width:1024px){.price-tiles{gap:var(--space-4)}}
+.price-tile{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.price-tile::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,transparent,var(--color-gold-bright),transparent);opacity:.6}
+.price-tile:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-gold)}
+.price-tile--primary{background:linear-gradient(135deg,var(--color-surface) 0%,var(--color-surface-offset) 100%);border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border))}
+.price-tile--primary::before{background:var(--gradient-gold-deep);opacity:1;height:4px}
+.price-tile__head{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-3)}
+.price-tile__label{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--color-text-muted)}
+.price-tile--primary .price-tile__label{color:var(--color-gold-bright)}
+.price-tile__flag{display:inline-flex;align-items:center;gap:6px;font-size:11px;color:var(--color-text-faint);font-weight:600;font-family:var(--font-mono);letter-spacing:.04em}
+.price-tile__value{font-family:var(--font-display);font-size:clamp(1.75rem,1.2rem + 2.2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.02em;line-height:1;font-variant-numeric:tabular-nums;margin-bottom:var(--space-2)}
+.price-tile--primary .price-tile__value{color:var(--color-gold-bright)}
+.price-tile__sub{font-size:var(--text-xs);color:var(--color-text-muted);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.price-tile__purity-dot{width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);flex-shrink:0}
 
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+/* LIVE STATUS */
+.live-status{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2) var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted)}
+.live-status__dot{width:8px;height:8px;border-radius:50%;background:var(--color-success);box-shadow:0 0 8px color-mix(in oklch,var(--color-success) 80%,transparent);animation:heroPulse 2s ease-in-out infinite;flex-shrink:0}
+.live-status__label{font-weight:600;color:var(--color-text)}
+.live-status__divider{color:var(--color-text-faint);user-select:none}
+.live-status__meta{font-variant-numeric:tabular-nums}
+.live-status__meta strong{color:var(--color-gold-bright);font-weight:600}
+.live-status__cta{margin-left:auto;display:inline-flex;align-items:center;gap:6px;padding:8px var(--space-3);background:var(--gradient-gold-luxe);color:#1a1410;border-radius:var(--radius-md);font-weight:700;font-size:11px;letter-spacing:.06em;text-transform:uppercase;text-decoration:none;min-height:36px}
+.live-status__cta:hover{filter:brightness(1.1);text-decoration:none;color:#1a1410}
 
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+/* TRUST STRIP */
+.trust-strip{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4);display:flex;flex-wrap:wrap;gap:var(--space-3);align-items:center;border-bottom:1px solid var(--color-divider)}
+.trust-strip__item{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+.trust-strip__item svg{width:14px;height:14px;color:var(--color-gold-bright);flex-shrink:0}
+.trust-strip__item--link{margin-left:auto;color:var(--color-primary);font-weight:600;text-decoration:none}
+.trust-strip__item--link:hover{color:var(--color-primary-hover);text-decoration:underline}
+@media(max-width:540px){.trust-strip__item--link{margin-left:0}}
 
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
+/* LIVE CALCULATOR */
+.calc-pro{max-width:1200px;margin:var(--space-10) auto;padding:0 var(--space-4)}
+@media(min-width:768px){.calc-pro{margin:var(--space-12) auto}}
+.calc-pro__card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden;box-shadow:var(--shadow-md)}
+.calc-pro__card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-gold-bright) 30%,var(--color-gold-bright) 70%,transparent 100%);opacity:.5}
+.calc-pro__head{padding:var(--space-6) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-4);flex-wrap:wrap}
+@media(min-width:768px){.calc-pro__head{padding:var(--space-8) var(--space-8) var(--space-5)}}
+.calc-pro__head-left{flex:1;min-width:200px}
+.calc-pro__title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);display:flex;align-items:center;gap:var(--space-2)}
+.calc-pro__title-icon{width:24px;height:24px;color:var(--color-gold-bright);flex-shrink:0}
+.calc-pro__sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;max-width:56ch}
+.calc-pro__head-badge{display:inline-flex;align-items:center;gap:6px;padding:6px var(--space-3);background:color-mix(in oklch,var(--color-success) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-success) 30%,transparent);color:var(--color-success);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase}
+.calc-pro__head-badge .live-dot{width:6px;height:6px;border-radius:50%;background:var(--color-success);animation:heroPulse 2s ease-in-out infinite}
+.calc-pro__body{padding:var(--space-5)}
+@media(min-width:768px){.calc-pro__body{padding:var(--space-6) var(--space-8) var(--space-8)}}
+.calc-pro__row{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-4)}
+@media(min-width:560px){.calc-pro__row{grid-template-columns:2fr 1fr;gap:var(--space-4)}}
+.calc-pro__field{display:flex;flex-direction:column;gap:var(--space-2)}
+.calc-pro__field-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__input,.calc-pro__select{width:100%;min-height:48px;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none;transition:border-color var(--transition),background var(--transition),box-shadow var(--transition)}
+.calc-pro__input:focus,.calc-pro__select:focus{border-color:var(--color-gold-bright);background:var(--color-surface);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent);outline:none}
+.calc-pro__input{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;font-variant-numeric:tabular-nums}
+.calc-pro__select-wrap{position:relative}
+.calc-pro__select-wrap::after{content:'';position:absolute;right:var(--space-4);top:50%;width:8px;height:8px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:translateY(-70%) rotate(45deg);pointer-events:none}
+.calc-pro__chips{display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-5);align-items:center}
+.calc-pro__chips-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-right:var(--space-2);width:100%}
+@media(min-width:560px){.calc-pro__chips-label{width:auto;margin-right:var(--space-1)}}
+.calc-chip{min-height:36px;padding:6px var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);cursor:pointer;transition:all var(--transition);white-space:nowrap}
+.calc-chip:hover{border-color:var(--color-gold-bright);color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset))}
+.calc-chip:focus-visible{outline:2px solid var(--color-gold-bright);outline-offset:2px}
+.calc-chip.active{background:var(--gradient-gold-luxe);color:#1a1410;border-color:transparent}
+.calc-pro__result{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface)) 0%,var(--color-surface) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-5);position:relative;overflow:hidden}
+.calc-pro__result::before{content:'';position:absolute;top:-50%;right:-20%;width:280px;height:280px;background:radial-gradient(circle,color-mix(in oklch,var(--color-gold-bright) 18%,transparent) 0%,transparent 60%);pointer-events:none}
+.calc-pro__result-primary{position:relative;display:flex;align-items:baseline;justify-content:space-between;padding-bottom:var(--space-4);margin-bottom:var(--space-4);border-bottom:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));flex-wrap:wrap;gap:var(--space-2)}
+.calc-pro__result-label-main{font-size:var(--text-sm);font-weight:700;color:var(--color-text);text-transform:uppercase;letter-spacing:.08em}
+.calc-pro__result-main{font-family:var(--font-display);font-size:clamp(2rem,1.5rem + 2vw,3rem);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.025em;line-height:1}
+.calc-pro__result-grid{position:relative;display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3) var(--space-4)}
+.calc-pro__result-item{display:flex;flex-direction:column;gap:var(--space-1)}
+.calc-pro__result-item-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__result-item-value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+.calc-pro__hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-4);line-height:1.6;max-width:62ch}
+.calc-pro__hint code{font-family:var(--font-mono);font-size:11px;background:var(--color-surface-offset-2);padding:2px 6px;border-radius:4px;color:var(--color-gold-bright);border:1px solid var(--color-divider)}
 
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
+/* STAT CARDS */
+.stat-cards{max-width:1200px;margin:0 auto var(--space-12);padding:0 var(--space-4);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+@media(min-width:768px){.stat-cards{grid-template-columns:repeat(4,1fr);gap:var(--space-4)}}
+.stat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);position:relative;overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.stat-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));transform:translateY(-2px)}
+.stat-card__icon{width:32px;height:32px;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.stat-card__value{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);letter-spacing:-.02em;line-height:1;margin-bottom:var(--space-2);font-variant-numeric:tabular-nums}
+.stat-card__label{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.4}
 
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+/* SECTION COMMON */
+.section{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
+.section--narrow{max-width:920px}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:var(--space-5);flex-wrap:wrap;gap:var(--space-3)}
+.section-head__left{flex:1;min-width:200px}
+.section-eyebrow{display:inline-block;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.section-title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);line-height:1.2;margin-bottom:var(--space-2);letter-spacing:-.015em}
+.section-sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;max-width:60ch}
 
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+/* PRICE TABLE */
+.price-table-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.price-table-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden}
+.price-table-card__head{padding:var(--space-5) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3)}
+@media(min-width:768px){.price-table-card__head{padding:var(--space-6) var(--space-8) var(--space-5)}}
+.price-table-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1)}
+.price-table-card__sub{font-size:var(--text-xs);color:var(--color-text-muted)}
+.price-table-card__sub strong{color:var(--color-success);font-weight:700}
+.currency-switch{display:inline-flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px;gap:2px;flex-wrap:wrap}
+.currency-switch__btn{min-height:32px;padding:6px var(--space-3);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);border-radius:var(--radius-full);cursor:pointer;transition:all var(--transition);letter-spacing:.04em}
+.currency-switch__btn:hover{color:var(--color-text)}
+.currency-switch__btn.active{background:var(--gradient-gold-luxe);color:#1a1410}
+.price-table-card__body{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.price-table-pro{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums;min-width:520px}
+.price-table-pro th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-5);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);white-space:nowrap}
+.price-table-pro th:not(:first-child){text-align:right}
+.price-table-pro td{padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.price-table-pro td:first-child{color:var(--color-text);font-weight:600;font-family:var(--font-display)}
+.price-table-pro td:not(:first-child){text-align:right;color:var(--color-text);font-weight:500}
+.price-table-pro td.price-table-pro__primary{color:var(--color-gold-bright);font-weight:700}
+.price-table-pro tr:last-child td{border-bottom:none}
+.price-table-pro tr:hover td{background:color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface))}
+.price-table-pro .weight-label-sub{color:var(--color-text-faint);font-size:11px;font-weight:400;display:block;margin-top:2px;font-family:var(--font-body)}
 
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+/* KARAT COMPARISON */
+.karat-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.karat-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:560px){.karat-cards{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:900px){.karat-cards{grid-template-columns:repeat(5,1fr);gap:var(--space-3)}}
+.karat-pro-card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4);text-decoration:none;transition:all var(--transition);overflow:hidden;display:flex;flex-direction:column;gap:var(--space-2);color:var(--color-text)}
+.karat-pro-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 50%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-md);color:var(--color-text);text-decoration:none}
+.karat-pro-card--current{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface)) 0%,var(--color-surface) 100%);border-color:var(--color-gold-bright);box-shadow:0 0 0 1px var(--color-gold-bright),var(--shadow-gold)}
+.karat-pro-card--current::before{content:'YOU ARE HERE';position:absolute;top:8px;right:8px;font-size:9px;font-weight:700;letter-spacing:.1em;color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 14%,transparent);padding:2px 6px;border-radius:4px;font-family:var(--font-mono)}
+.karat-pro-card__karat{font-family:var(--font-editorial);font-size:clamp(2rem,1.4rem + 2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.025em;line-height:1}
+.karat-pro-card--current .karat-pro-card__karat{color:var(--color-gold-bright);font-style:italic}
+.karat-pro-card__purity{font-size:var(--text-sm);color:var(--color-gold-bright);font-weight:700;font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+.karat-pro-card__hallmark{font-size:11px;font-weight:600;color:var(--color-text-faint);font-family:var(--font-mono);letter-spacing:.1em;text-transform:uppercase}
+.karat-pro-card__price{font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;padding-top:var(--space-2);border-top:1px solid var(--color-divider);margin-top:auto}
+.karat-pro-card__price-label{display:block;font-size:10px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-bottom:2px}
+.karat-pro-card__use{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
 
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+/* FORMULA BLOCK */
+.formula-block{max-width:920px;margin:var(--space-10) auto var(--space-8);padding:0 var(--space-4)}
+.formula-card{background:linear-gradient(180deg,var(--color-surface-offset) 0%,var(--color-surface) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6) var(--space-5);position:relative;overflow:hidden}
+@media(min-width:768px){.formula-card{padding:var(--space-8)}}
+.formula-card__eyebrow{font-size:11px;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.12em;margin-bottom:var(--space-3)}
+.formula-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-4)}
+.formula-card__equation{font-family:var(--font-mono);font-size:clamp(.875rem,.8rem + .5vw,1.125rem);color:var(--color-text);background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);overflow-x:auto;-webkit-overflow-scrolling:touch;white-space:nowrap;font-variant-numeric:tabular-nums;line-height:1.6}
+.formula-card__equation .op{color:var(--color-gold-bright);font-weight:600}
+.formula-card__equation .var{color:var(--color-primary);font-weight:600}
+.formula-card__steps{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:768px){.formula-card__steps{grid-template-columns:repeat(3,1fr)}}
+.formula-step{display:flex;gap:var(--space-3);padding:var(--space-3);background:var(--color-surface);border:1px solid var(--color-divider);border-radius:var(--radius-md)}
+.formula-step__num{flex-shrink:0;width:28px;height:28px;border-radius:50%;background:var(--gradient-gold-luxe);color:#1a1410;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
+.formula-step__text{font-size:var(--text-sm);color:var(--color-text);line-height:1.5}
+.formula-step__text strong{color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
 
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+/* LUXE USE CASES */
+.luxe-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.luxe-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.luxe-cards{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:1024px){.luxe-cards{grid-template-columns:repeat(3,1fr)}}
+.luxe-card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-5) var(--space-6);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.luxe-card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-gold-bright) 50%,transparent 100%);opacity:.7}
+.luxe-card::after{content:'';position:absolute;top:-30%;right:-30%;width:200px;height:200px;background:radial-gradient(circle,color-mix(in oklch,var(--color-gold-bright) 12%,transparent) 0%,transparent 65%);pointer-events:none;transition:opacity var(--transition)}
+.luxe-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-luxe)}
+.luxe-card__icon{width:48px;height:48px;color:var(--color-gold-bright);margin-bottom:var(--space-4)}
+.luxe-card__category{font-size:11px;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.14em;margin-bottom:var(--space-2);font-family:var(--font-mono)}
+.luxe-card__title{font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:600;color:var(--color-text);line-height:1.25;margin-bottom:var(--space-3);font-style:italic}
+.luxe-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin-bottom:var(--space-4)}
+.luxe-card__stat{display:flex;align-items:baseline;gap:var(--space-2);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.luxe-card__stat-val{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.luxe-card__stat-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
 
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+/* BULLION SWATCHES */
+.swatch-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-5) 0}
+@media(min-width:560px){.swatch-grid{grid-template-columns:repeat(3,1fr)}}
+.swatch-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.swatch-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-2px)}
+.swatch-card__color{height:140px;position:relative;display:flex;align-items:flex-end;justify-content:flex-start;padding:var(--space-3)}
+.swatch-card__color--bar1g{background:linear-gradient(135deg,#fbe084 0%,#f4cc4b 30%,#d4a017 70%,#8a5e00 100%)}
+.swatch-card__color--coin{background:radial-gradient(circle at 35% 35%,#fbe084 0%,#f4cc4b 25%,#e8af34 55%,#a87a1a 80%,#5e4000 100%)}
+.swatch-card__color--kilo{background:linear-gradient(160deg,#f6d97a 0%,#e8af34 25%,#c98a00 65%,#5e4000 100%)}
+.swatch-card__color::after{content:'';position:absolute;inset:0;background:radial-gradient(circle at 30% 30%,rgba(255,255,255,.45),transparent 50%);pointer-events:none}
+.swatch-card__hallmark{position:relative;font-family:var(--font-mono);font-size:11px;font-weight:700;color:#1a1410;background:rgba(255,255,255,.85);padding:4px 9px;border-radius:4px;letter-spacing:.08em;backdrop-filter:blur(4px)}
+.swatch-card__body{padding:var(--space-4)}
+.swatch-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1)}
+.swatch-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.55}
+
+/* ASSAY OFFICES */
+.assay-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:560px){.assay-grid{grid-template-columns:repeat(4,1fr)}}
+.assay-card{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3);text-align:center;transition:border-color var(--transition)}
+.assay-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border))}
+.assay-card__mark{display:flex;align-items:center;justify-content:center;width:40px;height:40px;margin:0 auto var(--space-2);color:var(--color-gold-bright)}
+.assay-card__mark svg{width:32px;height:32px}
+.assay-card__name{font-size:var(--text-xs);font-weight:700;color:var(--color-text);font-family:var(--font-display)}
+.assay-card__est{font-size:10px;color:var(--color-text-faint);margin-top:2px;font-family:var(--font-mono);letter-spacing:.05em}
+
+/* CENTRAL BANK CHART */
+.cbchart{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.cbchart-card{background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);padding:var(--space-6) var(--space-5);position:relative;overflow:hidden}
+@media(min-width:768px){.cbchart-card{padding:var(--space-8)}}
+.cbchart-card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-gold-bright) 50%,transparent 100%);opacity:.6}
+.cbchart-chart{display:grid;grid-template-columns:repeat(15,minmax(0,1fr));gap:4px;margin-top:var(--space-5);align-items:end;min-height:200px}
+@media(max-width:560px){.cbchart-chart{gap:3px;min-height:160px}}
+.cbchart-bar{position:relative;background:var(--color-surface-offset);border-radius:4px 4px 0 0;min-height:18px;transition:transform var(--transition);cursor:default}
+.cbchart-bar::after{content:attr(data-year);position:absolute;bottom:-22px;left:50%;transform:translateX(-50%);font-size:9px;font-weight:600;color:var(--color-text-faint);font-family:var(--font-mono);letter-spacing:.04em}
+@media(max-width:560px){.cbchart-bar::after{font-size:8px;bottom:-18px}}
+.cbchart-bar--peak{background:var(--gradient-gold-luxe)}
+.cbchart-bar--high{background:linear-gradient(180deg,color-mix(in oklch,var(--color-gold-bright) 70%,var(--color-surface)) 0%,color-mix(in oklch,var(--color-gold-bright) 45%,var(--color-surface)) 100%)}
+.cbchart-bar--mid{background:linear-gradient(180deg,color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-surface)) 0%,color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-surface)) 100%)}
+.cbchart-bar:hover{transform:translateY(-2px)}
+.cbchart-bar__label{position:absolute;top:-22px;left:50%;transform:translateX(-50%);font-size:10px;font-weight:700;color:var(--color-gold-bright);font-family:var(--font-mono);white-space:nowrap;background:var(--color-surface);padding:2px 6px;border-radius:4px;border:1px solid var(--color-border);opacity:0;pointer-events:none;transition:opacity var(--transition)}
+.cbchart-bar:hover .cbchart-bar__label{opacity:1}
+.cbchart-legend{display:flex;flex-wrap:wrap;gap:var(--space-3);margin-top:var(--space-8);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.cbchart-legend__item{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);color:var(--color-text-muted)}
+.cbchart-legend__swatch{width:14px;height:14px;border-radius:3px;flex-shrink:0}
+.cbchart-legend__swatch--peak{background:var(--gradient-gold-luxe)}
+.cbchart-legend__swatch--high{background:color-mix(in oklch,var(--color-gold-bright) 60%,var(--color-surface))}
+.cbchart-legend__swatch--mid{background:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-surface))}
+.cbchart-legend__swatch--low{background:var(--color-surface-offset);border:1px solid var(--color-border)}
+
+/* RESERVE TABLE */
+.reserve-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px solid var(--color-border);border-radius:var(--radius-lg);margin:var(--space-5) 0}
+.reserve-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:480px}
+.reserve-table th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-4);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
+.reserve-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text);vertical-align:top}
+.reserve-table td:first-child{font-weight:600;font-family:var(--font-display)}
+.reserve-table td:nth-child(2){color:var(--color-gold-bright);font-family:var(--font-mono);font-size:12px;letter-spacing:.04em;white-space:nowrap;text-align:right}
+.reserve-table td:nth-child(3){color:var(--color-text-muted);font-size:var(--text-xs)}
+.reserve-table tr:last-child td{border-bottom:none}
+
+/* PROSE */
+.content-section{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-12)}
+.prose-pro{max-width:760px;margin:0 auto}
+.prose-pro h2{font-family:var(--font-display);font-size:clamp(1.5rem,1.1rem + 1.5vw,2rem);font-weight:700;color:var(--color-text);margin:var(--space-12) 0 var(--space-4);line-height:1.2;letter-spacing:-.015em;position:relative;padding-top:var(--space-3)}
+.prose-pro h2::before{content:'';position:absolute;top:0;left:0;width:48px;height:3px;background:var(--gradient-gold-deep);border-radius:2px}
+.prose-pro h2:first-child{margin-top:0}
+.prose-pro h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-8) 0 var(--space-3);letter-spacing:-.01em}
+.prose-pro p{font-size:var(--text-base);color:var(--color-text);line-height:1.75;margin-bottom:var(--space-4)}
+.prose-pro ul,.prose-pro ol{padding-left:var(--space-5);margin-bottom:var(--space-5)}
+.prose-pro li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:var(--space-2)}
+.prose-pro li::marker{color:var(--color-gold-bright)}
+.prose-pro strong{color:var(--color-text);font-weight:700}
+.prose-pro a{color:var(--color-primary);text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;transition:color var(--transition)}
+.prose-pro a:hover{color:var(--color-primary-hover);text-decoration-thickness:2px}
+.prose-pro blockquote{margin:var(--space-5) 0;padding:var(--space-4) var(--space-5);background:var(--color-surface);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-md);font-family:var(--font-editorial);font-size:var(--text-lg);font-style:italic;color:var(--color-text);font-weight:500;line-height:1.5}
+.prose-pro blockquote strong{font-style:normal;font-family:var(--font-mono);color:var(--color-gold-bright);font-size:var(--text-base);font-weight:600}
+.snippet-answer{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);margin:var(--space-4) 0;font-size:var(--text-base);color:var(--color-text);line-height:1.7}
+.snippet-answer strong{color:var(--color-gold-bright)}
+.callout{background:var(--gradient-gold-soft);border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-5) 0;display:flex;gap:var(--space-3);align-items:flex-start}
+.callout__icon{flex-shrink:0;width:32px;height:32px;color:var(--color-gold-bright);margin-top:2px}
+.callout__title{font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);font-family:var(--font-display)}
+.callout__body{font-size:var(--text-sm);color:var(--color-text);line-height:1.6}
+
+/* FAQ */
+.faq-pro{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+.faq-pro__item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.faq-pro__item:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border))}
+.faq-pro__item[open]{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border))}
+.faq-pro__summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;min-height:60px}
+.faq-pro__summary::-webkit-details-marker{display:none}
+.faq-pro__summary:hover{background:var(--color-surface-offset)}
+.faq-pro__summary:focus-visible{outline:2px solid var(--color-gold-bright);outline-offset:-2px}
+.faq-pro__plus{flex-shrink:0;width:24px;height:24px;border:1px solid var(--color-border);border-radius:50%;display:flex;align-items:center;justify-content:center;position:relative;transition:transform var(--transition),border-color var(--transition),background var(--transition)}
+.faq-pro__plus::before,.faq-pro__plus::after{content:'';position:absolute;background:var(--color-text-muted);transition:transform var(--transition),background var(--transition)}
+.faq-pro__plus::before{width:10px;height:2px}
+.faq-pro__plus::after{width:2px;height:10px}
+.faq-pro__item[open] .faq-pro__plus{background:var(--color-gold-bright);border-color:var(--color-gold-bright);transform:rotate(45deg)}
+.faq-pro__item[open] .faq-pro__plus::before,.faq-pro__item[open] .faq-pro__plus::after{background:#1a1410}
+.faq-pro__body{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;border-top:1px solid var(--color-divider);padding-top:var(--space-4)}
+.faq-pro__body strong{color:var(--color-text)}
+
+/* STICKY MOBILE PRICE BAR */
+.sticky-price{position:fixed;bottom:0;left:0;right:0;background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-3) var(--space-4);z-index:80;display:none;align-items:center;gap:var(--space-3);box-shadow:0 -8px 24px rgba(0,0,0,.2);backdrop-filter:blur(12px);transform:translateY(100%);transition:transform .3s ease-out;padding-bottom:max(var(--space-3),env(safe-area-inset-bottom))}
+.sticky-price.visible{transform:translateY(0)}
+@media(max-width:768px){.sticky-price{display:flex}body{padding-bottom:80px}}
+.sticky-price__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.sticky-price__value{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.1}
+.sticky-price__info{flex:1;min-width:0}
+.sticky-price__cta{display:inline-flex;align-items:center;gap:6px;padding:10px var(--space-4);background:var(--gradient-gold-luxe);color:#1a1410;border-radius:var(--radius-md);font-size:var(--text-xs);font-weight:700;text-decoration:none;letter-spacing:.04em;text-transform:uppercase;min-height:44px;white-space:nowrap}
+.sticky-price__cta:hover{filter:brightness(1.1);color:#1a1410;text-decoration:none}
+
+/* DISCLAIMER */
+.disclaimer{margin-top:var(--space-8);padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--color-text-faint);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+.disclaimer strong{color:var(--color-text)}
 
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
-.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
 .mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
@@ -332,22 +449,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
 .footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
@@ -357,96 +458,37 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
+footer{background:var(--color-surface);border-top:1px solid var(--color-border)}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
-
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
-
-
-/* ── Shared layout CSS ── */
+/* Breadcrumb */
 .breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted)}
+.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted);flex-wrap:wrap}
 .breadcrumb li+li::before{content:"/";margin-right:var(--space-2);color:var(--color-text-faint)}
 .breadcrumb a{color:var(--color-text-muted);text-decoration:none}
 .breadcrumb a:hover{color:var(--color-primary)}
 .breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.hero-tag{display:inline-block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-.hero-title{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero-title{font-size:var(--text-xl)}
-.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:72ch;line-height:1.7;margin-bottom:var(--space-6)}
-.price-card{display:inline-flex;flex-direction:column;gap:var(--space-1);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-2)}
-.price-card{width:100%}
-.price-label{font-size:var(--text-sm);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.price-value{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-gold-bright);font-weight:400;line-height:1}
-.price-usd{font-size:var(--text-base);color:var(--color-text-muted)}
-.price-purity{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-1)}
-.prose{max-width:72ch}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-1)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose{max-width:100%}
-.content{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
-.data-source{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.faq-answer-summary{font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4);cursor:pointer;list-style:none;background:var(--color-surface-offset);transition:background .15s}
-.faq-answer-summary:hover{background:var(--color-surface-dynamic)}
-.faq-answer-summary::marker,.faq-answer-summary::-webkit-details-marker{display:none}
-.faq-answer-summary::after{content:"＋";float:right;color:var(--color-text-faint)}
-.faq-answer-summary::after{content:"－"}
-.faq-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-4);border-top:1px solid var(--color-divider)}
 
-/* ── Hero left column ── */
-.hero-left{display:flex;flex-direction:column;justify-content:flex-start;gap:var(--space-3)}
-.hero-left .hero-title{margin-bottom:0}
-.hero-left .hero-tag{margin-bottom:var(--space-2)}
-@media(max-width:768px){.hero-left{margin-bottom:var(--space-4)}}
-
-/* ── Data Table ── */
-.data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
-.data-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-4) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.data-table td{padding:var(--space-3) var(--space-4) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.data-table td:first-child{color:var(--color-text);font-weight:500}
-.data-table td:not(:first-child){text-align:right;padding-right:0}
-.data-table th:not(:first-child){text-align:right;padding-right:0}
-.data-table tr:last-child td{border-bottom:none}
-.data-table tr:hover td{background:var(--color-surface)}
-.data-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border-radius:var(--radius-md)}
-
-/* ── Trust bar ── */
-.trust-bar{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset,var(--color-surface));border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.trust-bar a{color:var(--color-primary);text-decoration:none}
-.trust-bar a:hover{text-decoration:underline}
-
-/* ── Share buttons ── */
+/* Share buttons */
 .share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) 0 var(--space-6);padding-top:var(--space-6);border-top:1px solid var(--color-border)}
 .share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
-.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface)}
-.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset)}
+.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface);min-height:44px}
+.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset);text-decoration:none}
 .share-buttons a svg{flex-shrink:0}
 
-/* ── Related guides grid ── */
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin-top:var(--space-6)}
-.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface-offset,var(--color-surface));border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s;min-height:140px;color:var(--color-text)}
-.related-card:hover{border-color:var(--color-primary);box-shadow:var(--shadow-sm)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin:var(--space-1) 0}
+/* Related guides */
+.related-guides{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.related-guides-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.related-guides-grid{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:900px){.related-guides-grid{grid-template-columns:repeat(4,1fr)}}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,transform .15s,box-shadow .15s;color:var(--color-text)}
+.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);transform:translateY(-2px);text-decoration:none;color:var(--color-text)}
+.related-card:hover .related-card__title{color:var(--color-gold-bright)}
+.related-card__tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);align-self:flex-start;padding:2px 8px;background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border-radius:99px}
+.related-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0;line-height:1.3;transition:color var(--transition)}
 .related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-
-/* ── Prose spacing ── */
-.prose p{margin-bottom:var(--space-4);line-height:1.7}
-.prose li{margin-bottom:var(--space-2);line-height:1.65}
-.prose h2{margin-top:var(--space-10);margin-bottom:var(--space-3)}
-.prose h3{margin-top:var(--space-6);margin-bottom:var(--space-2)}
 </style>
 
 <script type="application/ld+json">
@@ -457,12 +499,11 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   "url": "https://goldpricetools.com/24k-gold-price-per-gram",
   "speakable": {
     "@type": "SpeakableSpecification",
-    "cssSelector": [".snippet-answer", ".faq-answer"]
+    "cssSelector": [".snippet-answer", ".faq-pro__body"]
   }
 }
 </script>
 <link rel="stylesheet" href="/assets/site.css">
-<!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
 </head>
 <body>
@@ -533,205 +574,681 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </div>
   </div>
 </nav>
+
 <div class="breadcrumb-wrap">
   <ol class="breadcrumb" aria-label="Breadcrumb">
     <li><a href="/">Home</a></li>
+    <li><a href="/gold-price-per-gram">Gold Per Gram</a></li>
     <li aria-current="page">24K Gold Price Per Gram</li>
   </ol>
 </div>
 
-<div class="hero">
-  <div class="hero-left">
-<div class="hero-tag">Live Gold Price</div>
-  <h1 class="hero-title">24K Gold Price Per Gram Today</h1>
-  <p class="hero-sub">24K gold is the purest commercially available form (99.9% gold). Used in bullion bars, coins, and some high-end jewellery. Also called "pure gold" or "fine gold". Live price updated every 60 seconds from LBMA spot market.</p>
+<!-- ═══════════════════════════════════════════════════════════════
+     PREMIUM HERO — editorial typography + 3-currency tiles (USD primary)
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="hero-premium" aria-labelledby="hero-title">
+  <div class="hero-premium__inner">
+    <div class="hero-eyebrow">
+      <span class="hero-eyebrow__pulse" aria-hidden="true"></span>
+      <span>Live &middot; LBMA Spot &middot; 999 Fine Gold</span>
     </div>
-  <div class="price-card">
-    <div class="price-label">24K Gold &mdash; Price Per Gram</div>
-    <div class="price-value" id="price-gbp" data-nosnippet>&mdash;</div>
-    <div class="price-usd" id="price-usd" data-nosnippet></div>
-    <div class="price-purity">24K = 99.9% pure gold (999 hallmark)</div>
-  </div>
-</div>
+    <h1 class="hero-premium__title" id="hero-title">
+      24K Gold <span class="hero-premium__title-em">price per gram</span> today
+    </h1>
+    <p class="hero-premium__sub">Real-time <strong>24 karat</strong> (999 hallmark) gold valuation in <strong>USD</strong>, INR, GBP and EUR &mdash; refreshed every 60 seconds direct from LBMA spot data. <strong>99.9% pure gold</strong> &mdash; the global benchmark from which every other karat price is derived.</p>
 
-<div class="content">
-  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about">About our data</a></div>
-
-  <div class="prose">
-    <h2>What is 24K Gold?</h2>
-    <p>24K gold contains 24 parts gold out of 24 &mdash; a purity of <strong>99.9%</strong>. It is the purest commercially available form of gold. Because it is 99.9% pure, it is very soft and malleable. It is typically used for investment purposes such as bullion bars and coins, and occasionally for high-end traditional jewellery. The hallmark you will see on European and UK pieces is <strong>999</strong>. It is also often referred to as "pure gold" or "fine gold".</p>
-
-    <h2 id="q1-24K">How much is a gram of 24k gold worth?</h2>
-<p class="snippet-answer">24K gold is worth approximately <span id="snippet-price" data-nosnippet>[current spot price]</span> per gram today. This value is calculated by multiplying the live 24K spot price by 1.0, which represents the 99.9% gold purity of 24 karat gold. Dealers typically pay less than this melt value.</p>
-
-<h2 id="q2-24K">What is 24k gold?</h2>
-<p class="snippet-answer">24K gold is an alloy containing 14 parts pure gold out of 24, giving it a purity of 99.9%. It is the most popular gold alloy for jewellery in the United States, offering a great balance of durability, beautiful colour, and lasting value.</p>
-
-<h2 id="q3-24K">What does 999 mean on gold?</h2>
-<p class="snippet-answer">The 999 hallmark on gold indicates that the item is made of 24 karat gold. The number represents the gold's purity, showing it contains 999 parts pure gold per 1000, which equals 58.5% (or 99.9% standard). This is the common European hallmark for 24K.</p>
-
-<h2>24K Gold Price Table</h2>
-    <figure itemscope itemtype="https://schema.org/Table">
-      <figcaption>24K gold price per gram in USD and GBP — live, updated every 60 seconds</figcaption>
-      <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-      <div class="data-table-wrap"><table class="data-table" aria-label="24K gold price by weight">
-        <thead><tr><th>Weight</th><th>USD (live)</th><th>GBP (live)</th><th>INR (live)</th></tr></thead>
-        <tbody>
-          <tr><td>0.5g</td><td id="t-0-5-usd" data-nosnippet>&mdash;</td><td id="t-0-5-gbp" data-nosnippet>&mdash;</td><td id="t-0-5-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>1g</td><td id="t-1-usd" data-nosnippet>&mdash;</td><td id="t-1-gbp" data-nosnippet>&mdash;</td><td id="t-1-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>2g</td><td id="t-2-usd" data-nosnippet>&mdash;</td><td id="t-2-gbp" data-nosnippet>&mdash;</td><td id="t-2-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>5g</td><td id="t-5-usd" data-nosnippet>&mdash;</td><td id="t-5-gbp" data-nosnippet>&mdash;</td><td id="t-5-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>10g</td><td id="t-10-usd" data-nosnippet>&mdash;</td><td id="t-10-gbp" data-nosnippet>&mdash;</td><td id="t-10-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>20g</td><td id="t-20-usd" data-nosnippet>&mdash;</td><td id="t-20-gbp" data-nosnippet>&mdash;</td><td id="t-20-inr" data-nosnippet>&mdash;</td></tr>
-          <tr><td>1 <a href="/how-many-grams-in-troy-ounce">troy oz</a> (31.1g)</td><td id="t-31-usd" data-nosnippet>&mdash;</td><td id="t-31-gbp" data-nosnippet>&mdash;</td><td id="t-31-inr" data-nosnippet>&mdash;</td></tr>
-        </tbody>
-      </table></div>
-    </figure>
-
-    <h2>How Is the 24K Gold Price Calculated?</h2>
-    <p>The 24K gold price per gram is derived from the 24K (pure) gold spot price using the formula: <strong>24K price/g = 24K spot price per troy oz &divide; 31.1035 &times; 1.0</strong>. The spot price is set by the London Bullion Market Association (LBMA) twice daily. Our calculator fetches this price in real time and converts it to GBP using the live GBP/USD exchange rate.</p>
-
-    <h2>24K vs Other Karats</h2>
-    <figure itemscope itemtype="https://schema.org/Table">
-      <figcaption>Gold karat comparison — purity, hallmark, and typical use</figcaption>
-      <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-      <div class="data-table-wrap"><table class="data-table" aria-label="Gold karat comparison">
-        <thead><tr><th>Karat</th><th>Purity</th><th>Hallmark</th><th>Typical Use</th></tr></thead>
-        <tbody>
-          <tr><td>9K</td><td>37.5%</td><td>375</td><td>UK everyday jewellery</td></tr>
-          <tr><td><strong>24K</strong></td><td><strong>99.9%</strong></td><td><strong>999</strong></td><td><strong>Bullion bars, coins, fine jewellery</strong></td></tr>
-          <tr><td>18K</td><td>75.0%</td><td>750</td><td>Fine jewellery, luxury watches</td></tr>
-          <tr><td>22K</td><td>91.67%</td><td>916</td><td>South Asian bridal gold</td></tr>
-          <tr><td>24K</td><td>99.9%</td><td>999</td><td>Bullion coins and bars</td></tr>
-        </tbody>
-      </table></div>
-    </figure>
-
-    <h2>24K Purity Table</h2>
-<div class="data-table-wrap"><table class="data-table" aria-label="Karat purity and indicative prices">
-<thead><tr><th>Karat</th><th>Purity</th><th>USD/gram</th><th>GBP/gram</th></tr></thead>
-<tbody>
-<tr><td>24K</td><td>99.9%</td><td>--</td><td>--</td></tr>
-<tr><td>18K</td><td>75.0%</td><td>--</td><td>--</td></tr>
-<tr><td>24K</td><td>58.3%</td><td>--</td><td>--</td></tr>
-<tr><td>10K</td><td>41.7%</td><td>--</td><td>--</td></tr>
-<tr><td>9K</td><td>37.5%</td><td>--</td><td>--</td></tr>
-</tbody>
-</table></div>
-
-    
-    <h2>What is 24K Gold?</h2>
-    <p>24K gold contains 24 parts pure gold out of 24 parts, giving it a purity of <strong>99.90%</strong>. The hallmark stamp you will find on 24K items is <strong>999</strong>, which represents 99.9 parts per thousand of pure gold. 24K gold is the purest commercially available form of gold. It is used for investment-grade bullion bars and coins such as the Canadian Maple Leaf, as well as in electronics and medical devices.</p>
-    <p>24K gold is commonly used for Investment bullion bars, coins, and electronics. When you buy or sell 24K bullion bars and coins, the price you receive is calculated directly from the live gold spot price multiplied by the purity factor of 0.999.</p>
-
-    <h2>How to Calculate the 24K Gold Price Per Gram</h2>
-    <p>The formula for the 24K gold price per gram is straightforward:</p>
-    <blockquote><strong>24K price per gram = (Spot price per troy oz ÷ 31.1035) × 0.999</strong></blockquote>
-    <p>For example, if the gold spot price is $3,300 per troy ounce:</p>
-    <ul>
-      <li>Price per gram of pure gold = $3,300 ÷ 31.1035 = <strong>$106.10</strong></li>
-      <li>24K price per gram = $106.10 × 0.999 = <strong>$105.99</strong></li>
-    </ul>
-    <p>This is the <em>melt value</em> — the intrinsic gold content value. Jewellers, dealers, and pawnbrokers typically pay between 70%–95% of melt value when buying, depending on condition and local market demand. When selling, retailers add a <em>premium</em> of 10%–30% above melt value.</p>
-
-    <h2>The 999 Hallmark Explained</h2>
-    <p>In the UK, all gold items above a certain weight must be independently tested and stamped by one of the four UK Assay Offices (London, Birmingham, Sheffield, or Edinburgh) under the Hallmarking Act 1973. The <strong>999 hallmark</strong> guarantees that the item contains at least 99.90% pure gold. It is illegal under UK law to describe or sell an item as gold if it does not carry an approved hallmark.</p>
-    <p>On older or imported items, you may also see the hallmark written as <strong>.999</strong> or stamped alongside a date letter and assay office mark. When appraising estate jewellery, always check for the 999 stamp before calculating value.</p>
-
-    <h2>LBMA Good Delivery: The Global Gold Standard</h2>
-    <p>The <strong>London Bullion Market Association (LBMA)</strong> sets the global benchmark for gold quality and trading. When people refer to the "gold spot price," they mean the LBMA price — the price at which 24K gold trades between accredited refiners, banks, and dealers. Here’s how the system works:</p>
-    <ul>
-      <li><strong>Good Delivery bars</strong> — The standard unit of trade is the 400 troy ounce (~12.4kg) bar, refined to a minimum 995 fineness. Only bars produced by LBMA-accredited refiners are accepted. As of 2024, there are approximately 70 accredited refiners worldwide.</li>
-      <li><strong>Price fixing</strong> — The LBMA Gold Price is set twice daily (10:30 AM and 3:00 PM London time) through an electronic auction run by ICE Benchmark Administration. This auction replaced the historic "London Gold Fix" telephone process in 2015.</li>
-      <li><strong>Clearing</strong> — The London gold market clears approximately $30–40 billion of gold trades daily through the London Precious Metals Clearing Limited (LPMCL), making it the world's deepest and most liquid gold market.</li>
-      <li><strong>Retail bars</strong> — For individual investors, 24K gold is available in smaller denominations: 1g, 5g, 10g, 1oz, 50g, 100g, 250g, 500g, and 1kg bars. LBMA-accredited bars from refiners like PAMP, Valcambi, Umicore, and the Royal Mint carry the lowest premiums over spot.</li>
-    </ul>
-
-    <h2>Central Bank Gold Reserves: Why Nations Hoard 24K</h2>
-    <p>Central banks are the world’s largest holders of physical 24K gold. As of early 2025, global central bank reserves total approximately <strong>36,700 tonnes</strong> of gold, worth over $2.8 trillion. Key facts about sovereign gold holdings:</p>
-    <ul>
-      <li><strong>Top 5 holders</strong> — The United States (8,133t), Germany (3,352t), Italy (2,452t), France (2,437t), and Russia (2,333t). China officially reports ~2,264t but is widely believed to hold significantly more.</li>
-      <li><strong>Net buying since 2022</strong> — Central banks have been net buyers of gold every year since 2010, but the pace accelerated sharply in 2022–2024, with annual net purchases exceeding 1,000 tonnes — roughly double the historical average. This structural demand has been a major driver of higher gold prices.</li>
-      <li><strong>De-dollarisation</strong> — Many central banks (particularly China, India, Poland, and Turkey) are diversifying reserves away from US dollar assets and into physical gold, driven by geopolitical risk and the freezing of Russian central bank assets in 2022.</li>
-      <li><strong>UK reserves</strong> — The Bank of England holds approximately 310 tonnes of its own gold, plus ~5,600 tonnes in custody for other central banks, stored in vaults beneath Threadneedle Street. The UK controversially sold 395 tonnes between 1999–2002 ("Brown’s Bottom") at an average price of $275/oz.</li>
-    </ul>
-
-    <h2>Investing in 24K Gold: Physical vs Paper</h2>
-    <p>24K gold is <strong>the only purity used for investment-grade bullion</strong>. If you’re buying gold as an investment (rather than jewellery), you have several options, each with distinct trade-offs:</p>
-    <ul>
-      <li><strong>Physical bullion bars</strong> — Lowest premiums (typically 2–5% over spot for 100g+ bars). Must be stored securely. LBMA-accredited bars from PAMP, Valcambi, or the Royal Mint are most liquid. VAT-exempt as investment gold in the UK.</li>
-      <li><strong>Gold coins</strong> — UK Gold Britannia coins (24K, 1oz) are CGT-exempt as legal tender. Sovereigns (<a href="/22k-gold-price-per-gram">22K</a>) also qualify. Premiums are slightly higher than bars (5–12%), but liquidity is excellent.</li>
-      <li><strong>Gold ETFs</strong> — The easiest way to get exposure to the 24K gold price without physical storage. Popular options include iShares Physical Gold ETC (SGLN), Invesco Physical Gold (SGLD), and WisdomTree Physical Gold (PHAU). Management fees are typically 0.12–0.25% per year.</li>
-      <li><strong>Allocated storage</strong> — Services like BullionVault and The Royal Mint’s DigiGold let you buy 24K gold stored in LBMA-accredited vaults. You own specific bars, and storage costs are ~0.12% per year. This combines the low premium of bars with the convenience of digital access.</li>
-    </ul>
-    <p>For most UK investors, the choice between physical gold and ETFs comes down to tax efficiency: Britannia coins and Sovereigns are CGT-exempt, while ETF gains are taxable. For detailed comparison, see our <a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a> guide.</p>
-
-    <h2>Frequently Asked Questions</h2>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">How do I convert the 24K gold price from troy ounces to grams?</h3>
-      <p class="faq-answer">There are 31.1035 grams in one troy ounce. Divide the spot price (in any currency) by 31.1035 to get the price per gram of pure gold, then multiply by 0.999 to get the 24K price per gram. Our live calculator above does this automatically.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">What is the difference between 24K gold and gold-filled or gold-plated?</h3>
-      <p class="faq-answer">Solid 24K gold contains 99.90% pure gold throughout the item. Gold-filled has a layer of 24K gold mechanically bonded to a base metal core — it contains far less gold by weight. Gold-plated items have only a thin electroplated layer of gold, typically less than 0.05% of the item's total weight. Only solid 24K gold carries the 999 hallmark and has significant melt value.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Why does the 24K gold price per gram vary between different websites?</h3>
-      <p class="faq-answer">Small differences between sites reflect the timing of their data feed, the spot price source used (LBMA, COMEX, or OTC), and whether they include the GBP/USD exchange rate at slightly different timestamps. GoldPriceTools fetches live prices from gold-api.com and currency rates from the Frankfurter API, both updated every 60 seconds.</p>
+    <!-- 3-currency live price tiles — USD primary -->
+    <div class="price-tiles" role="region" aria-label="Live 24K gold prices">
+      <article class="price-tile price-tile--primary">
+        <div class="price-tile__head">
+          <span class="price-tile__label">USD / gram</span>
+          <span class="price-tile__flag">US &middot; PRIMARY</span>
+        </div>
+        <div class="price-tile__value" id="hero-usd" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>24K &middot; 99.9% purity &middot; 999 hallmark</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">GBP / gram</span>
+          <span class="price-tile__flag">UK</span>
+        </div>
+        <div class="price-tile__value" id="hero-gbp" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>24K &middot; Britannia &amp; bullion standard</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">EUR / gram</span>
+          <span class="price-tile__flag">EU</span>
+        </div>
+        <div class="price-tile__value" id="hero-eur" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>24K &middot; ECB reference rate</div>
+      </article>
     </div>
 
-    <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Dealer buy prices are typically 70&ndash;90% of melt value. Always verify with your dealer before selling.</div>
-  </div>
-</div>
-
-<div class="content" style="padding-bottom:1.5rem">
-<!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
-  <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/24k-gold-price-per-gram&text=24K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
-  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/24k-gold-price-per-gram&title=24K+Gold+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=24K+Gold+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2F24k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
-</div>
-</div>
-
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
-    <h2>Related Gold &amp; Silver Guides</h2>
-    <div class="related-guides-grid">
-      <a href="/22k-gold-price-per-gram" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">22K Gold Price Per Gram</div>
-        <div class="related-card__desc">Today's 22K gold price per gram — 91.67% pure gold.</div>
-      </a>
-      <a href="/silver-price-per-kilo" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">Silver Price Per Kilo</div>
-        <div class="related-card__desc">Live silver price per kilogram — the companion to gold for precious metals investors.</div>
-      </a>
-      <a href="/scrap-gold-calculator" class="related-card">
-        <div class="related-card__tag">Tool</div>
-        <div class="related-card__title">Scrap Gold Calculator</div>
-        <div class="related-card__desc">Calculate the melt value of 24K gold coins or bars using today's live price.</div>
-      </a>
-      <a href="/guides/gold-price-history" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold Price History</div>
-        <div class="related-card__desc">See how 24K gold prices have moved from 1970 to today and what drives long-term trends.</div>
-      </a>
-      <a href="/guides/gold-vs-silver-investment" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold vs Silver Investment</div>
-        <div class="related-card__desc">Compare 24K gold bars and silver bullion as long-term investments.</div>
-      </a>
-      <a href="/guides/how-to-invest-in-gold" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">How to Invest in Gold</div>
-        <div class="related-card__desc">From 24K bullion coins to ETFs — a beginner's guide to gold investing in the UK.</div>
+    <!-- Live status bar -->
+    <div class="live-status" role="status" aria-live="polite">
+      <span class="live-status__dot" aria-hidden="true"></span>
+      <span class="live-status__label">Live</span>
+      <span class="live-status__divider" aria-hidden="true">&middot;</span>
+      <span class="live-status__meta">24K spot: <strong id="spot-usd" data-nosnippet>&mdash;</strong></span>
+      <span class="live-status__divider" aria-hidden="true">&middot;</span>
+      <span class="live-status__meta">Updated <span id="updated-time">just now</span></span>
+      <span class="live-status__divider" aria-hidden="true">&middot;</span>
+      <span class="live-status__meta">Refresh in <span id="refresh-counter">60s</span></span>
+      <a href="#calculator" class="live-status__cta">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>
+        Calculate
       </a>
     </div>
   </div>
 </section>
+
+<!-- Trust strip -->
+<div class="trust-strip">
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    LBMA-sourced spot data
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+    60-second refresh
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/><circle cx="12" cy="12" r="10"/></svg>
+    USD &middot; INR &middot; GBP &middot; EUR
+  </span>
+  <a href="/about" class="trust-strip__item trust-strip__item--link">About our data &rarr;</a>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     LIVE CALCULATOR — flagship interactive tool (24K bullion focus)
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="calc-pro" id="calculator" aria-labelledby="calc-title">
+  <div class="calc-pro__card">
+    <div class="calc-pro__head">
+      <div class="calc-pro__head-left">
+        <h2 class="calc-pro__title" id="calc-title">
+          <svg class="calc-pro__title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M12 14h.01M16 14h.01M8 18h2M12 18h.01M16 18h.01"/></svg>
+          24K Pure Gold Calculator
+        </h2>
+        <p class="calc-pro__sub">Enter your weight &mdash; get live melt value, dealer payout estimate, and retail bullion price for any 24K (999) bar, Britannia, Maple Leaf or Gold Buffalo. <strong>USD primary</strong>.</p>
+      </div>
+      <span class="calc-pro__head-badge">
+        <span class="live-dot" aria-hidden="true"></span>
+        Live &middot; 60s refresh
+      </span>
+    </div>
+
+    <div class="calc-pro__body">
+      <div class="calc-pro__row">
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-weight">Weight (grams)</label>
+          <input class="calc-pro__input" type="number" id="calc-weight" inputmode="decimal" placeholder="e.g. 31.1035" min="0" step="0.01" value="1" aria-label="Weight in grams">
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-currency">Currency</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-currency" aria-label="Display currency">
+              <option value="USD" selected>USD ($)</option>
+              <option value="GBP">GBP (&pound;)</option>
+              <option value="EUR">EUR (&euro;)</option>
+              <option value="INR">INR (&#8377;)</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class="calc-pro__chips" role="group" aria-label="Quick weight presets">
+        <span class="calc-pro__chips-label">Quick weights:</span>
+        <button class="calc-chip" type="button" data-weight="1">1g bar</button>
+        <button class="calc-chip" type="button" data-weight="5">5g bar</button>
+        <button class="calc-chip" type="button" data-weight="10">10g bar</button>
+        <button class="calc-chip" type="button" data-weight="31.1035">1 oz Britannia</button>
+        <button class="calc-chip" type="button" data-weight="100">100g bar</button>
+        <button class="calc-chip" type="button" data-weight="1000">1kg bar</button>
+        <button class="calc-chip" type="button" data-weight="12441.4">LBMA 400oz</button>
+      </div>
+
+      <div class="calc-pro__result">
+        <div class="calc-pro__result-primary">
+          <span class="calc-pro__result-label-main">Melt value</span>
+          <span class="calc-pro__result-main" id="calc-melt" data-nosnippet>&mdash;</span>
+        </div>
+        <div class="calc-pro__result-grid">
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Dealer pays (~96%)</span>
+            <span class="calc-pro__result-item-value" id="calc-dealer" data-nosnippet>&mdash;</span>
+          </div>
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Retail bullion (~+4%)</span>
+            <span class="calc-pro__result-item-value" id="calc-retail" data-nosnippet>&mdash;</span>
+          </div>
+        </div>
+      </div>
+      <p class="calc-pro__hint">Formula: <code>weight &times; (spot &divide; 31.1035) &times; 0.999</code>. 24K is the highest-paying scrap (typically <strong>95&ndash;99%</strong> of melt &mdash; refiners prefer pure gold). LBMA-accredited retail bars typically carry a <strong>2&ndash;8%</strong> premium over spot depending on size. <a href="/where-to-sell-gold-silver">Find the best dealers&nbsp;&rarr;</a></p>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     STAT CARDS — key 24K facts at a glance
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="stat-cards" aria-label="24K gold key facts">
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+    <div class="stat-card__value">99.9%</div>
+    <div class="stat-card__label">Pure gold content &mdash; the purest commercial grade</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    <div class="stat-card__value">999</div>
+    <div class="stat-card__label">Hallmark for 24 karat gold (UK Assay Office)</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 21h18M5 21V8l7-5 7 5v13M9 12h6M9 16h6"/></svg>
+    <div class="stat-card__value">~36,700t</div>
+    <div class="stat-card__label">Global central bank gold reserves (2024)</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="6" width="18" height="12" rx="1"/><path d="M7 10h10M7 14h7"/></svg>
+    <div class="stat-card__value">400 oz</div>
+    <div class="stat-card__label">LBMA Good Delivery bar (~12.4 kg trading standard)</div>
+  </article>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     LIVE PRICE TABLE — by weight, currency switcher (USD default)
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="price-table-section" aria-labelledby="price-table-title">
+  <div class="price-table-card">
+    <div class="price-table-card__head">
+      <div>
+        <h2 class="price-table-card__title" id="price-table-title">24K Gold Price by Weight</h2>
+        <p class="price-table-card__sub"><strong>Live</strong> &middot; Updated every 60s &middot; 0.5g to 1 troy oz &middot; <strong>USD primary</strong></p>
+      </div>
+      <div class="currency-switch" role="tablist" aria-label="Choose currency to highlight">
+        <button class="currency-switch__btn active" role="tab" data-currency="USD" aria-selected="true">USD</button>
+        <button class="currency-switch__btn" role="tab" data-currency="GBP" aria-selected="false">GBP</button>
+        <button class="currency-switch__btn" role="tab" data-currency="EUR" aria-selected="false">EUR</button>
+        <button class="currency-switch__btn" role="tab" data-currency="INR" aria-selected="false">INR</button>
+      </div>
+    </div>
+    <div class="price-table-card__body">
+      <figure itemscope itemtype="https://schema.org/Table" style="margin:0">
+        <figcaption class="sr-only">24K gold price per gram in USD, GBP, EUR and INR — live, updated every 60 seconds</figcaption>
+        <table class="price-table-pro" aria-label="24K gold price by weight">
+          <thead><tr><th>Weight</th><th data-col="USD">USD</th><th data-col="GBP">GBP</th><th data-col="EUR">EUR</th><th data-col="INR">INR</th></tr></thead>
+          <tbody>
+            <tr><td>0.5g <span class="weight-label-sub">Mini bar</span></td><td id="t-0-5-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-0-5-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-0-5-eur" data-col="EUR" data-nosnippet>&mdash;</td><td id="t-0-5-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1g <span class="weight-label-sub">Per-gram benchmark</span></td><td id="t-1-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-1-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-1-eur" data-col="EUR" data-nosnippet>&mdash;</td><td id="t-1-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>5g <span class="weight-label-sub">PAMP / Valcambi bar</span></td><td id="t-5-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-5-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-5-eur" data-col="EUR" data-nosnippet>&mdash;</td><td id="t-5-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>10g <span class="weight-label-sub">Common retail bar</span></td><td id="t-10-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-10-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-10-eur" data-col="EUR" data-nosnippet>&mdash;</td><td id="t-10-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>20g <span class="weight-label-sub">Tola (Indian/Pakistani)</span></td><td id="t-20-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-20-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-20-eur" data-col="EUR" data-nosnippet>&mdash;</td><td id="t-20-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1 <a href="/how-many-grams-in-troy-ounce">troy oz</a> <span class="weight-label-sub">31.1035g &middot; Britannia / Maple Leaf</span></td><td id="t-31-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-31-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-31-eur" data-col="EUR" data-nosnippet>&mdash;</td><td id="t-31-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>100g <span class="weight-label-sub">Mid-size investor bar</span></td><td id="t-100-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-100-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-100-eur" data-col="EUR" data-nosnippet>&mdash;</td><td id="t-100-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1kg <span class="weight-label-sub">Large investor bar</span></td><td id="t-1000-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-1000-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-1000-eur" data-col="EUR" data-nosnippet>&mdash;</td><td id="t-1000-inr" data-col="INR" data-nosnippet>&mdash;</td></tr>
+          </tbody>
+        </table>
+      </figure>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     KARAT COMPARISON — bento cards (24K highlighted)
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="karat-section" aria-labelledby="karat-section-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Compare</span>
+      <h2 class="section-title" id="karat-section-title">24K vs Other Karats</h2>
+      <p class="section-sub">Compare live USD prices, purity and typical uses across every common gold karat &mdash; from 9K UK everyday wear to 24K pure bullion. All derived from the same LBMA spot, refreshed every 60 seconds.</p>
+    </div>
+  </div>
+  <div class="karat-cards">
+    <a href="/9k-gold-price-per-gram" class="karat-pro-card">
+      <div class="karat-pro-card__karat">9K</div>
+      <div class="karat-pro-card__purity">37.5% pure</div>
+      <div class="karat-pro-card__hallmark">375</div>
+      <div class="karat-pro-card__use">UK everyday jewellery</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-9-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/14k-gold-price-per-gram" class="karat-pro-card">
+      <div class="karat-pro-card__karat">14K</div>
+      <div class="karat-pro-card__purity">58.33% pure</div>
+      <div class="karat-pro-card__hallmark">585</div>
+      <div class="karat-pro-card__use">US engagement rings</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-14-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/18k-gold-price-per-gram" class="karat-pro-card">
+      <div class="karat-pro-card__karat">18K</div>
+      <div class="karat-pro-card__purity">75.0% pure</div>
+      <div class="karat-pro-card__hallmark">750</div>
+      <div class="karat-pro-card__use">Fine jewellery, Swiss watches</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-18-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/22k-gold-price-per-gram" class="karat-pro-card">
+      <div class="karat-pro-card__karat">22K</div>
+      <div class="karat-pro-card__purity">91.67% pure</div>
+      <div class="karat-pro-card__hallmark">916</div>
+      <div class="karat-pro-card__use">South Asian bridal &amp; Sovereigns</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-22-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <div class="karat-pro-card karat-pro-card--current">
+      <div class="karat-pro-card__karat">24K</div>
+      <div class="karat-pro-card__purity">99.9% pure</div>
+      <div class="karat-pro-card__hallmark">999</div>
+      <div class="karat-pro-card__use">Bullion bars, coins, central bank reserves</div>
+      <div class="karat-pro-card__price"><span class="karat-pro-card__price-label">USD / gram</span><span id="karat-24-usd" data-nosnippet>&mdash;</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     FORMULA BLOCK — how the 24K price is calculated
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="formula-block" aria-labelledby="formula-title">
+  <div class="formula-card">
+    <div class="formula-card__eyebrow">The Math</div>
+    <h2 class="formula-card__title" id="formula-title">How the 24K gold price is calculated</h2>
+    <p style="color:var(--color-text-muted);font-size:var(--text-sm);margin-bottom:var(--space-4);line-height:1.7">The 24K gold price per gram is derived <em>directly</em> from the LBMA spot price set twice daily in London. Because 24K is essentially pure gold, the purity multiplier is <strong style="color:var(--color-gold-bright)">0.999</strong> &mdash; the closest of any karat to the raw spot value. USD is the primary currency; live conversions to GBP, EUR and INR use ECB reference rates.</p>
+    <div class="formula-card__equation"><span class="var">24K price/g</span> <span class="op">=</span> (<span class="var">spot USD/oz</span> <span class="op">&divide;</span> 31.1035) <span class="op">&times;</span> 0.999</div>
+    <div class="formula-card__steps">
+      <div class="formula-step">
+        <div class="formula-step__num">1</div>
+        <div class="formula-step__text">Take the live LBMA spot price (<strong>USD per troy oz</strong> for pure gold)</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">2</div>
+        <div class="formula-step__text">Divide by <strong>31.1035</strong> grams in a troy oz to get the per-gram pure-gold price</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">3</div>
+        <div class="formula-step__text">Multiply by <strong>0.999</strong> &mdash; the 24K purity factor (24K = 99.9% pure)</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     WHY 24K MATTERS — LBMA / Central Banks / Sovereign Coins
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="luxe-section" aria-labelledby="luxe-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Why 24K matters</span>
+      <h2 class="section-title" id="luxe-title">The reserve currency of metals</h2>
+      <p class="section-sub">24K is the only purity used by the LBMA, central banks and the world's most-recognised sovereign coins. Three live USD valuations below, recalculated every 60 seconds against the same spot price you see at the top of this page.</p>
+    </div>
+  </div>
+  <div class="luxe-cards">
+    <article class="luxe-card">
+      <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <rect x="6" y="14" width="36" height="20" rx="2"/>
+        <path d="M10 18h28M10 22h28M10 26h28M10 30h28"/>
+        <path d="M6 14l4-6h28l4 6"/>
+      </svg>
+      <div class="luxe-card__category">LBMA Good Delivery</div>
+      <h3 class="luxe-card__title">The 400 oz bar standard</h3>
+      <p class="luxe-card__desc">The London Bullion Market clears roughly <strong>$30&ndash;40 billion</strong> of gold daily through <strong>~70 accredited refiners</strong>. The wholesale unit of trade is the 400 troy oz (~12.4kg) Good Delivery bar, minimum 995 fineness, delivered between LBMA vaults beneath the Bank of England and the City of London.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-lbma-melt" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">400 oz Good Delivery bar value</span>
+      </div>
+    </article>
+    <article class="luxe-card">
+      <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path d="M6 42h36M10 42V20l14-10 14 10v22"/>
+        <path d="M14 42V26M22 42V26M30 42V26M38 42V26"/>
+        <circle cx="24" cy="16" r="1.5" fill="currentColor"/>
+      </svg>
+      <div class="luxe-card__category">Central Bank Reserves</div>
+      <h3 class="luxe-card__title">The sovereign hoard</h3>
+      <p class="luxe-card__desc">Central banks hold approximately <strong>36,700 tonnes</strong> of pure gold &mdash; over <strong>$2.8 trillion</strong> at today's spot. Net annual purchases have exceeded 1,000 tonnes every year since 2022 as China, India, Poland and Turkey diversify away from US dollar assets. This structural demand has underpinned record highs.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-cb-melt" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">1 kg sovereign bar melt value</span>
+      </div>
+    </article>
+    <article class="luxe-card">
+      <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <circle cx="24" cy="24" r="18"/>
+        <circle cx="24" cy="24" r="14"/>
+        <path d="M24 16c-2.5 0-4 1.5-4 4s1.5 4 4 4 4-1.5 4-4-1.5-4-4-4z"/>
+        <path d="M20 26c1 2.5 2.5 4 4 4s3-1.5 4-4"/>
+        <path d="M18 22c-2-.5-3.5-2-3.5-4M30 22c2-.5 3.5-2 3.5-4"/>
+      </svg>
+      <div class="luxe-card__category">Britannia &amp; Maple Leaf</div>
+      <h3 class="luxe-card__title">CGT-exempt pure bullion</h3>
+      <p class="luxe-card__desc">The Royal Mint <strong>Gold Britannia</strong> (1oz, 24K, 9999 fine) is UK legal tender &mdash; therefore <strong>exempt from Capital Gains Tax and VAT</strong>. The Royal Canadian Mint <strong>Maple Leaf</strong> (9999 fine) and US Mint <strong>Gold Buffalo</strong> (9999 fine) are the global liquidity benchmarks for retail 24K bullion.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-britannia-melt" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">1 oz Britannia melt value</span>
+      </div>
+    </article>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     CENTRAL BANK NET PURCHASES CHART — drives long-term 24K demand
+     ═══════════════════════════════════════════════════════════════ -->
+<section class="cbchart" aria-labelledby="cbchart-title">
+  <div class="cbchart-card">
+    <span class="section-eyebrow">Structural demand</span>
+    <h2 class="section-title" id="cbchart-title" style="margin-top:var(--space-2)">Central bank net gold purchases (tonnes/year)</h2>
+    <p class="section-sub">Central banks turned net buyers in 2010 and have not looked back &mdash; with the 2022 freezing of Russian USD reserves triggering a step-change in 24K demand. Annual buying now runs at roughly double the 2010s pace, structurally supporting global 24K spot prices.</p>
+    <div class="cbchart-chart" role="img" aria-label="Central bank net gold purchases by year, 2010 through 2024, peaks in 2022 and 2023">
+      <div class="cbchart-bar cbchart-bar--mid" style="height:32%" data-year="2010"><span class="cbchart-bar__label">77t</span></div>
+      <div class="cbchart-bar cbchart-bar--mid" style="height:48%" data-year="2011"><span class="cbchart-bar__label">481t</span></div>
+      <div class="cbchart-bar cbchart-bar--high" style="height:55%" data-year="2012"><span class="cbchart-bar__label">544t</span></div>
+      <div class="cbchart-bar cbchart-bar--high" style="height:62%" data-year="2013"><span class="cbchart-bar__label">625t</span></div>
+      <div class="cbchart-bar cbchart-bar--high" style="height:58%" data-year="2014"><span class="cbchart-bar__label">584t</span></div>
+      <div class="cbchart-bar cbchart-bar--high" style="height:56%" data-year="2015"><span class="cbchart-bar__label">580t</span></div>
+      <div class="cbchart-bar cbchart-bar--mid" style="height:38%" data-year="2016"><span class="cbchart-bar__label">395t</span></div>
+      <div class="cbchart-bar cbchart-bar--high" style="height:36%" data-year="2017"><span class="cbchart-bar__label">379t</span></div>
+      <div class="cbchart-bar cbchart-bar--high" style="height:62%" data-year="2018"><span class="cbchart-bar__label">656t</span></div>
+      <div class="cbchart-bar cbchart-bar--high" style="height:62%" data-year="2019"><span class="cbchart-bar__label">605t</span></div>
+      <div class="cbchart-bar cbchart-bar--mid" style="height:24%" data-year="2020"><span class="cbchart-bar__label">255t</span></div>
+      <div class="cbchart-bar cbchart-bar--high" style="height:43%" data-year="2021"><span class="cbchart-bar__label">450t</span></div>
+      <div class="cbchart-bar cbchart-bar--peak" style="height:100%" data-year="2022"><span class="cbchart-bar__label">1,082t</span></div>
+      <div class="cbchart-bar cbchart-bar--peak" style="height:97%" data-year="2023"><span class="cbchart-bar__label">1,037t</span></div>
+      <div class="cbchart-bar cbchart-bar--peak" style="height:99%" data-year="2024"><span class="cbchart-bar__label">1,045t</span></div>
+    </div>
+    <div class="cbchart-legend">
+      <span class="cbchart-legend__item"><span class="cbchart-legend__swatch cbchart-legend__swatch--peak"></span>Record buying (post-2022 de-dollarisation)</span>
+      <span class="cbchart-legend__item"><span class="cbchart-legend__swatch cbchart-legend__swatch--high"></span>Strong demand (500&ndash;700t)</span>
+      <span class="cbchart-legend__item"><span class="cbchart-legend__swatch cbchart-legend__swatch--mid"></span>Moderate accumulation (200&ndash;500t)</span>
+      <span class="cbchart-legend__item"><span class="cbchart-legend__swatch cbchart-legend__swatch--low"></span>Tonnes purchased &middot; Source: World Gold Council</span>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════
+     EDITORIAL CONTENT — long-form, premium typography
+     ═══════════════════════════════════════════════════════════════ -->
+<div class="content-section">
+  <article class="prose-pro">
+    <h2 id="24k-gold-per-gram">How much is a gram of 24K gold worth?</h2>
+    <div class="snippet-answer">24K gold is worth approximately <strong><span id="snippet-price" data-nosnippet>[live USD value]</span> per gram</strong> today. This is calculated by dividing the live LBMA spot price (USD per troy ounce) by 31.1035 and multiplying by <strong>0.999</strong> &mdash; the purity factor of 24 karat gold (99.9% pure). USD is the primary currency shown across this page because gold is globally priced in US dollars on the LBMA; live conversions to GBP, EUR and INR use ECB reference rates fetched alongside the spot every 60 seconds.</div>
+
+    <h2 id="q2-24K">What is 24K gold?</h2>
+    <div class="snippet-answer">24K gold is the purest commercially available form of gold &mdash; containing <strong>24 parts pure gold out of 24</strong>, with a fineness of <strong>99.9%</strong>. It is the only purity used for investment-grade bullion (bars and most modern sovereign coins), and the standard for LBMA Good Delivery, central bank reserves and the electronics &amp; medical industries. The hallmark is <strong>999</strong> in Europe/UK or <strong>24K / 24KT / 9999</strong> in North America for four-nines refined product.</div>
+
+    <h2 id="q3-24K">What does the 999 hallmark mean?</h2>
+    <div class="snippet-answer">The <strong>999 hallmark</strong> certifies an item is 24 karat gold &mdash; 999 parts pure gold per 1,000, or 99.9% fine. In the UK this stamp must be applied by one of the four Assay Offices (London, Birmingham, Sheffield, Edinburgh) under the Hallmarking Act 1973. Premium modern bullion is often refined to <strong>9999</strong> (four-nines, 99.99%), the standard used by the Royal Canadian Mint Maple Leaf and US Mint Gold Buffalo.</div>
+
+    <h2>The 999 hallmark explained</h2>
+    <p>In the UK, gold items above 1g must be independently tested and stamped by one of the four UK Assay Offices under the <strong>Hallmarking Act 1973</strong>. The 999 stamp guarantees the item contains at least 99.9% pure gold. It is illegal to describe or sell an item as 24K gold in the UK if it does not carry an approved hallmark or an LBMA-accredited refiner assay certificate.</p>
+
+    <div class="assay-grid">
+      <div class="assay-card">
+        <div class="assay-card__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8c-3.5 0-6 2-6 5 0 2 1 3.5 2.5 4.5C11 18 9 19 9 22h14c0-3-2-4-3.5-4.5C21 16.5 22 15 22 13c0-3-2.5-5-6-5z"/><circle cx="13" cy="13" r=".8" fill="currentColor"/><circle cx="19" cy="13" r=".8" fill="currentColor"/><path d="M14 17h4"/></svg>
+        </div>
+        <div class="assay-card__name">London</div>
+        <div class="assay-card__est">Leopard's head &middot; 1300</div>
+      </div>
+      <div class="assay-card">
+        <div class="assay-card__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M16 6v18M10 8h12M9 18c0 4 3 7 7 7s7-3 7-7"/><circle cx="16" cy="6" r="2"/></svg>
+        </div>
+        <div class="assay-card__name">Birmingham</div>
+        <div class="assay-card__est">Anchor &middot; 1773</div>
+      </div>
+      <div class="assay-card">
+        <div class="assay-card__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="16" cy="16" r="3"/><path d="M16 5c-2 3-2 6 0 8M16 27c-2-3-2-6 0-8M5 16c3-2 6-2 8 0M27 16c-3-2-6-2-8 0M9 9c2 1 3 3 4 5M23 23c-2-1-3-3-4-5M9 23c2-1 3-3 4-5M23 9c-2 1-3 3-4 5"/></svg>
+        </div>
+        <div class="assay-card__name">Sheffield</div>
+        <div class="assay-card__est">Tudor rose &middot; 1773</div>
+      </div>
+      <div class="assay-card">
+        <div class="assay-card__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M6 26V14l4-3v3l3-2 3 2v-3l3 2 3-2v3l4 3v12z"/><path d="M13 26v-6h6v6"/><path d="M8 14V9M12 11V8M20 11V8M24 14V9"/></svg>
+        </div>
+        <div class="assay-card__name">Edinburgh</div>
+        <div class="assay-card__est">Castle &middot; 1457</div>
+      </div>
+    </div>
+
+    <h2>24K bullion formats: bar, coin, kilo</h2>
+    <p>24K is the only purity used for serious bullion. Retail bars range from 1g wallet-size pressed bars up to LBMA Good Delivery 400 oz wholesale bricks. The visual finish indicates the manufacturing process: cast bars (kilo and larger) have a rough textured surface; minted bars (smaller retail sizes) have a brilliant polished face.</p>
+
+    <div class="swatch-grid">
+      <div class="swatch-card">
+        <div class="swatch-card__color swatch-card__color--bar1g"><span class="swatch-card__hallmark">999.9 &middot; 1g</span></div>
+        <div class="swatch-card__body">
+          <div class="swatch-card__title">1g Minted Bar</div>
+          <div class="swatch-card__desc">The smallest retail format &mdash; PAMP Lady Fortuna, Valcambi, Royal Mint. Tamper-evident CertiCard. Premium is the highest at this size (8&ndash;15% over spot) but liquidity at any dealer worldwide is instant.</div>
+        </div>
+      </div>
+      <div class="swatch-card">
+        <div class="swatch-card__color swatch-card__color--coin"><span class="swatch-card__hallmark">9999 &middot; Coin</span></div>
+        <div class="swatch-card__body">
+          <div class="swatch-card__title">1 oz Britannia / Maple Leaf</div>
+          <div class="swatch-card__desc">The benchmark 24K retail coin (31.1035g). Royal Mint Britannia &amp; Royal Canadian Mint Maple Leaf are both 9999 fine. UK Britannia is <strong>CGT &amp; VAT exempt</strong> as legal tender &mdash; the most tax-efficient way to hold pure gold in Britain.</div>
+        </div>
+      </div>
+      <div class="swatch-card">
+        <div class="swatch-card__color swatch-card__color--kilo"><span class="swatch-card__hallmark">999.9 &middot; 1kg</span></div>
+        <div class="swatch-card__body">
+          <div class="swatch-card__title">1kg Cast Bar</div>
+          <div class="swatch-card__desc">The serious investor sweet spot. Premium drops to <strong>1.5&ndash;3%</strong> over spot for kilo bars from PAMP, Valcambi, Argor-Heraeus or the Royal Mint. Best efficiency per gram of any retail format.</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>LBMA Good Delivery: the global gold standard</h2>
+    <p>The <strong>London Bullion Market Association (LBMA)</strong> sets the global benchmark for gold quality and trading. When people refer to the "gold spot price," they mean the LBMA price &mdash; the price at which 24K gold trades between accredited refiners, banks, and dealers in <strong>USD per troy ounce</strong>. Here is how the system works:</p>
+    <ul>
+      <li><strong>Good Delivery bars</strong> &mdash; The standard unit of trade is the 400 troy ounce (~12.4kg) bar, refined to a minimum 995 fineness. Only bars produced by LBMA-accredited refiners are accepted. As of 2024 there are approximately 70 accredited refiners worldwide, including PAMP (Switzerland), Valcambi, Argor-Heraeus, Metalor and the Royal Mint Refinery.</li>
+      <li><strong>Twice-daily auction</strong> &mdash; The LBMA Gold Price is set at 10:30 AM and 3:00 PM London time through an electronic auction run by ICE Benchmark Administration. This auction replaced the historic 1919 "London Gold Fix" telephone process in 2015.</li>
+      <li><strong>Clearing</strong> &mdash; The London gold market clears approximately $30&ndash;40 billion of gold trades daily through London Precious Metals Clearing Limited (LPMCL), making it the world's deepest and most liquid gold market by a wide margin.</li>
+      <li><strong>Retail flow</strong> &mdash; For individual investors, 24K gold is available in 1g, 5g, 10g, 1oz, 50g, 100g, 250g, 500g and 1kg bars. LBMA-accredited bars from PAMP, Valcambi, Argor-Heraeus and the Royal Mint carry the lowest premiums over spot &mdash; usually 2&ndash;5% for 100g+ sizes.</li>
+    </ul>
+
+    <div class="callout">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+      <div>
+        <div class="callout__title">Pricing convention</div>
+        <div class="callout__body">All LBMA prices are quoted in <strong>USD per troy ounce</strong>. INR, GBP and EUR equivalents on this page are computed live from <strong>USD spot &times; ECB FX rate</strong> &mdash; both refreshed every 60 seconds against the same timestamp for consistency. This matches the methodology used across the rest of GoldPriceTools (calculators, karat pages, scrap tool).</div>
+      </div>
+    </div>
+
+    <h2>Central bank gold reserves: why nations hoard 24K</h2>
+    <p>Central banks are the world's largest holders of physical 24K gold. As of early 2025, global central bank reserves total approximately <strong>36,700 tonnes</strong> of gold, worth over <strong>$2.8 trillion</strong> at current spot. The composition of these reserves and the recent pace of accumulation is one of the most important long-term drivers of the 24K spot price:</p>
+
+    <div class="reserve-table-wrap">
+      <table class="reserve-table" aria-label="Top central bank gold reserves">
+        <thead><tr><th>Holder</th><th>Tonnes</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td>United States</td><td>8,133t</td><td>Fort Knox, West Point, Denver Mint &amp; NY Fed vaults</td></tr>
+          <tr><td>Germany</td><td>3,352t</td><td>Repatriated 674t from NY &amp; Paris (2013&ndash;2017)</td></tr>
+          <tr><td>Italy</td><td>2,452t</td><td>Held by Banca d'Italia, mostly in Rome</td></tr>
+          <tr><td>France</td><td>2,437t</td><td>Banque de France vaults, Paris</td></tr>
+          <tr><td>Russia</td><td>2,333t</td><td>Aggressive buyer 2014&ndash;2020; frozen abroad since 2022</td></tr>
+          <tr><td>China (PBoC)</td><td>~2,264t</td><td>Officially reported &mdash; widely believed to hold far more</td></tr>
+          <tr><td>Switzerland</td><td>1,040t</td><td>SNB &mdash; held domestically since 2014 referendum</td></tr>
+          <tr><td>India (RBI)</td><td>~840t</td><td>Net buyer 2017&ndash;present; ~510t repatriated from BoE 2024</td></tr>
+          <tr><td>United Kingdom</td><td>~310t</td><td>BoE holds + ~5,600t in custody for other central banks</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <ul>
+      <li><strong>Net buying since 2022</strong> &mdash; Central banks have been net buyers of gold every year since 2010, but the pace accelerated sharply in 2022&ndash;2024 with annual net purchases exceeding 1,000 tonnes &mdash; roughly double the historical average. This structural demand has been a major driver of the all-time high USD spot prices.</li>
+      <li><strong>De-dollarisation</strong> &mdash; Many central banks (particularly China, India, Poland, Singapore and Turkey) are diversifying reserves away from US dollar assets and into physical 24K gold, driven by geopolitical risk and the precedent set by the freezing of Russian central bank assets in 2022.</li>
+      <li><strong>The Brown's Bottom episode</strong> &mdash; The UK controversially sold 395 tonnes of its sovereign gold between 1999&ndash;2002 at an average price of roughly $275/oz. At today's USD spot, that sale would be worth approximately 12&ndash;13&times; more &mdash; a cautionary tale in modern gold market history.</li>
+    </ul>
+
+    <h2>How to calculate the 24K gold price per gram</h2>
+    <p>The formula is the simplest of any karat &mdash; because 24K is essentially pure gold, the purity multiplier is just <strong>0.999</strong>:</p>
+    <blockquote><strong>24K price per gram = (Spot price per troy oz &divide; 31.1035) &times; 0.999</strong></blockquote>
+    <p>For example, if the LBMA gold spot price is $3,300 per troy ounce:</p>
+    <ul>
+      <li>Price per gram of pure gold = $3,300 &divide; 31.1035 = <strong>$106.10</strong></li>
+      <li>24K price per gram = $106.10 &times; 0.999 = <strong>$105.99</strong></li>
+    </ul>
+    <p>This is the <em>melt value</em> &mdash; the intrinsic gold content value in USD. Refiners and dealers typically pay <strong>95&ndash;99%</strong> of melt value when buying 24K bullion (the highest payout of any karat &mdash; refiners prefer high-purity scrap). At retail, LBMA-accredited bars carry a <strong>2&ndash;8% premium</strong> over spot depending on bar size and mint. Use our <a href="/scrap-gold-calculator">scrap gold calculator</a> to estimate your live USD melt value before negotiating.</p>
+
+    <h2>Investing in 24K gold: physical vs paper</h2>
+    <p>24K gold is the <strong>only purity used for investment-grade bullion</strong>. If you are buying gold as an investment (rather than jewellery), you have several options, each with distinct trade-offs in cost, custody and tax treatment:</p>
+    <ul>
+      <li><strong>Physical bullion bars</strong> &mdash; Lowest premiums (typically 1.5&ndash;5% over spot for 100g+ bars). Must be stored securely &mdash; home safe with insurance rider, or allocated vault. LBMA-accredited bars from PAMP, Valcambi or the Royal Mint are most liquid. VAT-exempt as investment gold in the UK.</li>
+      <li><strong>Sovereign bullion coins</strong> &mdash; UK Gold Britannia (1oz, 24K, 9999) is CGT-exempt as legal tender. The Royal Canadian Mint Maple Leaf (9999) and US Mint Gold Buffalo (9999) are equally liquid globally. Premiums are slightly higher than bars (4&ndash;8%) but liquidity is excellent and recognisability is unrivalled. For comparison, see our <a href="/gold-coins-vs-bars">gold coins vs bars guide</a>.</li>
+      <li><strong>Gold ETFs</strong> &mdash; The easiest way to get exposure to the 24K gold price without physical storage. Popular options include iShares Physical Gold ETC (SGLN), Invesco Physical Gold (SGLD), and WisdomTree Physical Gold (PHAU). Management fees are typically 0.12&ndash;0.25% per year. ETF gains are taxable in the UK (no CGT exemption).</li>
+      <li><strong>Allocated digital storage</strong> &mdash; Services like BullionVault and the Royal Mint's DigiGold let you buy 24K gold stored in LBMA-accredited vaults. You own specific bars by serial number; storage costs are ~0.12% per year. Combines the low premium of bars with the convenience of digital access.</li>
+      <li><strong>Gold IRA (US investors)</strong> &mdash; 24K bullion (and 9999 sovereign coins) qualify for inclusion in a Self-Directed IRA. The IRS requires a custodian and an approved depository. See our <a href="/best-gold-ira-companies">best Gold IRA companies</a> guide for vetted custodians.</li>
+    </ul>
+    <p>For UK investors, the choice between physical 24K and ETFs typically comes down to tax efficiency: Britannia coins are CGT-exempt while ETF gains are taxable. For deeper analysis see our <a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a> guide.</p>
+
+    <h2>Selling 24K gold: what to expect</h2>
+    <p>24K bullion is the <strong>most liquid form of physical gold</strong> in the world. Because refiners can re-mint it with virtually no refining cost, payout percentages are the highest of any karat:</p>
+    <ul>
+      <li><strong>LBMA-accredited bars</strong> &mdash; Sell for <strong>97&ndash;99.5%</strong> of live USD spot at any reputable bullion dealer. Bring the original CertiCard / assay certificate; bars without provenance may be discounted 2&ndash;5% pending re-assay.</li>
+      <li><strong>Sovereign 24K coins (Britannia, Maple Leaf, Buffalo)</strong> &mdash; Sell for <strong>spot to spot + small premium</strong> at most bullion dealers. Proof and limited-edition mintages can command 30&ndash;100%+ over melt depending on year and condition.</li>
+      <li><strong>1g&ndash;10g minted bars</strong> &mdash; Sell at <strong>90&ndash;96%</strong> of spot &mdash; small sizes have proportionally higher resale spreads because the dealer cost basis is per-bar not per-ounce.</li>
+      <li><strong>Pawnshops / non-specialist buyers</strong> &mdash; Typically 80&ndash;90% of melt. Avoid for 24K bullion if you have access to a reputable LBMA-recognised dealer.</li>
+    </ul>
+    <p>Before selling any 24K item, weigh it on a calibrated 0.01g scale, check our calculator above for the live USD melt baseline, then get at least three quotes. See our guide on <a href="/where-to-sell-gold-silver">where to sell gold safely</a> for vetted dealer recommendations.</p>
+
+    <h2>Frequently asked questions</h2>
+    <div class="faq-pro">
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How do I convert the 24K gold price from troy ounces to grams?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">There are <strong>31.1035 grams in one troy ounce</strong>. Divide the spot price (in any currency) by 31.1035 to get the price per gram of pure gold, then multiply by 0.999 to get the 24K price per gram. Our live calculator above does this automatically using real-time LBMA spot data, with <strong>USD as the primary currency</strong>.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What's the difference between 24K, 999, 9999 and 99999 gold?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body"><strong>24K</strong> is the karat term for the purest commercial gold (99.9% or higher). <strong>999</strong> ("three-nines") is the standard LBMA fineness &mdash; minimum 99.9% pure. <strong>9999</strong> ("four-nines") is 99.99% pure, used for Royal Canadian Mint Maple Leafs, US Mint Gold Buffalos, and premium PAMP/Valcambi bars. <strong>99999</strong> ("five-nines", 99.999%) is the ultra-premium grade made famous by the Royal Canadian Mint's special Maple Leaf editions &mdash; one of the purest commercial gold products ever struck.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Why does the 24K gold price vary between different websites?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Small differences between sites reflect the timing of their data feed, the spot price source used (LBMA, COMEX, or OTC), and whether they include FX conversion at slightly different timestamps. GoldPriceTools fetches live <strong>USD spot prices from gold-api.com</strong> (LBMA-sourced) and currency rates from the <strong>Frankfurter API</strong> (ECB reference rates), both updated every 60 seconds and applied uniformly across every karat page on the site for consistency.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Is 24K gold too soft for jewellery?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">For Western markets &mdash; usually yes. Pure 24K gold has a Vickers hardness of only ~25 HV (vs ~120&ndash;150 HV for 18K), so rings and bracelets in 24K deform with daily wear. However, 24K jewellery is common across South Asia and East Asia, particularly for ceremonial pieces and investment chains where the higher melt value is prioritised over durability. For everyday Western jewellery, <a href="/18k-gold-price-per-gram">18K</a> or <a href="/14k-gold-price-per-gram">14K</a> are the practical choices.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Is 24K gold a good investment in 2026?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">24K gold has historically performed strongly during periods of currency debasement, high inflation, and geopolitical stress &mdash; all factors present in the 2022&ndash;2025 cycle. Central banks bought a record ~3,160 tonnes between 2022&ndash;2024, structurally supporting the price. <strong>This is not financial advice</strong> &mdash; gold can be volatile in the short term and pays no yield. For longer-form analysis, see our <a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026?</a> article and <a href="/guides/gold-price-prediction-2026">2026 prediction guide</a>.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Are Gold Britannia coins really tax-free in the UK?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Yes. The 1oz Gold Britannia (24K, 9999 fine, struck by the Royal Mint) is UK legal tender and is therefore <strong>exempt from Capital Gains Tax</strong> regardless of profit size &mdash; including amounts above the &pound;3,000 annual CGT allowance that taxes ETF gains. As investment-grade gold it is also <strong>VAT-exempt</strong> under HMRC's investment gold rules. The Gold Sovereign (<a href="/22k-gold-price-per-gram">22K</a>) shares the same exemption. See our <a href="/blog/uk-gold-cgt-guide">UK Gold CGT guide</a> for the full rules.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How accurate are these live prices?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Spot prices on this page come direct from the LBMA via gold-api.com and refresh every 60 seconds. Currency conversion from USD to GBP, EUR and INR uses the Frankfurter API (live ECB reference rates). These are <em>melt values</em> &mdash; the raw 24K gold content in USD. Dealer buy prices for 24K bullion are typically <strong>95&ndash;99% of melt</strong>; retail bullion bars and coins add a <strong>2&ndash;8% premium</strong> over melt depending on size and mint.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Is 24K gold real gold?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">24K gold is the <strong>realest gold there is</strong> &mdash; 99.9% pure, with no significant alloying metal. It is the purity used by the LBMA, central banks, the Royal Mint Britannia, the Royal Canadian Mint Maple Leaf, the US Mint Gold Buffalo and every major bullion bar refiner. The 999 hallmark certifies this purity under the UK Hallmarking Act 1973.</div>
+      </details>
+    </div>
+
+    <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Dealer buy prices for 24K bullion are typically 95&ndash;99% of melt; retail bullion premiums of 2&ndash;8% apply at purchase. Tax treatment depends on individual circumstances; consult a qualified professional. Always verify with your dealer before buying or selling.</div>
+  </article>
+</div>
+
+<!-- Social share buttons -->
+<div class="content-section" style="padding-top:0;padding-bottom:1.5rem">
+<div class="share-buttons" style="max-width:760px;margin:0 auto">
+  <span>Share:</span>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/24k-gold-price-per-gram&text=24K+Gold+Price+Per+Gram+Today+%28Live+USD%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/24k-gold-price-per-gram&title=24K+Gold+Price+Per+Gram+Today+%28Live+USD%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=24K+Gold+Price+Per+Gram+Today+%28Live+USD%29%20https%3A%2F%2Fgoldpricetools.com%2F24k-gold-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+</div>
+</div>
+
+<!-- Related Guides -->
+<section class="related-guides" aria-labelledby="related-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Keep reading</span>
+      <h2 class="section-title" id="related-title">Related Gold &amp; Silver Guides</h2>
+    </div>
+  </div>
+  <div class="related-guides-grid">
+    <a href="/22k-gold-price-per-gram" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">22K Gold Price Per Gram</div>
+      <div class="related-card__desc">Today's 22K gold price per gram &mdash; 91.67% pure, the South Asian bridal &amp; Sovereign standard.</div>
+    </a>
+    <a href="/18k-gold-price-per-gram" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">18K Gold Price Per Gram</div>
+      <div class="related-card__desc">Live 18K gold price per gram &mdash; the European/Swiss luxury watch &amp; jewellery standard.</div>
+    </a>
+    <a href="/gold-bar-value" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">Gold Bar Value Calculator</div>
+      <div class="related-card__desc">Live USD spot for every common 24K bar size from 1g pressed up to 1kg cast.</div>
+    </a>
+    <a href="/best-gold-ira-companies" class="related-card">
+      <span class="related-card__tag">US Guide</span>
+      <div class="related-card__title">Best Gold IRA Companies</div>
+      <div class="related-card__desc">Vetted custodians for holding 24K bullion (and 9999 coins) in a Self-Directed IRA.</div>
+    </a>
+    <a href="/gold-coins-vs-bars" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Gold Coins vs Bars</div>
+      <div class="related-card__desc">Britannia vs PAMP bar &mdash; which 24K format gives the best value per gram.</div>
+    </a>
+    <a href="/scrap-gold-calculator" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">Scrap Gold Calculator</div>
+      <div class="related-card__desc">Live USD melt value for 24K bullion bars and 999 hallmarked items.</div>
+    </a>
+    <a href="/guides/gold-price-history" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Gold Price History</div>
+      <div class="related-card__desc">How the 24K LBMA spot has moved from 1970 to today and what drives long-term trends.</div>
+    </a>
+    <a href="/gold-silver-ratio" class="related-card">
+      <span class="related-card__tag">Live Tool</span>
+      <div class="related-card__title">Gold-Silver Ratio</div>
+      <div class="related-card__desc">Track the live gold-to-silver ratio &mdash; a key indicator for precious metals timing.</div>
+    </a>
+  </div>
+</section>
+
+<!-- Sticky mobile price bar -->
+<div class="sticky-price" id="stickyPrice" role="complementary" aria-label="Live price quick access">
+  <div class="sticky-price__info">
+    <div class="sticky-price__label">24K &middot; USD/g</div>
+    <div class="sticky-price__value" id="sticky-usd" data-nosnippet>&mdash;</div>
+  </div>
+  <a href="#calculator" class="sticky-price__cta">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M8 18h2"/></svg>
+    Calculate
+  </a>
+</div>
 
 <footer>
   <div class="footer-inner">
@@ -740,7 +1257,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds. USD primary currency.</p>
       <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
@@ -753,7 +1270,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -806,51 +1322,275 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </div>
   <div class="footer-bottom">
     <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
-    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com. USD primary.</span>
   </div>
 </footer>
 
 <script>
-async function fetchFx(){
-  try{
-    const r=await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,INR',{cache:'no-store'});
-    if(!r.ok)throw new Error();
-    const d=await r.json();
-    window._gbpusd=d.rates.GBP||0.79;window._usdinr=d.rates.INR||83.5;
-  }catch{window._gbpusd=0.79;}
-}
-async function fetchSpot(){
-  const PURITY=1.0;
-  try{
-    const r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
-    if(!r.ok)throw new Error();
-    const d=await r.json();
-    const spotUSD=d.price;
-    const pgUSD=spotUSD/31.1035*PURITY;
-    const pgGBP=pgUSD*(window._gbpusd||0.79);
-    const pgINR=pgUSD*(window._usdinr||83.5);
-    document.getElementById('price-gbp').textContent='$'+pgUSD.toFixed(2)+'/g';
-    document.getElementById('price-usd').textContent='£'+pgGBP.toFixed(2)+'/g GBP';
-    const snippetEl = document.getElementById('snippet-price');
-    if(snippetEl) snippetEl.textContent='$'+pgUSD.toFixed(2)+' USD (£'+pgGBP.toFixed(2)+' GBP)';
-    const weights=[0.5,1,2,5,10,20,31.1035];
-    const ids=['0-5','1','2','5','10','20','31'];
-    weights.forEach((w,i)=>{
-      const g=document.getElementById('t-'+ids[i]+'-gbp');
-      const u=document.getElementById('t-'+ids[i]+'-usd');
-      if(g)g.textContent='£'+(pgGBP*w).toFixed(2);
-      if(u)u.textContent='$'+(pgUSD*w).toFixed(2);
-      const inrEl=document.getElementById('t-'+ids[i]+'-inr');
-      if(inrEl)inrEl.textContent='₹'+(pgINR*w).toFixed(2);
-    });
-    gtag('event','price_view',{metal:'gold',karat:'24K'});
-  }catch(e){
-    console.warn('Price fetch failed',e);
+/* ───────── Live price engine — USD primary, multi-currency ─────────
+   Sources:
+     • Gold spot:  https://api.gold-api.com/price/XAU  (LBMA-derived USD/oz)
+     • FX rates:   https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR
+   Refresh: 60s — kept identical to 22K/18K/14K/10K/9K pages for cross-page consistency.
+*/
+(function(){
+  const PURITY_24K = 0.999;
+  const PURITY_KARATS = {9:0.375, 10:0.4167, 14:0.5833, 18:0.75, 22:0.9167, 24:0.999};
+  const G_PER_OZ = 31.1035;
+  const REFRESH_MS = 60000;
+  let lastFetchTs = 0;
+  let countdownTimer = null;
+
+  // Currency formatters — USD is primary
+  const fmtUSD = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
+  const fmtGBP = new Intl.NumberFormat('en-GB',{style:'currency',currency:'GBP',maximumFractionDigits:2});
+  const fmtEUR = new Intl.NumberFormat('en-IE',{style:'currency',currency:'EUR',maximumFractionDigits:2});
+  const fmtINR = new Intl.NumberFormat('en-IN',{style:'currency',currency:'INR',maximumFractionDigits:0});
+  const fmtSpot = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
+
+  function $(id){return document.getElementById(id);}
+
+  async function fetchFx(){
+    try{
+      const r = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR',{cache:'no-store'});
+      if(!r.ok) throw new Error('FX fetch failed');
+      const d = await r.json();
+      window._gbpusd = d.rates.GBP || 0.79;
+      window._eurusd = d.rates.EUR || 0.92;
+      window._usdinr = d.rates.INR || 83.5;
+    }catch(e){
+      console.warn('FX fallback used',e);
+      window._gbpusd = window._gbpusd || 0.79;
+      window._eurusd = window._eurusd || 0.92;
+      window._usdinr = window._usdinr || 83.5;
+    }
   }
-}
-Promise.all([fetchFx(),fetchSpot()]);
-setInterval(fetchSpot,60000);
+
+  async function fetchSpot(){
+    try{
+      const r = await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
+      if(!r.ok) throw new Error('Spot fetch failed');
+      const d = await r.json();
+      const spotUSD = d.price;
+      window._spotUSD = spotUSD;
+      lastFetchTs = Date.now();
+      render(spotUSD);
+      gtag('event','price_view',{metal:'gold',karat:'24K'});
+    }catch(e){
+      console.warn('Spot fetch failed',e);
+    }
+  }
+
+  function render(spotUSD){
+    const gbp = window._gbpusd || 0.79;
+    const eur = window._eurusd || 0.92;
+    const inr = window._usdinr || 83.5;
+    const pg24USD = (spotUSD / G_PER_OZ) * PURITY_24K;
+    const pg24GBP = pg24USD * gbp;
+    const pg24EUR = pg24USD * eur;
+    const pg24INR = pg24USD * inr;
+
+    // Hero tiles — USD primary
+    const usdEl = $('hero-usd');
+    const gbpEl = $('hero-gbp');
+    const eurEl = $('hero-eur');
+    if(usdEl) usdEl.textContent = fmtUSD.format(pg24USD);
+    if(gbpEl) gbpEl.textContent = fmtGBP.format(pg24GBP);
+    if(eurEl) eurEl.textContent = fmtEUR.format(pg24EUR);
+
+    // Sticky mobile bar (USD)
+    const stickyEl = $('sticky-usd');
+    if(stickyEl) stickyEl.textContent = fmtUSD.format(pg24USD);
+
+    // Spot reference
+    const spotEl = $('spot-usd');
+    if(spotEl) spotEl.textContent = fmtSpot.format(spotUSD) + ' /oz';
+
+    // Snippet inline price (USD primary)
+    const snippetEl = $('snippet-price');
+    if(snippetEl) snippetEl.textContent = fmtUSD.format(pg24USD) + ' (' + fmtGBP.format(pg24GBP) + ' GBP, ' + fmtEUR.format(pg24EUR) + ' EUR)';
+
+    // Weight table — 0.5g, 1g, 5g, 10g, 20g, 1oz, 100g, 1kg
+    const weights = [0.5, 1, 5, 10, 20, G_PER_OZ, 100, 1000];
+    const ids    = ['0-5','1','5','10','20','31','100','1000'];
+    weights.forEach((w,i) => {
+      const u = $('t-'+ids[i]+'-usd');
+      const g = $('t-'+ids[i]+'-gbp');
+      const e = $('t-'+ids[i]+'-eur');
+      const n = $('t-'+ids[i]+'-inr');
+      if(u) u.textContent = fmtUSD.format(pg24USD * w);
+      if(g) g.textContent = fmtGBP.format(pg24GBP * w);
+      if(e) e.textContent = fmtEUR.format(pg24EUR * w);
+      if(n) n.textContent = fmtINR.format(pg24INR * w);
+    });
+
+    // Karat comparison cards — all in USD
+    Object.keys(PURITY_KARATS).forEach(k => {
+      const el = $('karat-'+k+'-usd');
+      if(el){
+        const p = PURITY_KARATS[k];
+        el.textContent = fmtUSD.format((spotUSD / G_PER_OZ) * p);
+      }
+    });
+
+    // Luxe card melt values — all in USD
+    const lbmaEl     = $('luxe-lbma-melt');      // 400 troy oz Good Delivery
+    const cbEl       = $('luxe-cb-melt');        // 1kg sovereign bar
+    const britEl     = $('luxe-britannia-melt'); // 31.1035g Britannia
+    if(lbmaEl) lbmaEl.textContent = fmtUSD.format(pg24USD * G_PER_OZ * 400);
+    if(cbEl)   cbEl.textContent   = fmtUSD.format(pg24USD * 1000);
+    if(britEl) britEl.textContent = fmtUSD.format(pg24USD * G_PER_OZ);
+
+    // Calculator — update live
+    updateCalculator();
+
+    // Update timestamp
+    updateTimestamp();
+    startCountdown();
+  }
+
+  function updateTimestamp(){
+    const el = $('updated-time');
+    if(!el) return;
+    el.textContent = 'just now';
+  }
+
+  function startCountdown(){
+    if(countdownTimer) clearInterval(countdownTimer);
+    const counterEl = $('refresh-counter');
+    const updatedEl = $('updated-time');
+    countdownTimer = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - lastFetchTs) / 1000);
+      const remaining = Math.max(0, 60 - elapsed);
+      if(counterEl) counterEl.textContent = remaining + 's';
+      if(updatedEl){
+        if(elapsed < 10) updatedEl.textContent = 'just now';
+        else if(elapsed < 60) updatedEl.textContent = elapsed + 's ago';
+        else updatedEl.textContent = Math.floor(elapsed/60) + 'm ago';
+      }
+    }, 1000);
+  }
+
+  // ───────── Calculator interaction ─────────
+  function updateCalculator(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD) return;
+    const weightEl = $('calc-weight');
+    const currencyEl = $('calc-currency');
+    if(!weightEl || !currencyEl) return;
+    const weight = parseFloat(weightEl.value) || 0;
+    const currency = currencyEl.value;
+
+    const pg24USD = (spotUSD / G_PER_OZ) * PURITY_24K;
+    let pricePerGram, fmt;
+    if(currency === 'GBP'){
+      pricePerGram = pg24USD * (window._gbpusd || 0.79);
+      fmt = fmtGBP;
+    }else if(currency === 'EUR'){
+      pricePerGram = pg24USD * (window._eurusd || 0.92);
+      fmt = fmtEUR;
+    }else if(currency === 'INR'){
+      pricePerGram = pg24USD * (window._usdinr || 83.5);
+      fmt = fmtINR;
+    }else{
+      pricePerGram = pg24USD;
+      fmt = fmtUSD;
+    }
+
+    const melt = pricePerGram * weight;
+    const dealer = melt * 0.96; // 24K dealer payout midpoint (95-99% — highest of any karat)
+    const retail = melt * 1.04; // 24K bullion retail premium midpoint (2-8% over spot for accredited bars)
+
+    const meltEl = $('calc-melt');
+    const dealerEl = $('calc-dealer');
+    const retailEl = $('calc-retail');
+    if(meltEl) meltEl.textContent = fmt.format(melt);
+    if(dealerEl) dealerEl.textContent = fmt.format(dealer);
+    if(retailEl) retailEl.textContent = fmt.format(retail);
+  }
+
+  // Calculator listeners
+  function bindCalculator(){
+    const weightEl = $('calc-weight');
+    const currencyEl = $('calc-currency');
+    if(weightEl) weightEl.addEventListener('input', updateCalculator);
+    if(currencyEl) currencyEl.addEventListener('change', updateCalculator);
+    document.querySelectorAll('.calc-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const w = chip.getAttribute('data-weight');
+        if(weightEl){
+          weightEl.value = w;
+          updateCalculator();
+        }
+        document.querySelectorAll('.calc-chip').forEach(c => c.classList.remove('active'));
+        chip.classList.add('active');
+        gtag('event','calc_chip_click',{weight:w,karat:'24K'});
+      });
+    });
+  }
+
+  // Currency switch (highlights column in price table)
+  function bindCurrencySwitch(){
+    const btns = document.querySelectorAll('.currency-switch__btn');
+    btns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const cur = btn.getAttribute('data-currency');
+        btns.forEach(b => {
+          b.classList.toggle('active', b === btn);
+          b.setAttribute('aria-selected', b === btn ? 'true' : 'false');
+        });
+        document.querySelectorAll('.price-table-pro td, .price-table-pro th').forEach(c => {
+          c.classList.toggle('price-table-pro__primary', c.getAttribute('data-col') === cur);
+        });
+        const calcCur = $('calc-currency');
+        if(calcCur && calcCur.value !== cur){
+          calcCur.value = cur;
+          updateCalculator();
+        }
+      });
+    });
+    // Set initial highlight — USD default
+    document.querySelectorAll('.price-table-pro td[data-col="USD"], .price-table-pro th[data-col="USD"]').forEach(c => c.classList.add('price-table-pro__primary'));
+  }
+
+  // Sticky mobile bar — show after scroll past hero
+  function bindStickyBar(){
+    const bar = $('stickyPrice');
+    if(!bar) return;
+    let visible = false;
+    window.addEventListener('scroll', () => {
+      const show = window.scrollY > 400;
+      if(show !== visible){
+        bar.classList.toggle('visible', show);
+        visible = show;
+      }
+    }, {passive: true});
+  }
+
+  // Init
+  document.addEventListener('DOMContentLoaded', () => {
+    bindCalculator();
+    bindCurrencySwitch();
+    bindStickyBar();
+  });
+
+  // Boot
+  Promise.all([fetchFx(), fetchSpot()]).catch(e => console.warn('init',e));
+  setInterval(fetchSpot, REFRESH_MS);
+})();
 </script>
+<script>(function(){
+  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
+  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+  root.setAttribute('data-theme',theme);
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);try{localStorage.setItem('gpt-theme',theme);}catch(e){}themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
+  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
+  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
+  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
+  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
+})();</script>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>
 let _deepReadFired = false;


### PR DESCRIPTION
## Summary

Rebuilds `24k-gold-price-per-gram.html` from a legacy 868-line layout into a premium, mobile-first editorial article that mirrors and extends the 22K template. Positioned as **the LBMA benchmark page** for pure (999) gold — the reference price every other karat derives from.

USD is the primary currency in every hero tile, calculator default, sticky bar and editorial snippet; GBP / EUR / INR are computed live from the same single spot fetch.

## What changed

**Hero & status**
- Editorial Playfair Display title with gold-gradient italic emphasis
- 3 live USD/GBP/EUR price tiles (USD marked primary)
- Live status bar with 60s countdown and Calculate CTA
- Trust strip (LBMA / 60s refresh / 4 currencies)

**Live calculator (pure-bullion focus)**
- `PURITY_24K = 0.999`, weight chips: 1g / 5g / 10g / 1oz Britannia / 100g / 1kg / LBMA 400oz
- Melt + dealer (~96%) + retail bullion (~+4%) outputs
- USD / GBP / EUR / INR currency selector

**Data sections**
- 4 stat cards: 99.9% / 999 / ~36,700t reserves / 400 oz
- Live price table 0.5g→1kg × 4 currencies, USD highlighted by default
- 5-card karat comparison (9K/14K/18K/22K/**24K current**)
- Formula block with 3-step explanation
- 3 "Why 24K matters" luxe cards: LBMA Good Delivery / Central Bank Reserves / Britannia & Maple Leaf — each shows a live USD melt value
- 15-bar Central Bank Net Purchases chart (2010–2024, World Gold Council data) replacing the bridal-seasonal chart
- LBMA Assay Office grid + central bank reserves table

**Editorial prose**
- 999 hallmark, LBMA Good Delivery, central bank de-dollarisation, physical vs paper, CGT-exempt Britannia, Gold IRA
- 8-item premium FAQ accordion (matches FAQPage schema)
- Sticky mobile USD price bar with Calculate CTA

**Live data engine (unchanged contract)**
- `https://api.gold-api.com/price/XAU` for LBMA-derived USD/oz
- `https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR` for ECB FX
- 60s refresh, single `_spotUSD` source feeds every UI element
- Same `PURITY_KARATS` map keeps cross-page karat math byte-identical to the 22K/18K/14K/10K/9K pages

## Test plan

- [ ] Run `python3 tools/playwright_audit.py https://goldpricetools.com/24k-gold-price-per-gram` after deploy (per DEVELOPMENT_RULES.md)
- [ ] Verify hero, sticky bar and calculator agree on USD/g (same spot, same purity)
- [ ] Verify karat-comparison cards match live values on each sibling karat page
- [ ] Verify Britannia melt = 1 oz × USD/g; LBMA bar = 400 oz × USD/g
- [ ] Verify currency switcher highlights USD column by default, swaps to GBP/EUR/INR on click
- [ ] Mobile @375px: hero tiles stack, sticky bar visible after scroll, mobile menu opens
- [ ] Dark & light theme parity (toggle persists in `localStorage`)
- [ ] FAQ schema parses (rich-results test)

https://claude.ai/code/session_016xr618d14BppVSsKiZrbYV

---
_Generated by [Claude Code](https://claude.ai/code/session_016xr618d14BppVSsKiZrbYV)_