### PR TITLE
Redesign Zakat calculator with premium mobile-first Islamic-inspired UI

### DIFF
--- a/zakat-gold-silver-calculator.html
+++ b/zakat-gold-silver-calculator.html
@@ -451,36 +451,291 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </div>
   </div>
 </nav>
-</div>
 
-<!-- HERO -->
-<section class="hero" aria-label="Zakat Calculator">
-  <div style="grid-column: 1 / -1; text-align: center;">
-    <div class="hero-badge"><span class="live-dot"></span> Live Spot Prices</div>
-    <h1>Zakat Calculator for Gold &amp; Silver &mdash; 2026 Nisab Threshold</h1>
-    <p class="hero-desc" style="margin: 0 auto 1.5rem;">Calculate your exact Zakat (2.5%) on gold and silver wealth based on real-time global market prices.</p>
+<!-- BREADCRUMB -->
+<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li><a href="/scrap-gold-calculator">Calculators</a></li><li aria-current="page">Zakat Calculator</li></ol></div>
 
-    <div id="nisab-indicator" style="background:var(--color-surface); border:1px solid var(--color-border); border-radius:var(--radius-lg); padding:var(--space-4); max-width: 600px; margin: 0 auto; box-shadow:var(--shadow-sm);">
-      <div style="font-size:var(--text-xs); font-weight:600; color:var(--color-text-muted); text-transform:uppercase; letter-spacing:.08em; margin-bottom:var(--space-2);">Current Nisab Status</div>
-      <div id="nisab-status-text" style="font-size:var(--text-lg); font-weight:700; color:var(--color-text);">Loading Nisab threshold...</div>
-      <div style="font-size:var(--text-sm); color:var(--color-text-muted); margin-top:var(--space-1);">Based on 85g of 24K pure gold at live spot price</div>
+<!-- HERO — Premium Liquid Glass + Islamic Geometric -->
+<section class="zk-hero" aria-label="Zakat Calculator">
+  <div class="zk-hero__pattern" aria-hidden="true">
+    <svg width="100%" height="100%" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <pattern id="arabesque" x="0" y="0" width="120" height="120" patternUnits="userSpaceOnUse">
+          <g fill="none" stroke="currentColor" stroke-width="1" opacity="0.35">
+            <path d="M60 0 L120 60 L60 120 L0 60 Z"/>
+            <circle cx="60" cy="60" r="28"/>
+            <path d="M32 60 L60 32 L88 60 L60 88 Z"/>
+            <path d="M0 0 L60 60 M120 0 L60 60 M0 120 L60 60 M120 120 L60 60"/>
+          </g>
+        </pattern>
+        <radialGradient id="heroGlow" cx="50%" cy="40%" r="60%">
+          <stop offset="0%" stop-color="var(--color-gold-bright)" stop-opacity="0.18"/>
+          <stop offset="100%" stop-color="var(--color-gold-bright)" stop-opacity="0"/>
+        </radialGradient>
+      </defs>
+      <rect width="100%" height="100%" fill="url(#arabesque)" color="var(--color-gold-bright)"/>
+      <rect width="100%" height="100%" fill="url(#heroGlow)"/>
+    </svg>
+  </div>
+
+  <div class="zk-hero__inner">
+    <div class="zk-hero__badge">
+      <span class="live-dot"></span>
+      <span>LIVE&nbsp;·&nbsp;2026 Nisab Threshold</span>
+    </div>
+    <h1 class="zk-hero__title">Zakat Calculator for <span class="zk-grad-gold">Gold</span> &amp; <span class="zk-grad-silver">Silver</span></h1>
+    <p class="zk-hero__sub">Calculate your <strong>2.5% Zakat</strong> due on precious-metal wealth using real-time global spot prices in USD, refreshed every 60&nbsp;seconds. Built on classical Nisab thresholds derived from Sunnah.</p>
+
+    <!-- Dual Nisab status cards -->
+    <div class="zk-nisab-grid" role="group" aria-label="Live Nisab thresholds">
+      <article class="zk-nisab-card zk-nisab-card--gold">
+        <header class="zk-nisab-card__head">
+          <span class="zk-nisab-card__tag">Gold Nisab</span>
+          <span class="zk-nisab-card__chip">85&nbsp;g · 24K pure</span>
+        </header>
+        <div class="zk-nisab-card__value" id="goldNisabValue">$—</div>
+        <div class="zk-nisab-card__meta">
+          <span>Spot: <strong id="goldSpotMini">$—/oz</strong></span>
+          <span class="zk-nisab-card__sep">·</span>
+          <span>Updated <strong id="lastUpdated">—</strong></span>
+        </div>
+      </article>
+
+      <article class="zk-nisab-card zk-nisab-card--silver">
+        <header class="zk-nisab-card__head">
+          <span class="zk-nisab-card__tag">Silver Nisab</span>
+          <span class="zk-nisab-card__chip">595&nbsp;g · 99.9% fine</span>
+        </header>
+        <div class="zk-nisab-card__value" id="silverNisabValue">$—</div>
+        <div class="zk-nisab-card__meta">
+          <span>Spot: <strong id="silverSpotMini">$—/oz</strong></span>
+          <span class="zk-nisab-card__sep">·</span>
+          <span>Recommended threshold</span>
+        </div>
+      </article>
+    </div>
+
+    <div class="zk-hero__pillars" aria-hidden="true">
+      <span class="zk-pill"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> Hawl: 1 lunar year</span>
+      <span class="zk-pill"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12h18M12 3v18"/></svg> Rate: 2.5%</span>
+      <span class="zk-pill"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L4 7v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V7l-8-5z"/></svg> Classical sources</span>
     </div>
   </div>
 </section>
 
 
 <style>
