### PR TITLE
Redesign gold bar value calculator — USD primary, mobile-first, live multi-currency

### DIFF
--- a/gold-bar-value.html
+++ b/gold-bar-value.html
@@ -7,23 +7,25 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold Bar Value Calculator — How Much Is a Gold Bar Worth?</title>
+<title>Gold Bar Value Calculator — Live USD Melt Value (1g to 400oz) | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Live gold bar value calculator. Find out how much your 1 oz, 10 oz, 1 kg, or Good Delivery gold bar is worth today. Prices updated every 60 seconds.">
+<meta name="description" content="Free gold bar value calculator: tap any size from 1g to 400oz LBMA Good Delivery to see the live USD (primary), GBP, EUR &amp; INR melt value. LBMA spot prices refresh every 60 seconds.">
 <meta name="robots" content="index, follow">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/gold-bar-value">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/gold-bar-value">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/gold-bar-value">
 <link rel="canonical" href="https://goldpricetools.com/gold-bar-value">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Gold Bar Value Calculator","item":"https://goldpricetools.com/gold-bar-value"}]}</script>
-<meta property="og:title" content="Gold Bar Value Calculator — How Much Is a Gold Bar Worth?">
-<meta property="og:description" content="Live gold bar value calculator. Find out how much your 1 oz, 10 oz, 1 kg, or Good Delivery gold bar is worth today. Prices updated every 60 seconds.">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"GoldPriceTools Gold Bar Value Calculator","url":"https://goldpricetools.com/gold-bar-value","description":"Free gold bar value calculator. Tap any standard bar size from 1g to 400oz LBMA Good Delivery to see the live USD (primary), GBP, EUR and INR melt value. LBMA spot refreshed every 60 seconds.","applicationCategory":"FinanceApplication","operatingSystem":"Web Browser","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"HowTo","name":"How to Calculate the Value of a Gold Bar","description":"Calculate the live USD melt value of any standard gold bar size using the live LBMA spot price.","totalTime":"PT1M","tool":[{"@type":"HowToTool","name":"GoldPriceTools Gold Bar Value Calculator"}],"step":[{"@type":"HowToStep","position":1,"name":"Choose your bar size","text":"Tap one of the nine standard bar size chips — from 1g retail bars up to the 400oz LBMA Good Delivery bar."},{"@type":"HowToStep","position":2,"name":"Enter quantity","text":"Use the +/- steppers to set how many bars you want to value."},{"@type":"HowToStep","position":3,"name":"Read your live USD melt value","text":"The result box shows the USD (primary) melt value with live GBP, EUR and INR conversions calculated from the LBMA spot price. A premium gauge below estimates typical retail buy and dealer sell-back prices."}]}</script>
+<meta property="og:title" content="Gold Bar Value Calculator — Live USD Melt Value (1g to 400oz Good Delivery)">
+<meta property="og:description" content="Live gold bar value calculator with USD-primary pricing. Calculate the melt value of any standard bar size from 1g retail to 400oz LBMA Good Delivery in USD, GBP, EUR &amp; INR.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/gold-bar-value">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is Good Delivery?","acceptedAnswer":{"@type":"Answer","text":"Good Delivery is a set of rules issued by the London Bullion Market Association (LBMA) describing the physical characteristics of gold and silver bars used in settlement in the wholesale market. A Good Delivery gold bar must weigh approximately 400 troy ounces and have a minimum purity of 995.0."}},{"@type":"Question","name":"How are gold bars priced?","acceptedAnswer":{"@type":"Answer","text":"Gold bars are priced based on the live spot price of gold per troy ounce, plus a dealer premium. This premium covers the cost of fabrication, assaying, distribution, and the dealer's profit margin. Larger bars generally have smaller percentage premiums compared to fractional bars."}},{"@type":"Question","name":"What is the cheapest way to buy a 1g gold bar?","acceptedAnswer":{"@type":"Answer","text":"The cheapest way to buy a 1g gold bar is often through a reputable online bullion dealer rather than a physical coin shop, as online dealers have lower overheads. However, be aware that 1g bars carry the highest percentage premiums (often 10-20% above spot price) due to manufacturing costs."}},{"@type":"Question","name":"Where is the best place to buy gold bars?","acceptedAnswer":{"@type":"Answer","text":"The best place to buy gold bars is through authorised, well-established bullion dealers who are members of industry organisations. Always compare premiums over the spot price and verify the dealer's reputation through independent reviews before purchasing."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How is a gold bar valued?","acceptedAnswer":{"@type":"Answer","text":"A gold bar's melt value is its weight in troy ounces multiplied by the live USD spot price per troy ounce. A 100g bar contains 3.215 troy ounces. At a $3,200/oz spot price, that's a melt value of approximately $10,288 USD. The retail price you actually pay includes a small premium above the melt value."}},{"@type":"Question","name":"What is the most popular gold bar size for investors?","acceptedAnswer":{"@type":"Answer","text":"The 1 troy ounce (31.1g) and the 100g bar are the most popular investment sizes worldwide. The 1oz bar is the global retail benchmark, easy to buy, sell and store. The 100g bar offers a slightly lower premium per gram and is widely accepted by dealers, banks and refineries."}},{"@type":"Question","name":"What is a Good Delivery bar?","acceptedAnswer":{"@type":"Answer","text":"A Good Delivery bar is the LBMA's standard wholesale gold bar, weighing 350 to 430 troy ounces (about 11 to 13 kg) at minimum 99.5 percent fineness. These bars trade between LBMA-member banks, central banks and refiners and are not generally sold to retail investors."}},{"@type":"Question","name":"Are gold bars tax-free?","acceptedAnswer":{"@type":"Answer","text":"Investment-grade gold bars at 99.5 percent or higher purity are VAT-exempt across the UK and EU under the Investment Gold Directive. In the United States there is no federal sales tax on bullion but state sales tax rules vary. Capital gains tax always applies on profits when sold."}},{"@type":"Question","name":"Where can I buy gold bars?","acceptedAnswer":{"@type":"Answer","text":"Buy from LBMA-accredited or industry-association-member dealers. Reputable global names include JM Bullion, APMEX, Kitco and Money Metals Exchange in the US; The Royal Mint, BullionVault, Hatton Garden Metals and Atkinsons Bullion in the UK; Heraeus, Umicore, PAMP and Argor-Heraeus refiners in the EU. Always compare premium over USD spot before purchasing."}},{"@type":"Question","name":"Does the weight on a gold bar include the assay card?","acceptedAnswer":{"@type":"Answer","text":"No. The stated weight on a gold bar refers only to the gold content. The assay card, packaging and capsule add negligible weight and have no gold value. Always verify the bar weight matches the certificate and that the bar's serial number matches the assay card."}},{"@type":"Question","name":"Which currency does this calculator use?","acceptedAnswer":{"@type":"Answer","text":"USD is the primary display currency, the world's reserve currency and the standard quote for the global LBMA gold market. GBP, EUR and INR conversions appear alongside every USD figure and update live using ECB reference rates from the Frankfurter API."}}]}</script>
 <script>
   window.dataLayer=window.dataLayer||[];
   function gtag(){dataLayer.push(arguments);}
@@ -51,6 +53,8 @@
 <meta name="theme-color" content="#0f0e0c">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://api.gold-api.com">
+<link rel="preconnect" href="https://api.frankfurter.dev">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
 <style>
 
@@ -451,6 +455,203 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 /* ── Disclaimer ── */
 .disclaimer-box{margin-top:var(--space-8);padding:var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-border);font-size:var(--text-sm);color:var(--color-text-faint);line-height:1.6}
 .disclaimer-box strong{color:var(--color-text-muted)}
