### PR TITLE
Redesign scrap gold calculator — premium mobile-first UI, USD primary

### DIFF
--- a/scrap-gold-calculator.html
+++ b/scrap-gold-calculator.html
@@ -7,9 +7,9 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Scrap Gold Calculator (Free UK) — Live Melt Value by Karat | GoldPriceTools</title>
+<title>Scrap Gold Calculator — Live USD Melt Value by Karat | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Free scrap gold calculator: enter weight and karat to calculate live melt value in GBP and USD. Supports 9K, 10K, 14K, 18K, 22K & 24K gold. See what your gold is worth today.">
+<meta name="description" content="Free scrap gold calculator: enter weight and karat to calculate live melt value in USD (primary), GBP, EUR & INR. Supports 9K, 10K, 14K, 18K, 22K & 24K gold. See what your gold is worth today.">
 <meta name="robots" content="index, follow">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/scrap-gold-calculator">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/scrap-gold-calculator">
@@ -18,12 +18,12 @@
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Scrap Gold Calculator","item":"https://goldpricetools.com/scrap-gold-calculator"}]}</script>
 <!-- SoftwareApplication JSON-LD (WP-58) -->
 <script type="application/ld+json">
-{"@context": "https://schema.org", "@type": "SoftwareApplication", "name": "GoldPriceTools Scrap Gold Calculator", "url": "https://goldpricetools.com/scrap-gold-calculator", "description": "Free scrap gold calculator. Enter weight and karat to calculate the current melt value of your gold jewellery using live LBMA spot prices. Supports 9K, 10K, 14K, 18K, 22K, and 24K gold.", "applicationCategory": "FinanceApplication", "operatingSystem": "Web Browser", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "GBP"}}
+{"@context": "https://schema.org", "@type": "SoftwareApplication", "name": "GoldPriceTools Scrap Gold Calculator", "url": "https://goldpricetools.com/scrap-gold-calculator", "description": "Free scrap gold calculator. Enter weight and karat to calculate the current melt value of your gold jewellery using live LBMA spot prices in USD (primary), with GBP, EUR and INR conversions. Supports 9K, 10K, 14K, 18K, 22K, and 24K gold.", "applicationCategory": "FinanceApplication", "operatingSystem": "Web Browser", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}
 </script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to Calculate Scrap Gold Value","description":"Calculate the melt value of scrap gold jewellery using the current live gold spot price.","totalTime":"PT2M","tool":[{"@type":"HowToTool","name":"GoldPriceTools Scrap Gold Calculator"},{"@type":"HowToTool","name":"Precision scales (0.01g accuracy)"}],"step":[{"@type":"HowToStep","position":1,"name":"Weigh your gold","text":"Weigh each piece of gold jewellery separately on precision scales. Note the weight in grams. Do not include clasps, stones, or non-gold components."},{"@type":"HowToStep","position":2,"name":"Identify the karat","text":"Check the hallmark stamped on the item: 375=9K, 585=14K, 750=18K, 916=22K, 999=24K. If no hallmark, take to a jeweller for acid or XRF testing."},{"@type":"HowToStep","position":3,"name":"Enter details in the calculator","text":"Enter the weight in grams and select the karat below. Add multiple rows if you have pieces of different karats."},{"@type":"HowToStep","position":4,"name":"Read your live melt value","text":"The calculator shows the current melt value from the live LBMA gold spot price. Dealers typically pay 70-90% of melt value."}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I calculate scrap gold value?","acceptedAnswer":{"@type":"Answer","text":"Weigh your gold in grams, identify the karat from the hallmark (375=9K, 585=14K, 750=18K, 916=22K), then multiply weight \u00d7 purity \u00d7 spot price per gram. Our calculator does this automatically with the live LBMA spot price."}},{"@type":"Question","name":"What percentage of melt value do scrap gold dealers pay?","acceptedAnswer":{"@type":"Answer","text":"UK scrap gold dealers typically pay 70-90% of melt value. Online specialist refiners pay the most (85-92%). High street jewellers typically pay the least (60-75%). Always get at least 3 quotes."}},{"@type":"Question","name":"How do I find the karat of my gold?","acceptedAnswer":{"@type":"Answer","text":"Look for a hallmark stamped on the item: 375 = 9K, 585 = 14K, 750 = 18K, 916 = 22K, 999 = 24K. In the UK, look for Assay Office marks alongside the fineness number."}},{"@type":"Question","name":"What is melt value?","acceptedAnswer":{"@type":"Answer","text":"Melt value (also called scrap value or intrinsic value) is the value of the pure gold content of an item based on the current spot price. It is calculated as: weight (grams) x purity (%) x spot price per gram."}}]}</script>
-<meta property="og:title" content="Scrap Gold Calculator — Live Melt Value">
-<meta property="og:description" content="Free scrap gold calculator. Enter weight and karat to find the live melt value of your gold jewellery in GBP and USD.">
+<meta property="og:title" content="Scrap Gold Calculator — Live USD Melt Value">
+<meta property="og:description" content="Free scrap gold calculator. Enter weight and karat to find the live melt value of your gold jewellery in USD (primary), GBP, EUR and INR.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/scrap-gold-calculator">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
@@ -472,20 +472,187 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .disclaimer-box{margin-top:var(--space-8);padding:var(--space-4);background:var(--color-surface-offset,var(--color-surface));border-radius:var(--radius-md);border-left:3px solid var(--color-border);font-size:var(--text-sm);color:var(--color-text-faint);line-height:1.6}
 .disclaimer-box strong{color:var(--color-text-muted)}
 