-  .zakat-calc-wrap { max-width: 800px; margin: 0 auto; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-xl); padding: var(--space-6); box-shadow: var(--shadow-md); margin-bottom: var(--space-8); }
-  .zakat-section-title { font-family: var(--font-display); font-size: var(--text-xl); color: var(--color-gold-bright); margin-bottom: var(--space-4); border-bottom: 1px solid var(--color-border); padding-bottom: var(--space-2); }
-  .zakat-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); margin-bottom: var(--space-4); }
-  @media(max-width: 600px) { .zakat-row { grid-template-columns: 1fr; } }
-  .zakat-result-box { background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: var(--space-4); text-align: center; }
-  .zakat-result-label { font-size: var(--text-xs); font-weight: 600; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: .05em; margin-bottom: var(--space-1); }
-  .zakat-result-value { font-size: var(--text-2xl); font-weight: 700; color: var(--color-text); font-variant-numeric: tabular-nums; }
-  .zakat-total-box { background: color-mix(in oklch, var(--color-gold-bright) 10%, var(--color-surface)); border: 2px solid var(--color-gold-bright); border-radius: var(--radius-lg); padding: var(--space-5); text-align: center; margin-top: var(--space-6); }
-  .zakat-status-badge { display: inline-block; padding: var(--space-1) var(--space-3); border-radius: var(--radius-full); font-size: var(--text-sm); font-weight: 700; margin-top: var(--space-3); }
-  .zakat-status-above { background: rgba(74, 222, 128, 0.2); color: #4ade80; border: 1px solid rgba(74, 222, 128, 0.5); }
-  .zakat-status-below { background: rgba(248, 113, 113, 0.2); color: #f87171; border: 1px solid rgba(248, 113, 113, 0.5); }
+/* ====================================================================
+   ZAKAT CALCULATOR — Premium Liquid Glass + Bento Grid
+   Mobile-first · Glassmorphism · Islamic geometric accents
+   ==================================================================== */
+
+/* ── Hero ── */
+.zk-hero{position:relative;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-10);overflow:hidden;isolation:isolate}
+.zk-hero__pattern{position:absolute;inset:0;z-index:-1;color:var(--color-gold-bright);opacity:.18;pointer-events:none;mask-image:radial-gradient(ellipse at center, #000 30%, transparent 75%);-webkit-mask-image:radial-gradient(ellipse at center, #000 30%, transparent 75%)}
+[data-theme="light"] .zk-hero__pattern{opacity:.12}
+.zk-hero__inner{max-width:880px;margin:0 auto;text-align:center;position:relative}
+.zk-hero__badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));padding:6px 14px;border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);letter-spacing:.08em;text-transform:uppercase;margin-bottom:var(--space-5);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
+.zk-hero__title{font-family:var(--font-display);font-size:clamp(2rem,1.4rem + 3.2vw,3.75rem);font-weight:700;line-height:1.08;letter-spacing:-.02em;color:var(--color-text);margin-bottom:var(--space-4)}
+.zk-grad-gold{background:linear-gradient(135deg,#f4c849 0%,var(--color-gold-bright) 50%,#b07a00 100%);-webkit-background-clip:text;background-clip:text;color:transparent;display:inline-block}
+.zk-grad-silver{background:linear-gradient(135deg,#e5e7eb 0%,#9ca3af 50%,#6b7280 100%);-webkit-background-clip:text;background-clip:text;color:transparent;display:inline-block}
+.zk-hero__sub{font-size:clamp(1rem,.9rem + .5vw,1.18rem);color:var(--color-text-muted);max-width:62ch;margin:0 auto var(--space-8);line-height:1.7}
+.zk-hero__sub strong{color:var(--color-text);font-weight:600}
+
+/* Dual Nisab grid */
+.zk-nisab-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin:var(--space-6) auto var(--space-6);max-width:760px;text-align:left}
+@media(min-width:640px){.zk-nisab-grid{grid-template-columns:1fr 1fr;gap:var(--space-4)}}
+.zk-nisab-card{position:relative;background:color-mix(in oklch,var(--color-surface) 75%,transparent);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);backdrop-filter:blur(16px) saturate(140%);-webkit-backdrop-filter:blur(16px) saturate(140%);box-shadow:var(--shadow-md);transition:transform 220ms cubic-bezier(.4,0,.2,1),border-color 220ms,box-shadow 220ms;overflow:hidden}
+.zk-nisab-card::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at top right,currentColor 0%,transparent 60%);opacity:.06;pointer-events:none;z-index:0}
+.zk-nisab-card>*{position:relative;z-index:1}
+.zk-nisab-card--gold{color:var(--color-gold-bright)}
+.zk-nisab-card--silver{color:var(--color-silver)}
+.zk-nisab-card:hover{transform:translateY(-2px);border-color:currentColor;box-shadow:var(--shadow-lg)}
+.zk-nisab-card__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap}
+.zk-nisab-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:currentColor}
+.zk-nisab-card__chip{font-size:11px;font-weight:600;padding:3px 10px;border-radius:var(--radius-full);background:color-mix(in oklch,currentColor 14%,transparent);border:1px solid color-mix(in oklch,currentColor 25%,transparent);color:currentColor}
+.zk-nisab-card__value{font-family:var(--font-display);font-size:clamp(1.75rem,1.2rem + 2.5vw,2.5rem);font-weight:700;line-height:1.05;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em;margin-bottom:var(--space-2)}
+.zk-nisab-card__meta{font-size:var(--text-xs);color:var(--color-text-muted);display:flex;flex-wrap:wrap;align-items:center;gap:6px}
+.zk-nisab-card__meta strong{color:var(--color-text);font-weight:600;font-variant-numeric:tabular-nums}
+.zk-nisab-card__sep{color:var(--color-text-faint)}
+
+.zk-hero__pillars{display:flex;flex-wrap:wrap;justify-content:center;gap:var(--space-2);margin-top:var(--space-4)}
+.zk-pill{display:inline-flex;align-items:center;gap:6px;font-size:11px;font-weight:600;letter-spacing:.04em;color:var(--color-text-muted);padding:6px 12px;border:1px solid var(--color-border);border-radius:var(--radius-full);background:var(--color-surface-offset)}
+.zk-pill svg{color:var(--color-gold-bright)}
+
+/* ── Currency switcher ── */
+.zk-currency-bar{max-width:1100px;margin:0 auto var(--space-6);padding:0 var(--space-4);display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:var(--space-3)}
+.zk-currency-bar__label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint)}
+.zk-currency-chips{display:flex;flex-wrap:wrap;gap:6px}
+.zk-currency-chip{padding:6px 12px;font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-full);cursor:pointer;transition:all 180ms cubic-bezier(.4,0,.2,1);font-variant-numeric:tabular-nums;min-height:32px}
+.zk-currency-chip:hover{color:var(--color-text);border-color:var(--color-gold-bright)}
+.zk-currency-chip.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright);box-shadow:0 4px 12px color-mix(in oklch,var(--color-gold-bright) 30%,transparent)}
+
+/* ── Bento Calculator ── */
+.zk-calc{max-width:1100px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+.zk-calc__grid{display:grid;grid-template-columns:1fr;gap:var(--space-5)}
+@media(min-width:900px){.zk-calc__grid{grid-template-columns:1fr 1fr;gap:var(--space-5)}}
+
+.zk-card{position:relative;background:color-mix(in oklch,var(--color-surface) 88%,transparent);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);box-shadow:var(--shadow-sm);overflow:hidden}
+@media(min-width:640px){.zk-card{padding:var(--space-6)}}
+.zk-card__header{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-5);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-divider)}
+.zk-card__icon{width:42px;height:42px;display:grid;place-items:center;border-radius:var(--radius-lg);background:color-mix(in oklch,currentColor 12%,transparent);border:1px solid color-mix(in oklch,currentColor 25%,transparent);flex-shrink:0}
+.zk-card__icon svg{color:currentColor}
+.zk-card--gold{color:var(--color-gold-bright)}
+.zk-card--silver{color:var(--color-silver)}
+.zk-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);line-height:1.2;margin-bottom:2px}
+.zk-card__sub{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+
+/* Form layouts */
+.zk-form-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
+@media(min-width:540px){.zk-form-grid{grid-template-columns:1fr 1fr}}
+.zk-field{display:flex;flex-direction:column;gap:6px}
+.zk-field__label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
+.zk-input-group{display:flex;align-items:stretch;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);overflow:hidden;transition:border-color 180ms,box-shadow 180ms;min-height:48px}
+.zk-input-group:focus-within{border-color:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+.zk-input{flex:1;padding:12px 14px;background:transparent;border:none;font-size:var(--text-base);color:var(--color-text);font-variant-numeric:tabular-nums;font-weight:600;outline:none;min-width:0;-moz-appearance:textfield}
+.zk-input::-webkit-outer-spin-button,.zk-input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
+.zk-input-group__select{border:none;border-left:1px solid var(--color-border);background:var(--color-surface);color:var(--color-text-muted);padding:0 32px 0 14px;font-size:var(--text-sm);font-weight:600;cursor:pointer;-webkit-appearance:none;-moz-appearance:none;appearance:none;background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%237a7974' stroke-width='2'><path d='M2 4l4 4 4-4'/></svg>");background-repeat:no-repeat;background-position:right 10px center;background-size:10px;outline:none;min-width:90px}
+.zk-input-group__select:focus{color:var(--color-text)}
+
+.zk-select-full{width:100%;padding:12px 36px 12px 14px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);font-weight:600;cursor:pointer;-webkit-appearance:none;-moz-appearance:none;appearance:none;background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%237a7974' stroke-width='2'><path d='M2 4l4 4 4-4'/></svg>");background-repeat:no-repeat;background-position:right 12px center;background-size:12px;outline:none;min-height:48px;transition:border-color 180ms,box-shadow 180ms}
+.zk-select-full:focus{border-color:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+
+/* Result tiles inside calculator */
+.zk-result-grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);margin-top:var(--space-5)}
+.zk-result-tile{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);text-align:left}
+.zk-result-tile__label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:6px}
+.zk-result-tile__value{font-family:var(--font-display);font-size:clamp(1.25rem,.9rem + 1.4vw,1.75rem);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;line-height:1.1;letter-spacing:-.02em}
+.zk-result-tile__value--accent{color:var(--color-gold-bright)}
+.zk-result-tile__value--silver{color:var(--color-silver)}
+.zk-result-tile__meta{font-size:11px;color:var(--color-text-faint);margin-top:4px;font-variant-numeric:tabular-nums}
+
+/* ── Combined Total — Hero result ── */
+.zk-total{position:relative;max-width:1100px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+.zk-total__inner{position:relative;background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface)) 0%,color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface)) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-6) var(--space-5);box-shadow:0 12px 40px color-mix(in oklch,var(--color-gold-bright) 12%,transparent);overflow:hidden;text-align:center}
+@media(min-width:640px){.zk-total__inner{padding:var(--space-8)}}
+.zk-total__inner::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at 50% 0%,var(--color-gold-bright) 0%,transparent 60%);opacity:.08;pointer-events:none}
+.zk-total__inner>*{position:relative;z-index:1}
+.zk-total__label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.zk-total__value{font-family:var(--font-display);font-size:clamp(2.5rem,1.6rem + 4vw,4.5rem);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;letter-spacing:-.03em;margin-bottom:var(--space-3);text-shadow:0 4px 24px color-mix(in oklch,var(--color-gold-bright) 30%,transparent)}
+.zk-total__breakdown{display:flex;flex-wrap:wrap;justify-content:center;gap:var(--space-3);margin-top:var(--space-4);font-size:var(--text-sm);color:var(--color-text-muted)}
+.zk-total__breakdown span{padding:6px 12px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-full);font-variant-numeric:tabular-nums}
+.zk-total__breakdown strong{color:var(--color-text);font-weight:700}
+
+/* Nisab status bar */
+.zk-nisab-progress{margin-top:var(--space-5);padding-top:var(--space-5);border-top:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-divider))}
+.zk-nisab-progress__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap;font-size:var(--text-sm)}
+.zk-nisab-progress__label{font-weight:600;color:var(--color-text)}
+.zk-nisab-progress__amount{font-variant-numeric:tabular-nums;color:var(--color-text-muted);font-weight:600}
+.zk-nisab-bar{position:relative;height:10px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);overflow:hidden}
+.zk-nisab-bar__fill{position:absolute;inset:0 auto 0 0;width:0%;background:linear-gradient(90deg,#4ade80,#22c55e);border-radius:var(--radius-full);transition:width 500ms cubic-bezier(.4,0,.2,1)}
+.zk-nisab-bar__fill--below{background:linear-gradient(90deg,#fbbf24,#f59e0b)}
+.zk-nisab-status{display:inline-flex;align-items:center;gap:8px;margin-top:var(--space-3);padding:8px 14px;border-radius:var(--radius-full);font-size:var(--text-sm);font-weight:700;letter-spacing:.02em}
+.zk-nisab-status--above{background:color-mix(in oklch,#4ade80 18%,var(--color-surface));color:#4ade80;border:1px solid color-mix(in oklch,#4ade80 40%,transparent)}
+.zk-nisab-status--below{background:color-mix(in oklch,#fbbf24 18%,var(--color-surface));color:#fbbf24;border:1px solid color-mix(in oklch,#fbbf24 40%,transparent)}
+.zk-nisab-status svg{flex-shrink:0}
+
+/* ── Hawl Tracker ── */
+.zk-hawl{max-width:1100px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+.zk-hawl__card{background:color-mix(in oklch,var(--color-surface) 88%,transparent);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-4);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);display:grid;grid-template-columns:1fr;gap:var(--space-4);align-items:center}
+@media(min-width:768px){.zk-hawl__card{grid-template-columns:1.2fr 1fr;padding:var(--space-6)}}
+.zk-hawl__intro h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
+.zk-hawl__intro p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:50ch}
+.zk-hawl__form{display:flex;flex-direction:column;gap:var(--space-3)}
+.zk-hawl__date{width:100%;padding:14px 16px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);font-weight:600;outline:none;font-family:inherit;min-height:48px;color-scheme:inherit;transition:border-color 180ms,box-shadow 180ms}
+.zk-hawl__date:focus{border-color:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+.zk-hawl__result{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;display:none}
+.zk-hawl__result.visible{display:block}
+.zk-hawl__result strong{color:var(--color-gold-bright);font-weight:700;font-variant-numeric:tabular-nums;display:block;font-size:var(--text-lg);font-family:var(--font-display);margin-bottom:4px}
+.zk-hawl__result em{color:var(--color-text);font-style:normal;font-weight:600}
+
+/* ── Compare Nisab Card ── */
+.zk-compare{max-width:1100px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+.zk-compare__title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2);text-align:center}
+.zk-compare__sub{font-size:var(--text-sm);color:var(--color-text-muted);text-align:center;max-width:60ch;margin:0 auto var(--space-5)}
+.zk-compare__grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:640px){.zk-compare__grid{grid-template-columns:1fr 1fr}}
+.zk-compare__bar{position:relative;height:80px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);overflow:hidden}
+.zk-compare__bar-fill{position:absolute;left:0;top:0;bottom:0;width:0%;background:linear-gradient(90deg,color-mix(in oklch,currentColor 14%,transparent) 0%,color-mix(in oklch,currentColor 6%,transparent) 100%);transition:width 600ms cubic-bezier(.4,0,.2,1)}
+.zk-compare__bar--gold{color:var(--color-gold-bright)}
+.zk-compare__bar--silver{color:var(--color-silver)}
+.zk-compare__bar-content{position:relative;display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);height:100%}
+.zk-compare__bar-label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:currentColor}
+.zk-compare__bar-value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* ── Educational Sections — Bento ── */
+.zk-edu{max-width:1100px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+.zk-edu__header{text-align:center;margin-bottom:var(--space-6)}
+.zk-edu__eyebrow{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.zk-edu__title{font-family:var(--font-display);font-size:clamp(1.5rem,1.2rem + 1.4vw,2.25rem);font-weight:700;color:var(--color-text);line-height:1.2;margin-bottom:var(--space-3)}
+.zk-edu__intro{font-size:var(--text-base);color:var(--color-text-muted);max-width:65ch;margin:0 auto;line-height:1.7}
+.zk-edu__bento{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin-top:var(--space-6)}
+@media(min-width:640px){.zk-edu__bento{grid-template-columns:repeat(2,1fr)}.zk-edu__card--feature{grid-column:1 / -1}}
+@media(min-width:1024px){.zk-edu__bento{grid-template-columns:2fr 1fr 1fr;grid-template-rows:auto auto;grid-template-areas:"feat condA condB" "feat condC condD"}.zk-edu__card--feature{grid-area:feat;grid-column:auto}}
+.zk-edu__card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);transition:border-color 220ms,transform 220ms,box-shadow 220ms}
+.zk-edu__card:hover{border-color:var(--color-gold-bright);transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.zk-edu__card--feature{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface)) 0%,var(--color-surface) 80%)}
+.zk-edu__card--feature .zk-edu__card-icon{width:54px;height:54px}
+.zk-edu__card-icon{width:42px;height:42px;display:grid;place-items:center;border-radius:var(--radius-lg);background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));color:var(--color-gold-bright);margin-bottom:var(--space-4)}
+.zk-edu__card-title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2);line-height:1.25}
+.zk-edu__card--feature .zk-edu__card-title{font-size:var(--text-xl)}
+.zk-edu__card-text{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7}
+.zk-edu__card-text strong{color:var(--color-text);font-weight:600}
+.zk-edu__list{list-style:none;margin-top:var(--space-3);display:flex;flex-direction:column;gap:8px}
+.zk-edu__list li{display:flex;align-items:flex-start;gap:10px;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55}
+.zk-edu__list li::before{content:"";flex-shrink:0;width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);margin-top:7px;box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+
+/* ── Madhab comparison table ── */
+.zk-madhab{max-width:1100px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+.zk-madhab__title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2);text-align:center}
+.zk-madhab__sub{font-size:var(--text-sm);color:var(--color-text-muted);text-align:center;max-width:65ch;margin:0 auto var(--space-5)}
+.zk-madhab__scroll{overflow-x:auto;-webkit-overflow-scrolling:touch;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);margin:0 calc(-1 * var(--space-4))}
+@media(min-width:768px){.zk-madhab__scroll{margin:0}}
+.zk-madhab__table{width:100%;min-width:560px;border-collapse:collapse}
+.zk-madhab__table thead{background:var(--color-surface-offset)}
+.zk-madhab__table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);padding:14px 16px;border-bottom:1px solid var(--color-border)}
+.zk-madhab__table th:first-child{padding-left:24px}
+.zk-madhab__table th:last-child{padding-right:24px;text-align:center}
+.zk-madhab__table td{padding:14px 16px;font-size:var(--text-sm);color:var(--color-text-muted);border-bottom:1px solid var(--color-divider);vertical-align:top}
+.zk-madhab__table td:first-child{color:var(--color-text);font-weight:600;padding-left:24px}
+.zk-madhab__table td:last-child{padding-right:24px;text-align:center;font-weight:700}
+.zk-madhab__table tr:last-child td{border-bottom:none}
+.zk-madhab-yes{color:#4ade80}
+.zk-madhab-no{color:#f87171}
+.zk-madhab-cond{color:var(--color-gold-bright)}
+
+/* ── FAQ Accordion ── */
+.zk-faq{max-width:880px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+.zk-faq__title{font-family:var(--font-display);font-size:clamp(1.5rem,1.2rem + 1.4vw,2.25rem);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2);text-align:center}
+.zk-faq__sub{font-size:var(--text-sm);color:var(--color-text-muted);text-align:center;margin-bottom:var(--space-6)}
+.zk-faq__list{display:flex;flex-direction:column;gap:var(--space-3)}
+.zk-faq__item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color 220ms}
+.zk-faq__item[open]{border-color:var(--color-gold-bright);box-shadow:var(--shadow-sm)}
+.zk-faq__q{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;background:transparent;transition:background 180ms;min-height:56px}
+.zk-faq__q:hover{background:var(--color-surface-offset)}
+.zk-faq__q::-webkit-details-marker,.zk-faq__q::marker{display:none}
+.zk-faq__q-icon{width:28px;height:28px;display:grid;place-items:center;border-radius:50%;border:1px solid var(--color-border);color:var(--color-text-muted);background:var(--color-surface-offset);transition:transform 240ms cubic-bezier(.4,0,.2,1),color 180ms;flex-shrink:0}
+.zk-faq__item[open] .zk-faq__q-icon{transform:rotate(45deg);color:var(--color-gold-bright);border-color:var(--color-gold-bright)}
+.zk-faq__a{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.75}
+.zk-faq__a p+p{margin-top:var(--space-3)}
+.zk-faq__a strong{color:var(--color-text);font-weight:600}
+
+/* ── Trust / disclaimer banner ── */
+.zk-trust{max-width:1100px;margin:0 auto var(--space-8);padding:0 var(--space-4)}
+.zk-trust__inner{display:flex;align-items:flex-start;gap:var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.zk-trust__inner svg{flex-shrink:0;color:var(--color-gold-bright);margin-top:2px}
+.zk-trust__inner strong{color:var(--color-text);font-weight:600}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce){
+  .zk-nisab-card,.zk-edu__card,.zk-nisab-bar__fill,.zk-compare__bar-fill,.zk-faq__q-icon{transition-duration:0ms!important;animation:none!important}
+}
+
+/* Light mode adjustments */
+[data-theme="light"] .zk-nisab-card,
+[data-theme="light"] .zk-card,
+[data-theme="light"] .zk-hawl__card{background:color-mix(in oklch,var(--color-surface) 92%,transparent)}
+[data-theme="light"] .zk-total__inner{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface)) 0%,var(--color-surface) 100%)}
 
 .footer-brand-col{max-width:260px}.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}.footer-col a:hover{color:var(--color-text)}.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}.blog-preview-inner{max-width:1200px;margin:0 auto}.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}.blog-preview-all:hover{color:var(--color-primary-hover)}.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h/.1);border-radius:99px;align-self:flex-start}.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 