+
+/* ╔═══════════════════════════════════════════════════════════════════╗
+   ║  GOLD-BAR-VALUE  ·  USD-PRIMARY REDESIGN  (mobile-first)          ║
+   ║  Shared component vocabulary with /scrap-gold-calculator          ║
+   ╚═══════════════════════════════════════════════════════════════════╝ */
+
+/* ── Hero wrap & layout ── */
+.hero-wrap{max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-6)}
+.hero-grid{display:grid;grid-template-columns:1fr;gap:var(--space-6);align-items:start}
+@media(min-width:880px){.hero-grid{grid-template-columns:1.05fr .95fr;gap:var(--space-8);align-items:center}.hero-wrap{padding-top:var(--space-10)}}
+.hero-left{display:flex;flex-direction:column;gap:var(--space-3);min-width:0}
+.hero-left .hero-tag{display:inline-flex;align-items:center;gap:6px;width:fit-content;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 26%,var(--color-border));padding:5px 11px;border-radius:var(--radius-full);font-size:11px;font-weight:700;color:var(--color-gold-bright);letter-spacing:.08em;text-transform:uppercase;margin:0}
+.hero-left .hero-tag .live-dot{width:6px;height:6px}
+.hero-left h1.hero-title{font-family:var(--font-display);font-size:clamp(1.875rem,1.1rem + 3vw,3rem);line-height:1.1;letter-spacing:-.02em;color:var(--color-text);margin:0}
+.hero-left h1.hero-title .accent{background:linear-gradient(135deg,var(--color-gold-bright) 0%,#f0bf4d 60%,var(--color-gold) 100%);-webkit-background-clip:text;background-clip:text;color:transparent}
+.hero-left .hero-sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:54ch;line-height:1.65;margin:0}
+.hero-trust-row{display:flex;flex-wrap:wrap;gap:6px;margin-top:var(--space-2)}
+.hero-trust-row .pill{display:inline-flex;align-items:center;gap:6px;padding:5px 10px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:11px;font-weight:600;color:var(--color-text-muted);letter-spacing:.02em}
+.hero-trust-row .pill svg{color:var(--color-gold-bright);opacity:.95}
+
+/* ── Live spot tile (hero right) ── */
+.spot-tile{display:grid;grid-template-columns:1fr auto;gap:var(--space-3) var(--space-4);align-items:center;background:linear-gradient(135deg,var(--color-surface) 0%,var(--color-surface-offset) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4) var(--space-5);box-shadow:var(--shadow-md);margin:0;position:relative;overflow:hidden}
+.spot-tile::before{content:"";position:absolute;inset:auto -30% -60% auto;width:60%;height:120%;background:radial-gradient(closest-side,color-mix(in oklch,var(--color-gold-bright) 16%,transparent) 0%,transparent 70%);filter:blur(28px);pointer-events:none}
+.spot-tile>*{position:relative;z-index:1}
+.spot-tile__head{display:flex;align-items:center;gap:var(--space-2);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-muted);grid-column:1/-1}
+.spot-tile__head .live-dot{width:7px;height:7px}
+.spot-tile__primary{display:flex;flex-direction:column;gap:2px;min-width:0}
+.spot-tile__label{font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--color-text-faint)}
+.spot-tile__value{font-family:var(--font-display);font-size:clamp(1.625rem,1rem + 2.4vw,2.25rem);color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;letter-spacing:-.01em}
+.spot-tile__alts{display:flex;flex-wrap:wrap;gap:6px;justify-content:flex-end;max-width:55%}
+.spot-tile__pill{font-size:11px;font-weight:600;color:var(--color-text-muted);background:var(--color-surface-offset-2);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:4px 10px;font-variant-numeric:tabular-nums;white-space:nowrap}
+.spot-tile__pill strong{color:var(--color-text);font-weight:700;margin-right:4px}
+.spot-tile__refresh{grid-column:1/-1;display:flex;align-items:center;gap:6px;font-size:11px;color:var(--color-text-faint);padding-top:var(--space-3);border-top:1px dashed var(--color-border)}
+.spot-tile__refresh svg{flex-shrink:0;opacity:.7}
+@media(max-width:520px){.spot-tile__alts{max-width:none;justify-content:flex-start;grid-column:1/-1}}
+
+/* ── Calculator section shell ── */
+.gbv-calc{max-width:1200px;margin:0 auto var(--space-8);padding:0 var(--space-4)}
+.gbv-calc__panel{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.gbv-calc__head{display:flex;align-items:flex-end;justify-content:space-between;gap:var(--space-3);padding:var(--space-5) var(--space-5) 0;flex-wrap:wrap}
+.gbv-calc__eyebrow{font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--color-gold-bright);display:block;margin-bottom:6px}
+.gbv-calc__title{font-family:var(--font-display);font-size:clamp(1.25rem,1rem + 1vw,1.625rem);color:var(--color-text);margin:0;line-height:1.2;letter-spacing:-.01em}
+.gbv-calc__quicklink{font-size:12px;font-weight:600;color:var(--color-primary);text-decoration:none;display:inline-flex;align-items:center;gap:4px;padding:6px 0}
+.gbv-calc__quicklink:hover{color:var(--color-primary-hover);text-decoration:underline}
+.gbv-calc__body{display:flex;flex-direction:column;gap:var(--space-4);padding:var(--space-5)}
+@media(min-width:600px){.gbv-calc__body{padding:var(--space-6)}}
+
+/* ── Step labels (shared with scrap calc) ── */
+.calc-step{display:flex;align-items:center;gap:var(--space-2);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-faint);margin-top:var(--space-2)}
+.calc-step:first-child{margin-top:0}
+.calc-step__num{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:50%;background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));color:var(--color-gold-bright);font-size:11px;font-weight:700}
+
+/* ── Bar size chips (radiogroup) ── */
+.bar-chips{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
+@media(min-width:500px){.bar-chips{grid-template-columns:repeat(3,1fr)}}
+@media(min-width:760px){.bar-chips{grid-template-columns:repeat(5,1fr)}}
+.bar-chip{position:relative;display:flex;flex-direction:column;align-items:flex-start;gap:2px;padding:12px 12px 11px;min-height:62px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);color:var(--color-text);font:inherit;cursor:pointer;text-align:left;transition:border-color .18s,background .18s,transform .15s,box-shadow .25s;-webkit-tap-highlight-color:transparent}
+.bar-chip:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));background:color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface-offset))}
+.bar-chip:active{transform:scale(.985)}
+.bar-chip[aria-checked="true"]{border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));box-shadow:0 0 0 1px var(--color-gold-bright) inset, 0 8px 22px color-mix(in oklch,var(--color-gold-bright) 14%,transparent)}
+.bar-chip__size{font-family:var(--font-display);font-size:1.0625rem;font-weight:600;color:var(--color-text);letter-spacing:-.01em;line-height:1.15}
+.bar-chip[aria-checked="true"] .bar-chip__size{color:var(--color-gold-bright)}
+.bar-chip__sub{font-size:10.5px;color:var(--color-text-muted);font-weight:500;line-height:1.3}
+.bar-chip__flag{position:absolute;top:-6px;right:8px;font-size:8.5px;font-weight:800;letter-spacing:.1em;padding:2px 6px;border-radius:var(--radius-full);background:var(--color-gold-bright);color:#0f0e0c;text-transform:uppercase;white-space:nowrap;line-height:1.4}
+.bar-chip--gd .bar-chip__flag{background:linear-gradient(135deg,var(--color-gold-bright),#f0bf4d);color:#0f0e0c}
+.bar-chip--popular .bar-chip__flag{background:var(--color-primary);color:#fff}
+
+/* ── Quantity stepper ── */
+.qty-wrap{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+.qty-stepper{display:inline-flex;align-items:stretch;border:1px solid var(--color-border);border-radius:var(--radius-md);overflow:hidden;background:var(--color-surface-offset)}
+.qty-btn{display:inline-flex;align-items:center;justify-content:center;min-width:44px;min-height:44px;font-size:1.125rem;font-weight:600;color:var(--color-text-muted);background:transparent;border:none;cursor:pointer;-webkit-tap-highlight-color:transparent;transition:background .15s,color .15s}
+.qty-btn:hover{background:var(--color-surface-dynamic);color:var(--color-gold-bright)}
+.qty-btn:active{background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-dynamic))}
+.qty-input{width:84px;min-height:44px;padding:0 var(--space-3);text-align:center;background:var(--color-surface);border:none;border-left:1px solid var(--color-border);border-right:1px solid var(--color-border);font-size:1rem;font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;-moz-appearance:textfield}
+.qty-input::-webkit-outer-spin-button,.qty-input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
+.qty-input:focus{outline:none;background:var(--color-surface-2)}
+.qty-helper{font-size:12px;color:var(--color-text-faint);font-weight:500}
+
+/* ── Result box (USD primary) ── */
+.result-box{position:relative;background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface-offset)) 0%,color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface-offset)) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 32%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-3);overflow:hidden}
+.result-box::after{content:"";position:absolute;top:-40%;right:-20%;width:60%;height:160%;background:radial-gradient(closest-side,color-mix(in oklch,var(--color-gold-bright) 24%,transparent) 0%,transparent 70%);filter:blur(28px);pointer-events:none}
+.result-box>*{position:relative;z-index:1}
+.result-label{font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-muted)}
+.result-usd{font-family:var(--font-display);font-size:clamp(2rem,1rem + 4.5vw,3.25rem);color:var(--color-gold-bright);font-variant-numeric:tabular-nums;font-weight:500;letter-spacing:-.02em;line-height:1}
+.result-alts{display:flex;flex-wrap:wrap;gap:6px}
+.result-alt{display:inline-flex;align-items:center;gap:5px;font-size:12px;font-weight:600;color:var(--color-text-muted);background:color-mix(in oklch,var(--color-surface) 70%,transparent);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:5px 11px;font-variant-numeric:tabular-nums;white-space:nowrap;backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px)}
+.result-alt strong{color:var(--color-text);font-weight:700}
+.result-foot{display:flex;flex-wrap:wrap;align-items:center;gap:6px;padding-top:var(--space-2);font-size:12px;color:var(--color-text-muted);border-top:1px dashed color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border))}
+.result-foot__chip{font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;padding:3px 8px;background:color-mix(in oklch,var(--color-gold-bright) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));border-radius:var(--radius-full);color:var(--color-gold-bright)}
+.result-foot__sep{opacity:.5}
+.result-foot strong{color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ── Premium-over-spot gauge ── */
+.premium-gauge{padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.premium-gauge__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2);margin-bottom:var(--space-3);flex-wrap:wrap}
+.premium-gauge__title{font-size:12px;font-weight:700;color:var(--color-text);display:flex;align-items:center;gap:6px}
+.premium-gauge__title svg{color:var(--color-gold-bright)}
+.premium-gauge__range{font-size:11px;font-weight:600;color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));border-radius:var(--radius-full);padding:3px 9px;font-variant-numeric:tabular-nums;white-space:nowrap}
+.premium-bar{position:relative;height:8px;border-radius:99px;background:var(--color-surface-offset-2);border:1px solid var(--color-border);overflow:hidden;margin-bottom:6px}
+.premium-bar__fill{position:absolute;inset:0 auto 0 0;background:linear-gradient(90deg,color-mix(in oklch,var(--color-gold-bright) 60%,transparent),var(--color-gold-bright));border-radius:99px;transition:width .35s cubic-bezier(.2,.8,.2,1)}
+.premium-gauge__legend{display:flex;justify-content:space-between;font-size:10px;font-weight:600;color:var(--color-text-faint);margin-top:6px;letter-spacing:.04em}
+.premium-vals{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);margin-top:var(--space-3);padding-top:var(--space-3);border-top:1px dashed var(--color-border)}
+.premium-val__label{font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted);margin-bottom:4px;display:flex;align-items:center;gap:5px}
+.premium-val__label::before{content:"";display:inline-block;width:8px;height:8px;border-radius:50%}
+.premium-val--retail .premium-val__label::before{background:var(--color-gold-bright)}
+.premium-val--sell .premium-val__label::before{background:color-mix(in oklch,var(--color-silver) 60%,var(--color-text-faint))}
+.premium-val__amount{font-family:var(--font-display);font-size:1.125rem;font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.01em;line-height:1.15}
+.premium-val--retail .premium-val__amount{color:var(--color-gold-bright)}
+.premium-val__sub{font-size:11px;color:var(--color-text-muted);font-variant-numeric:tabular-nums;margin-top:2px}
+
+/* ── Feature trio (shared with scrap calc) ── */
+.feat-trio{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-6) 0}
+@media(min-width:600px){.feat-trio{grid-template-columns:repeat(3,1fr);gap:var(--space-4)}}
+.feat-card{display:flex;align-items:flex-start;gap:var(--space-3);padding:var(--space-4) var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);transition:border-color .2s,box-shadow .25s,transform .25s}
+.feat-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 32%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.feat-card__icon{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;flex-shrink:0;border-radius:var(--radius-md);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 26%,var(--color-border));color:var(--color-gold-bright)}
+.feat-card__title{font-size:13.5px;font-weight:700;color:var(--color-text);margin:0 0 3px;line-height:1.25}
+.feat-card__desc{font-size:12.5px;color:var(--color-text-muted);line-height:1.5;margin:0}
+
+/* ── Data source pulse strip ── */
+.data-source{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;font-size:12.5px;line-height:1.5;margin-top:var(--space-2);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold-bright);color:var(--color-text-muted)}
+.data-source__pulse{display:inline-flex;align-items:center;gap:6px;font-weight:600;color:var(--color-text)}
+.data-source__pulse .live-dot{width:7px;height:7px}
+.data-source__sep{opacity:.45}
+.data-source__updated time{color:var(--color-text);font-weight:600}
+.data-source a{color:var(--color-primary);text-decoration:none}
+.data-source a:hover{text-decoration:underline}
+
+/* ── Live bar value grid (bento) ── */
+.bar-grid-section{margin:var(--space-10) 0 var(--space-8)}
+.bar-grid-section__head{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-3);margin-bottom:var(--space-5);flex-wrap:wrap}
+.bar-grid-section__title{font-family:var(--font-display);font-size:clamp(1.375rem,1rem + 1.5vw,1.875rem);color:var(--color-text);margin:0;letter-spacing:-.02em;line-height:1.2}
+.bar-grid-section__caption{font-size:13px;color:var(--color-text-muted);margin:6px 0 0;line-height:1.55;max-width:64ch}
+.bar-cells{display:grid;grid-template-columns:repeat(auto-fill,minmax(170px,1fr));gap:var(--space-3)}
+@media(min-width:600px){.bar-cells{gap:var(--space-4)}}
+.bar-cell{position:relative;display:flex;flex-direction:column;align-items:flex-start;gap:4px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);text-align:left;font:inherit;color:var(--color-text);cursor:pointer;transition:border-color .25s,transform .25s,box-shadow .25s;overflow:hidden;-webkit-tap-highlight-color:transparent}
+.bar-cell:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.bar-cell:active{transform:translateY(0)}
+.bar-cell::after{content:"";position:absolute;top:0;right:0;width:90px;height:90px;background:radial-gradient(closest-side,color-mix(in oklch,var(--color-gold-bright) 14%,transparent) 0%,transparent 70%);pointer-events:none;opacity:.7}
+.bar-cell[data-active="true"]{border-color:var(--color-gold-bright);box-shadow:0 0 0 1px var(--color-gold-bright) inset,var(--shadow-md)}
+.bar-cell__head{display:flex;align-items:center;justify-content:space-between;width:100%;margin-bottom:2px;gap:6px}
+.bar-cell__size{font-family:var(--font-display);font-size:1.375rem;font-weight:600;color:var(--color-text);line-height:1.05;letter-spacing:-.02em}
+.bar-cell__hall{font-size:9.5px;font-weight:700;letter-spacing:.1em;color:var(--color-gold-bright);text-transform:uppercase;background:color-mix(in oklch,var(--color-gold-bright) 10%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 26%,var(--color-border));border-radius:var(--radius-full);padding:2px 7px;white-space:nowrap}
+.bar-cell__weight{font-size:11px;font-weight:600;color:var(--color-text-muted);margin-bottom:6px;letter-spacing:.02em}
+.bar-cell__usd{font-size:1.1875rem;font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.01em;line-height:1.2}
+.bar-cell__sub{font-size:11px;color:var(--color-text-muted);font-variant-numeric:tabular-nums;margin-top:2px;line-height:1.4}
+.bar-cell__per{font-size:9.5px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-faint);margin-top:6px}
+
+/* ── Mobile sticky CTA ── */
+.mobile-sticky{position:fixed;left:8px;right:8px;bottom:8px;z-index:90;display:none;align-items:center;justify-content:space-between;gap:var(--space-3);background:color-mix(in oklch,var(--color-surface) 92%,transparent);backdrop-filter:blur(14px) saturate(140%);-webkit-backdrop-filter:blur(14px) saturate(140%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));border-radius:var(--radius-xl);padding:10px 14px;box-shadow:0 12px 32px oklch(0 0 0/0.35)}
+.mobile-sticky__left{display:flex;flex-direction:column;min-width:0}
+.mobile-sticky__label{font-size:9px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--color-text-muted)}
+.mobile-sticky__val{font-family:var(--font-display);font-size:1.125rem;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;margin-top:2px}
+.mobile-sticky__btn{display:inline-flex;align-items:center;gap:6px;background:linear-gradient(135deg,var(--color-gold-bright),#d19900);color:#0f0e0c;font-size:13px;font-weight:700;padding:10px 14px;border-radius:var(--radius-full);text-decoration:none;white-space:nowrap;border:none;cursor:pointer;transition:transform .15s,box-shadow .25s;min-height:40px}
+.mobile-sticky__btn:hover{transform:translateY(-1px);box-shadow:0 6px 18px color-mix(in oklch,var(--color-gold-bright) 38%,transparent);color:#0f0e0c;text-decoration:none}
+.mobile-sticky__btn:visited,.mobile-sticky__btn:active{color:#0f0e0c}
+@media(max-width:768px){.mobile-sticky.is-visible{display:flex}body{padding-bottom:80px}}
+
+/* ── Skeleton shimmer for loading states ── */
+@keyframes shimmer{0%{background-position:-200% 0}100%{background-position:200% 0}}
+[data-loading="true"]{background:linear-gradient(90deg,var(--color-surface-offset) 0%,var(--color-surface-dynamic) 50%,var(--color-surface-offset) 100%);background-size:200% 100%;animation:shimmer 1.4s ease-in-out infinite;color:transparent!important;border-radius:6px}
+
+/* ── FAQ details/summary expanders ── */
+.faq-section{margin-top:var(--space-10)}
+.faq-section>h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-4)}
+.faq-list{display:flex;flex-direction:column;gap:8px}
+.faq-list .faq-item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);overflow:hidden;transition:border-color .2s}
+.faq-list .faq-item:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border))}
+.faq-list .faq-item[open]{border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border))}
+.faq-list summary.faq-answer-summary{font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4) var(--space-5);cursor:pointer;list-style:none;display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);background:transparent;transition:background .15s}
+.faq-list summary.faq-answer-summary:hover{background:var(--color-surface-offset)}
+.faq-list summary.faq-answer-summary::-webkit-details-marker{display:none}
+.faq-list summary.faq-answer-summary::after{content:"";flex-shrink:0;width:14px;height:14px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:rotate(45deg) translate(-2px,-2px);transition:transform .25s}
+.faq-list .faq-item[open] summary.faq-answer-summary::after{transform:rotate(-135deg) translate(-2px,-2px);border-color:var(--color-gold-bright)}
+.faq-list .faq-answer{font-size:14.5px;color:var(--color-text-muted);line-height:1.7;padding:0 var(--space-5) var(--space-4)}
+.faq-list .faq-answer p{margin:0}
+.faq-list .faq-answer p+p{margin-top:var(--space-3)}
+.faq-list .faq-answer strong{color:var(--color-text)}
+
+/* ── Premium breakdown info-list ── */
+.premium-breakdown{display:grid;grid-template-columns:1fr;gap:var(--space-2);margin:var(--space-4) 0 var(--space-6);padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+@media(min-width:680px){.premium-breakdown{grid-template-columns:1fr 1fr;gap:var(--space-3)}}
+.premium-breakdown__row{display:flex;align-items:flex-start;gap:var(--space-3);padding:var(--space-3);background:var(--color-surface-offset);border-radius:var(--radius-md);border:1px solid var(--color-border)}
+.premium-breakdown__band{flex-shrink:0;display:inline-flex;align-items:center;justify-content:center;min-width:64px;padding:6px 10px;background:color-mix(in oklch,var(--color-gold-bright) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.04em;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;white-space:nowrap}
+.premium-breakdown__text{display:flex;flex-direction:column;gap:2px;min-width:0}
+.premium-breakdown__title{font-size:13px;font-weight:700;color:var(--color-text);line-height:1.25}
+.premium-breakdown__desc{font-size:12px;color:var(--color-text-muted);line-height:1.45}
+
+/* ── Prose tweaks for redesign ── */
+.content{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-12)}
+.prose h2{font-family:var(--font-display);font-size:clamp(1.375rem,1rem + 1.5vw,1.75rem);color:var(--color-text);margin:var(--space-10) 0 var(--space-3);line-height:1.2;letter-spacing:-.01em}
+.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
+.prose p,.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
+.prose p{margin-bottom:var(--space-4);max-width:72ch}
+.prose ul,.prose ol{padding-left:1.4em;margin-bottom:var(--space-4)}
+.prose li{margin-bottom:var(--space-2);max-width:70ch}
+.prose strong{color:var(--color-text)}
 </style>
 
 <script type="application/ld+json">
@@ -545,160 +746,427 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </ol>
 </div>
 
-<div class="hero">
-  <div class="hero-left">
-<div class="hero-tag">Live Gold Bar Calculator</div>
-  <h1 class="hero-title">Gold Bar Value Calculator &mdash; How Much Is a Gold Bar Worth?</h1>
-  <p class="hero-sub">Calculate the real-time value of your gold bars based on live LBMA spot prices. Choose from 9 standard sizes from 1g up to 400 oz Good Delivery.</p>
-
+<section class="hero-wrap" aria-labelledby="page-title">
+  <div class="hero-grid">
+    <div class="hero-left">
+      <span class="hero-tag" role="status">
+        <span class="live-dot" aria-hidden="true"></span> Live Bar Value · LBMA Spot
+      </span>
+      <h1 id="page-title" class="hero-title">Gold Bar Value Calculator &mdash; <span class="accent">live USD melt value</span> for every standard size</h1>
+      <p class="hero-sub">Tap any of the nine standard investment bar sizes — from 1g retail to a 400oz LBMA Good Delivery bar — to see the live USD-primary melt value with instant GBP, EUR and INR conversions. Spot price refreshes every 60 seconds.</p>
+      <div class="hero-trust-row" aria-label="Calculator trust signals">
+        <span class="pill"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> USD-primary pricing</span>
+        <span class="pill"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></svg> 60-second refresh</span>
+        <span class="pill"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s-8-4.5-8-12V5l8-3 8 3v5c0 7.5-8 12-8 12z"/></svg> LBMA-sourced</span>
+      </div>
     </div>
-  <div class="calc-section" style="max-width: 480px; margin: 0 auto; text-align: left;">
-    <div class="calc-panel active" style="padding: 1.5rem;">
-      <div class="form-group" style="margin-bottom: 1rem;">
-        <label class="form-label" for="bar-size">Bar Size</label>
-        <div class="form-select-wrap">
-          <select class="form-select" id="bar-size">
-            <option value="12441.39">Good Delivery (400 oz)</option>
-            <option value="3110.35">100 oz</option>
-            <option value="1000">1 kg (32.15 oz)</option>
-            <option value="311.035">10 oz</option>
-            <option value="31.1035">1 oz</option>
-            <option value="10">10 g</option>
-            <option value="5">5 g</option>
-            <option value="2.5">2.5 g</option>
-            <option value="1" selected>1 g</option>
-          </select>
+
+    <aside class="spot-tile" role="region" aria-label="Live gold spot price">
+      <div class="spot-tile__head"><span class="live-dot" aria-hidden="true"></span> Live Gold Spot · LBMA</div>
+      <div class="spot-tile__primary">
+        <span class="spot-tile__label">USD per Troy Ounce</span>
+        <span class="spot-tile__value" id="spot-usd" data-nosnippet data-loading="true">&mdash;</span>
+      </div>
+      <div class="spot-tile__alts" aria-label="Spot price in other currencies">
+        <span class="spot-tile__pill"><strong>GBP</strong><span id="spot-gbp">&mdash;</span></span>
+        <span class="spot-tile__pill"><strong>EUR</strong><span id="spot-eur">&mdash;</span></span>
+        <span class="spot-tile__pill"><strong>INR</strong><span id="spot-inr">&mdash;</span></span>
+      </div>
+      <div class="spot-tile__refresh">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></svg>
+        Updated <time id="updated-stamp">just now</time> · auto-refresh every 60s
+      </div>
+    </aside>
+  </div>
+</section>
+
+<section class="gbv-calc" aria-labelledby="calc-title">
+  <div class="gbv-calc__panel">
+    <header class="gbv-calc__head">
+      <div>
+        <span class="gbv-calc__eyebrow">Bar Value Calculator</span>
+        <h2 id="calc-title" class="gbv-calc__title">Calculate your bar&rsquo;s live USD melt value</h2>
+      </div>
+      <a href="#bar-grid" class="gbv-calc__quicklink">Browse all 9 sizes
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14"/><path d="M19 12l-7 7-7-7"/></svg>
+      </a>
+    </header>
+    <div class="gbv-calc__body">
+      <div class="calc-step"><span class="calc-step__num">1</span> Choose your bar size</div>
+      <div class="bar-chips" role="radiogroup" aria-labelledby="calc-title">
+        <button type="button" class="bar-chip" role="radio" aria-checked="false" data-grams="1">
+          <span class="bar-chip__size">1 g</span>
+          <span class="bar-chip__sub">Retail / gifts</span>
+        </button>
+        <button type="button" class="bar-chip" role="radio" aria-checked="false" data-grams="2.5">
+          <span class="bar-chip__size">2.5 g</span>
+          <span class="bar-chip__sub">Retail</span>
+        </button>
+        <button type="button" class="bar-chip" role="radio" aria-checked="false" data-grams="5">
+          <span class="bar-chip__size">5 g</span>
+          <span class="bar-chip__sub">Retail</span>
+        </button>
+        <button type="button" class="bar-chip" role="radio" aria-checked="false" data-grams="10">
+          <span class="bar-chip__size">10 g</span>
+          <span class="bar-chip__sub">Retail</span>
+        </button>
+        <button type="button" class="bar-chip bar-chip--popular" role="radio" aria-checked="true" data-grams="31.1035">
+          <span class="bar-chip__flag">Popular</span>
+          <span class="bar-chip__size">1 oz</span>
+          <span class="bar-chip__sub">31.10 g &middot; benchmark</span>
+        </button>
+        <button type="button" class="bar-chip" role="radio" aria-checked="false" data-grams="100">
+          <span class="bar-chip__size">100 g</span>
+          <span class="bar-chip__sub">Investor</span>
+        </button>
+        <button type="button" class="bar-chip" role="radio" aria-checked="false" data-grams="250">
+          <span class="bar-chip__size">250 g</span>
+          <span class="bar-chip__sub">Investor</span>
+        </button>
+        <button type="button" class="bar-chip" role="radio" aria-checked="false" data-grams="1000">
+          <span class="bar-chip__size">1 kg</span>
+          <span class="bar-chip__sub">32.15 oz &middot; dealer</span>
+        </button>
+        <button type="button" class="bar-chip" role="radio" aria-checked="false" data-grams="3110.348">
+          <span class="bar-chip__size">100 oz</span>
+          <span class="bar-chip__sub">COMEX</span>
+        </button>
+        <button type="button" class="bar-chip bar-chip--gd" role="radio" aria-checked="false" data-grams="12441.393">
+          <span class="bar-chip__flag">Good Delivery</span>
+          <span class="bar-chip__size">400 oz</span>
+          <span class="bar-chip__sub">LBMA / central bank</span>
+        </button>
+      </div>
+
+      <div class="calc-step"><span class="calc-step__num">2</span> Quantity</div>
+      <div class="qty-wrap">
+        <div class="qty-stepper" role="group" aria-label="Bar quantity">
+          <button type="button" class="qty-btn" id="qty-down" aria-label="Decrease quantity">&minus;</button>
+          <input class="qty-input" type="number" id="bar-qty" value="1" min="1" max="9999" step="1" inputmode="numeric" aria-label="Number of bars">
+          <button type="button" class="qty-btn" id="qty-up" aria-label="Increase quantity">+</button>
+        </div>
+        <span class="qty-helper">Number of bars in your holding</span>
+      </div>
+
+      <div class="calc-step"><span class="calc-step__num">3</span> Live melt value</div>
+      <div class="result-box" role="status" aria-live="polite">
+        <span class="result-label">Total Gold Value &middot; USD primary</span>
+        <span class="result-usd" id="res-usd" data-nosnippet data-loading="true">&mdash;</span>
+        <div class="result-alts">
+          <span class="result-alt"><strong>GBP</strong><span id="res-gbp">&mdash;</span></span>
+          <span class="result-alt"><strong>EUR</strong><span id="res-eur">&mdash;</span></span>
+          <span class="result-alt"><strong>INR</strong><span id="res-inr">&mdash;</span></span>
+        </div>
+        <div class="result-foot">
+          <span class="result-foot__chip">24K &middot; 99.99% pure</span>
+          <span class="result-foot__sep">&middot;</span>
+          <span>Pure gold content: <strong id="pure-grams">&mdash;</strong></span>
         </div>
       </div>
-      <div class="form-group">
-        <label class="form-label" for="bar-qty">Quantity</label>
-        <input type="number" class="form-input" id="bar-qty" value="1" min="1" step="1">
+
+      <div class="premium-gauge" aria-label="Estimated premium over spot for the selected bar size">
+        <div class="premium-gauge__head">
+          <span class="premium-gauge__title">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12h4l3-9 4 18 3-9h4"/></svg>
+            Typical premium over spot
+          </span>
+          <span class="premium-gauge__range" id="premium-range">&mdash;</span>
+        </div>
+        <div class="premium-bar" aria-hidden="true"><span class="premium-bar__fill" id="premium-fill"></span></div>
+        <div class="premium-gauge__legend"><span>0% spot</span><span>5%</span><span>10%</span><span>15%+</span></div>
+        <div class="premium-vals">
+          <div class="premium-val premium-val--retail">
+            <div class="premium-val__label">Estimated retail buy price</div>
+            <div class="premium-val__amount" id="retail-usd">&mdash;</div>
+            <div class="premium-val__sub" id="retail-gbp">&mdash;</div>
+          </div>
+          <div class="premium-val premium-val--sell">
+            <div class="premium-val__label">Estimated dealer sell-back</div>
+            <div class="premium-val__amount" id="sellback-usd">&mdash;</div>
+            <div class="premium-val__sub" id="sellback-gbp">&mdash;</div>
+          </div>
+        </div>
       </div>
-      <div class="calc-result">
-        <div class="calc-result-label">Total Gold Value</div>
-        <div class="calc-result-value" id="price-gbp" data-nosnippet>&mdash;</div>
-        <div class="price-usd" id="price-usd" data-nosnippet></div>
-        <div class="calc-result-meta">Based on 24K pure gold spot price</div>
-      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Mobile sticky CTA — shows live USD total with quick path to dealer guidance -->
+<div class="mobile-sticky" id="mobile-sticky" aria-hidden="true">
+  <div class="mobile-sticky__left">
+    <span class="mobile-sticky__label">Live gold value</span>
+    <span class="mobile-sticky__val" id="sticky-usd">&mdash;</span>
+  </div>
+  <a href="/where-to-sell-gold-silver" class="mobile-sticky__btn">
+    Where to buy
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="M13 5l7 7-7 7"/></svg>
+  </a>
+</div>
+
+<main class="content">
+
+<p class="data-source">
+  <span class="data-source__pulse"><span class="live-dot" aria-hidden="true"></span> Live data</span>
+  <span class="data-source__sep">&middot;</span>
+  <span>LBMA spot via <a href="https://www.gold-api.com" rel="noopener" target="_blank">gold-api.com</a> &middot; FX from <a href="https://www.frankfurter.dev" rel="noopener" target="_blank">Frankfurter API</a> (ECB reference rates)</span>
+  <span class="data-source__sep">&middot;</span>
+  <span class="data-source__updated">Last update <time id="last-update">&mdash;</time></span>
+  <span class="data-source__sep">&middot;</span>
+  <a href="/about">About our data</a>
+</p>
+
+<div class="feat-trio">
+  <div class="feat-card">
+    <span class="feat-card__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9 12l2 2 4-4"/></svg>
+    </span>
+    <div>
+      <h3 class="feat-card__title">USD-primary, multi-currency</h3>
+      <p class="feat-card__desc">Live USD melt value with GBP, EUR &amp; INR conversions at live ECB reference rates.</p>
+    </div>
+  </div>
+  <div class="feat-card">
+    <span class="feat-card__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></svg>
+    </span>
+    <div>
+      <h3 class="feat-card__title">Refreshes every 60 seconds</h3>
+      <p class="feat-card__desc">Spot prices straight from the LBMA via gold-api.com. No stale or cached quotes.</p>
+    </div>
+  </div>
+  <div class="feat-card">
+    <span class="feat-card__icon" aria-hidden="true">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s-8-4.5-8-12V5l8-3 8 3v5c0 7.5-8 12-8 12z"/></svg>
+    </span>
+    <div>
+      <h3 class="feat-card__title">1g to 400oz Good Delivery</h3>
+      <p class="feat-card__desc">Every standard investment bar size — retail 1g through institutional 400oz LBMA.</p>
     </div>
   </div>
 </div>
 
-<div class="content">
-
-<p class="data-source">Live gold bar prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
-
 <article class="prose">
 
-  <h2>Gold Bar Sizes &amp; Their Value</h2>
-  <p>Gold bars are produced in a wide range of standard sizes to suit investors of all scales — from small retail buyers to central banks. The calculator above covers all nine standard investment bar sizes. Here is what each weighs and roughly what it is worth at today's spot price:</p>
-
-  <table class="data-table">
-    <thead><tr><th>Bar Size</th><th>Weight (grams)</th><th>Weight (troy oz)</th><th>Typical Buyer</th></tr></thead>
-    <tbody>
-      <tr><td>1 g</td><td>1.000</td><td>0.032</td><td>Retail / gifts</td></tr>
-      <tr><td>5 g</td><td>5.000</td><td>0.161</td><td>Retail</td></tr>
-      <tr><td>10 g</td><td>10.000</td><td>0.322</td><td>Retail</td></tr>
-      <tr><td>1 troy oz</td><td>31.103</td><td>1.000</td><td>Retail / investors</td></tr>
-      <tr><td>100 g</td><td>100.000</td><td>3.215</td><td>Investors</td></tr>
-      <tr><td>250 g</td><td>250.000</td><td>8.038</td><td>Investors</td></tr>
-      <tr><td>1 kg</td><td>1,000.000</td><td>32.151</td><td>Investors / dealers</td></tr>
-      <tr><td>100 troy oz</td><td>3,110.348</td><td>100.000</td><td>Professional / COMEX</td></tr>
-      <tr><td>400 troy oz (Good Delivery)</td><td>12,441.393</td><td>400.000</td><td>Central banks / LBMA</td></tr>
-    </tbody>
-  </table>
+  <section class="bar-grid-section" id="bar-grid" aria-labelledby="bar-grid-title">
+    <div class="bar-grid-section__head">
+      <div>
+        <h2 id="bar-grid-title" class="bar-grid-section__title">Live USD Value of Every Standard Gold Bar</h2>
+        <p class="bar-grid-section__caption">USD melt value for the nine standard investment bar sizes &mdash; refreshed from the LBMA spot price every 60 seconds. Tap any card to load it into the calculator above.</p>
+      </div>
+    </div>
+    <div class="bar-cells" role="list">
+      <button type="button" class="bar-cell" role="listitem" data-grams="1">
+        <div class="bar-cell__head"><span class="bar-cell__size">1 g</span><span class="bar-cell__hall">Retail</span></div>
+        <div class="bar-cell__weight">0.032 troy oz</div>
+        <div class="bar-cell__usd" id="bv-1" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-1-gbp">&mdash;</span> &middot; <span id="bv-1-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+      <button type="button" class="bar-cell" role="listitem" data-grams="2.5">
+        <div class="bar-cell__head"><span class="bar-cell__size">2.5 g</span><span class="bar-cell__hall">Retail</span></div>
+        <div class="bar-cell__weight">0.080 troy oz</div>
+        <div class="bar-cell__usd" id="bv-2_5" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-2_5-gbp">&mdash;</span> &middot; <span id="bv-2_5-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+      <button type="button" class="bar-cell" role="listitem" data-grams="5">
+        <div class="bar-cell__head"><span class="bar-cell__size">5 g</span><span class="bar-cell__hall">Retail</span></div>
+        <div class="bar-cell__weight">0.161 troy oz</div>
+        <div class="bar-cell__usd" id="bv-5" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-5-gbp">&mdash;</span> &middot; <span id="bv-5-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+      <button type="button" class="bar-cell" role="listitem" data-grams="10">
+        <div class="bar-cell__head"><span class="bar-cell__size">10 g</span><span class="bar-cell__hall">Retail</span></div>
+        <div class="bar-cell__weight">0.322 troy oz</div>
+        <div class="bar-cell__usd" id="bv-10" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-10-gbp">&mdash;</span> &middot; <span id="bv-10-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+      <button type="button" class="bar-cell" role="listitem" data-grams="31.1035">
+        <div class="bar-cell__head"><span class="bar-cell__size">1 oz</span><span class="bar-cell__hall">Popular</span></div>
+        <div class="bar-cell__weight">31.103 g &middot; benchmark</div>
+        <div class="bar-cell__usd" id="bv-31_1035" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-31_1035-gbp">&mdash;</span> &middot; <span id="bv-31_1035-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+      <button type="button" class="bar-cell" role="listitem" data-grams="100">
+        <div class="bar-cell__head"><span class="bar-cell__size">100 g</span><span class="bar-cell__hall">Investor</span></div>
+        <div class="bar-cell__weight">3.215 troy oz</div>
+        <div class="bar-cell__usd" id="bv-100" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-100-gbp">&mdash;</span> &middot; <span id="bv-100-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+      <button type="button" class="bar-cell" role="listitem" data-grams="250">
+        <div class="bar-cell__head"><span class="bar-cell__size">250 g</span><span class="bar-cell__hall">Investor</span></div>
+        <div class="bar-cell__weight">8.038 troy oz</div>
+        <div class="bar-cell__usd" id="bv-250" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-250-gbp">&mdash;</span> &middot; <span id="bv-250-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+      <button type="button" class="bar-cell" role="listitem" data-grams="1000">
+        <div class="bar-cell__head"><span class="bar-cell__size">1 kg</span><span class="bar-cell__hall">Dealer</span></div>
+        <div class="bar-cell__weight">32.151 troy oz</div>
+        <div class="bar-cell__usd" id="bv-1000" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-1000-gbp">&mdash;</span> &middot; <span id="bv-1000-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+      <button type="button" class="bar-cell" role="listitem" data-grams="3110.348">
+        <div class="bar-cell__head"><span class="bar-cell__size">100 oz</span><span class="bar-cell__hall">COMEX</span></div>
+        <div class="bar-cell__weight">3,110.348 g</div>
+        <div class="bar-cell__usd" id="bv-3110_348" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-3110_348-gbp">&mdash;</span> &middot; <span id="bv-3110_348-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+      <button type="button" class="bar-cell" role="listitem" data-grams="12441.393">
+        <div class="bar-cell__head"><span class="bar-cell__size">400 oz</span><span class="bar-cell__hall">LBMA GD</span></div>
+        <div class="bar-cell__weight">12,441.393 g</div>
+        <div class="bar-cell__usd" id="bv-12441_393" data-loading="true">&mdash;</div>
+        <div class="bar-cell__sub"><span id="bv-12441_393-gbp">&mdash;</span> &middot; <span id="bv-12441_393-eur">&mdash;</span></div>
+        <div class="bar-cell__per">USD melt value</div>
+      </button>
+    </div>
+  </section>
 
   <h2>What Is the LBMA Good Delivery Standard?</h2>
-  <p>The London Bullion Market Association (LBMA) sets the global standard for wholesale gold bars. A Good Delivery bar weighs between 350 and 430 troy ounces (approximately 10.9–13.4 kg) and must be at least 99.5% pure gold. These are the bars that central banks and institutional investors trade, and they are the source of the spot price used in this calculator.</p>
-  <p>For retail investors, the most popular bar sizes are the 1 troy ounce and the 100g bar — both offer a reasonable balance between the premium over spot price and ease of resale. Larger bars carry lower premiums per gram but are less liquid for individual sellers.</p>
+  <p>The London Bullion Market Association (LBMA) sets the global standard for wholesale gold bars. A Good Delivery bar weighs between 350 and 430 troy ounces (roughly 10.9&ndash;13.4 kg) and must be at least 99.5% pure gold. These are the bars traded between central banks, LBMA-member banks and large institutional investors, and they are the source of the live USD spot price this calculator uses.</p>
+  <p>For retail investors, the 1 troy ounce and the 100 g bars are the most popular &mdash; they offer a balanced trade-off between premium-over-spot and ease of resale. Larger bars carry lower premiums per gram but are less liquid for individual sellers.</p>
 
-  <h2>Spot Price vs What You Pay</h2>
-  <p>The calculator shows the <strong>melt value</strong> — the theoretical value of the pure gold content at the current LBMA spot price. In practice, the price you pay for a gold bar includes a <strong>premium over spot</strong>. This premium covers refining, fabrication, dealer margins, and distribution costs.</p>
-  <ul>
-    <li><strong>Small bars (1g–10g):</strong> Premiums of 5–15% over spot. High fabrication cost relative to gold content.</li>
-    <li><strong>1 troy oz bars:</strong> Premiums of 2–5% over spot. The most liquid retail size.</li>
-    <li><strong>100g–1kg bars:</strong> Premiums of 1–3% over spot. Better value per gram for larger purchases.</li>
-    <li><strong>Good Delivery (400 oz):</strong> Premiums under 0.5%. Institutional market only.</li>
-  </ul>
-  <p>When selling gold bars, most dealers will offer 97–99% of spot for 1oz+ bars in good condition with assay card. Smaller bars may fetch 95–97% of spot due to higher verification costs.</p>
+  <h2>Spot Price vs What You Actually Pay</h2>
+  <p>This calculator shows the <strong>melt value</strong> &mdash; the theoretical USD value of the pure gold content at the current LBMA spot price. In practice, the price you pay for a physical gold bar includes a <strong>premium over spot</strong> that covers refining, fabrication, dealer margin and distribution costs. The premium varies sharply by size:</p>
 
-  <h2>Investment Gold Bars in the UK</h2>
-  <p>In the United Kingdom, investment gold bars are exempt from VAT under HMRC's investment gold rules, provided they meet the required purity threshold (99.5% or higher). This makes them significantly more tax-efficient than jewellery or collectible items. However, profits on gold bars are subject to Capital Gains Tax (CGT). UK investors should note that gold sovereign coins and Britannia coins are CGT-exempt as legal tender, making them a tax-efficient alternative for smaller investments.</p>
-
-  <h2>How to Read This Calculator</h2>
-  <ol>
-    <li><strong>Select a bar size</strong> from the dropdown — choose from 1g up to 400oz Good Delivery.</li>
-    <li><strong>Enter a quantity</strong> — calculate the value of one bar or multiple bars at once.</li>
-    <li><strong>Read the live value</strong> — the GBP and USD figures update automatically from the LBMA spot price every 60 seconds.</li>
-    <li><strong>Remember the premium</strong> — the value shown is spot melt value; actual buy/sell prices include a premium or discount to spot.</li>
-  </ol>
-
-  <h2>Frequently Asked Questions</h2>
-  <div class="faq-section">
-    <div class="faq-item">
-      <h3>How is a gold bar valued?</h3>
-      <div class="faq-answer"><p>A gold bar's value is calculated as its weight in troy ounces multiplied by the current spot price per troy ounce. For example, a 100g bar contains 3.215 troy ounces. At a spot price of $3,200/oz, its melt value is approximately $10,288. The actual market price includes a small premium above this figure.</p></div>
+  <div class="premium-breakdown" role="list">
+    <div class="premium-breakdown__row" role="listitem">
+      <span class="premium-breakdown__band">5&ndash;15%</span>
+      <div class="premium-breakdown__text">
+        <span class="premium-breakdown__title">Small bars (1g &ndash; 10g)</span>
+        <span class="premium-breakdown__desc">High fabrication cost relative to gold content. Best as gifts, not investment.</span>
+      </div>
     </div>
-    <div class="faq-item">
-      <h3>What is the most popular gold bar size for investors?</h3>
-      <div class="faq-answer"><p>The 1 troy ounce (31.1g) and 100g bar are the most popular investment sizes. The 1oz bar is the global benchmark — easy to buy, sell, and store. The 100g bar offers a slightly lower premium per gram and is widely accepted by dealers, banks, and refineries worldwide.</p></div>
+    <div class="premium-breakdown__row" role="listitem">
+      <span class="premium-breakdown__band">2&ndash;5%</span>
+      <div class="premium-breakdown__text">
+        <span class="premium-breakdown__title">1 troy oz bars</span>
+        <span class="premium-breakdown__desc">The most liquid retail size globally. Easy to sell anywhere.</span>
+      </div>
     </div>
-    <div class="faq-item">
-      <h3>Are gold bars VAT-free in the UK?</h3>
-      <div class="faq-answer"><p>Yes. Investment gold bars that are at least 99.5% pure and weigh more than 1g are exempt from VAT in the UK under HMRC's investment gold provisions. This applies to bars from LBMA-approved refiners. Decorative or jewellery-grade gold items do not qualify for VAT exemption.</p></div>
+    <div class="premium-breakdown__row" role="listitem">
+      <span class="premium-breakdown__band">1&ndash;3%</span>
+      <div class="premium-breakdown__text">
+        <span class="premium-breakdown__title">100 g &ndash; 1 kg bars</span>
+        <span class="premium-breakdown__desc">Better value per gram for larger holdings. Widely accepted by dealers and banks.</span>
+      </div>
     </div>
-    <div class="faq-item">
-      <h3>What is a Good Delivery bar?</h3>
-      <div class="faq-answer"><p>A Good Delivery bar is the LBMA's standard wholesale gold bar, weighing between 350 and 430 troy ounces (roughly 11–13kg) with a minimum fineness of 99.5%. These bars are traded between LBMA-member banks, central banks, and refiners. They are not typically sold to retail investors — the 400oz size in this calculator represents the maximum Good Delivery weight.</p></div>
-    </div>
-    <div class="faq-item">
-      <h3>Where can I buy gold bars in the UK?</h3>
-      <div class="faq-answer"><p>Reputable UK gold bar dealers include The Royal Mint, Hatton Garden Metals, BullionVault, Gold Investments, and Atkinsons Bullion. Always compare premiums over spot before purchasing. Buy from LBMA-accredited or BNTA-member dealers to ensure authenticity and resale value.</p></div>
-    </div>
-    <div class="faq-item">
-      <h3>Does the weight on a gold bar include the assay card?</h3>
-      <div class="faq-answer"><p>No. The stated weight on a gold bar refers only to the gold content. The assay card, packaging, and capsule add negligible weight and have no gold value. Always verify the bar weight matches the certificate and that the serial number on the bar matches the assay card.</p></div>
+    <div class="premium-breakdown__row" role="listitem">
+      <span class="premium-breakdown__band">&lt; 0.5%</span>
+      <div class="premium-breakdown__text">
+        <span class="premium-breakdown__title">Good Delivery (400 oz)</span>
+        <span class="premium-breakdown__desc">Institutional only &mdash; LBMA-member banks, central banks and refiners.</span>
+      </div>
     </div>
   </div>
 
+  <p>When <strong>selling</strong> gold bars, most dealers will offer 97&ndash;99% of spot for 1oz+ bars in good condition with an assay card. Smaller bars typically fetch 95&ndash;97% of spot due to higher verification overhead. Use the calculator&rsquo;s premium gauge above to estimate both your retail buy price and your likely sell-back value.</p>
+
+  <h2>Gold Bar Tax Treatment &mdash; US, UK &amp; EU</h2>
+  <p><strong>United States:</strong> Investment-grade gold bars (.995+ purity) are treated as collectibles by the IRS, taxed at the long-term collectibles capital gains rate (currently capped at 28%) when held longer than one year. No federal sales tax on physical bullion, though state sales tax rules vary.</p>
+  <p><strong>United Kingdom:</strong> Investment gold bars meeting the 99.5% purity threshold are exempt from VAT under HMRC&rsquo;s investment gold rules. Profits are subject to Capital Gains Tax (CGT). UK investors should note that gold sovereign and Britannia coins are CGT-exempt as legal tender &mdash; a tax-efficient alternative for smaller holdings.</p>
+  <p><strong>European Union:</strong> The EU Investment Gold Directive (98/80/EC) exempts investment-grade gold bars (995+ fineness) from VAT across all member states. Capital gains treatment varies by country.</p>
+
+  <h2>How to Read This Calculator</h2>
+  <ol>
+    <li><strong>Tap a bar size chip</strong> &mdash; nine standard sizes from 1g retail to 400oz LBMA Good Delivery. The popular 1 oz benchmark is selected by default.</li>
+    <li><strong>Set quantity</strong> with the &plus;&thinsp;/&thinsp;&minus; steppers if you hold more than one bar.</li>
+    <li><strong>Read the live USD value</strong> &mdash; the result box updates automatically. GBP, EUR and INR pills show live conversions at ECB reference rates.</li>
+    <li><strong>Use the premium gauge</strong> to estimate the typical retail buy price and dealer sell-back &mdash; not the same as raw melt value.</li>
+  </ol>
+
+  <section class="faq-section" aria-labelledby="faq-title">
+    <h2 id="faq-title">Frequently Asked Questions</h2>
+    <div class="faq-list">
+      <details class="faq-item" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-answer-summary" itemprop="name">How is a gold bar valued?</summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <div itemprop="text"><p>A gold bar&rsquo;s melt value is its weight in troy ounces multiplied by the live USD spot price per troy ounce. A 100 g bar contains 3.215 troy ounces. At a $3,200/oz spot price, that&rsquo;s a melt value of <strong>$10,288 USD</strong>. The retail price you actually pay includes a small premium above the melt value.</p></div>
+        </div>
+      </details>
+      <details class="faq-item" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-answer-summary" itemprop="name">What is the most popular gold bar size for investors?</summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <div itemprop="text"><p>The 1 troy ounce (31.1 g) and the 100 g bar are the most popular investment sizes worldwide. The 1 oz bar is the global retail benchmark &mdash; easy to buy, sell and store. The 100 g bar offers a slightly lower premium per gram and is widely accepted by dealers, banks and refineries.</p></div>
+        </div>
+      </details>
+      <details class="faq-item" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-answer-summary" itemprop="name">What is a Good Delivery bar?</summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <div itemprop="text"><p>A Good Delivery bar is the LBMA&rsquo;s standard wholesale gold bar, weighing 350&ndash;430 troy ounces (about 11&ndash;13 kg) at minimum 99.5% fineness. These bars trade between LBMA-member banks, central banks and refiners and are not generally sold to retail investors. The 400 oz size in this calculator represents the upper Good Delivery weight.</p></div>
+        </div>
+      </details>
+      <details class="faq-item" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-answer-summary" itemprop="name">Are gold bars tax-free?</summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <div itemprop="text"><p>Investment-grade gold bars at 99.5%+ purity are VAT-exempt across the UK and EU under the Investment Gold Directive. In the US there is no federal sales tax on bullion but state sales tax rules vary. <strong>Capital gains tax always applies</strong> on profits when sold &mdash; collectibles rate up to 28% in the US, standard CGT in the UK and EU.</p></div>
+        </div>
+      </details>
+      <details class="faq-item" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-answer-summary" itemprop="name">Where can I buy gold bars?</summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <div itemprop="text"><p>Buy from LBMA-accredited or industry-association-member dealers. Reputable global names include JM Bullion, APMEX, Kitco, Money Metals Exchange (US); The Royal Mint, BullionVault, Hatton Garden Metals, Atkinsons Bullion (UK); Heraeus, Umicore, PAMP, Argor-Heraeus (EU refiners). Always compare premium over USD spot before purchasing.</p></div>
+        </div>
+      </details>
+      <details class="faq-item" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-answer-summary" itemprop="name">Does the weight on a gold bar include the assay card?</summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <div itemprop="text"><p>No. The stated weight on a gold bar refers only to the gold content. The assay card, packaging and capsule add negligible weight and have no gold value. Always verify the bar weight matches the certificate and that the bar&rsquo;s serial number matches the assay card.</p></div>
+        </div>
+      </details>
+      <details class="faq-item" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+        <summary class="faq-answer-summary" itemprop="name">Which currency does this calculator use?</summary>
+        <div class="faq-answer" itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
+          <div itemprop="text"><p>USD is the primary display currency &mdash; the world&rsquo;s reserve currency and the standard quote for the global LBMA gold market. GBP, EUR and INR conversions appear alongside every USD figure and update live using ECB reference rates from the Frankfurter API.</p></div>
+        </div>
+      </details>
+    </div>
+  </section>
+
   <div class="disclaimer-box">
-    <strong>Disclaimer:</strong> Values shown are indicative melt values based on live LBMA spot prices and are for reference only. Actual buy and sell prices from dealers will differ. This is not financial advice. Gold prices can fall as well as rise.
+    <strong>Disclaimer:</strong> Values shown are indicative melt values based on live LBMA spot prices and ECB reference FX rates, provided for reference only. Actual buy and sell prices from dealers will differ. This is not financial advice. Gold prices can fall as well as rise.
   </div>
 
 </article>
 
-<div class="share-buttons">
+<div class="share-buttons" aria-label="Share this calculator">
   <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/gold-bar-value&amp;text=Gold%20Bar%20Value%20Calculator" target="_blank" rel="noopener" data-platform="twitter"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.259 5.63zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg> X</a>
-  <a href="https://reddit.com/submit?url=https://goldpricetools.com/gold-bar-value&amp;title=Gold%20Bar%20Value%20Calculator" target="_blank" rel="noopener" data-platform="reddit"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=Gold%20Bar%20Value%20Calculator%20https://goldpricetools.com/gold-bar-value" target="_blank" rel="noopener" data-platform="whatsapp"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/gold-bar-value&amp;text=Live%20USD%20Gold%20Bar%20Value%20Calculator" target="_blank" rel="noopener" data-platform="twitter"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.259 5.63zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg> X</a>
+  <a href="https://reddit.com/submit?url=https://goldpricetools.com/gold-bar-value&amp;title=Gold%20Bar%20Value%20Calculator%20%E2%80%94%20Live%20USD%20Melt%20Value" target="_blank" rel="noopener" data-platform="reddit"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=Gold%20Bar%20Value%20Calculator%20%E2%80%94%20live%20USD%20melt%20value%3A%20https://goldpricetools.com/gold-bar-value" target="_blank" rel="noopener" data-platform="whatsapp"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 
-<h2 style="font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:var(--space-8) 0 var(--space-4)">Related Gold &amp; Silver Guides</h2>
+<h2 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-10) 0 var(--space-4);letter-spacing:-.01em">Related Gold &amp; Silver Tools</h2>
 <div class="related-guides-grid">
   <a href="/scrap-gold-calculator" class="related-card">
     <span class="related-card__tag">TOOL</span>
     <span class="related-card__title">Scrap Gold Calculator</span>