-/* ── Scrap Gold Calculator elements ── */
-.calc-card{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:0;min-width:0}
-.calc-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted);margin-bottom:var(--space-2);display:block}
-.calc-input,.calc-select{width:100%;padding:var(--space-2) var(--space-3);font-size:var(--text-base);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);color:var(--color-text);outline:none;transition:border-color .15s,box-shadow .15s;box-sizing:border-box}
-.calc-input:focus,.calc-select:focus{border-color:var(--color-primary);box-shadow:0 0 0 2px color-mix(in oklch,var(--color-primary) 15%,transparent)}
-.calc-del{display:inline-flex;align-items:center;justify-content:center;width:2rem;height:2rem;background:transparent;border:1px solid var(--color-border);border-radius:var(--radius-md);color:var(--color-text-muted);font-size:1rem;cursor:pointer;transition:background .15s,color .15s,border-color .15s;flex-shrink:0;margin-bottom:2px}
-.calc-del:hover{background:var(--color-surface-dynamic);color:var(--color-text);border-color:var(--color-text-muted)}
-.calc-add{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);margin-top:var(--space-2);background:transparent;border:1px dashed var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:500;color:var(--color-primary);cursor:pointer;transition:background .15s,border-color .15s;align-self:flex-start}
-.calc-add:hover{background:color-mix(in oklch,var(--color-primary) 6%,var(--color-surface));border-color:var(--color-primary)}
-.result-box{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);margin-top:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
-.result-label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
-.result-gbp{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.2}
-.result-usd{font-size:var(--text-sm);color:var(--color-text-muted)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr 1fr auto}}
+/* ╔══════════════════════════════════════════════════════════════════╗
+   ║  SCRAP GOLD CALCULATOR — Premium Mobile-First Redesign           ║
+   ║  USD Primary · Liquid-Glass Accents · Performance-First           ║
+   ╚══════════════════════════════════════════════════════════════════╝ */
+
+/* ── Hero shell — mobile-first, expands at md+ ── */
+.scrap-hero{max-width:1200px;margin:0 auto;padding:var(--space-6) var(--space-4) var(--space-4);display:grid;grid-template-columns:1fr;gap:var(--space-5)}
+@media(min-width:900px){.scrap-hero{grid-template-columns:minmax(0,1fr) minmax(0,1.15fr);gap:var(--space-8);padding:var(--space-10) var(--space-4) var(--space-6);align-items:start}}
+.scrap-hero__left{display:flex;flex-direction:column;gap:var(--space-3)}
+.scrap-hero__eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);align-self:flex-start;background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));padding:6px 12px;border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--color-gold-bright)}
+.scrap-hero__eyebrow .live-dot{width:6px;height:6px}
+.scrap-hero__title{font-family:var(--font-display);font-size:clamp(1.875rem,1.2rem + 3vw,3rem);line-height:1.08;color:var(--color-text);letter-spacing:-.02em;margin:0}
+.scrap-hero__title .accent{background:linear-gradient(135deg,var(--color-gold-bright) 0%,#f5cb5c 50%,var(--color-gold-bright) 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;color:var(--color-gold-bright)}
+.scrap-hero__desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.65;max-width:54ch;margin:0}
+/* Live spot tile under hero copy */
+.spot-tile{display:grid;grid-template-columns:1fr auto;gap:var(--space-3) var(--space-4);align-items:center;background:linear-gradient(135deg,var(--color-surface) 0%,var(--color-surface-offset) 100%);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);box-shadow:var(--shadow-sm);margin-top:var(--space-2)}
+.spot-tile__head{display:flex;align-items:center;gap:var(--space-2);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-muted);grid-column:1/-1}
+.spot-tile__head .live-dot{width:7px;height:7px}
+.spot-tile__primary{display:flex;flex-direction:column;gap:2px;min-width:0}
+.spot-tile__label{font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--color-text-faint)}
+.spot-tile__value{font-family:var(--font-display);font-size:clamp(1.5rem,1rem + 2vw,2rem);color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;letter-spacing:-.01em}
+.spot-tile__alts{display:flex;flex-wrap:wrap;gap:6px;justify-content:flex-end;max-width:55%}
+.spot-tile__pill{font-size:11px;font-weight:600;color:var(--color-text-muted);background:var(--color-surface-offset-2);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:4px 10px;font-variant-numeric:tabular-nums;white-space:nowrap}
+.spot-tile__pill strong{color:var(--color-text);font-weight:700;margin-right:4px}
+.spot-tile__refresh{grid-column:1/-1;display:flex;align-items:center;gap:6px;font-size:11px;color:var(--color-text-faint);padding-top:var(--space-3);border-top:1px dashed var(--color-border)}
+.spot-tile__refresh svg{flex-shrink:0;opacity:.7}
+@media(max-width:520px){.spot-tile__alts{max-width:none;justify-content:flex-start;grid-column:1/-1}}
+
+/* ── Calculator card — the centrepiece ── */
+.calc-card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-4);min-width:0;box-shadow:var(--shadow-md);overflow:hidden}
+.calc-card::before{content:"";position:absolute;inset:0;background:radial-gradient(120% 80% at 100% 0%,color-mix(in oklch,var(--color-gold-bright) 8%,transparent) 0%,transparent 60%);pointer-events:none;z-index:0}
+.calc-card>*{position:relative;z-index:1}
+@media(min-width:600px){.calc-card{padding:var(--space-6)}}
+.calc-card__head{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-3);flex-wrap:wrap}
+.calc-card__heading{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:0;line-height:1.2}
+.calc-card__sub{font-size:var(--text-xs);color:var(--color-text-muted);margin:4px 0 0 0;line-height:1.5}
+.calc-card__badge{display:inline-flex;align-items:center;gap:6px;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 24%,var(--color-border));padding:5px 10px;border-radius:var(--radius-full);flex-shrink:0}
+
+/* Step counter — visual flow */
+.calc-step{display:flex;align-items:center;gap:var(--space-2);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-faint)}
+.calc-step__num{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:50%;background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));color:var(--color-gold-bright);font-size:11px;font-weight:700}
+
+/* Calculator row */
+#calc-rows{display:flex;flex-direction:column;gap:var(--space-3)}
+.calc-row{display:grid;grid-template-columns:1fr;gap:var(--space-3);padding:var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);align-items:end;position:relative;transition:border-color .25s,box-shadow .25s}
+.calc-row:focus-within{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 14%,transparent)}
+@media(min-width:520px){.calc-row{grid-template-columns:1.1fr 1fr auto;gap:var(--space-3) var(--space-4);padding:var(--space-4)}}
+
+.calc-field{display:flex;flex-direction:column;gap:6px;min-width:0}
+.calc-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);display:flex;align-items:center;gap:6px}
+
+/* Weight input with grams suffix */
+.calc-weight-wrap{position:relative;display:flex;align-items:stretch}
+.calc-input{width:100%;min-height:48px;padding:var(--space-3) 48px var(--space-3) var(--space-4);font-size:1.0625rem;font-weight:600;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);color:var(--color-text);outline:none;transition:border-color .2s,box-shadow .2s;box-sizing:border-box;font-variant-numeric:tabular-nums;letter-spacing:-.01em;-moz-appearance:textfield}
+.calc-input::-webkit-outer-spin-button,.calc-input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
+.calc-input:focus{border-color:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 14%,transparent)}
+.calc-input::placeholder{color:var(--color-text-faint);font-weight:400}
+.calc-weight-suffix{position:absolute;right:14px;top:50%;transform:translateY(-50%);font-size:13px;font-weight:600;color:var(--color-text-muted);pointer-events:none;background:var(--color-surface-offset-2);padding:3px 8px;border-radius:var(--radius-sm);border:1px solid var(--color-border)}
+
+/* Karat segmented chip picker — replaces dropdown */
+.karat-chips{display:flex;flex-wrap:wrap;gap:6px}
+.karat-chip{flex:1 1 calc(33.333% - 4px);min-width:60px;min-height:44px;display:inline-flex;align-items:center;justify-content:center;gap:4px;padding:8px 6px;font-size:13px;font-weight:700;color:var(--color-text-muted);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);cursor:pointer;transition:background .2s,color .2s,border-color .2s,transform .15s;font-variant-numeric:tabular-nums;-webkit-tap-highlight-color:transparent}
+.karat-chip:hover{color:var(--color-text);border-color:var(--color-text-muted)}
+.karat-chip:active{transform:scale(.97)}
+.karat-chip[aria-checked="true"]{background:linear-gradient(135deg,var(--color-gold-bright) 0%,#d19900 100%);color:#0f0e0c;border-color:var(--color-gold-bright);box-shadow:0 4px 14px color-mix(in oklch,var(--color-gold-bright) 32%,transparent)}
+.karat-chip__purity{font-size:9px;font-weight:600;opacity:.85;letter-spacing:.04em}
+.karat-chip[aria-checked="true"] .karat-chip__purity{opacity:.78}
+.karat-chip:focus-visible{outline:2px solid var(--color-gold-bright);outline-offset:2px}
+
+/* Delete button */
+.calc-del{display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;background:transparent;border:1px solid var(--color-border);border-radius:var(--radius-md);color:var(--color-text-muted);cursor:pointer;transition:background .2s,color .2s,border-color .2s,transform .15s;flex-shrink:0;align-self:end}
+.calc-del:hover{background:color-mix(in oklch,#f87171 8%,var(--color-surface));color:#f87171;border-color:#f87171}
+.calc-del:active{transform:scale(.95)}
+.calc-del svg{display:block}
+
+/* Quick-add weight presets */
+.calc-presets{display:flex;flex-wrap:wrap;gap:6px;padding-top:var(--space-1)}
+.calc-presets-label{width:100%;font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-faint);margin-bottom:2px}
+.calc-preset{min-height:32px;padding:6px 12px;font-size:12px;font-weight:600;color:var(--color-text-muted);background:var(--color-surface-offset-2);border:1px solid var(--color-border);border-radius:var(--radius-full);cursor:pointer;transition:background .2s,color .2s,border-color .2s;-webkit-tap-highlight-color:transparent;font-variant-numeric:tabular-nums}
+.calc-preset:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset-2))}
+.calc-preset:active{transform:scale(.96)}
+
+/* Add row button */
+.calc-add{display:inline-flex;align-items:center;justify-content:center;gap:8px;width:100%;min-height:44px;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px dashed color-mix(in oklch,var(--color-gold-bright) 38%,var(--color-border));border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;color:var(--color-gold-bright);cursor:pointer;transition:background .2s,border-color .2s,transform .15s;-webkit-tap-highlight-color:transparent}
+.calc-add:hover{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border-color:var(--color-gold-bright);border-style:solid}
+.calc-add:active{transform:scale(.99)}
+
+/* Pure gold readout — micro-strip between rows and result */
+.calc-pure{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:13px}
+.calc-pure__label{color:var(--color-text-muted);font-weight:500}
+.calc-pure__value{color:var(--color-text);font-weight:700;font-variant-numeric:tabular-nums}
+
+/* Result box — USD primary */
+.result-box{position:relative;background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset)) 0%,color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface-offset)) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 32%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-3);overflow:hidden}
+.result-box::after{content:"";position:absolute;top:-40%;right:-20%;width:60%;height:160%;background:radial-gradient(closest-side,color-mix(in oklch,var(--color-gold-bright) 22%,transparent) 0%,transparent 70%);filter:blur(28px);pointer-events:none}
+.result-box>*{position:relative;z-index:1}
+.result-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);display:flex;align-items:center;gap:8px}
+.result-label::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);box-shadow:0 0 8px var(--color-gold-bright);animation:pulse 2s ease-in-out infinite}
+.result-usd{font-family:var(--font-display);font-size:clamp(2rem,1.4rem + 3vw,3rem);color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;letter-spacing:-.02em;font-weight:500}
+.result-alts{display:flex;flex-wrap:wrap;gap:6px;margin-top:2px}
+.result-alt{display:inline-flex;align-items:baseline;gap:5px;font-size:13px;background:color-mix(in oklch,var(--color-surface) 60%,transparent);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:5px 11px;font-variant-numeric:tabular-nums;color:var(--color-text)}
+.result-alt strong{color:var(--color-text-muted);font-weight:600;font-size:11px;letter-spacing:.04em}
+
+/* Dealer-payout gauge */
+.payout-gauge{margin-top:var(--space-2);padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.payout-gauge__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2);margin-bottom:var(--space-3);flex-wrap:wrap}
+.payout-gauge__title{font-size:12px;font-weight:700;letter-spacing:.04em;color:var(--color-text);display:flex;align-items:center;gap:6px}
+.payout-gauge__title svg{color:var(--color-gold-bright)}
+.payout-gauge__range{font-size:11px;font-weight:600;color:var(--color-text-muted);font-variant-numeric:tabular-nums}
+.payout-bar{position:relative;height:10px;background:linear-gradient(90deg,#f87171 0%,#facc15 50%,#4ade80 100%);border-radius:var(--radius-full);overflow:hidden;opacity:.85}
+.payout-bar__mark{position:absolute;top:-3px;bottom:-3px;width:2px;background:var(--color-text);border-radius:1px}
+.payout-bar__mark--low{left:70%}
+.payout-bar__mark--high{left:92%}
+.payout-gauge__legend{display:flex;justify-content:space-between;font-size:10px;font-weight:600;color:var(--color-text-faint);margin-top:8px;letter-spacing:.04em;text-transform:uppercase}
+.payout-vals{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);margin-top:var(--space-3)}
+.payout-val{padding:var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md)}
+.payout-val__label{font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-muted);margin-bottom:4px;display:flex;align-items:center;gap:6px}
+.payout-val__low::before,.payout-val__high::before{content:"";display:inline-block;width:8px;height:8px;border-radius:50%}
+.payout-val__low::before{background:#facc15}
+.payout-val__high::before{background:#4ade80}
+.payout-val__amount{font-size:1.125rem;font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+.payout-val__amount-sub{font-size:11px;color:var(--color-text-muted);font-variant-numeric:tabular-nums;margin-top:2px}
+
+/* ── Feature trio — quick value tiles below calculator (mobile + desktop) ── */
+.feat-trio{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-6)}
+@media(min-width:600px){.feat-trio{grid-template-columns:repeat(3,1fr);gap:var(--space-4)}}
+.feat-card{display:flex;align-items:flex-start;gap:var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
+.feat-card__icon{flex-shrink:0;width:36px;height:36px;border-radius:var(--radius-md);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));color:var(--color-gold-bright);display:flex;align-items:center;justify-content:center;border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border))}
+.feat-card__title{font-size:13px;font-weight:700;color:var(--color-text);margin:0 0 2px;letter-spacing:-.01em}
+.feat-card__desc{font-size:12px;color:var(--color-text-muted);line-height:1.55;margin:0}
+
+/* ── Karat reference grid — USD primary ── */
+.karat-ref{margin:var(--space-10) 0 var(--space-8)}
+.karat-ref__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);margin-bottom:var(--space-5);flex-wrap:wrap}
+.karat-ref__title{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:0;letter-spacing:-.02em}
+.karat-ref__caption{font-size:13px;color:var(--color-text-muted);margin:6px 0 0;line-height:1.55;max-width:60ch}
+.karat-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:560px){.karat-grid{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:900px){.karat-grid{grid-template-columns:repeat(3,1fr);gap:var(--space-4)}}
+.karat-cell{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);transition:border-color .25s,transform .25s,box-shadow .25s;overflow:hidden}
+.karat-cell:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 38%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.karat-cell::after{content:"";position:absolute;top:0;right:0;width:80px;height:80px;background:radial-gradient(closest-side,color-mix(in oklch,var(--color-gold-bright) 14%,transparent) 0%,transparent 70%);pointer-events:none}
+.karat-cell__head{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-3)}
+.karat-cell__karat{font-family:var(--font-display);font-size:1.5rem;font-weight:600;color:var(--color-text);line-height:1;letter-spacing:-.02em}
+.karat-cell__hall{font-size:10px;font-weight:700;letter-spacing:.1em;color:var(--color-gold-bright);text-transform:uppercase;background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 26%,var(--color-border));border-radius:var(--radius-full);padding:3px 8px}
+.karat-cell__purity{font-size:11px;font-weight:600;color:var(--color-text-muted);margin-bottom:var(--space-2);letter-spacing:.04em}
+.karat-cell__price-usd{font-size:1.375rem;font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.01em;line-height:1.2}
+.karat-cell__price-sub{font-size:11px;color:var(--color-text-muted);margin-top:2px;font-variant-numeric:tabular-nums}
+.karat-cell__per{font-size:10px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--color-text-faint);margin-top:6px}
+
+/* ── Mobile sticky CTA strip ── */
+.mobile-sticky{position:fixed;left:8px;right:8px;bottom:8px;z-index:90;display:none;align-items:center;justify-content:space-between;gap:var(--space-3);background:color-mix(in oklch,var(--color-surface) 92%,transparent);backdrop-filter:blur(14px) saturate(140%);-webkit-backdrop-filter:blur(14px) saturate(140%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));border-radius:var(--radius-xl);padding:10px 14px;box-shadow:0 12px 32px oklch(0 0 0/0.35)}
+.mobile-sticky__left{display:flex;flex-direction:column;min-width:0}
+.mobile-sticky__label{font-size:9px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--color-text-muted)}
+.mobile-sticky__val{font-family:var(--font-display);font-size:1.125rem;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;margin-top:2px}
+.mobile-sticky__btn{display:inline-flex;align-items:center;gap:6px;background:linear-gradient(135deg,var(--color-gold-bright),#d19900);color:#0f0e0c;font-size:13px;font-weight:700;padding:10px 14px;border-radius:var(--radius-full);text-decoration:none;white-space:nowrap;border:none;cursor:pointer;transition:transform .15s,box-shadow .25s;min-height:40px}
+.mobile-sticky__btn:hover{transform:translateY(-1px);box-shadow:0 6px 18px color-mix(in oklch,var(--color-gold-bright) 38%,transparent)}
+@media(max-width:768px){.mobile-sticky.is-visible{display:flex}}
+
+/* ── Trust strip refinement (uses .data-source from base) ── */
+.data-source{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;font-size:13px;line-height:1.5}
+.data-source__pulse{display:inline-flex;align-items:center;gap:6px;font-weight:600;color:var(--color-text)}
+.data-source__pulse .live-dot{width:7px;height:7px}
+.data-source__sep{color:var(--color-text-faint)}
+.data-source__updated{color:var(--color-text-muted);font-variant-numeric:tabular-nums}
+
+/* ── Prose H2 accent — gold underline ── */
+.prose h2{position:relative;padding-bottom:var(--space-2);border-bottom:1px solid var(--color-divider)}
+.prose h2::after{content:"";position:absolute;left:0;bottom:-1px;width:48px;height:2px;background:linear-gradient(90deg,var(--color-gold-bright),transparent);border-radius:1px}
+
+/* ── Tighter mobile content padding ── */
+@media(max-width:600px){
+  .content{padding:0 var(--space-3) var(--space-12)}
+  .scrap-hero{padding:var(--space-4) var(--space-3) var(--space-3)}
+}
+
+/* ── Reduced motion respect ── */
+@media(prefers-reduced-motion:reduce){
+  .result-label::before{animation:none}
+  .karat-cell:hover{transform:none}
+}
 </style>
 
 <script type="application/ld+json">
@@ -585,24 +752,145 @@ function fireCalcEngaged() {
   </div>
 </nav>
 <div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">Scrap Gold Calculator</li></ol></div>
-<div class="hero">
-  <div class="hero-left">
-<div class="hero-tag">Free Calculator</div>
-  <h1 class="hero-title">Scrap Gold Calculator</h1>
-  <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Find out what your scrap gold jewellery is worth today. Enter weight and karat &mdash; live melt value is calculated instantly.</p>
-    </div>
-  <div class="calc-card">
-    <div id="calc-rows">
-      <!-- STATIC-FIRST: Calculator karat options pre-rendered for SEO; values are JS-updated by design -->
-      <div class="calc-row" data-row="0">
-        <div><div class="calc-label">Weight (grams)</div><input class="calc-input" type="number" min="0" step="0.01" placeholder="e.g. 5.5" id="w-0" oninput="fireCalcEngaged(); calc()"></div>
-        <div><div class="calc-label">Karat</div><select class="calc-select" id="k-0" onchange="fireCalcEngaged(); calc()"><option value="0.999">24K (99.9%)</option><option value="0.9167">22K (91.67%)</option><option value="0.75">18K (75%)</option><option value="0.5833" selected>14K (58.33%)</option><option value="0.4167">10K (41.67%)</option><option value="0.375">9K (37.5%)</option></select></div>
-        <button class="calc-del" onclick="delRow(0)" aria-label="Remove row">&times;</button>
+
+<section class="scrap-hero" aria-labelledby="scrap-h1">
+  <div class="scrap-hero__left">
+    <span class="scrap-hero__eyebrow"><span class="live-dot" aria-hidden="true"></span> Free · Live LBMA Spot</span>
+    <h1 class="scrap-hero__title" id="scrap-h1">Scrap Gold Calculator <span class="accent">Live Melt Value</span></h1>
+    <p class="scrap-hero__desc">Find out what your scrap gold jewellery is worth in seconds. Enter weight and karat &mdash; the live melt value is calculated instantly in <strong style="color:var(--color-text)">USD</strong> with GBP, EUR &amp; INR conversions.</p>
+
+    <!-- Live spot tile (USD primary) -->
+    <div class="spot-tile" role="region" aria-label="Live gold spot price">
+      <div class="spot-tile__head"><span class="live-dot" aria-hidden="true"></span> Live Gold Spot · LBMA</div>
+      <div class="spot-tile__primary">
+        <span class="spot-tile__label">USD per Troy Ounce</span>
+        <span class="spot-tile__value" id="spot-usd" data-nosnippet>—</span>
+      </div>
+      <div class="spot-tile__alts" aria-label="Spot price in other currencies">
+        <span class="spot-tile__pill"><strong>GBP</strong><span id="spot-gbp">—</span></span>
+        <span class="spot-tile__pill"><strong>EUR</strong><span id="spot-eur">—</span></span>
+        <span class="spot-tile__pill"><strong>INR</strong><span id="spot-inr">—</span></span>
+      </div>
+      <div class="spot-tile__refresh">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12a9 9 0 0 1 15.5-6.4L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15.5 6.4L3 16"/><path d="M3 21v-5h5"/></svg>
+        <span>Updates every 60s · <span id="updated-stamp">just now</span></span>
       </div>
     </div>
-    <button class="calc-add" onclick="addRow()">+ Add another item</button>
-    <div class="result-box"><div class="result-label">Total Melt Value</div><div class="result-gbp" id="res-gbp" data-nosnippet>&mdash;</div><div class="result-usd" id="res-usd" data-nosnippet></div></div>
   </div>
+
+  <div class="calc-card" aria-labelledby="calc-heading">
+    <div class="calc-card__head">
+      <div>
+        <h2 class="calc-card__heading" id="calc-heading">Calculate your gold</h2>
+        <p class="calc-card__sub">Add as many items as you need — totals refresh live.</p>
+      </div>
+      <span class="calc-card__badge"><svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="6"/></svg> USD Primary</span>
+    </div>
+
+    <div class="calc-step"><span class="calc-step__num">1</span> Weight &amp; karat</div>
+
+    <div id="calc-rows" role="group" aria-label="Gold item rows">
+      <!-- STATIC-FIRST: First row pre-rendered for SEO; karat is a segmented chip group -->
+      <div class="calc-row" data-row="0">
+        <div class="calc-field">
+          <label class="calc-label" for="w-0">Weight</label>
+          <div class="calc-weight-wrap">
+            <input class="calc-input" type="number" inputmode="decimal" min="0" step="0.01" placeholder="0.00" id="w-0" aria-label="Weight in grams" oninput="fireCalcEngaged(); calc()">
+            <span class="calc-weight-suffix" aria-hidden="true">g</span>
+          </div>
+        </div>
+        <div class="calc-field">
+          <span class="calc-label" id="k-label-0">Karat</span>
+          <div class="karat-chips" role="radiogroup" aria-labelledby="k-label-0" data-karat-group="0">
+            <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.375">9K<span class="karat-chip__purity">·375</span></button>
+            <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.4167">10K<span class="karat-chip__purity">·417</span></button>
+            <button type="button" class="karat-chip" role="radio" aria-checked="true" data-purity="0.5833">14K<span class="karat-chip__purity">·585</span></button>
+            <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.75">18K<span class="karat-chip__purity">·750</span></button>
+            <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.9167">22K<span class="karat-chip__purity">·916</span></button>
+            <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.999">24K<span class="karat-chip__purity">·999</span></button>
+          </div>
+        </div>
+        <button class="calc-del" onclick="delRow(0)" aria-label="Remove this item">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- Quick presets -->
+    <div class="calc-presets" role="group" aria-label="Quick weight presets">
+      <span class="calc-presets-label">Quick presets</span>
+      <button type="button" class="calc-preset" data-preset="1">1g</button>
+      <button type="button" class="calc-preset" data-preset="3.5">3.5g ring</button>
+      <button type="button" class="calc-preset" data-preset="7">7g chain</button>
+      <button type="button" class="calc-preset" data-preset="15">15g</button>
+      <button type="button" class="calc-preset" data-preset="31.1035">1 oz</button>
+      <button type="button" class="calc-preset" data-preset="100">100g</button>
+    </div>
+
+    <button type="button" class="calc-add" onclick="addRow()" aria-label="Add another gold item">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+      Add another item
+    </button>
+
+    <!-- Pure gold content readout -->
+    <div class="calc-pure" aria-live="polite">
+      <span class="calc-pure__label">Pure gold content</span>
+      <span class="calc-pure__value" id="pure-grams">—</span>
+    </div>
+
+    <div class="calc-step"><span class="calc-step__num">2</span> Your melt value</div>
+
+    <!-- Result box — USD primary -->
+    <div class="result-box" role="status" aria-live="polite">
+      <span class="result-label">Total Melt Value (USD primary)</span>
+      <span class="result-usd" id="res-usd" data-nosnippet>—</span>
+      <div class="result-alts">
+        <span class="result-alt"><strong>GBP</strong><span id="res-gbp">—</span></span>
+        <span class="result-alt"><strong>EUR</strong><span id="res-eur">—</span></span>
+        <span class="result-alt"><strong>INR</strong><span id="res-inr">—</span></span>
+      </div>
+    </div>
+
+    <!-- Dealer payout gauge -->
+    <div class="payout-gauge" aria-label="Dealer payout estimate">
+      <div class="payout-gauge__head">
+        <span class="payout-gauge__title">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 1v22"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+          What dealers typically pay
+        </span>
+        <span class="payout-gauge__range">70% – 92% of melt</span>
+      </div>
+      <div class="payout-bar" aria-hidden="true">
+        <span class="payout-bar__mark payout-bar__mark--low" title="70%"></span>
+        <span class="payout-bar__mark payout-bar__mark--high" title="92%"></span>
+      </div>
+      <div class="payout-gauge__legend"><span>Pawnbroker</span><span>High street</span><span>Refiner</span></div>
+      <div class="payout-vals">
+        <div class="payout-val">
+          <div class="payout-val__label payout-val__low">Low quote (70%)</div>
+          <div class="payout-val__amount" id="payout-low-usd">—</div>
+          <div class="payout-val__amount-sub" id="payout-low-gbp">—</div>
+        </div>
+        <div class="payout-val">
+          <div class="payout-val__label payout-val__high">Best quote (92%)</div>
+          <div class="payout-val__amount" id="payout-high-usd">—</div>
+          <div class="payout-val__amount-sub" id="payout-high-gbp">—</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Mobile sticky CTA — shows live total + quick scroll to dealer guidance -->
+<div class="mobile-sticky" id="mobile-sticky" aria-hidden="true">
+  <div class="mobile-sticky__left">
+    <span class="mobile-sticky__label">Live melt total</span>
+    <span class="mobile-sticky__val" id="sticky-usd">—</span>
+  </div>
+  <a href="/where-to-sell-gold-silver" class="mobile-sticky__btn" onclick="fireScrapIntent()">
+    Where to sell
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M13 5l7 7-7 7"/></svg>
+  </a>
 </div>
 
 
@@ -611,7 +899,47 @@ function fireCalcEngaged() {
 
 
 <div class="content">
-<p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
+
+<!-- Feature trio — quick value tiles -->
+<div class="feat-trio">
+  <div class="feat-card">
+    <span class="feat-card__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9 12l2 2 4-4"/></svg>
+    </span>
+    <div>
+      <h3 class="feat-card__title">USD-primary, multi-currency</h3>
+      <p class="feat-card__desc">Live USD melt value with GBP, EUR &amp; INR conversions at ECB reference rates.</p>
+    </div>
+  </div>
+  <div class="feat-card">
+    <span class="feat-card__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></svg>
+    </span>
+    <div>
+      <h3 class="feat-card__title">Refreshes every 60s</h3>
+      <p class="feat-card__desc">Spot prices straight from the LBMA via gold-api.com. No stale quotes.</p>
+    </div>
+  </div>
+  <div class="feat-card">
+    <span class="feat-card__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s-8-4.5-8-12V5l8-3 8 3v5c0 7.5-8 12-8 12z"/></svg>
+    </span>
+    <div>
+      <h3 class="feat-card__title">9K → 24K supported</h3>
+      <p class="feat-card__desc">Every common hallmark — 375, 417, 585, 750, 916 &amp; 999. One-tap karat select.</p>
+    </div>
+  </div>
+</div>
+
+<p class="data-source" style="margin-top:var(--space-6)">
+  <span class="data-source__pulse"><span class="live-dot" aria-hidden="true"></span> Live data</span>
+  <span class="data-source__sep">·</span>
+  <span>LBMA spot via <a href="https://www.gold-api.com" rel="noopener" target="_blank">gold-api.com</a> · FX from <a href="https://www.frankfurter.dev" rel="noopener" target="_blank">Frankfurter API</a> (ECB)</span>
+  <span class="data-source__sep">·</span>
+  <span class="data-source__updated">Last update <time id="last-update">—</time></span>
+  <span class="data-source__sep">·</span>
+  <a href="/about">About our data</a>
+</p>
 
 <article class="prose">
 
@@ -620,60 +948,68 @@ function fireCalcEngaged() {
     <li><strong>Enter the weight in grams.</strong> Use a digital jewellery scale for accuracy — even small errors in weight significantly affect the melt value. Kitchen scales are not precise enough for gold weighing.</li>
     <li><strong>Select the karat purity.</strong> Check your jewellery for a hallmark stamp (e.g. 375 = 9K, 585 = 14K, 750 = 18K, 916 = 22K, 999 = 24K). If there is no stamp, a testing kit or acid test can confirm purity.</li>
     <li><strong>Add multiple items.</strong> Use the &ldquo;+ Add another item&rdquo; button to calculate the combined melt value of several pieces at once.</li>
-    <li><strong>Read the live melt value.</strong> The result shown is the theoretical melt value in GBP and USD, calculated from the current LBMA spot price. Dealers will offer a percentage of this figure.</li>
+    <li><strong>Read the live melt value.</strong> The result is shown in USD (primary) with live GBP, EUR and INR conversions at ECB reference rates, calculated from the current LBMA spot price. Dealers will offer a percentage of this figure.</li>
   </ol>
 
   <h2>Scrap Gold Melt Value Formula</h2>
-  <p>The melt value of any gold item is calculated using three inputs: the weight in grams, the gold purity as a decimal, and the live spot price per gram of pure 24K gold.</p>
-  <p><strong>Melt Value = Weight (g) &times; Purity (decimal) &times; Spot Price (per gram of 24K gold)</strong></p>
-  <p>For example, a 10g gold ring hallmarked 750 (18K) with a live 24K spot price of £107/g is worth:</p>
-  <p>10 &times; 0.75 &times; £107 = <strong>£802.50 melt value</strong></p>
+  <p>The melt value of any gold item is calculated using three inputs: the weight in grams, the gold purity as a decimal, and the live spot price per gram of pure 24K gold. USD is used as the global benchmark — GBP, EUR and INR figures are derived using live ECB reference rates.</p>
+  <p><strong>Melt Value (USD) = Weight (g) &times; Purity (decimal) &times; Spot Price per gram of 24K gold (USD)</strong></p>
+  <p>For example, a 10g gold ring hallmarked 750 (18K) at a live spot of $3,300 per troy ounce (about $106.10 per gram of 24K) is worth:</p>
+  <p>10 &times; 0.75 &times; $106.10 = <strong>$795.75 USD melt value</strong> (roughly £628 / €730 at typical ECB rates).</p>
   <p>This is the maximum theoretical value of the pure gold content. Dealers will typically offer between 70% and 92% of this figure depending on their margin and overhead.</p>
 
-  <h2>Current Scrap Gold Prices by Karat</h2>
-  <p>The table below shows today&rsquo;s indicative scrap gold melt value per gram for each karat, updated live from the LBMA spot price.</p>
-  <div class="data-table-wrap">
-    <table class="data-table">
-      <thead>
-        <tr>
-          <th>Karat</th>
-          <th>Hallmark</th>
-          <th>Purity</th>
-          <th>GBP/gram (live)</th>
-          <th>USD/gram (live)</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr><td>24K</td><td>999</td><td>99.9%</td><td id="s24-gbp">--</td><td id="s24-usd">--</td></tr>
-        <tr><td>22K</td><td>916</td><td>91.67%</td><td id="s22-gbp">--</td><td id="s22-usd">--</td></tr>
-        <tr><td>18K</td><td>750</td><td>75.0%</td><td id="s18-gbp">--</td><td id="s18-usd">--</td></tr>
-        <tr><td>14K</td><td>585</td><td>58.33%</td><td id="s14-gbp">--</td><td id="s14-usd">--</td></tr>
-        <tr><td>10K</td><td>417</td><td>41.67%</td><td id="s10-gbp">--</td><td id="s10-usd">--</td></tr>
-        <tr><td>9K</td><td>375</td><td>37.5%</td><td id="s9-gbp">--</td><td id="s9-usd">--</td></tr>
-      </tbody>
-    </table>
-  </div>
-  <script>
-  (function(){
-    function fillScrapTable(){
-      if(!window._spot||!window._gbpusd) return;
-      var usd24=window._spot/31.1035;
-      var gbp24=usd24*window._gbpusd;
-      var karats=[{k:'24',p:0.999},{k:'22',p:0.9167},{k:'18',p:0.75},{k:'14',p:0.5833},{k:'10',p:0.4167},{k:'9',p:0.375}];
-      karats.forEach(function(item){
-        var eg=document.getElementById('s'+item.k+'-gbp');
-        var eu=document.getElementById('s'+item.k+'-usd');
-        if(eg) eg.textContent='£'+(gbp24*item.p).toFixed(2);
-        if(eu) eu.textContent='$'+(usd24*item.p).toFixed(2);
-      });
-    }
-    function tryFill(){
-      if(window._spot&&window._gbpusd){ fillScrapTable(); } else { setTimeout(tryFill, 600); }
-    }
-    tryFill();
-    window.addEventListener('goldprice_updated', fillScrapTable);
-  })();
-  </script>
+  <section class="karat-ref" aria-labelledby="karat-ref-title">
+    <div class="karat-ref__head">
+      <div>
+        <h2 id="karat-ref-title" style="margin:0;border-bottom:none;padding-bottom:0">Current Scrap Gold Prices by Karat</h2>
+        <p class="karat-ref__caption">Live USD melt value per gram for each karat, with GBP &amp; EUR conversion. Refreshed from the LBMA spot price every 60 seconds.</p>
+      </div>
+    </div>
+    <div class="karat-grid" role="list">
+      <div class="karat-cell" role="listitem">
+        <div class="karat-cell__head"><span class="karat-cell__karat">24K</span><span class="karat-cell__hall">999</span></div>
+        <div class="karat-cell__purity">99.9% pure · investment grade</div>
+        <div class="karat-cell__price-usd" id="s24-usd">—</div>
+        <div class="karat-cell__price-sub"><span id="s24-gbp">—</span> · <span id="s24-eur">—</span></div>
+        <div class="karat-cell__per">USD / gram</div>
+      </div>
+      <div class="karat-cell" role="listitem">
+        <div class="karat-cell__head"><span class="karat-cell__karat">22K</span><span class="karat-cell__hall">916</span></div>
+        <div class="karat-cell__purity">91.67% pure · Asian jewellery</div>
+        <div class="karat-cell__price-usd" id="s22-usd">—</div>
+        <div class="karat-cell__price-sub"><span id="s22-gbp">—</span> · <span id="s22-eur">—</span></div>
+        <div class="karat-cell__per">USD / gram</div>
+      </div>
+      <div class="karat-cell" role="listitem">
+        <div class="karat-cell__head"><span class="karat-cell__karat">18K</span><span class="karat-cell__hall">750</span></div>
+        <div class="karat-cell__purity">75% pure · fine jewellery</div>
+        <div class="karat-cell__price-usd" id="s18-usd">—</div>
+        <div class="karat-cell__price-sub"><span id="s18-gbp">—</span> · <span id="s18-eur">—</span></div>
+        <div class="karat-cell__per">USD / gram</div>
+      </div>
+      <div class="karat-cell" role="listitem">
+        <div class="karat-cell__head"><span class="karat-cell__karat">14K</span><span class="karat-cell__hall">585</span></div>
+        <div class="karat-cell__purity">58.33% pure · US/EU jewellery</div>
+        <div class="karat-cell__price-usd" id="s14-usd">—</div>
+        <div class="karat-cell__price-sub"><span id="s14-gbp">—</span> · <span id="s14-eur">—</span></div>
+        <div class="karat-cell__per">USD / gram</div>
+      </div>
+      <div class="karat-cell" role="listitem">
+        <div class="karat-cell__head"><span class="karat-cell__karat">10K</span><span class="karat-cell__hall">417</span></div>
+        <div class="karat-cell__purity">41.67% pure · US standard</div>
+        <div class="karat-cell__price-usd" id="s10-usd">—</div>
+        <div class="karat-cell__price-sub"><span id="s10-gbp">—</span> · <span id="s10-eur">—</span></div>
+        <div class="karat-cell__per">USD / gram</div>
+      </div>
+      <div class="karat-cell" role="listitem">
+        <div class="karat-cell__head"><span class="karat-cell__karat">9K</span><span class="karat-cell__hall">375</span></div>
+        <div class="karat-cell__purity">37.5% pure · UK everyday</div>
+        <div class="karat-cell__price-usd" id="s9-usd">—</div>
+        <div class="karat-cell__price-sub"><span id="s9-gbp">—</span> · <span id="s9-eur">—</span></div>
+        <div class="karat-cell__per">USD / gram</div>
+      </div>
+    </div>
+  </section>
 
   <h2>What Is Scrap Gold?</h2>
   <p>Scrap gold refers to any gold item sold purely for its metal content rather than its design or craftsmanship. Common scrap gold includes broken jewellery, old rings and chains, gold coins sold at melt value, dental gold, and gold that is out of fashion or damaged beyond repair.</p>
@@ -717,7 +1053,7 @@ function fireCalcEngaged() {
       <h3 itemprop="name">How do I calculate scrap gold value?</h3>
       <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
         <div itemprop="text">
-          <p>Multiply the weight in grams by the gold purity as a decimal, then multiply by the current 24K spot price per gram. For example, 5g of 18K gold = 5 &times; 0.75 &times; £107 = £401.25. Our calculator does this automatically using live LBMA prices.</p>
+          <p>Multiply the weight in grams by the gold purity as a decimal, then multiply by the current 24K spot price per gram (USD). For example, 5g of 18K gold at $106.10/g 24K = 5 &times; 0.75 &times; $106.10 = <strong>$397.88 USD melt value</strong>. Our calculator does this automatically using live LBMA prices and converts to GBP, EUR and INR with live ECB rates.</p>
         </div>
       </div>
     </div>
@@ -882,88 +1218,289 @@ function fireCalcEngaged() {
   </div>
   <div class="footer-bottom">
     <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
-    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com. USD primary.</span>
   </div>
 </footer>
 <script>
+/* ╔═══════════════════════════════════════════════════════════════════╗
+   ║ Scrap Gold Calculator — USD-primary engine                        ║
+   ║ Sources: LBMA spot via gold-api.com · FX via frankfurter.dev (ECB)║
+   ║ Refresh: 60s · Formulas mirror karat-page implementations         ║
+   ╚═══════════════════════════════════════════════════════════════════╝ */
+(function(){
+  'use strict';
 
+  const G_PER_OZ = 31.1035;
+  const REFRESH_MS = 60000;
 
+  // Shared global state — keep window._spot for back-compat with goldprice_updated listeners
+  window._spotUSD = null;
+  window._spot    = null;       // alias retained for legacy listeners
+  window._gbpusd  = 0.79;
+  window._eurusd  = 0.92;
+  window._usdinr  = 83.5;
+  let rowCount = 1;
+  let lastFetchTs = 0;
 
+  // Formatters
+  const fmtUSD = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
+  const fmtUSD0 = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:0});
+  const fmtGBP = new Intl.NumberFormat('en-GB',{style:'currency',currency:'GBP',maximumFractionDigits:2});
+  const fmtEUR = new Intl.NumberFormat('en-IE',{style:'currency',currency:'EUR',maximumFractionDigits:2});
+  const fmtINR = new Intl.NumberFormat('en-IN',{style:'currency',currency:'INR',maximumFractionDigits:0});
+  const fmtGram = new Intl.NumberFormat('en-US',{maximumFractionDigits:3,minimumFractionDigits:2});
 
-let rowCount = 1;
-window._spot = null;
-window._gbpusd = 0.79;
+  function $(id){return document.getElementById(id);}
 
-function calc() {
-  if (!window._spot) {
-    document.getElementById('res-gbp').textContent = 'Loading…';
-    document.getElementById('res-usd').textContent = '';
-    return;
+  // ── Karat chip selection (per row, radiogroup semantics) ──
+  function bindKaratChips(group){
+    if(group.dataset.bound) return;
+    group.dataset.bound = '1';
+    const chips = group.querySelectorAll('.karat-chip');
+    chips.forEach(chip => {
+      chip.addEventListener('click', () => {
+        chips.forEach(c => c.setAttribute('aria-checked','false'));
+        chip.setAttribute('aria-checked','true');
+        if(typeof fireCalcEngaged === 'function') fireCalcEngaged();
+        calc();
+      });
+      chip.addEventListener('keydown', (e) => {
+        const keys = ['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'];
+        if(!keys.includes(e.key)) return;
+        e.preventDefault();
+        const arr = Array.from(chips);
+        const idx = arr.indexOf(chip);
+        const dir = (e.key==='ArrowRight'||e.key==='ArrowDown') ? 1 : -1;
+        const next = arr[(idx + dir + arr.length) % arr.length];
+        next.focus();
+        next.click();
+      });
+    });
   }
-  let totalUSD = 0;
-  let inputsFilled = 0;
-  for (let i = 0; i < rowCount; i++) {
-    const w = document.getElementById('w-' + i);
-    const k = document.getElementById('k-' + i);
-    if (w && k) {
+
+  function getRowPurity(rowIdx){
+    const group = document.querySelector('[data-karat-group="'+rowIdx+'"]');
+    if(!group) return 0;
+    const selected = group.querySelector('.karat-chip[aria-checked="true"]');
+    return selected ? parseFloat(selected.dataset.purity) : 0;
+  }
+
+  // ── Core calculation ──
+  function calc(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD){
+      $('res-usd').textContent = 'Loading…';
+      $('res-gbp').textContent = '—';
+      $('res-eur').textContent = '—';
+      $('res-inr').textContent = '—';
+      $('pure-grams').textContent = '—';
+      return;
+    }
+    const usdPerGram24 = spotUSD / G_PER_OZ;
+    let totalUSD = 0;
+    let totalPure = 0;
+    let inputsFilled = 0;
+    for(let i=0;i<rowCount;i++){
+      const w = $('w-'+i);
+      if(!w) continue;
       const wv = parseFloat(w.value) || 0;
-      const kv = parseFloat(k.value) || 0;
-      totalUSD += wv * kv * (window._spot / 31.1035);
-      if (wv > 0) inputsFilled++;
+      const kv = getRowPurity(i);
+      if(wv > 0){
+        inputsFilled++;
+        totalPure += wv * kv;
+        totalUSD  += wv * kv * usdPerGram24;
+      }
+    }
+    const totalGBP = totalUSD * window._gbpusd;
+    const totalEUR = totalUSD * window._eurusd;
+    const totalINR = totalUSD * window._usdinr;
+
+    // Main result — USD primary
+    $('res-usd').textContent = totalUSD > 0 ? fmtUSD.format(totalUSD) : fmtUSD.format(0);
+    $('res-gbp').textContent = fmtGBP.format(totalGBP);
+    $('res-eur').textContent = fmtEUR.format(totalEUR);
+    $('res-inr').textContent = fmtINR.format(totalINR);
+
+    // Pure gold content readout
+    $('pure-grams').textContent = totalPure > 0
+      ? fmtGram.format(totalPure) + ' g of pure 24K equivalent'
+      : '— enter weight to see';
+
+    // Dealer payout gauge
+    const lowUSD  = totalUSD * 0.70;
+    const highUSD = totalUSD * 0.92;
+    $('payout-low-usd').textContent  = fmtUSD.format(lowUSD);
+    $('payout-high-usd').textContent = fmtUSD.format(highUSD);
+    $('payout-low-gbp').textContent  = fmtGBP.format(lowUSD * window._gbpusd);
+    $('payout-high-gbp').textContent = fmtGBP.format(highUSD * window._gbpusd);
+
+    // Sticky mobile bar
+    const sticky = $('sticky-usd');
+    const stickyBar = $('mobile-sticky');
+    if(sticky) sticky.textContent = fmtUSD.format(totalUSD);
+    if(stickyBar) stickyBar.classList.toggle('is-visible', totalUSD > 0);
+
+    // Analytics
+    if(inputsFilled >= 1 && typeof fireCalcEngaged === 'function') fireCalcEngaged();
+    if(inputsFilled >= 3 && typeof fireScrapIntent === 'function') fireScrapIntent();
+    if(typeof gtag !== 'undefined') gtag('event','scrap_calculator_used',{value: Math.round(totalUSD)});
+  }
+  window.calc = calc;
+
+  // ── Karat reference grid fill (USD primary) ──
+  function fillKaratGrid(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD) return;
+    const usdPerGram24 = spotUSD / G_PER_OZ;
+    const gbpFactor = window._gbpusd;
+    const eurFactor = window._eurusd;
+    const karats = [
+      {k:'24', p:0.999},
+      {k:'22', p:0.9167},
+      {k:'18', p:0.75},
+      {k:'14', p:0.5833},
+      {k:'10', p:0.4167},
+      {k:'9',  p:0.375}
+    ];
+    karats.forEach(({k,p}) => {
+      const pUSD = usdPerGram24 * p;
+      const usdEl = $('s'+k+'-usd');
+      const gbpEl = $('s'+k+'-gbp');
+      const eurEl = $('s'+k+'-eur');
+      if(usdEl) usdEl.textContent = fmtUSD.format(pUSD);
+      if(gbpEl) gbpEl.textContent = fmtGBP.format(pUSD * gbpFactor);
+      if(eurEl) eurEl.textContent = fmtEUR.format(pUSD * eurFactor);
+    });
+  }
+
+  // ── Live spot tile fill ──
+  function fillSpotTile(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD) return;
+    const u = $('spot-usd'); if(u) u.textContent = fmtUSD.format(spotUSD);
+    const g = $('spot-gbp'); if(g) g.textContent = fmtGBP.format(spotUSD * window._gbpusd);
+    const e = $('spot-eur'); if(e) e.textContent = fmtEUR.format(spotUSD * window._eurusd);
+    const n = $('spot-inr'); if(n) n.textContent = fmtINR.format(spotUSD * window._usdinr);
+  }
+
+  // ── Updated stamp ──
+  function refreshUpdatedStamp(){
+    if(!lastFetchTs) return;
+    const secs = Math.floor((Date.now() - lastFetchTs)/1000);
+    const stamp = $('updated-stamp');
+    const last = $('last-update');
+    const txt = secs < 5 ? 'just now'
+              : secs < 60 ? secs + 's ago'
+              : Math.floor(secs/60) + 'm ago';
+    if(stamp) stamp.textContent = txt;
+    if(last)  last.textContent  = txt;
+  }
+  setInterval(refreshUpdatedStamp, 1000);
+
+  // ── Row add/remove ──
+  function addRow(){
+    const id = rowCount++;
+    const row = document.createElement('div');
+    row.className = 'calc-row';
+    row.dataset.row = id;
+    row.innerHTML = `
+      <div class="calc-field">
+        <label class="calc-label" for="w-${id}">Weight</label>
+        <div class="calc-weight-wrap">
+          <input class="calc-input" type="number" inputmode="decimal" min="0" step="0.01" placeholder="0.00" id="w-${id}" aria-label="Weight in grams" oninput="calc()">
+          <span class="calc-weight-suffix" aria-hidden="true">g</span>
+        </div>
+      </div>
+      <div class="calc-field">
+        <span class="calc-label" id="k-label-${id}">Karat</span>
+        <div class="karat-chips" role="radiogroup" aria-labelledby="k-label-${id}" data-karat-group="${id}">
+          <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.375">9K<span class="karat-chip__purity">·375</span></button>
+          <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.4167">10K<span class="karat-chip__purity">·417</span></button>
+          <button type="button" class="karat-chip" role="radio" aria-checked="true" data-purity="0.5833">14K<span class="karat-chip__purity">·585</span></button>
+          <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.75">18K<span class="karat-chip__purity">·750</span></button>
+          <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.9167">22K<span class="karat-chip__purity">·916</span></button>
+          <button type="button" class="karat-chip" role="radio" aria-checked="false" data-purity="0.999">24K<span class="karat-chip__purity">·999</span></button>
+        </div>
+      </div>
+      <button class="calc-del" onclick="delRow(${id})" aria-label="Remove this item">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
+      </button>`;
+    $('calc-rows').appendChild(row);
+    bindKaratChips(row.querySelector('.karat-chips'));
+    const w = row.querySelector('.calc-input');
+    if(w) setTimeout(() => w.focus(), 60);
+  }
+  window.addRow = addRow;
+
+  function delRow(id){
+    const el = document.querySelector('[data-row="'+id+'"]');
+    if(el && document.querySelectorAll('.calc-row').length > 1){
+      el.remove();
+      calc();
     }
   }
-  const totalGBP = totalUSD * window._gbpusd;
-  document.getElementById('res-gbp').textContent = '£' + totalGBP.toFixed(2);
-  document.getElementById('res-usd').textContent = '$' + totalUSD.toFixed(2) + ' USD';
-  if (inputsFilled >= 1) fireCalcEngaged();
-  if (inputsFilled >= 3) fireScrapIntent();
-  if (typeof gtag !== 'undefined') gtag('event', 'scrap_calculator_used', {value: totalGBP});
-}
+  window.delRow = delRow;
 
-function addRow() {
-  const id = rowCount++;
-  const div = document.createElement('div');
-  div.className = 'calc-row';
-  div.dataset.row = id;
-  div.innerHTML = `<div><div class="calc-label">Weight (grams)</div><input class="calc-input" type="number" min="0" step="0.01" placeholder="e.g. 5.5" id="w-${id}" oninput="calc()"></div><div><div class="calc-label">Karat</div><select class="calc-select" id="k-${id}" onchange="calc()"><option value="0.999">24K (99.9%)</option><option value="0.9167">22K (91.67%)</option><option value="0.75">18K (75%)</option><option value="0.5833" selected>14K (58.33%)</option><option value="0.4167">10K (41.67%)</option><option value="0.375">9K (37.5%)</option></select></div><button class="calc-del" onclick="delRow(${id})" aria-label="Remove row">&times;</button>`;
-  document.getElementById('calc-rows').appendChild(div);
-}
-
-function delRow(id) {
-  const el = document.querySelector('[data-row="' + id + '"]');
-  if (el && document.querySelectorAll('.calc-row').length > 1) {
-    el.remove();
-    calc();
+  // ── Quick presets — apply to last row's weight input ──
+  function bindPresets(){
+    document.querySelectorAll('.calc-preset').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const grams = parseFloat(btn.dataset.preset);
+        const rows = document.querySelectorAll('.calc-row');
+        const last = rows[rows.length - 1];
+        if(!last) return;
+        const input = last.querySelector('.calc-input');
+        if(input){
+          input.value = grams;
+          input.dispatchEvent(new Event('input', {bubbles: true}));
+          input.focus();
+        }
+      });
+    });
   }
-}
 
-async function fetchFx() {
-  try {
-    const r = await fetch('https://api.goldpricetoolsworker.io/fx', {cache: 'no-store'});
-    if (!r.ok) throw new Error();
-    const d = await r.json();
-    window._gbpusd = d.GBPUSD || 0.79;
-  } catch {
-    window._gbpusd = 0.79;
+  // ── Data fetchers ──
+  async function fetchFx(){
+    try{
+      const r = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR',{cache:'no-store'});
+      if(!r.ok) throw new Error('FX HTTP '+r.status);
+      const d = await r.json();
+      window._gbpusd = d.rates.GBP || window._gbpusd;
+      window._eurusd = d.rates.EUR || window._eurusd;
+      window._usdinr = d.rates.INR || window._usdinr;
+    }catch(e){
+      console.warn('FX fallback used', e);
+    }
   }
-}
 
-async function fetchSpot() {
-  try {
-    const r = await fetch('https://api.gold-api.com/price/XAU', {cache: 'no-store'});
-    if (!r.ok) throw new Error();
-    const d = await r.json();
-    window._spot = d.price;
-    calc();
-    window.dispatchEvent(new Event('goldprice_updated'));
-  } catch(e) {
-    console.warn('Gold API failed', e);
-    document.getElementById('res-gbp').textContent = 'API unavailable';
+  async function fetchSpot(){
+    try{
+      const r = await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
+      if(!r.ok) throw new Error('Spot HTTP '+r.status);
+      const d = await r.json();
+      window._spotUSD = d.price;
+      window._spot    = d.price;  // legacy alias
+      lastFetchTs = Date.now();
+      fillSpotTile();
+      fillKaratGrid();
+      refreshUpdatedStamp();
+      calc();
+      window.dispatchEvent(new Event('goldprice_updated'));
+      if(typeof gtag !== 'undefined') gtag('event','price_view',{metal:'gold',page:'scrap-calculator'});
+    }catch(e){
+      console.warn('Spot fetch failed', e);
+      const u = $('res-usd'); if(u && !window._spotUSD) u.textContent = 'API unavailable';
+    }
   }
-}
 
-Promise.all([fetchFx(), fetchSpot()]);
-setInterval(fetchSpot, 60000);
+  // ── Init ──
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.karat-chips').forEach(bindKaratChips);
+    bindPresets();
+    Promise.all([fetchFx(), fetchSpot()]).catch(e => console.warn('init',e));
+    setInterval(fetchSpot, REFRESH_MS);
+  });
+})();
 </script>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 


### PR DESCRIPTION
## Summary

Full premium redesign of `/scrap-gold-calculator` using the **ui-ux-pro-max** design system (Liquid Glass · Premium dark + gold accent). Mobile-first with progressive enhancement, fully accessible, and aligned with the rest of the site's USD-primary data contract.

## Key changes

### Currency & data accuracy (per directive)
- **USD is now the primary currency** across the hero, calculator result, payout gauge, karat reference grid, and mobile sticky bar.
- Replaced the single-pair `goldpricetoolsworker.io/fx` call with **`api.frankfurter.dev`** (ECB reference rates), matching `24k-gold-price-per-gram.html` and the rest of the karat pages — guarantees identical FX numbers site-wide.
- Spot source unchanged (`api.gold-api.com/price/XAU`), same 60s refresh, same `goldprice_updated` event for compatibility.
- All formulas mirror the karat pages: `pricePerGramUSD = spotUSD / 31.1035`, `melt = weight × purity × pricePerGramUSD`.

### Hero & calculator
- Pulsing live spot tile with USD primary and GBP/EUR/INR pills, plus a "last updated" stamp that ticks every second.
- Calculator card with radial gold gradient accent, step counter, and `aria-live` result region.
- Karat `<select>` replaced with a **segmented chip picker** (radiogroup + arrow-key navigation) — one-tap karat selection, no native select scrolling on mobile.
- Weight input uses `inputmode="decimal"` for numeric mobile keyboard, with a styled "g" suffix pill.
- **Quick presets**: 1g, 3.5g ring, 7g chain, 15g, 1 oz, 100g — apply to the most recent row.
- **Pure-gold content readout** (e.g. "5.83 g of pure 24K equivalent") between rows and result.
- **Dealer payout gauge** (70%–92%) with low/best quote split shown in USD + GBP.

### Karat reference
- Old GBP-first table replaced with a responsive card grid (1 / 2 / 3 col across breakpoints).
- USD primary, GBP + EUR secondary, hover lift with radial accent.

### Mobile experience
- Sticky bottom CTA appears only when the user has entered a value — shows live USD total and links to `/where-to-sell-gold-silver` (fires `scrap_seller_intent`).
- All touch targets ≥ 44×44px, smooth focus rings, no layout shifts on hover.

### Accessibility
- Semantic `<section>`, `<h1>`/`<h2>` hierarchy preserved.
- All inputs labelled, all icon-only buttons have `aria-label`, all chips use proper `radiogroup`/`radio` roles with `aria-checked`.
- `prefers-reduced-motion` respected (disables pulse + hover lift).
- Result block uses `role="status"` with `aria-live="polite"`.

### SEO
- All existing JSON-LD schemas preserved (BreadcrumbList, SoftwareApplication, HowTo, FAQPage, WebPage).
- `SoftwareApplication.offers.priceCurrency` updated `GBP → USD` to reflect new primary currency.
- Title and meta description updated to lead with USD.
- Worked example in prose and FAQ updated to USD with GBP/EUR aside.

## Test plan
- [ ] Open `/scrap-gold-calculator` on mobile (375px), tablet (768px), desktop (1280px) — verify no horizontal scroll, all chips wrap, sticky bar fits.
- [ ] Confirm live spot tile populates with USD primary and GBP/EUR/INR pills within ~1s.
- [ ] Enter 10g, tap 18K chip → confirm USD value matches `weight × purity × (spotUSD / 31.1035)`.
- [ ] Cross-check the calculator result against the 24K page's gram price × weight × purity — numbers should match exactly (same FX, same spot).
- [ ] Tap each quick preset → verify weight populates and result updates.
- [ ] Verify karat reference grid USD figures match `24k-gold-price-per-gram.html` `per-gram` row to the cent.
- [ ] Tab through chips → arrow keys cycle selection.
- [ ] Toggle dark/light theme → all gradients, gold accents, and borders remain readable.
- [ ] Inspect Lighthouse — Performance, Accessibility, SEO should all stay green.
- [ ] DevTools throttle to slow 3G → calculator shows "Loading…" then resolves cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GH9Uje6SgjbQFSGDkvJGWF)_