@@ -567,133 +822,404 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .prose h3{margin-top:var(--space-6);margin-bottom:var(--space-2)}
 </style>
 
-<div class="main-wrap" style="display: block;">
-  <div class="zakat-calc-wrap">
-    <!-- GOLD ZAKAT -->
-    <h2 class="zakat-section-title">Gold Zakat Calculator</h2>
-    <div class="zakat-row">
-      <div class="form-group">
-        <label class="form-label" for="zg-weight">Weight</label>
-        <div style="display:flex; gap:0;">
-          <input class="form-input" type="number" id="zg-weight" value="0" min="0" step="0.01" style="border-top-right-radius:0; border-bottom-right-radius:0; border-right:0;">
-          <div class="form-select-wrap">
-            <select class="form-select" id="zg-unit" style="border-top-left-radius:0; border-bottom-left-radius:0;">
-              <option value="g">Grams</option>
-              <option value="oz">Troy Oz</option>
-            </select>
-          </div>
-        </div>
-      </div>
-      <div class="form-group">
-        <label class="form-label" for="zg-karat">Karat / Purity</label>
-        <div class="form-select-wrap">
-          <select class="form-select" id="zg-karat">
-            <option value="1.0">24K (99.99%)</option>
-            <option value="0.9167">22K (91.67%)</option>
-            <option value="0.875">21K (87.5%)</option>
-            <option value="0.75">18K (75%)</option>
-            <option value="0.5833">14K (58.33%)</option>
-            <option value="0.375">9K (37.5%)</option>
-          </select>
-        </div>
-      </div>
-    </div>
-    <div class="zakat-row">
-      <div class="zakat-result-box">
-        <div class="zakat-result-label">Pure Gold Value</div>
-        <div class="zakat-result-value" id="zg-value">$0.00</div>
-      </div>
-      <div class="zakat-result-box">
-        <div class="zakat-result-label">Zakat Due (2.5%)</div>
-        <div class="zakat-result-value" style="color:var(--color-gold-bright);" id="zg-zakat">$0.00</div>
-      </div>
-    </div>
-
-    <!-- SILVER ZAKAT -->
-    <h2 class="zakat-section-title" style="margin-top:var(--space-8);">Silver Zakat Calculator</h2>
-    <div class="zakat-row">
-      <div class="form-group">
-        <label class="form-label" for="zs-weight">Weight</label>
-        <div style="display:flex; gap:0;">
-          <input class="form-input" type="number" id="zs-weight" value="0" min="0" step="0.01" style="border-top-right-radius:0; border-bottom-right-radius:0; border-right:0;">
-          <div class="form-select-wrap">
-            <select class="form-select" id="zs-unit" style="border-top-left-radius:0; border-bottom-left-radius:0;">
-              <option value="g">Grams</option>
-              <option value="oz">Troy Oz</option>
-            </select>
-          </div>
-        </div>
-      </div>
-      <div class="form-group">
-        <label class="form-label" for="zs-purity">Purity</label>
-        <div class="form-select-wrap">
-          <select class="form-select" id="zs-purity">
-            <option value="0.999">Fine Silver (99.9%)</option>
-            <option value="0.925">Sterling (92.5%)</option>
-            <option value="0.900">Coin Silver (90%)</option>
-            <option value="0.800">800 Silver (80%)</option>
-          </select>
-        </div>
-      </div>
-    </div>
-    <div class="zakat-row">
-      <div class="zakat-result-box">
-        <div class="zakat-result-label">Pure Silver Value</div>
-        <div class="zakat-result-value" id="zs-value">$0.00</div>
-      </div>
-      <div class="zakat-result-box">
-        <div class="zakat-result-label">Zakat Due (2.5%)</div>
-        <div class="zakat-result-value" style="color:var(--color-silver);" id="zs-zakat">$0.00</div>
-      </div>
-    </div>
-
-    <!-- TOTAL ZAKAT -->
-    <div class="zakat-total-box">
-      <div class="zakat-result-label" style="color:var(--color-text);">Total Zakat Due (Gold + Silver)</div>
-      <div class="zakat-result-value" style="font-size:3rem; color:var(--color-gold-bright);" id="zt-zakat">$0.00</div>
-      <div id="zt-status" class="zakat-status-badge zakat-status-below">Below Nisab Threshold</div>
-    </div>
-  </div>
-
-  <div style="max-width: 800px; margin: 0 auto var(--space-8); padding: 0 var(--space-4);">
-    <h2 style="font-family:var(--font-display); font-size:var(--text-xl); margin-bottom:var(--space-4);">What Is Zakat on Gold &amp; Silver?</h2>
-    <p style="margin-bottom:var(--space-4); color:var(--color-text-muted);">Zakat is one of the Five Pillars of Islam, requiring adult Muslims who meet the minimum wealth threshold (Nisab) to donate a portion of their wealth to those in need. For gold and silver, the required rate is 2.5% of the total value, provided the wealth has been held for one full lunar year (Hawl).</p>
-    <p style="margin-bottom:var(--space-4); color:var(--color-text-muted);">Zakat is calculated on the <strong>pure metal content</strong>. This means if you have 18K gold jewellery, you only pay Zakat on the 75% that is pure gold. Our calculator automatically adjusts for karat purity, ensuring you pay exactly what is due based on the current live market price.</p>
-
-    <h2 style="font-family:var(--font-display); font-size:var(--text-xl); margin-top:var(--space-8); margin-bottom:var(--space-4);">Nisab Threshold 2026</h2>
-    <p style="margin-bottom:var(--space-4); color:var(--color-text-muted);">The Nisab is the minimum amount of wealth a Muslim must possess before they are obligated to pay Zakat. The thresholds for precious metals were historically set by the Prophet Muhammad (PBUH) as:</p>
-    <ul style="margin-bottom:var(--space-4); margin-left:var(--space-6); color:var(--color-text-muted);">
-      <li style="margin-bottom:var(--space-2);"><strong>Gold Nisab:</strong> 20 mithqal (Dinar), which modern scholars equate to <strong>85 grams of pure 24K gold</strong>.</li>
-      <li style="margin-bottom:var(--space-2);"><strong>Silver Nisab:</strong> 200 dirhams, equated to <strong>595 grams of pure silver</strong>.</li>
-    </ul>
-    <p style="margin-bottom:var(--space-4); color:var(--color-text-muted);">Because the prices of gold and silver fluctuate constantly, the monetary value of the Nisab changes every day. Our calculator fetches the live spot prices to give you the exact Nisab threshold in your local currency today.</p>
-
-    <h2 style="font-family:var(--font-display); font-size:var(--text-xl); margin-top:var(--space-8); margin-bottom:var(--space-4);">Frequently Asked Questions</h2>
-    <div style="background:var(--color-surface); border:1px solid var(--color-border); border-radius:var(--radius-lg); padding:var(--space-6);">
-
-      <div style="margin-bottom:var(--space-4);">
-        <h3 style="font-size:var(--text-base); margin-bottom:var(--space-1);">Do I pay Zakat on jewellery I wear?</h3>
-        <p style="color:var(--color-text-muted); font-size:var(--text-sm);">There is a difference of opinion among Islamic scholars. The Hanafi school requires Zakat on all gold and silver, whether worn or kept for investment. The Shafi'i, Maliki, and Hanbali schools generally exempt reasonable amounts of gold and silver jewellery kept for personal, customary wear.</p>
-      </div>
-
-      <div style="margin-bottom:var(--space-4);">
-        <h3 style="font-size:var(--text-base); margin-bottom:var(--space-1);">Which Nisab should I use, gold or silver?</h3>
-        <p style="color:var(--color-text-muted); font-size:var(--text-sm);">Most modern scholars advise using the silver Nisab threshold because it is significantly lower in value than the gold Nisab. Using the silver Nisab ensures more people qualify to pay Zakat, thereby benefiting more people in need. However, if your wealth consists entirely of gold, you may use the gold Nisab.</p>
-      </div>
-
-      <div style="margin-bottom:var(--space-4);">
-        <h3 style="font-size:var(--text-base); margin-bottom:var(--space-1);">Is Zakat calculated on the purchase price or current value?</h3>
-        <p style="color:var(--color-text-muted); font-size:var(--text-sm);">Zakat must be calculated on the <strong>current market value</strong> of the gold or silver on the day your Zakat is due (your Hawl date), not on the original purchase price.</p>
-      </div>
-
-      <div>
-        <h3 style="font-size:var(--text-base); margin-bottom:var(--space-1);">Do I include gemstones or diamonds in the weight?</h3>
-        <p style="color:var(--color-text-muted); font-size:var(--text-sm);">No. Zakat on jewellery is only calculated on the weight of the gold or silver. You should subtract the estimated weight of any diamonds, rubies, pearls, or other non-gold/silver materials before calculating.</p>
-      </div>
-
-    </div>
+<!-- CURRENCY SWITCHER -->
+<div class="zk-currency-bar" role="group" aria-label="Currency selector">
+  <span class="zk-currency-bar__label">Display Currency · USD primary</span>
+  <div class="zk-currency-chips" id="currencyChips">
+    <button class="zk-currency-chip active" data-currency="USD" aria-pressed="true">USD&nbsp;$</button>
+    <button class="zk-currency-chip" data-currency="EUR" aria-pressed="false">EUR&nbsp;€</button>
+    <button class="zk-currency-chip" data-currency="GBP" aria-pressed="false">GBP&nbsp;£</button>
+    <button class="zk-currency-chip" data-currency="SAR" aria-pressed="false">SAR&nbsp;﷼</button>
+    <button class="zk-currency-chip" data-currency="AED" aria-pressed="false">AED&nbsp;د.إ</button>
+    <button class="zk-currency-chip" data-currency="MYR" aria-pressed="false">MYR&nbsp;RM</button>
+    <button class="zk-currency-chip" data-currency="IDR" aria-pressed="false">IDR&nbsp;Rp</button>
+    <button class="zk-currency-chip" data-currency="INR" aria-pressed="false">INR&nbsp;₹</button>
+    <button class="zk-currency-chip" data-currency="PKR" aria-pressed="false">PKR&nbsp;₨</button>
   </div>
 </div>