-    <span class="related-card__desc">Calculate the melt value of your gold jewellery using today&rsquo;s live spot price.</span>
+    <span class="related-card__desc">Calculate the live USD melt value of your gold jewellery by karat &mdash; 9K to 24K supported.</span>
   </a>
   <a href="/guides/gold-bar-guide" class="related-card">
     <span class="related-card__tag">GUIDE</span>
-    <span class="related-card__title">Gold Bar Guide</span>
-    <span class="related-card__desc">From 1g to 400oz Good Delivery bars &mdash; learn about gold bar sizes and premiums.</span>
+    <span class="related-card__title">Gold Bar Buying Guide</span>
+    <span class="related-card__desc">From 1g to 400oz Good Delivery &mdash; sizes, premiums, refiners and storage.</span>
   </a>
   <a href="/24k-gold-price-per-gram" class="related-card">
     <span class="related-card__tag">LIVE PRICE</span>
     <span class="related-card__title">24K Gold Price Per Gram</span>
-    <span class="related-card__desc">Live 24K (pure) gold price per gram &mdash; the benchmark for all karat calculations.</span>
+    <span class="related-card__desc">Live USD per gram for pure 24K gold &mdash; the benchmark for all bar value math.</span>
   </a>
   <a href="/gold-coins-vs-bars" class="related-card">
     <span class="related-card__tag">GUIDE</span>
     <span class="related-card__title">Gold Coins vs Gold Bars</span>