+
+<!-- BENTO CALCULATOR -->
+<section class="zk-calc" aria-label="Zakat calculators">
+  <div class="zk-calc__grid">
+
+    <!-- GOLD CALCULATOR CARD -->
+    <article class="zk-card zk-card--gold">
+      <header class="zk-card__header">
+        <div class="zk-card__icon" aria-hidden="true">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 L20 6 L20 18 L12 22 L4 18 L4 6 Z"/><path d="M12 22 V12 M4 6 L12 12 L20 6"/></svg>
+        </div>
+        <div>
+          <h2 class="zk-card__title">Gold Zakat</h2>
+          <p class="zk-card__sub">Live 24K spot · auto karat purity adjust</p>
+        </div>
+      </header>
+
+      <div class="zk-form-grid">
+        <div class="zk-field">
+          <label class="zk-field__label" for="zg-weight">Total Gold Weight</label>
+          <div class="zk-input-group">
+            <input class="zk-input" type="number" id="zg-weight" value="0" min="0" step="0.01" inputmode="decimal" placeholder="0">
+            <select class="zk-input-group__select" id="zg-unit" aria-label="Weight unit">
+              <option value="g">Grams</option>
+              <option value="oz">Troy Oz</option>
+              <option value="kg">Kilograms</option>
+              <option value="tola">Tola</option>
+              <option value="bhori">Bhori</option>
+            </select>
+          </div>
+        </div>
+        <div class="zk-field">
+          <label class="zk-field__label" for="zg-karat">Karat / Purity</label>
+          <select class="zk-select-full" id="zg-karat">
+            <option value="0.9999">24K · 99.99% pure</option>
+            <option value="0.9167">22K · 91.67% pure</option>
+            <option value="0.8750">21K · 87.50% pure</option>
+            <option value="0.7500">18K · 75.00% pure</option>
+            <option value="0.5833">14K · 58.33% pure</option>
+            <option value="0.4167">10K · 41.67% pure</option>
+            <option value="0.3750">9K · 37.50% pure</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="zk-result-grid">
+        <div class="zk-result-tile">
+          <div class="zk-result-tile__label">Pure Gold Value</div>
+          <div class="zk-result-tile__value" id="zg-value">$0.00</div>
+          <div class="zk-result-tile__meta" id="zg-meta">0g pure</div>
+        </div>
+        <div class="zk-result-tile">
+          <div class="zk-result-tile__label">Zakat Due · 2.5%</div>
+          <div class="zk-result-tile__value zk-result-tile__value--accent" id="zg-zakat">$0.00</div>
+          <div class="zk-result-tile__meta" id="zg-zakat-meta">on gold portion</div>
+        </div>
+      </div>
+    </article>
+
+    <!-- SILVER CALCULATOR CARD -->
+    <article class="zk-card zk-card--silver">
+      <header class="zk-card__header">
+        <div class="zk-card__icon" aria-hidden="true">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7 L16 12 L12 17 L8 12 Z"/></svg>
+        </div>
+        <div>
+          <h2 class="zk-card__title">Silver Zakat</h2>
+          <p class="zk-card__sub">Live XAG spot · purity grade adjust</p>
+        </div>
+      </header>
+
+      <div class="zk-form-grid">
+        <div class="zk-field">
+          <label class="zk-field__label" for="zs-weight">Total Silver Weight</label>
+          <div class="zk-input-group">
+            <input class="zk-input" type="number" id="zs-weight" value="0" min="0" step="0.01" inputmode="decimal" placeholder="0">
+            <select class="zk-input-group__select" id="zs-unit" aria-label="Weight unit">
+              <option value="g">Grams</option>
+              <option value="oz">Troy Oz</option>
+              <option value="kg">Kilograms</option>
+              <option value="tola">Tola</option>
+            </select>
+          </div>
+        </div>
+        <div class="zk-field">
+          <label class="zk-field__label" for="zs-purity">Silver Purity</label>
+          <select class="zk-select-full" id="zs-purity">
+            <option value="0.999">Fine Silver · 99.9%</option>
+            <option value="0.958">Britannia · 95.8%</option>
+            <option value="0.925">Sterling · 92.5%</option>
+            <option value="0.900">Coin Silver · 90%</option>
+            <option value="0.800">.800 Silver · 80%</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="zk-result-grid">
+        <div class="zk-result-tile">
+          <div class="zk-result-tile__label">Pure Silver Value</div>
+          <div class="zk-result-tile__value" id="zs-value">$0.00</div>
+          <div class="zk-result-tile__meta" id="zs-meta">0g pure</div>
+        </div>
+        <div class="zk-result-tile">
+          <div class="zk-result-tile__label">Zakat Due · 2.5%</div>
+          <div class="zk-result-tile__value zk-result-tile__value--silver" id="zs-zakat">$0.00</div>
+          <div class="zk-result-tile__meta" id="zs-zakat-meta">on silver portion</div>
+        </div>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<!-- COMBINED TOTAL -->
+<section class="zk-total" aria-label="Total Zakat due">
+  <div class="zk-total__inner">
+    <div class="zk-total__label">Total Zakat Due — Gold + Silver</div>
+    <div class="zk-total__value" id="zt-zakat">$0.00</div>
+    <div class="zk-total__breakdown">
+      <span>Total wealth: <strong id="zt-wealth">$0.00</strong></span>
+      <span>Gold portion: <strong id="zt-gold">$0.00</strong></span>
+      <span>Silver portion: <strong id="zt-silver">$0.00</strong></span>
+    </div>
+
+    <div class="zk-nisab-progress">
+      <div class="zk-nisab-progress__head">
+        <span class="zk-nisab-progress__label">Progress to Silver Nisab (recommended)</span>
+        <span class="zk-nisab-progress__amount" id="zt-progress-text">$0.00 / $0.00</span>
+      </div>
+      <div class="zk-nisab-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+        <div class="zk-nisab-bar__fill zk-nisab-bar__fill--below" id="zt-bar"></div>
+      </div>
+      <div id="zt-status" class="zk-nisab-status zk-nisab-status--below" role="status">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg>
+        <span id="zt-status-text">Below Nisab — no Zakat is currently obligatory</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- NISAB COMPARISON -->
+<section class="zk-compare" aria-label="Compare gold and silver Nisab thresholds">
+  <h2 class="zk-compare__title">Gold vs Silver Nisab — Visual Comparison</h2>
+  <p class="zk-compare__sub">Most contemporary scholars recommend using the <strong style="color:var(--color-silver)">silver Nisab</strong> because its lower value qualifies more wealth for Zakat, benefiting more people in need.</p>
+  <div class="zk-compare__grid">
+    <div class="zk-compare__bar zk-compare__bar--gold">
+      <div class="zk-compare__bar-fill" id="cmpGoldFill"></div>
+      <div class="zk-compare__bar-content">
+        <span class="zk-compare__bar-label">Gold Nisab · 85g</span>
+        <span class="zk-compare__bar-value" id="cmpGoldVal">$—</span>
+      </div>
+    </div>
+    <div class="zk-compare__bar zk-compare__bar--silver">
+      <div class="zk-compare__bar-fill" id="cmpSilverFill"></div>
+      <div class="zk-compare__bar-content">
+        <span class="zk-compare__bar-label">Silver Nisab · 595g</span>
+        <span class="zk-compare__bar-value" id="cmpSilverVal">$—</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HAWL TRACKER -->
+<section class="zk-hawl" aria-label="Hawl tracker">
+  <div class="zk-hawl__card">
+    <div class="zk-hawl__intro">
+      <h3>Hawl Tracker — Your 1-Year Lunar Cycle</h3>
+      <p>Zakat becomes obligatory when wealth stays above Nisab for one full <strong>lunar year (Hawl)</strong>. Enter the date you first crossed Nisab to calculate your next Zakat due date.</p>
+    </div>
+    <div class="zk-hawl__form">
+      <label class="zk-field__label" for="hawlStart">Date you first crossed Nisab</label>
+      <input class="zk-hawl__date" type="date" id="hawlStart">
+      <div class="zk-hawl__result" id="hawlResult" role="status" aria-live="polite"></div>
+    </div>
+  </div>
+</section>
+
+<!-- TRUST BANNER -->
+<div class="zk-trust">
+  <div class="zk-trust__inner">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 7v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V7l-8-5z"/><path d="M9 12l2 2 4-4"/></svg>
+    <span><strong>Live spot prices:</strong> Sourced from LBMA via gold-api.com and refreshed every 60 seconds. <strong>FX rates</strong> via frankfurter.dev. Nisab calculations follow classical jurisprudence (85g gold / 595g silver). This tool is informational — confirm your Zakat amount with a qualified scholar.</span>
+  </div>
+</div>
+
+<!-- EDUCATIONAL BENTO -->
+<section class="zk-edu" aria-label="What is Zakat on gold and silver">
+  <div class="zk-edu__header">
+    <div class="zk-edu__eyebrow">A Pillar of Islam</div>
+    <h2 class="zk-edu__title">Understanding Zakat on Gold &amp; Silver</h2>
+    <p class="zk-edu__intro">Zakat is the third Pillar of Islam — a mandatory annual purification of wealth (2.5%) given to qualifying recipients once a Muslim's eligible wealth exceeds the Nisab threshold and has been held for a lunar year (Hawl).</p>
+  </div>
+
+  <div class="zk-edu__bento">
+    <article class="zk-edu__card zk-edu__card--feature">
+      <div class="zk-edu__card-icon" aria-hidden="true">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L4 7v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V7l-8-5z"/></svg>
+      </div>
+      <h3 class="zk-edu__card-title">Conditions for Zakat to be Due</h3>
+      <p class="zk-edu__card-text">All four classical conditions must be satisfied for Zakat on precious metals:</p>
+      <ul class="zk-edu__list">
+        <li><strong>Ownership:</strong> the gold or silver must be in your full ownership and control.</li>
+        <li><strong>Nisab:</strong> your total qualifying wealth must reach or exceed the threshold (85g gold or 595g silver).</li>
+        <li><strong>Hawl:</strong> the wealth has remained above Nisab for one complete lunar year (~354 days).</li>
+        <li><strong>Intention:</strong> Zakat is given with the explicit intention of fulfilling the obligation.</li>
+      </ul>
+    </article>
+
+    <article class="zk-edu__card">
+      <div class="zk-edu__card-icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+      </div>
+      <h3 class="zk-edu__card-title">The Hawl</h3>
+      <p class="zk-edu__card-text">One full <strong>lunar year</strong> (≈354 days) of continuous ownership above Nisab. The Hijri calendar is the reference, not the solar year.</p>
+    </article>
+
+    <article class="zk-edu__card">
+      <div class="zk-edu__card-icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h18M12 3v18"/></svg>
+      </div>
+      <h3 class="zk-edu__card-title">The Rate</h3>
+      <p class="zk-edu__card-text">A fixed <strong>2.5%</strong> (1/40th) of the current market value — not the historic purchase price — of the pure gold or silver content.</p>
+    </article>
+
+    <article class="zk-edu__card">
+      <div class="zk-edu__card-icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 L20 6 L20 18 L12 22 L4 18 L4 6 Z"/></svg>
+      </div>
+      <h3 class="zk-edu__card-title">Pure Content Only</h3>
+      <p class="zk-edu__card-text">Calculated on the <strong>actual pure metal</strong> — 18K gold is 75% pure, sterling silver is 92.5% pure. Subtract gemstones, diamonds, and pearls before weighing.</p>
+    </article>
+
+    <article class="zk-edu__card">
+      <div class="zk-edu__card-icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+      </div>
+      <h3 class="zk-edu__card-title">8 Categories of Recipients</h3>
+      <p class="zk-edu__card-text">Defined in Surah At-Tawbah 9:60 — the poor, the needy, those who collect Zakat, reverts, those in bondage, debtors, in the cause of Allah, and the wayfarer.</p>
+    </article>
+  </div>
+</section>
+
+<!-- MADHAB COMPARISON -->
+<section class="zk-madhab" aria-label="Madhab differences on jewellery Zakat">
+  <h2 class="zk-madhab__title">Jewellery Zakat — Differences Between Madhabs</h2>
+  <p class="zk-madhab__sub">There is a recognised difference of scholarly opinion regarding Zakat on gold and silver jewellery that is worn for personal use. Always follow the ruling of a qualified scholar in your tradition.</p>
+  <div class="zk-madhab__scroll">
+    <table class="zk-madhab__table">
+      <thead>
+        <tr>
+          <th>School (Madhab)</th>
+          <th>Position on Worn Jewellery</th>
+          <th>Investment / Stored</th>
+          <th>Zakat?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Hanafi</td>
+          <td>Zakat is due on all gold &amp; silver, including worn jewellery.</td>
+          <td>Zakat is due.</td>
+          <td class="zk-madhab-yes">Always</td>
+        </tr>
+        <tr>
+          <td>Shafi'i</td>
+          <td>Reasonable, customary worn jewellery is exempt.</td>
+          <td>Zakat is due.</td>
+          <td class="zk-madhab-cond">If stored</td>
+        </tr>
+        <tr>
+          <td>Maliki</td>
+          <td>Reasonable, customary worn jewellery is exempt.</td>
+          <td>Zakat is due.</td>
+          <td class="zk-madhab-cond">If stored</td>
+        </tr>
+        <tr>
+          <td>Hanbali</td>
+          <td>Reasonable, customary worn jewellery is exempt.</td>
+          <td>Zakat is due.</td>
+          <td class="zk-madhab-cond">If stored</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- FAQ ACCORDION -->
+<section class="zk-faq" aria-label="Frequently asked questions">
+  <h2 class="zk-faq__title">Frequently Asked Questions</h2>
+  <p class="zk-faq__sub">Common questions about calculating Zakat on gold and silver in 2026.</p>
+
+  <div class="zk-faq__list">
+    <details class="zk-faq__item">
+      <summary class="zk-faq__q">
+        <span>Do I pay Zakat on jewellery I wear?</span>
+        <span class="zk-faq__q-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+        </span>
+      </summary>
+      <div class="zk-faq__a">
+        <p>There is a recognised difference of opinion. The <strong>Hanafi school</strong> requires Zakat on all gold and silver, whether worn or stored. The <strong>Shafi'i, Maliki, and Hanbali schools</strong> generally exempt reasonable amounts of jewellery kept for personal, customary wear, but require Zakat on jewellery held for investment or saving purposes.</p>
+        <p>Follow the ruling of a qualified scholar in your school of thought.</p>
+      </div>
+    </details>
+
+    <details class="zk-faq__item">
+      <summary class="zk-faq__q">
+        <span>Which Nisab should I use — gold or silver?</span>
+        <span class="zk-faq__q-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+        </span>
+      </summary>
+      <div class="zk-faq__a">
+        <p>Most modern scholars advise using the <strong>silver Nisab</strong> threshold because it is significantly lower in value than the gold Nisab. Using the silver Nisab ensures more wealth qualifies for Zakat, benefitting more people in need.</p>
+        <p>If your wealth consists <em>entirely</em> of gold and no other Zakatable assets, you may use the gold Nisab. Otherwise, the silver Nisab is the safer default.</p>
+      </div>
+    </details>
+
+    <details class="zk-faq__item">
+      <summary class="zk-faq__q">
+        <span>Is Zakat calculated on the purchase price or today's value?</span>
+        <span class="zk-faq__q-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+        </span>
+      </summary>
+      <div class="zk-faq__a">
+        <p>Zakat must be calculated on the <strong>current market value</strong> on the day your Zakat is due (your Hawl date) — never the original purchase price. This calculator uses live spot prices refreshed every 60 seconds from global precious-metals markets.</p>
+      </div>
+    </details>
+
+    <details class="zk-faq__item">
+      <summary class="zk-faq__q">
+        <span>Do I include gemstones, diamonds, or pearls in the weight?</span>
+        <span class="zk-faq__q-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+        </span>
+      </summary>
+      <div class="zk-faq__a">
+        <p><strong>No.</strong> Zakat on jewellery is only calculated on the weight of the gold or silver itself. Subtract the estimated weight of diamonds, rubies, pearls, or any other non-precious-metal materials before entering the weight.</p>
+        <p>A jeweller can usually give you the exact metal weight from a hallmark certificate or assay.</p>
+      </div>
+    </details>
+
+    <details class="zk-faq__item">
+      <summary class="zk-faq__q">
+        <span>How does karat purity affect the Zakat I owe?</span>
+        <span class="zk-faq__q-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+        </span>
+      </summary>
+      <div class="zk-faq__a">
+        <p>Zakat is paid on the <strong>pure gold content only</strong>. 24K gold is 99.99% pure; 18K is 75% pure; 14K is 58.33% pure; 9K is 37.5% pure. So 100g of 18K jewellery contains 75g of pure gold — and Zakat (2.5%) is calculated on the value of that 75g at today's spot price.</p>
+        <p>Our calculator handles this automatically — just select your karat from the dropdown.</p>
+      </div>
+    </details>
+
+    <details class="zk-faq__item">
+      <summary class="zk-faq__q">
+        <span>Can I pay Zakat in cash instead of giving gold/silver?</span>
+        <span class="zk-faq__q-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+        </span>
+      </summary>
+      <div class="zk-faq__a">
+        <p><strong>Yes.</strong> The majority of contemporary scholars permit paying the cash equivalent of the Zakat due, as long as the cash value is calculated using the current spot price of the precious metal on the Hawl date.</p>
+        <p>This is what our calculator does — it shows you the exact <em>cash amount</em> equivalent to 2.5% of your pure gold and silver value at this moment.</p>
+      </div>
+    </details>
+
+    <details class="zk-faq__item">
+      <summary class="zk-faq__q">
+        <span>When should I pay my Zakat?</span>
+        <span class="zk-faq__q-icon" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+        </span>
+      </summary>
+      <div class="zk-faq__a">
+        <p>Zakat is due once a full lunar year (~354 days) has elapsed since your wealth first reached or exceeded the Nisab. This is called your <strong>Hawl date</strong>. Use the Hawl Tracker above to calculate when your next Zakat is due.</p>
+        <p>Many Muslims choose to pay during Ramadan because the spiritual rewards are amplified — but you must still pay on or before your actual Hawl date if it falls outside Ramadan.</p>
+      </div>
+    </details>
+  </div>
+</section>
 <!-- AD SLOT 4 — Above footer, multiplex -->
 <div class="ad-slot" aria-label="Advertisement">
   <ins class="adsbygoogle"
@@ -703,86 +1229,282 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
        data-ad-slot="9961009949"></ins>
 
 <script>
-  let spotGold = 0;
-  let spotSilver = 0;
+/* ====================================================================
+   ZAKAT CALCULATOR — Live engine
+   Live spot: api.gold-api.com (XAU/XAG)  · 60s refresh
+   FX rates : frankfurter.dev              · 600s refresh
+   USD is the canonical pricing currency — all calcs done in USD,
+   then converted at display time using fxRates[].
+   ==================================================================== */
+(function(){
+  'use strict';
 
+  // ─── Constants ─────────────────────────────────────────────────────
+  const TROY_OZ_TO_GRAM = 31.1035;
+  const KG_TO_GRAM      = 1000;
+  const TOLA_TO_GRAM    = 11.6638;     // South Asian standard tola
+  const BHORI_TO_GRAM   = 11.664;      // Bangladesh bhori (≈1 tola)
+  const ZAKAT_RATE      = 0.025;       // 2.5%
+  const GOLD_NISAB_G    = 85;          // 85 g pure 24K gold
+  const SILVER_NISAB_G  = 595;         // 595 g pure silver
+  const LUNAR_YEAR_DAYS = 354;         // Islamic lunar year
+
+  const UNIT_TO_GRAM = { g:1, oz:TROY_OZ_TO_GRAM, kg:KG_TO_GRAM, tola:TOLA_TO_GRAM, bhori:BHORI_TO_GRAM };
+
+  const CURRENCY_SYMBOLS = {
+    USD:'$', EUR:'€', GBP:'£', SAR:'﷼', AED:'د.إ',
+    MYR:'RM', IDR:'Rp', INR:'₹', PKR:'₨', CAD:'C$', AUD:'A$'
+  };
+  const CURRENCY_DECIMALS = { IDR:0, PKR:0, INR:0 };  // currencies typically shown without decimals
+
+  // ─── State ─────────────────────────────────────────────────────────
+  let goldSpotOz   = null;     // USD per troy oz
+  let silverSpotOz = null;
+  let displayCurrency = 'USD';
+  let fxRates = { USD:1, EUR:0.92, GBP:0.79, SAR:3.75, AED:3.67, MYR:4.68, IDR:15820, INR:83.4, PKR:278.5, CAD:1.36, AUD:1.50 };
+  let lastUpdate = null;
+
+  // ─── DOM helpers ───────────────────────────────────────────────────
+  const $ = (id) => document.getElementById(id);
+  const setText = (id, val) => { const el = $(id); if (el) el.textContent = val; };
+
+  function fmt(usdValue, currency) {
+    if (!isFinite(usdValue)) usdValue = 0;
+    const cur = currency || displayCurrency;
+    const rate = fxRates[cur] || 1;
+    const sym  = CURRENCY_SYMBOLS[cur] || '$';
+    const dec  = CURRENCY_DECIMALS[cur] !== undefined ? CURRENCY_DECIMALS[cur] : 2;
+    return sym + (usdValue * rate).toLocaleString('en-US', { minimumFractionDigits: dec, maximumFractionDigits: dec });
+  }
+
+  function fmtUSD(v) {
+    if (!isFinite(v)) v = 0;
+    return '$' + v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  // ─── Data fetching ─────────────────────────────────────────────────
   async function fetchPrices() {
     try {
       const [gRes, sRes] = await Promise.all([
-        fetch('https://api.gold-api.com/price/XAU', {cache: 'no-store'}),
-        fetch('https://api.gold-api.com/price/XAG', {cache: 'no-store'})
+        fetch('https://api.gold-api.com/price/XAU', { cache: 'no-store' }),
+        fetch('https://api.gold-api.com/price/XAG', { cache: 'no-store' })
       ]);
-      const gData = await gRes.json();
-      const sData = await sRes.json();
-      spotGold = gData.price;
-      spotSilver = sData.price;
-      updateCalculations();
-    } catch(e) {
-      console.warn("Failed to fetch spot prices");
+      if (!gRes.ok || !sRes.ok) throw new Error('Spot API error');
+      const [gData, sData] = await Promise.all([gRes.json(), sRes.json()]);
+      if (!gData.price || !sData.price) throw new Error('Missing price fields');
+      goldSpotOz   = gData.price;
+      silverSpotOz = sData.price;
+      lastUpdate   = new Date();
+      renderAll();
+    } catch (e) {
+      console.warn('[zakat] price fetch failed —', e.message);
+      // Fall back to last-known or sensible defaults
+      if (!goldSpotOz)   goldSpotOz   = 4692;
+      if (!silverSpotOz) silverSpotOz = 75;
+      lastUpdate = lastUpdate || new Date();
+      renderAll();
     }
   }
 
-  function updateCalculations() {
-    if(!spotGold || !spotSilver) return;
+  async function fetchFx() {
+    try {
+      const res = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=EUR,GBP,SAR,AED,MYR,IDR,INR,PKR,CAD,AUD');
+      if (!res.ok) throw new Error('FX API error');
+      const data = await res.json();
+      if (data && data.rates) fxRates = { USD: 1, ...data.rates };
+      renderAll();
+    } catch (e) {
+      console.warn('[zakat] FX fetch failed — using defaults:', e.message);
+    }
+  }
 
-    const goldPerGram = spotGold / 31.1035;
-    const silverPerGram = spotSilver / 31.1035;
+  // ─── Core calculations ─────────────────────────────────────────────
+  function getWeightGrams(inputId, unitId) {
+    const w = parseFloat($(inputId).value) || 0;
+    const u = $(unitId).value;
+    return w * (UNIT_TO_GRAM[u] || 1);
+  }
 
-    // Nisab calculations
-    const goldNisabValue = 85 * goldPerGram;
-    const silverNisabValue = 595 * silverPerGram;
+  function calcGold() {
+    if (!goldSpotOz) return { pureG: 0, valueUSD: 0, zakatUSD: 0 };
+    const grams  = getWeightGrams('zg-weight', 'zg-unit');
+    const purity = parseFloat($('zg-karat').value) || 0.9999;
+    const pureG  = grams * purity;
+    const ppg    = goldSpotOz / TROY_OZ_TO_GRAM;
+    const value  = pureG * ppg;
+    const zakat  = value * ZAKAT_RATE;
+    return { pureG, valueUSD: value, zakatUSD: zakat, purity, grams };
+  }
 
-    document.getElementById('nisab-status-text').textContent =
-      "Current nisab threshold: $" + goldNisabValue.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}) +
-      " (based on 85g gold at $" + spotGold.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2}) + "/oz)";
+  function calcSilver() {
+    if (!silverSpotOz) return { pureG: 0, valueUSD: 0, zakatUSD: 0 };
+    const grams  = getWeightGrams('zs-weight', 'zs-unit');
+    const purity = parseFloat($('zs-purity').value) || 0.999;
+    const pureG  = grams * purity;
+    const ppg    = silverSpotOz / TROY_OZ_TO_GRAM;
+    const value  = pureG * ppg;
+    const zakat  = value * ZAKAT_RATE;
+    return { pureG, valueUSD: value, zakatUSD: zakat, purity, grams };
+  }
 