-    <span class="related-card__desc">Compare the pros and cons of coins and bars for investment and storage.</span>
+    <span class="related-card__desc">Compare premiums, liquidity, tax treatment and storage for coins versus bars.</span>
   </a>
 </div>
 
-</div>
+</main>
 
 <footer>
   <div class="footer-inner">
@@ -778,47 +1246,257 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 </footer>
 
 <script>
-async function fetchFx(){
-  try{
-    const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});
-    if(!r.ok)throw new Error();
-    const d=await r.json();
-    window._gbpusd=d.GBPUSD||0.79;
-  }catch{window._gbpusd=0.79;}
-}
-async function fetchSpot(){
-  try {
-    const r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
-    if(!r.ok)throw new Error();
-    const d=await r.json();
-    window._spotUSD = d.price;
-    updateCalc();
-  }catch(e){
-    console.warn('Price fetch failed',e);
+/* ╔═══════════════════════════════════════════════════════════════════╗
+   ║ Gold Bar Value Calculator — USD-primary live engine               ║
+   ║ Sources: LBMA spot via gold-api.com · FX via frankfurter.dev (ECB)║
+   ║ Refresh: 60s · Multi-currency · Mirrors scrap-gold-calculator     ║
+   ╚═══════════════════════════════════════════════════════════════════╝ */
+(function(){
+  'use strict';
+
+  const G_PER_OZ = 31.1035;
+  const REFRESH_MS = 60000;
+
+  // Shared global state (back-compat with goldprice_updated listeners)
+  window._spotUSD = null;
+  window._spot    = null;
+  window._gbpusd  = 0.79;
+  window._eurusd  = 0.92;
+  window._usdinr  = 83.5;
+  let lastFetchTs = 0;
+
+  // Premium-over-spot bands by bar size (gram weight → [low%, high%])
+  function premiumBand(grams){
+    if(grams <= 10)        return {low:5,  high:15, label:'5 – 15%',  retailMid:10,  sellbackPct:96};   // tiny retail
+    if(grams < 31.1)       return {low:3,  high:10, label:'3 – 10%',  retailMid:6,   sellbackPct:96};   // 10g–<1oz
+    if(grams <= 31.1035)   return {low:2,  high:5,  label:'2 – 5%',   retailMid:3.5, sellbackPct:98};   // 1 oz benchmark
+    if(grams < 100)        return {low:2,  high:5,  label:'2 – 5%',   retailMid:3.5, sellbackPct:97};
+    if(grams <= 1000)      return {low:1,  high:3,  label:'1 – 3%',   retailMid:2,   sellbackPct:98};   // 100g–1kg
+    if(grams <= 3110.348)  return {low:0.5,high:2,  label:'0.5 – 2%', retailMid:1,   sellbackPct:99};   // 100oz
+    return                       {low:0.1,high:0.5, label:'< 0.5%',   retailMid:0.3, sellbackPct:99.5}; // Good Delivery
   }
-}
-function updateCalc() {
-  if(!window._spotUSD) return;
-  const gbpusd = window._gbpusd || 0.79;
-  const spotPerGramUSD = window._spotUSD / 31.1035;
-  const spotPerGramGBP = spotPerGramUSD * gbpusd;
 
-  const sizeGrams = parseFloat(document.getElementById('bar-size').value) || 0;
-  const qty = parseFloat(document.getElementById('bar-qty').value) || 0;
+  // Formatters — USD primary
+  const fmtUSD  = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
+  const fmtUSD0 = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:0});
+  const fmtGBP  = new Intl.NumberFormat('en-GB',{style:'currency',currency:'GBP',maximumFractionDigits:2});
+  const fmtEUR  = new Intl.NumberFormat('en-IE',{style:'currency',currency:'EUR',maximumFractionDigits:2});
+  const fmtINR  = new Intl.NumberFormat('en-IN',{style:'currency',currency:'INR',maximumFractionDigits:0});
+  const fmtGram = new Intl.NumberFormat('en-US',{maximumFractionDigits:3,minimumFractionDigits:2});
 
-  const totalGrams = sizeGrams * qty;
-  const totalUSD = totalGrams * spotPerGramUSD;
-  const totalGBP = totalGrams * spotPerGramGBP;
+  // Use compact (e.g. $12.4M) for very large totals on the bar grid only
+  function smartUSD(value){
+    if(value >= 1_000_000) return fmtUSD0.format(value);
+    return fmtUSD.format(value);
+  }
 
-  document.getElementById('price-gbp').textContent = '£' + totalGBP.toLocaleString('en-GB', {minimumFractionDigits:2, maximumFractionDigits:2});
-  document.getElementById('price-usd').textContent = '$' + totalUSD.toLocaleString('en-US', {minimumFractionDigits:2, maximumFractionDigits:2});
-}
+  function $(id){return document.getElementById(id);}
+  function clearSkeleton(el){if(el){el.removeAttribute('data-loading');}}
 
-document.getElementById('bar-size').addEventListener('change', updateCalc);
-document.getElementById('bar-qty').addEventListener('input', updateCalc);
+  // ── Bar size chip selection ──
+  const chips = document.querySelectorAll('.bar-chip');
+  function selectChip(grams){
+    chips.forEach(c => {
+      const isMatch = parseFloat(c.dataset.grams) === parseFloat(grams);
+      c.setAttribute('aria-checked', isMatch ? 'true' : 'false');
+    });
+    document.querySelectorAll('.bar-cell').forEach(cell => {
+      cell.dataset.active = (parseFloat(cell.dataset.grams) === parseFloat(grams)) ? 'true' : 'false';
+    });
+    calc();
+  }
+  chips.forEach(chip => {
+    chip.addEventListener('click', () => selectChip(parseFloat(chip.dataset.grams)));
+    chip.addEventListener('keydown', e => {
+      const keys = ['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'];
+      if(!keys.includes(e.key)) return;
+      e.preventDefault();
+      const arr = Array.from(chips);
+      const idx = arr.indexOf(chip);
+      const dir = (e.key==='ArrowRight'||e.key==='ArrowDown') ? 1 : -1;
+      const next = arr[(idx + dir + arr.length) % arr.length];
+      next.focus();
+      next.click();
+    });
+  });
 
-Promise.all([fetchFx(),fetchSpot()]);
-setInterval(fetchSpot,60000);
+  // Tap bar grid card to load into calculator + scroll up
+  document.querySelectorAll('.bar-cell').forEach(cell => {
+    cell.addEventListener('click', () => {
+      const grams = parseFloat(cell.dataset.grams);
+      selectChip(grams);
+      const calc = document.querySelector('.gbv-calc');
+      if(calc) calc.scrollIntoView({behavior:'smooth', block:'start'});
+      if(typeof gtag !== 'undefined') gtag('event','bar_cell_load',{grams});
+    });
+  });
+
+  // ── Quantity stepper ──
+  const qtyInput = $('bar-qty');
+  $('qty-down').addEventListener('click', () => {
+    const v = Math.max(1, (parseInt(qtyInput.value,10) || 1) - 1);
+    qtyInput.value = v;
+    calc();
+  });
+  $('qty-up').addEventListener('click', () => {
+    const v = Math.min(9999, (parseInt(qtyInput.value,10) || 1) + 1);
+    qtyInput.value = v;
+    calc();
+  });
+  qtyInput.addEventListener('input', calc);
+
+  function getSelectedGrams(){
+    const sel = document.querySelector('.bar-chip[aria-checked="true"]');
+    return sel ? parseFloat(sel.dataset.grams) : 31.1035;
+  }
+
+  // ── Core calculation ──
+  function calc(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD) return;
+    const usdPerGram = spotUSD / G_PER_OZ;
+    const grams = getSelectedGrams();
+    const qty   = Math.max(1, parseInt(qtyInput.value,10) || 1);
+    const totalGrams = grams * qty;
+
+    const totalUSD = totalGrams * usdPerGram;
+    const totalGBP = totalUSD * window._gbpusd;
+    const totalEUR = totalUSD * window._eurusd;
+    const totalINR = totalUSD * window._usdinr;
+
+    // Result box (USD primary)
+    const resUSD = $('res-usd');
+    clearSkeleton(resUSD);
+    resUSD.textContent = fmtUSD.format(totalUSD);
+    $('res-gbp').textContent = fmtGBP.format(totalGBP);
+    $('res-eur').textContent = fmtEUR.format(totalEUR);
+    $('res-inr').textContent = fmtINR.format(totalINR);
+
+    $('pure-grams').textContent = fmtGram.format(totalGrams) + ' g (24K)';
+
+    // Sticky mobile
+    const stickyVal = $('sticky-usd');
+    const stickyBar = $('mobile-sticky');
+    if(stickyVal) stickyVal.textContent = fmtUSD.format(totalUSD);
+    if(stickyBar){
+      stickyBar.classList.add('is-visible');
+      stickyBar.setAttribute('aria-hidden','false');
+    }
+
+    // Premium gauge
+    const band = premiumBand(grams);
+    $('premium-range').textContent = band.label;
+    const midOfFifteen = Math.min(100, (band.retailMid / 15) * 100);
+    $('premium-fill').style.width = midOfFifteen.toFixed(1) + '%';
+
+    const retailUSD = totalUSD * (1 + band.retailMid/100);
+    const sellbackUSD = totalUSD * (band.sellbackPct/100);
+    $('retail-usd').textContent  = fmtUSD.format(retailUSD);
+    $('retail-gbp').textContent  = fmtGBP.format(retailUSD * window._gbpusd);
+    $('sellback-usd').textContent = fmtUSD.format(sellbackUSD);
+    $('sellback-gbp').textContent = fmtGBP.format(sellbackUSD * window._gbpusd);
+
+    if(typeof gtag !== 'undefined') gtag('event','bar_calculator_used',{value:Math.round(totalUSD)});
+  }
+  window.calcBarValue = calc;
+
+  // ── Live spot tile ──
+  function fillSpotTile(){
+    const s = window._spotUSD;
+    if(!s) return;
+    const u = $('spot-usd'); if(u){clearSkeleton(u); u.textContent = fmtUSD.format(s);}
+    const g = $('spot-gbp'); if(g) g.textContent = fmtGBP.format(s * window._gbpusd);
+    const e = $('spot-eur'); if(e) e.textContent = fmtEUR.format(s * window._eurusd);
+    const n = $('spot-inr'); if(n) n.textContent = fmtINR.format(s * window._usdinr);
+  }
+
+  // ── Live bar grid (all 9 sizes) ──
+  const gridSizes = [
+    {g:1,         key:'1'},
+    {g:2.5,       key:'2_5'},
+    {g:5,         key:'5'},
+    {g:10,        key:'10'},
+    {g:31.1035,   key:'31_1035'},
+    {g:100,       key:'100'},
+    {g:250,       key:'250'},
+    {g:1000,      key:'1000'},
+    {g:3110.348,  key:'3110_348'},
+    {g:12441.393, key:'12441_393'}
+  ];
+  function fillBarGrid(){
+    const s = window._spotUSD;
+    if(!s) return;
+    const usdPerGram = s / G_PER_OZ;
+    gridSizes.forEach(({g,key}) => {
+      const usd = g * usdPerGram;
+      const elUSD = $('bv-' + key);
+      const elGBP = $('bv-' + key + '-gbp');
+      const elEUR = $('bv-' + key + '-eur');
+      if(elUSD){
+        clearSkeleton(elUSD);
+        elUSD.textContent = smartUSD(usd);
+      }
+      if(elGBP) elGBP.textContent = fmtGBP.format(usd * window._gbpusd);
+      if(elEUR) elEUR.textContent = fmtEUR.format(usd * window._eurusd);
+    });
+  }
+
+  // ── Updated stamps ──
+  function refreshUpdatedStamp(){
+    if(!lastFetchTs) return;
+    const secs = Math.floor((Date.now() - lastFetchTs)/1000);
+    const txt = secs < 5  ? 'just now'
+              : secs < 60 ? secs + 's ago'
+              : Math.floor(secs/60) + 'm ago';
+    const a = $('updated-stamp'); if(a) a.textContent = txt;
+    const b = $('last-update');   if(b) b.textContent = txt;
+  }
+  setInterval(refreshUpdatedStamp, 1000);
+
+  // ── Data fetchers ──
+  async function fetchFx(){
+    try{
+      const r = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR',{cache:'no-store'});
+      if(!r.ok) throw new Error('FX HTTP '+r.status);
+      const d = await r.json();
+      window._gbpusd = d.rates.GBP || window._gbpusd;
+      window._eurusd = d.rates.EUR || window._eurusd;
+      window._usdinr = d.rates.INR || window._usdinr;
+    }catch(e){
+      console.warn('FX fallback used', e);
+    }
+  }
+
+  async function fetchSpot(){
+    try{
+      const r = await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
+      if(!r.ok) throw new Error('Spot HTTP '+r.status);
+      const d = await r.json();
+      window._spotUSD = d.price;
+      window._spot    = d.price;
+      lastFetchTs = Date.now();
+      fillSpotTile();
+      fillBarGrid();
+      refreshUpdatedStamp();
+      calc();
+      window.dispatchEvent(new Event('goldprice_updated'));
+      if(typeof gtag !== 'undefined') gtag('event','price_view',{metal:'gold',page:'gold-bar-value'});
+    }catch(e){
+      console.warn('Spot fetch failed', e);
+      const u = $('res-usd');
+      if(u && !window._spotUSD){clearSkeleton(u); u.textContent = 'API unavailable';}
+    }
+  }
+
+  // ── Init ──
+  function init(){
+    selectChip(31.1035); // 1 oz benchmark default
+    Promise.all([fetchFx(), fetchSpot()]).catch(e => console.warn('init',e));
+    setInterval(fetchSpot, REFRESH_MS);
+  }
+  if(document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();
 </script>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>


### PR DESCRIPTION
## Summary

Premium redesign of `/gold-bar-value` that mirrors the visual vocabulary of `/scrap-gold-calculator` (`spot-tile`, `result-box`, `feat-trio`, `mobile-sticky`, `data-source` pulse strip) and lifts the page from a basic dropdown calculator to a full bento-grid USD-primary tool.

### What changed

- **Live data pipeline**: replaced the broken `goldpricetoolsworker.io/fx` worker call with the same live sources the rest of the site uses — LBMA spot via `gold-api.com/price/XAU` and ECB FX via `frankfurter.dev` (USD → GBP/EUR/INR), refreshed every 60 seconds. All money figures on the page are driven from a single fetched USD spot price, so the spot tile, result box, premium gauge, bento grid and mobile-sticky bar always agree.
- **USD as primary currency** across the hero spot tile, result box, premium gauge, mobile sticky CTA and the live bar-value grid, with GBP / EUR / INR as live secondary pills.
- **Interactive bar-size chip selector** (10 sizes: 1g, 2.5g, 5g, 10g, 1oz, 100g, 250g, 1kg, 100oz, 400oz LBMA Good Delivery) replaces the old `<select>` dropdown. Includes `POPULAR` flag on 1 oz benchmark and `GOOD DELIVERY` flag on 400 oz, full radiogroup keyboard navigation, and 62px+ touch targets.
- **`+ / −` quantity stepper** with 44px tap targets.
- **Live "Bar Value Grid"** (bento style) showing USD value for every standard size, updating each 60s tick. Tap any card to load that size into the calculator above.
- **Premium-over-spot gauge** with a visual bar, size-aware band (5–15% for small bars, 2–5% for 1 oz, 1–3% for 100g–1kg, <0.5% for Good Delivery), plus estimated retail buy price and estimated dealer sell-back (USD + GBP sub-line).
- **Mobile sticky bar** with live USD total and "Where to buy" CTA on ≤768px.
- **FAQ** rebuilt as `<details>/<summary>` expanders with a polished chevron animation.
- **Premium breakdown** info-list explaining the 4 dealer premium bands by bar size.
- **Tax section** updated to cover US (collectibles rate, 28% cap), UK (VAT-exempt + CGT) and EU (Directive 98/80/EC).
- **Schemas added**: `SoftwareApplication` (priceCurrency USD) and `HowTo` JSON-LD; `FAQPage` rewritten to match the new 7 body FAQs.
- **Meta** title & description updated to lead with USD primary and 1g → 400oz range.

### Verified

- HTML parses cleanly (all tags closed, all 5 JSON-LD blocks valid)
- Headless Chromium audit (1440 × 900 desktop, 768 × 1024 tablet, iPhone 14 Pro, 375 × 812 phone) — no horizontal overflow at any breakpoint
- API-mocked render confirms math consistency across spot tile / result box / premium gauge / sticky bar / 10-cell bar grid (1 oz benchmark = $3,287.42 → 1 g = $105.69, 1 kg = $105,692.93, 400 oz = $1,314,967)
- Mobile sticky bar appears at ≤768px with live USD total
- Dark + light theme both render without contrast regressions

## Test plan

- [ ] Manually open `/gold-bar-value` and tap through every chip — result + gauge + sticky should update instantly
- [ ] Tap a card in the live bar grid — calculator should load that size and smooth-scroll up
- [ ] Verify live prices in spot tile, result box and bar grid all derive from the same USD spot
- [ ] Test on real iPhone (sticky bar appears, no horizontal scroll, chips are easy to hit)
- [ ] Test on Android Chrome and desktop Chrome / Safari / Firefox
- [ ] Confirm Google Rich Results test passes for the SoftwareApplication, HowTo and FAQPage schemas
- [ ] Run `python3 tools/playwright_audit.py https://goldpricetools.com/gold-bar-value` after deploy


---
_Generated by [Claude Code](https://claude.ai/code/session_01ADPrRYQXPXv4V3p2KbDKtM)_