-    // Gold Zaket
-    let gw = parseFloat(document.getElementById('zg-weight').value) || 0;
-    let gu = document.getElementById('zg-unit').value;
-    if(gu === 'oz') gw = gw * 31.1035;
-    let gk = parseFloat(document.getElementById('zg-karat').value) || 1.0;
+  // ─── Render ────────────────────────────────────────────────────────
+  function renderAll() {
+    if (!goldSpotOz || !silverSpotOz) return;
 
-    let gVal = gw * gk * goldPerGram;
-    let gZak = gVal * 0.025;
+    const goldPerG   = goldSpotOz   / TROY_OZ_TO_GRAM;
+    const silverPerG = silverSpotOz / TROY_OZ_TO_GRAM;
 
-    document.getElementById('zg-value').textContent = "$" + gVal.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
-    document.getElementById('zg-zakat').textContent = "$" + gZak.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+    const goldNisabUSD   = GOLD_NISAB_G   * goldPerG;
+    const silverNisabUSD = SILVER_NISAB_G * silverPerG;
 
-    // Silver Zakat
-    let sw = parseFloat(document.getElementById('zs-weight').value) || 0;
-    let su = document.getElementById('zs-unit').value;
-    if(su === 'oz') sw = sw * 31.1035;
-    let sp = parseFloat(document.getElementById('zs-purity').value) || 0.999;
+    // Hero — Nisab cards
+    setText('goldNisabValue', fmt(goldNisabUSD));
+    setText('silverNisabValue', fmt(silverNisabUSD));
+    setText('goldSpotMini', fmtUSD(goldSpotOz) + '/oz');
+    setText('silverSpotMini', fmtUSD(silverSpotOz) + '/oz');
+    if (lastUpdate) {
+      const t = lastUpdate.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
+      setText('lastUpdated', t + ' UTC');
+    }
 
-    let sVal = sw * sp * silverPerGram;
-    let sZak = sVal * 0.025;
+    // Live ticker (USD always — global reserve currency)
+    const goldGramUSD   = goldSpotOz / TROY_OZ_TO_GRAM;
+    const silverGramUSD = silverSpotOz / TROY_OZ_TO_GRAM;
+    const tickerVals = [
+      ['t-xau',  fmtUSD(goldSpotOz)],     ['t-xau2',  fmtUSD(goldSpotOz)],
+      ['t-xag',  fmtUSD(silverSpotOz)],   ['t-xag2',  fmtUSD(silverSpotOz)],
+      ['t-24k',  fmtUSD(goldGramUSD * 0.9999)], ['t-24k2', fmtUSD(goldGramUSD * 0.9999)],
+      ['t-18k',  fmtUSD(goldGramUSD * 0.75)],   ['t-18k2', fmtUSD(goldGramUSD * 0.75)],
+      ['t-14k',  fmtUSD(goldGramUSD * 0.5833)], ['t-14k2', fmtUSD(goldGramUSD * 0.5833)],
+      ['t-10k',  fmtUSD(goldGramUSD * 0.4167)], ['t-10k2', fmtUSD(goldGramUSD * 0.4167)],
+      ['t-agoz', fmtUSD(silverSpotOz)],         ['t-agoz2', fmtUSD(silverSpotOz)],
+      ['t-agkg', fmtUSD(silverSpotOz * 32.1507)], ['t-agkg2', fmtUSD(silverSpotOz * 32.1507)]
+    ];
+    tickerVals.forEach(([id, v]) => setText(id, v));
 
-    document.getElementById('zs-value').textContent = "$" + sVal.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
-    document.getElementById('zs-zakat').textContent = "$" + sZak.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+    // Gold calc
+    const g = calcGold();
+    setText('zg-value', fmt(g.valueUSD));
+    setText('zg-zakat', fmt(g.zakatUSD));
+    setText('zg-meta', g.pureG.toFixed(2) + 'g pure · ' + (g.purity * 100).toFixed(2) + '% purity');
+    setText('zg-zakat-meta', '@ ' + fmtUSD(goldPerG) + '/g spot');
 
-    // Total
-    let totalZak = gZak + sZak;
-    let totalVal = gVal + sVal;
-    document.getElementById('zt-zakat').textContent = "$" + totalZak.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+    // Silver calc
+    const s = calcSilver();
+    setText('zs-value', fmt(s.valueUSD));
+    setText('zs-zakat', fmt(s.zakatUSD));
+    setText('zs-meta', s.pureG.toFixed(2) + 'g pure · ' + (s.purity * 100).toFixed(2) + '% purity');
+    setText('zs-zakat-meta', '@ ' + fmtUSD(silverPerG) + '/g spot');
 
-    const statusEl = document.getElementById('zt-status');
-    // Using gold nisab as default for comparison, but if user has mostly silver, it might be silver nisab. The requirement says:
-    // "Above/Below nisab" indicator with colour coding.
-    // Usually Nisab is met if total value >= silver Nisab (the lower one).
-    if(totalVal >= silverNisabValue) {
-        statusEl.textContent = "Above Nisab Threshold (Zakat is Due)";
-        statusEl.className = "zakat-status-badge zakat-status-above";
+    // Combined total
+    const totalWealthUSD = g.valueUSD + s.valueUSD;
+    const totalZakatUSD  = g.zakatUSD + s.zakatUSD;
+    setText('zt-zakat',  fmt(totalZakatUSD));
+    setText('zt-wealth', fmt(totalWealthUSD));
+    setText('zt-gold',   fmt(g.valueUSD));
+    setText('zt-silver', fmt(s.valueUSD));
+
+    // Nisab progress (against silver Nisab — recommended threshold)
+    const pct = silverNisabUSD > 0 ? Math.min(100, (totalWealthUSD / silverNisabUSD) * 100) : 0;
+    const bar = $('zt-bar');
+    if (bar) bar.style.width = pct.toFixed(1) + '%';
+    const progressLabel = fmt(totalWealthUSD) + ' / ' + fmt(silverNisabUSD);
+    setText('zt-progress-text', progressLabel);
+    const barWrap = bar ? bar.parentElement : null;
+    if (barWrap) barWrap.setAttribute('aria-valuenow', pct.toFixed(0));
+
+    // Above/Below status
+    const statusEl  = $('zt-status');
+    const statusTxt = $('zt-status-text');
+    if (statusEl && statusTxt) {
+      if (totalWealthUSD >= silverNisabUSD && totalWealthUSD > 0) {
+        statusEl.className = 'zk-nisab-status zk-nisab-status--above';
+        statusEl.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4 12 14.01l-3-3"/></svg><span id="zt-status-text">Above Nisab — Zakat of ' + fmt(totalZakatUSD) + ' is obligatory if held for one Hawl</span>';
+        if (bar) bar.className = 'zk-nisab-bar__fill';
+      } else {
+        statusEl.className = 'zk-nisab-status zk-nisab-status--below';
+        statusEl.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg><span id="zt-status-text">Below Nisab — no Zakat is currently obligatory on this wealth</span>';
+        if (bar) bar.className = 'zk-nisab-bar__fill zk-nisab-bar__fill--below';
+      }
+    }
+
+    // Comparison bars (normalize to wider one = 100%)
+    const maxN = Math.max(goldNisabUSD, silverNisabUSD);
+    if (maxN > 0) {
+      const gFill = $('cmpGoldFill');
+      const sFill = $('cmpSilverFill');
+      if (gFill) gFill.style.width = ((goldNisabUSD / maxN) * 100).toFixed(1) + '%';
+      if (sFill) sFill.style.width = ((silverNisabUSD / maxN) * 100).toFixed(1) + '%';
+    }
+    setText('cmpGoldVal',   fmt(goldNisabUSD));
+    setText('cmpSilverVal', fmt(silverNisabUSD));
+
+    // Hawl re-render if a date is set
+    updateHawl();
+  }
+
+  // ─── Hawl tracker ──────────────────────────────────────────────────
+  function updateHawl() {
+    const input = $('hawlStart');
+    const out   = $('hawlResult');
+    if (!input || !out) return;
+    const v = input.value;
+    if (!v) { out.classList.remove('visible'); out.innerHTML = ''; return; }
+
+    const startDate = new Date(v + 'T00:00:00');
+    if (isNaN(startDate.getTime())) { out.classList.remove('visible'); return; }
+
+    const dueDate = new Date(startDate);
+    dueDate.setDate(dueDate.getDate() + LUNAR_YEAR_DAYS);
+    const today = new Date(); today.setHours(0,0,0,0);
+    const diffDays = Math.ceil((dueDate - today) / (1000 * 60 * 60 * 24));
+
+    const fmtDate = (d) => d.toLocaleDateString('en-GB', { year:'numeric', month:'long', day:'numeric' });
+
+    let body = '';
+    if (diffDays > 0) {
+      body = '<strong>' + diffDays + ' day' + (diffDays === 1 ? '' : 's') + ' remaining</strong>Your next Zakat is due on <em>' + fmtDate(dueDate) + '</em>. Calculate on that date using current spot prices.';
+    } else if (diffDays === 0) {
+      body = '<strong>Zakat is due today</strong>Today is your Hawl date. Pay the calculated Zakat amount above today.';
     } else {
-        statusEl.textContent = "Below Nisab Threshold (No Zakat Due)";
-        statusEl.className = "zakat-status-badge zakat-status-below";
+      const overdue = Math.abs(diffDays);
+      body = '<strong>Overdue by ' + overdue + ' day' + (overdue === 1 ? '' : 's') + '</strong>Your Hawl date passed on <em>' + fmtDate(dueDate) + '</em>. Zakat for that cycle is owed retrospectively — calculate it using the spot price on the Hawl date if known.';
     }
+    out.innerHTML = body;
+    out.classList.add('visible');
   }
 
-  document.querySelectorAll('input, select').forEach(el => {
-    el.addEventListener('input', updateCalculations);
-  });
+  // ─── Currency switcher ─────────────────────────────────────────────
+  function bindCurrencyChips() {
+    const chips = document.querySelectorAll('#currencyChips .zk-currency-chip');
+    chips.forEach(chip => {
+      chip.addEventListener('click', () => {
+        chips.forEach(c => { c.classList.remove('active'); c.setAttribute('aria-pressed','false'); });
+        chip.classList.add('active');
+        chip.setAttribute('aria-pressed','true');
+        displayCurrency = chip.dataset.currency;
+        renderAll();
+      });
+    });
+  }
 
-  fetchPrices();
+  // ─── Wire inputs ───────────────────────────────────────────────────
+  function bindInputs() {
+    ['zg-weight','zg-unit','zg-karat','zs-weight','zs-unit','zs-purity'].forEach(id => {
+      const el = $(id);
+      if (el) el.addEventListener('input', renderAll);
+    });
+    const hawl = $('hawlStart');
+    if (hawl) hawl.addEventListener('input', updateHawl);
+  }
+
+  // ─── Boot ──────────────────────────────────────────────────────────
+  bindCurrencyChips();
+  bindInputs();
+  Promise.all([fetchFx(), fetchPrices()]);
+  setInterval(fetchPrices, 60_000);      // 60s — matches site-wide live data cadence
+  setInterval(fetchFx,    600_000);      // 10min FX
+})();
 </script>
 
 </div>
@@ -898,228 +1620,25 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 </footer>
 
 <script>
-const TROY_OZ_TO_GRAM = 31.1035;
-const KARATS = [
-  {k:'24K', purity:0.9999, label:'24 Karat Gold'},
-  {k:'22K', purity:0.9167, label:'22 Karat Gold'},
-  {k:'18K', purity:0.75,   label:'18 Karat Gold'},
-  {k:'14K', purity:0.5833, label:'14 Karat Gold'},
-  {k:'10K', purity:0.4167, label:'10 Karat Gold'},
-  {k:'9K',  purity:0.375,  label:'9 Karat Gold'}
-];
-const GOLD_API_BASE  = 'https://api.gold-api.com/price';
-const FX_BASE        = 'https://api.frankfurter.dev/v1/latest?from=USD';
-let goldSpotOz = null, silverSpotOz = null;
-let fxRates = { USD:1, GBP:0.74, EUR:0.855, CAD:1.367, AUD:1.398, INR:94.11 };
-let goldChart = null, silverChart = null;
-let currentGoldRange = '1M', currentSilverRange = '1M';
-let chartHistoryCache = {};
+/* Engagement events for analytics — fired once per session */
 (function(){
-  const t = document.querySelector('[data-theme-toggle]'), r = document.documentElement;
-  let d = matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light';
-  r.setAttribute('data-theme', d);
-  if(t) t.addEventListener('click', () => {
-    d = d === 'dark' ? 'light' : 'dark';
-    r.setAttribute('data-theme', d);
-    t.setAttribute('aria-label', 'Switch to ' + (d==='dark'?'light':'dark') + ' mode');
-    t.innerHTML = d === 'dark'
-      ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>'
-      : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
-    if(goldChart) goldChart.update();
-    if(silverChart) silverChart.update();
+  let _calcFired = false;
+  document.addEventListener('input', (e) => {
+    if (_calcFired) return;
+    if (e.target && (e.target.id === 'zg-weight' || e.target.id === 'zs-weight')) {
+      _calcFired = true;
+      if (typeof gtag === 'function') gtag('event', 'calculator_engaged', { event_category: 'zakat' });
+    }
+  });
+  let _scrapFired = false;
+  document.querySelectorAll('a[href*="/scrap-gold-calculator"]').forEach(a => {
+    a.addEventListener('click', () => {
+      if (_scrapFired) return;
+      _scrapFired = true;
+      if (typeof gtag === 'function') gtag('event', 'scrap_seller_intent', { event_category: 'zakat' });
+    });
   });
 })();
-const CURRENCY_SYMBOLS = { USD:'$', GBP:'£', EUR:'€', CAD:'C$', AUD:'A$', INR:'₹' };
-function fmtCurr(usdVal, currency) {
-  const rate = fxRates[currency] || 1;
-  const sym  = CURRENCY_SYMBOLS[currency] || '$';
-  return sym + (usdVal * rate).toLocaleString('en-US', {minimumFractionDigits:2, maximumFractionDigits:2});
-}
-function fmtUSD(val) {
-  return '$' + val.toLocaleString('en-US', {minimumFractionDigits:2, maximumFractionDigits:2});
-}
-async function fetchFxRates() {
-  try {
-    const res  = await fetch(`${FX_BASE}&to=GBP,EUR,CAD,AUD,INR`);
-    if (!res.ok) throw new Error('FX fetch failed');
-    const data = await res.json();
-    if (data && data.rates) fxRates = { USD: 1, ...data.rates };
-  } catch (e) { console.warn('FX rates fetch failed — using defaults:', e.message); }
-}
-async function fetchPrices() {
-  try {
-    const [gRes, sRes] = await Promise.all([fetch(`${GOLD_API_BASE}/XAU`), fetch(`${GOLD_API_BASE}/XAG`)]);
-    if (!gRes.ok || !sRes.ok) throw new Error('API response error');
-    const [gData, sData] = await Promise.all([gRes.json(), sRes.json()]);
-    if (!gData.price || !sData.price) throw new Error('Missing price fields');
-    goldSpotOz   = gData.price;
-    silverSpotOz = sData.price;
-    updateAll({price:gData.price,prev_close_price:gData.prev_close_price},{price:sData.price,prev_close_price:sData.prev_close_price});
-  } catch (err) {
-    console.warn('Price fetch failed — using static fallback:', err.message);
-    goldSpotOz   = goldSpotOz   || 4692;
-    silverSpotOz = silverSpotOz || 75.0;
-    updateAll({ price: goldSpotOz }, { price: silverSpotOz });
-  }
-}
-function updateAll(gData, sData) {
-  const gOz = gData.price, sOz = sData.price;
-  const gGram = gOz / TROY_OZ_TO_GRAM;
-  const sGram = sOz / TROY_OZ_TO_GRAM;
-  const gChg = gData.prev_close_price ? ((gOz - gData.prev_close_price) / gData.prev_close_price * 100).toFixed(2) : null;
-  const sChg = sData.prev_close_price ? ((sOz - sData.prev_close_price) / sData.prev_close_price * 100).toFixed(2) : null;
-  setText('spotGoldOz',   fmtUSD(gOz));
-  setText('spotSilverOz', fmtUSD(sOz));
-  setText('spotGoldGram', fmtUSD(gGram));
-  setText('spotSilverKg', fmtUSD(sOz * 32.1507));
-  if(gChg !== null) { const el = document.getElementById('spotGoldChg');   el.textContent = (gChg > 0 ? '▲' : '▼') + ' ' + Math.abs(gChg) + '% today'; el.className = 'spot-card-change ' + (gChg >= 0 ? 'up' : 'down'); }
-  if(sChg !== null) { const el = document.getElementById('spotSilverChg'); el.textContent = (sChg > 0 ? '▲' : '▼') + ' ' + Math.abs(sChg) + '% today'; el.className = 'spot-card-change ' + (sChg >= 0 ? 'up' : 'down'); }
-  const td = [['t-xau',fmtUSD(gOz)],['t-xag',fmtUSD(sOz)],['t-24k',fmtUSD(gGram*0.9999)],['t-18k',fmtUSD(gGram*0.75)],['t-14k',fmtUSD(gGram*0.5833)],['t-10k',fmtUSD(gGram*0.4167)],['t-agoz',fmtUSD(sOz)],['t-agkg',fmtUSD(sOz*32.1507)],['t-xau2',fmtUSD(gOz)],['t-xag2',fmtUSD(sOz)],['t-24k2',fmtUSD(gGram*0.9999)],['t-18k2',fmtUSD(gGram*0.75)],['t-14k2',fmtUSD(gGram*0.5833)],['t-10k2',fmtUSD(gGram*0.4167)],['t-agoz2',fmtUSD(sOz)],['t-agkg2',fmtUSD(sOz*32.1507)]];
-  td.forEach(([id,val]) => setText(id, val));
-  setText('qr-24g',fmtUSD(gGram*0.9999));setText('qr-18g',fmtUSD(gGram*0.75));setText('qr-14g',fmtUSD(gGram*0.5833));setText('qr-10g',fmtUSD(gGram*0.4167));setText('qr-24oz',fmtUSD(gOz*0.9999));setText('qr-18oz',fmtUSD(gOz*0.75));setText('qr-14oz',fmtUSD(gOz*0.5833));setText('qr-10oz',fmtUSD(gOz*0.4167));
-  setText('qr-ag999g',fmtUSD(sGram*0.999));setText('qr-ag925g',fmtUSD(sGram*0.925));setText('qr-ag999oz',fmtUSD(sOz*0.999));setText('qr-ag999kg',fmtUSD(sOz*32.1507*0.999));
-  setText('faq-14k',fmtUSD(gGram*0.5833));setText('faq-10k',fmtUSD(gGram*0.4167));setText('faq-18k',fmtUSD(gGram*0.75));setText('faq-sterling',fmtUSD(sGram*0.925));setText('faq-bar400',fmtUSD(gOz*400));setText('faq-bar1oz',fmtUSD(gOz));setText('faq-1g',fmtUSD(gGram));setText('faq-agkg',fmtUSD(sOz*32.1507));
-  setText('lastUpdated', new Date().toLocaleTimeString('en-GB',{hour:'2-digit',minute:'2-digit',second:'2-digit'}) + ' BST');
-  buildKaratGrid(gOz); calcGold(); calcSilver(); calcScrap(); calcBars(); calcConverter();
-}
-function buildKaratGrid(gOz) {
-  const grid = document.getElementById('karatGrid');
-  if (!grid) return;
-  if (grid.dataset.built === '1') {
-    KARATS.forEach(k => {
-      const perG = gOz / TROY_OZ_TO_GRAM * k.purity;
-      const el   = document.getElementById('kg-' + k.k);
-      if (el) {
-        el.querySelector('.kv-usd').textContent = fmtUSD(perG);
-        el.querySelector('.kv-gbp').textContent = '£' + (perG * (fxRates.GBP||0.74)).toFixed(2);
-        el.querySelector('.kv-eur').textContent = '€' + (perG * (fxRates.EUR||0.855)).toFixed(2);
-        el.querySelector('.kv-oz').textContent  = fmtUSD(gOz * k.purity);
-        el.querySelector('.kv-kg').textContent  = fmtUSD(perG * 1000);
-      }
-    }); return;
-  }
-  grid.innerHTML = ''; grid.dataset.built = '1';
-  KARATS.forEach(k => {
-    const perG = gOz / TROY_OZ_TO_GRAM * k.purity;
-    const card = document.createElement('div');
-    card.className = 'karat-card'; card.id = 'kg-' + k.k;
-    card.innerHTML = `<div class="karat-card-header"><span class="karat-card-title" id="karat-${k.k}-heading">${k.label}</span><span class="karat-card-purity">${(k.purity*100).toFixed(2)}% pure</span></div><table class="karat-table" aria-labelledby="karat-${k.k}-heading"><tr><td>Per gram (USD)</td><td class="kv-usd">${fmtUSD(perG)}</td></tr><tr><td>Per gram (GBP)</td><td class="kv-gbp">£${(perG*(fxRates.GBP||0.74)).toFixed(2)}</td></tr><tr><td>Per gram (EUR)</td><td class="kv-eur">€${(perG*(fxRates.EUR||0.855)).toFixed(2)}</td></tr><tr><td>Per troy oz</td><td class="kv-oz">${fmtUSD(gOz*k.purity)}</td></tr><tr><td>Per kilogram</td><td class="kv-kg">${fmtUSD(perG*1000)}</td></tr></table></div>`;
-    grid.appendChild(card);
-  });
-}
-function calcGold() {
-  if (!goldSpotOz) return;
-  const purity=parseFloat(document.getElementById('goldKarat').value),weight=parseFloat(document.getElementById('goldWeight').value)||0,unit=parseFloat(document.getElementById('goldUnit').value),currency=document.getElementById('goldCurrency').value,grams=weight*unit,usdVal=(goldSpotOz/TROY_OZ_TO_GRAM)*purity*grams;
-  setText('goldResult',fmtCurr(usdVal,currency));setText('goldResultMeta',`${grams.toFixed(4)}g × ${(purity*100).toFixed(2)}% purity × ${fmtUSD(goldSpotOz/TROY_OZ_TO_GRAM)}/g spot`);
-}
-function calcSilver() {
-  if (!silverSpotOz) return;
-  const purity=parseFloat(document.getElementById('silverPurity').value),weight=parseFloat(document.getElementById('silverWeight').value)||0,unit=parseFloat(document.getElementById('silverUnit').value),currency=document.getElementById('silverCurrency').value,grams=weight*unit,usdVal=(silverSpotOz/TROY_OZ_TO_GRAM)*purity*grams;
-  setText('silverResult',fmtCurr(usdVal,currency));setText('silverResultMeta',`${grams.toFixed(4)}g × ${(purity*100).toFixed(2)}% purity × ${fmtUSD(silverSpotOz/TROY_OZ_TO_GRAM)}/g spot`);
-}
-function calcScrap() {
-  let inputsFilled = 0;
-  if (!goldSpotOz) return;
-  const ppg=goldSpotOz/TROY_OZ_TO_GRAM;let totalWeight=0,totalPureOz=0,totalValue=0;
-  document.querySelectorAll('#scrapRows tr').forEach(row=>{
-    const purity=parseFloat(row.dataset.purity),input=row.querySelector('input'),grams=parseFloat(input?.value)||0,value=ppg*purity*grams,valCell=row.querySelector('.scrap-row-val');
-    if(valCell) valCell.textContent=grams>0?fmtUSD(value):'—';
-    if (grams > 0) inputsFilled++;
-    totalWeight+=grams;totalPureOz+=(grams*purity)/TROY_OZ_TO_GRAM;totalValue+=value;
-  });
-  setText('scrapTotalWeight',totalWeight.toFixed(3)+' g');setText('scrapPureOz',totalPureOz.toFixed(4)+' oz t');setText('scrapTotalValue',fmtUSD(totalValue));
-  if (inputsFilled >= 3) fireScrapIntent();
-}
-function calcBars() {
-  if (!goldSpotOz) return;
-  const sizeOz=parseFloat(document.getElementById('barSize').value),qty=parseInt(document.getElementById('barQty').value)||1,val=goldSpotOz*sizeOz*qty,label=document.getElementById('barSize').selectedOptions[0].text;
-  setText('barResult',fmtUSD(val));setText('barResultMeta',`${qty} × ${label} @ ${fmtUSD(goldSpotOz)}/oz`);
-}
-function calcConverter() {
-  const amount=parseFloat(document.getElementById('convInput').value)||0,from=parseFloat(document.getElementById('convFrom').value),grams=amount*from,fmt=(v,dec)=>v.toLocaleString('en-US',{minimumFractionDigits:dec||4,maximumFractionDigits:dec||4});
-  setText('cv-g',fmt(grams,4)+' g');setText('cv-ozt',fmt(grams/31.1035,4)+' oz t');setText('cv-kg',fmt(grams/1000,6)+' kg');setText('cv-dwt',fmt(grams/1.55517,4)+' dwt');setText('cv-gr',fmt(grams/0.0648,2)+' gr');setText('cv-lb',fmt(grams/453.592,6)+' lb');
-}
-async function fetchChartHistory(metal, range) {
-  const key=`${metal}-${range}`;
-  if(chartHistoryCache[key]) return chartHistoryCache[key];
-  try {
-    const res=await fetch(`/chart-data/${metal}-${range}.json`);
-    if(!res.ok) throw new Error(`HTTP ${res.status}`);
-    const json=await res.json();
-    if(json.labels&&json.data&&json.data.length>0){chartHistoryCache[key]=json;return json;}
-    throw new Error('Empty chart data');
-  } catch(e){console.warn(`Chart data unavailable (${key}):`,e.message);return null;}
-}
-async function buildChart(canvasId,loadingId,metal,range,color,chartRef) {
-  const loadingEl=document.getElementById(loadingId);
-  if(loadingEl) loadingEl.style.display='flex';
-  const history=await fetchChartHistory(metal,range);
-  if(loadingEl) loadingEl.style.display='none';
-  if(typeof Chart==='undefined') return chartRef;
-  const style=getComputedStyle(document.documentElement),textMuted=style.getPropertyValue('--color-text-muted').trim(),border=style.getPropertyValue('--color-border').trim();
-  const isShortRange=(range==='1M'||range==='3M');
-  const labelFmt=isShortRange?(s)=>{const d=new Date(s);return d.toLocaleDateString('en-GB',{day:'2-digit',month:'short'});}:(s)=>{const d=new Date(s);return d.toLocaleDateString('en-GB',{month:'short',year:'2-digit'});};
-  const labels=history?history.labels.map(labelFmt):[],data=history?history.data:[];
-  if(!history||data.length===0){if(loadingEl){loadingEl.textContent='Chart data unavailable';loadingEl.style.display='flex';}return chartRef;}
-  if(chartRef) chartRef.destroy();
-  chartRef=new Chart(document.getElementById(canvasId),{type:'line',data:{labels,datasets:[{data,borderColor:color,borderWidth:2,fill:true,backgroundColor:ctx=>{const g=ctx.chart.ctx.createLinearGradient(0,0,0,280);g.addColorStop(0,color+'33');g.addColorStop(1,color+'00');return g;}}]},options:{responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false},tooltip:{mode:'index',intersect:false,backgroundColor:'rgba(0,0,0,0.8)',titleColor:'#fff',bodyColor:'#fff',padding:10,callbacks:{label:ctx=>' $'+ctx.parsed.y.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2})}}},scales:{x:{ticks:{color:textMuted,font:{size:11},maxTicksLimit:8},grid:{color:border+'40'}},y:{ticks:{color:textMuted,font:{size:11},callback:v=>'$'+v.toLocaleString()},grid:{color:border+'40'},position:'right'}},elements:{point:{radius:0,hitRadius:10},line:{tension:0.3}}}});
-  return chartRef;
-}
-async function buildCharts() {
-  if(typeof Chart==='undefined'||!goldSpotOz) return;
-  const style=getComputedStyle(document.documentElement),goldColor=style.getPropertyValue('--color-gold-bright').trim()||'#e8af34',silverColor=style.getPropertyValue('--color-silver').trim()||'#9ca3af';
-  goldChart=await buildChart('goldChart','goldChartLoading','XAU',currentGoldRange,goldColor,goldChart);
-  silverChart=await buildChart('silverChart','silverChartLoading','XAG',currentSilverRange,silverColor,silverChart);
-}
-document.querySelectorAll('[data-range]').forEach(btn=>{
-  btn.addEventListener('click',async function(){
-    document.querySelectorAll('[data-range]').forEach(b=>b.classList.remove('active'));
-    this.classList.add('active');currentGoldRange=this.dataset.range;
-    if(goldSpotOz&&typeof Chart!=='undefined'){const style=getComputedStyle(document.documentElement),color=style.getPropertyValue('--color-gold-bright').trim()||'#e8af34';goldChart=await buildChart('goldChart','goldChartLoading','XAU',currentGoldRange,color,goldChart);}
-  });
-});
-document.querySelectorAll('[data-range-silver]').forEach(btn=>{
-  btn.addEventListener('click',async function(){
-    document.querySelectorAll('[data-range-silver]').forEach(b=>b.classList.remove('active'));
-    this.classList.add('active');currentSilverRange=this.dataset.rangeSilver;
-    if(silverSpotOz&&typeof Chart!=='undefined'){const style=getComputedStyle(document.documentElement),color=style.getPropertyValue('--color-silver').trim()||'#9ca3af';silverChart=await buildChart('silverChart','silverChartLoading','XAG',currentSilverRange,color,silverChart);}
-  });
-});
-document.querySelectorAll('.calc-tab').forEach(tab=>{
-  tab.addEventListener('click',function(){
-    document.querySelectorAll('.calc-tab').forEach(t=>{t.classList.remove('active');t.setAttribute('aria-selected','false');});
-    document.querySelectorAll('.calc-panel').forEach(p=>p.classList.remove('active'));
-    this.classList.add('active');this.setAttribute('aria-selected','true');
-    document.getElementById('panel-'+this.dataset.tab).classList.add('active');
-  });
-});
-let _scrapIntentFired = false;
-document.addEventListener("DOMContentLoaded", () => { document.querySelectorAll('a[href*="/scrap-gold-calculator"]').forEach(a => { a.addEventListener('click', fireScrapIntent); }); });
-function fireScrapIntent() {
-  if (!_scrapIntentFired) {
-    gtag("event", "scrap_seller_intent");
-    _scrapIntentFired = true;
-  }
-}
-
-let _calcEngagedFired = false;
-function fireCalcEngaged() {
-  if (!_calcEngagedFired) {
-    gtag("event", "calculator_engaged");
-    _calcEngagedFired = true;
-  }
-}
-
-['goldKarat','goldWeight','goldUnit','goldCurrency'].forEach(id=>document.getElementById(id)?.addEventListener('input',() => { fireCalcEngaged(); calcGold(); }));
-['silverPurity','silverWeight','silverUnit','silverCurrency'].forEach(id=>document.getElementById(id)?.addEventListener('input',() => { fireCalcEngaged(); calcSilver(); }));
-document.querySelectorAll('#scrapRows input').forEach(inp=>inp.addEventListener('input',() => { fireCalcEngaged(); calcScrap(); }));
-['barSize','barQty'].forEach(id=>document.getElementById(id)?.addEventListener('input',() => { fireCalcEngaged(); calcBars(); }));
-['convInput','convFrom'].forEach(id=>document.getElementById(id)?.addEventListener('input',calcConverter));
-function setText(id,val){const el=document.getElementById(id);if(el) el.textContent=val;}
-Promise.all([fetchFxRates(),fetchPrices()]).then(()=>{if(goldSpotOz){calcGold();calcSilver();buildKaratGrid(goldSpotOz);}});
-setInterval(fetchPrices,60_000);
-setInterval(fetchFxRates,600_000);
-const chartPoll=setInterval(()=>{if(typeof Chart!=='undefined'&&goldSpotOz){clearInterval(chartPoll);buildCharts();}},200);
 </script>
 
 <!-- SITELINKS SEARCHBOX — handles ?q= parameter from Google Search Box (WP-56) -->


### PR DESCRIPTION
## Summary

Complete UI/UX overhaul of `/zakat-gold-silver-calculator` using the **ui-ux-pro-max** design intelligence skill. The redesigned page applies a **Liquid Glass + Bento Grid** pattern with subtle Islamic geometric SVG accents — a recommendation pulled directly from the design-system search for `"Islamic religious finance zakat calculator service elegant premium"`.

Mobile-first design that scales beautifully from 375px iPhone to 1440px desktop with WCAG-compliant touch targets and accessibility throughout.

## What changed

### Hero
- New gradient title (`Gold` in premium gold gradient, `Silver` in cool silver gradient)
- **Dual live Nisab status cards** showing the gold (85g) and silver (595g) thresholds side-by-side in USD primary
- Subtle Islamic arabesque SVG pattern with radial gold glow behind hero
- Pill badges: Hawl (1 lunar year) · Rate (2.5%) · Classical sources

### Calculator (Bento)
- Two glassmorphic calculator cards (Gold + Silver) side-by-side on desktop, stacked on mobile
- **5 weight units per metal**: grams, troy oz, kg, tola (South Asia), bhori (Bangladesh)
- **7 karat options** for gold (24K → 9K) with displayed purity percentages
- **5 silver purity grades** (Fine 99.9% → .800 European)
- Live result tiles showing pure metal value + Zakat due (2.5%) + per-gram spot reference
- **9-currency switcher** chips: USD primary, plus EUR / GBP / SAR / AED / MYR / IDR / INR / PKR — covers all major Muslim-majority markets

### Combined Total + Nisab Progress
- Hero number with animated **Nisab progress bar** against the silver Nisab (recommended threshold)
- Above/below Nisab status badge with semantic icons (warning vs check)
- Breakdown chips: total wealth, gold portion, silver portion

### New tools
- **Hawl Tracker** — date picker that calculates next Zakat due date using the 354-day lunar year, with overdue / due-today / countdown states
- **Visual Gold vs Silver Nisab comparison** with proportional bars

### Educational content
- **Bento educational grid**: feature card "Conditions for Zakat to be Due" (Ownership / Nisab / Hawl / Intention) + 4 detail cards (Hawl · Rate · Pure Content · 8 Categories of Recipients from Surah At-Tawbah 9:60)
- **Madhab comparison table** (Hanafi / Shafi'i / Maliki / Hanbali) with horizontal scroll on mobile
- **7-question accordion FAQ** with smooth + → × icon animations

### Live data accuracy (preserved)
- `api.gold-api.com/price/XAU` and `XAG` — 60-second refresh (matches site-wide cadence)
- `api.frankfurter.dev` FX rates — 10-minute refresh
- **USD is canonical** — all calculations done in USD then converted at display time
- Live ticker bar still populated from same fetch cycle
- Removed leftover template JS that referenced non-existent DOM IDs (charts, scrap rows, karat grid, etc.)
- Fixed pre-existing orphan `</div>` immediately below `</nav>`

## Verified with Playwright

Tested at iPhone 375px, tablet 768px, desktop 1440px:

| Check | Mobile | Tablet | Desktop |
|---|---|---|---|
| 85g 24K gold → $11,614.65 (≈ Nisab) | ✓ | ✓ | ✓ |
| Zakat on 85g = $290.37 (2.5%) | ✓ | ✓ | ✓ |
| 595g fine silver → $1,117.01 (≈ Silver Nisab) | ✓ | ✓ | ✓ |
| Currency switch USD → GBP (× 0.79) | ✓ | ✓ | ✓ |
| No horizontal scroll on body | ✓ | ✓ | ✓ |
| No JS console errors | ✓ | ✓ | ✓ |
| New interactive components ≥32px touch height | ✓ | – | – |

## Test plan

- [ ] Visit `/zakat-gold-silver-calculator` on iPhone — verify single-column stack, all cards readable, no horizontal scroll
- [ ] Verify Gold Nisab + Silver Nisab cards show live USD values at top
- [ ] Enter 100g gold + 1000g silver — verify Total Zakat ≈ $388 (varies with live spot)
- [ ] Switch currency to GBP, EUR, SAR — verify all values convert correctly
- [ ] Try unit switch (grams → troy oz → tola) — verify gold value scales correctly
- [ ] Try karat switch (24K → 18K → 9K) — verify pure-gold portion drops appropriately
- [ ] Pick a Hawl date in the past — verify "Overdue" status; pick a future date — verify countdown
- [ ] Open all 7 FAQ accordions and confirm + icon rotates to ×
- [ ] Test in light and dark mode (theme toggle in nav)
- [ ] Confirm 60-second auto-refresh updates Nisab cards and ticker

https://claude.ai/code/session_01KfdurvGuZZzvoB6LtdLNGm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfdurvGuZZzvoB6LtdLNGm)_