### PR TITLE
Redesign troy ounce conversion page with premium mobile-first UI and live USD

### DIFF
--- a/how-many-grams-in-troy-ounce.html
+++ b/how-many-grams-in-troy-ounce.html
@@ -2,81 +2,70 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
-  <script>
+<script>
 (function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
 </script>
-    <meta name="cf-no-email-obfuscation">
+<meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>How Many Grams in a Troy Ounce? 31.1035g — Instant Calculator | GoldPriceTools</title>
-  <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="1 troy ounce = 31.1035 grams. Instantly convert between troy ounces, grams, and kilograms for gold and silver. Includes live gold price reference table and weight conversion chart.">
+<title>How Many Grams in a Troy Ounce? 31.1035g — Live USD Converter | GoldPriceTools</title>
+<meta name="google-adsense-account" content="ca-pub-8849494330640880">
+<meta name="description" content="1 troy ounce = 31.1035 grams. Instantly convert troy ounces ↔ grams ↔ kilograms with live USD gold &amp; silver prices. International LBMA standard for precious metals.">
 <meta name="robots" content="index, follow">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/how-many-grams-in-troy-ounce">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/how-many-grams-in-troy-ounce">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/how-many-grams-in-troy-ounce">
 <link rel="canonical" href="https://goldpricetools.com/how-many-grams-in-troy-ounce">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"How Many Grams in a Troy Ounce?","item":"https://goldpricetools.com/how-many-grams-in-troy-ounce"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How many grams are in a troy ounce?","acceptedAnswer":{"@type":"Answer","text":"There are exactly 31.1035 grams in one troy ounce. This is the internationally recognised unit used for pricing gold, silver, platinum and palladium on global commodity markets."}},{"@type":"Question","name":"What is the difference between a troy ounce and a regular ounce?","acceptedAnswer":{"@type":"Answer","text":"A troy ounce (31.1035 grams) is heavier than a regular avoirdupois ounce (28.3495 grams). The troy ounce is 9.7% heavier. Gold prices quoted per ounce always use the troy ounce, not the regular ounce."}},{"@type":"Question","name":"How many troy ounces are in a kilogram of gold?","acceptedAnswer":{"@type":"Answer","text":"There are 32.1507 troy ounces in one kilogram. To convert: 1000 grams \u00f7 31.1035 grams/troy oz = 32.1507 troy oz."}},{"@type":"Question","name":"Why is gold measured in troy ounces?","acceptedAnswer":{"@type":"Answer","text":"Gold has been measured in troy ounces since the Middle Ages, originating from the trade fairs of Troyes, France. The troy weight system was formalised in England in the 15th century and has been the international standard for precious metals ever since."}},{"@type":"Question","name":"How do I convert troy ounces to grams?","acceptedAnswer":{"@type":"Answer","text":"Multiply troy ounces by 31.1035 to get grams. To convert grams to troy ounces, divide by 31.1035. Example: 2 troy oz = 2 \u00d7 31.1035 = 62.207 grams."}}]}</script>
-<meta property="og:title" content="How Many Grams in a Troy Ounce? (31.1035g Explained)">
-<meta property="og:description" content="A troy ounce equals 31.1035 grams. Learn the difference from regular ounces and how to convert for gold pricing.">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Calculators","item":"https://goldpricetools.com/scrap-gold-calculator"},{"@type":"ListItem","position":3,"name":"How Many Grams in a Troy Ounce?","item":"https://goldpricetools.com/how-many-grams-in-troy-ounce"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How many grams are in a troy ounce?","acceptedAnswer":{"@type":"Answer","text":"There are exactly 31.1035 grams in one troy ounce. This is the internationally recognised unit used for pricing gold, silver, platinum and palladium on global commodity markets."}},{"@type":"Question","name":"What is the difference between a troy ounce and a regular ounce?","acceptedAnswer":{"@type":"Answer","text":"A troy ounce (31.1035 grams) is heavier than a regular avoirdupois ounce (28.3495 grams). The troy ounce is 9.7% heavier. Gold prices quoted per ounce always use the troy ounce, not the regular ounce."}},{"@type":"Question","name":"How many troy ounces are in a kilogram of gold?","acceptedAnswer":{"@type":"Answer","text":"There are 32.1507 troy ounces in one kilogram. To convert: 1000 grams ÷ 31.1035 grams/troy oz = 32.1507 troy oz."}},{"@type":"Question","name":"Why is gold measured in troy ounces?","acceptedAnswer":{"@type":"Answer","text":"Gold has been measured in troy ounces since the Middle Ages, originating from the trade fairs of Troyes, France. The troy weight system was formalised in England in the 15th century and has been the international standard for precious metals ever since."}},{"@type":"Question","name":"How do I convert troy ounces to grams?","acceptedAnswer":{"@type":"Answer","text":"Multiply troy ounces by 31.1035 to get grams. To convert grams to troy ounces, divide by 31.1035. Example: 2 troy oz = 2 × 31.1035 = 62.207 grams."}},{"@type":"Question","name":"How much is one pound of gold worth?","acceptedAnswer":{"@type":"Answer","text":"One avoirdupois pound (453.59 grams) of gold equals 14.5833 troy ounces. Multiply 14.5833 by the live gold spot price in USD per troy ounce to get the value of one pound of gold today."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"Troy Ounce to Gram Converter","applicationCategory":"FinanceApplication","operatingSystem":"Web","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://goldpricetools.com/how-many-grams-in-troy-ounce"}</script>
+<meta property="og:title" content="How Many Grams in a Troy Ounce? 31.1035g — Live USD Converter">
+<meta property="og:description" content="A troy ounce equals 31.1035 grams. Live USD gold &amp; silver prices, instant unit conversion, and the LBMA international standard explained.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/how-many-grams-in-troy-ounce">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
-<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
 <script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
 <script>
 (adsbygoogle = window.adsbygoogle || []).push({
   google_ad_client: "ca-pub-8849494330640880",
   enable_page_level_ads: true,
   overlays: {bottom: false},
-  vignette: {
-    new_triggers: false
-  }
+  vignette: {new_triggers: false}
 });
 </script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="manifest" href="/manifest.json">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
+<meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://api.gold-api.com">
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org/",
+  "@type": "WebPage",
+  "name": "How Many Grams In Troy Ounce",
+  "url": "https://goldpricetools.com/how-many-grams-in-troy-ounce",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": [".snippet-answer", ".troy-faq__a"]
+  }
+}
+</script>
 <style>
-
-/* ── Guides mega panel — category links ── */
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-
-
+/* ── Base tokens (matches site-wide system) ── */
 :root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
 [data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-/* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-
-
 html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
@@ -89,7 +78,7 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 
-/* TICKER */
+/* ── TICKER ── */
 .ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
 .ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
 .ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
@@ -100,178 +89,10 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
 .ticker-label{color:var(--color-text-muted)}
 .ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
 .live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
 
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
-
-/* AD SLOTS */
-.ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
-.ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
-
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
-
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
-
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
-
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
-
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
-
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
-
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
-
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
-
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
-
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
-
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
-
-#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-
-/* MEGA MENU */
+/* ── Mega menu / Nav (preserved) ── */
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
@@ -295,6 +116,13 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
 .mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
 .mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 .nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
 .theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
 .theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
@@ -325,140 +153,364 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
+/* ── Breadcrumb ── */
+.breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
+.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted);flex-wrap:wrap}
+.breadcrumb li+li::before{content:"/";margin-right:var(--space-2);color:var(--color-text-faint)}
+.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
+.breadcrumb a:hover{color:var(--color-primary)}
+.breadcrumb li[aria-current="page"]{color:var(--color-text)}
+</style>
 
-/* BLOG PREVIEW SECTION */
+<style>
+/* =====================================================================
+   TROY OUNCE PRECISION REFERENCE — "The Bullion Standard"
+   Premium editorial + liquid-glass + bento grid + scientific precision
+   Mobile-first · scales accurately · WCAG AA · USD primary
+   ===================================================================== */
+
+/* ── HERO ── */
+.troy-hero{position:relative;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-6);overflow:hidden;isolation:isolate}
+@media(min-width:768px){.troy-hero{padding:var(--space-10) var(--space-4) var(--space-8)}}
+.troy-hero__pattern{position:absolute;inset:0;z-index:-1;color:var(--color-gold-bright);opacity:.18;pointer-events:none;mask-image:radial-gradient(ellipse at 50% 30%,#000 25%,transparent 75%);-webkit-mask-image:radial-gradient(ellipse at 50% 30%,#000 25%,transparent 75%)}
+[data-theme="light"] .troy-hero__pattern{opacity:.10}
+.troy-hero__inner{position:relative;display:grid;grid-template-columns:1fr;gap:var(--space-6);align-items:center}
+@media(min-width:900px){.troy-hero__inner{grid-template-columns:1.15fr 1fr;gap:var(--space-8)}}
+.troy-hero__left{display:flex;flex-direction:column;gap:var(--space-4)}
+.troy-hero__eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));padding:6px 14px;border-radius:var(--radius-full);font-size:11px;font-weight:700;color:var(--color-gold-bright);letter-spacing:.1em;text-transform:uppercase;backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);align-self:flex-start}
+.troy-hero__eyebrow svg{width:13px;height:13px;flex-shrink:0}
+.troy-hero__title{font-family:var(--font-display);font-size:clamp(2rem,1.3rem + 3.4vw,3.75rem);font-weight:700;line-height:1.05;letter-spacing:-.025em;color:var(--color-text);margin:0}
+.troy-grad-gold{background:linear-gradient(135deg,#f4c849 0%,var(--color-gold-bright) 55%,#b07a00 100%);-webkit-background-clip:text;background-clip:text;color:transparent;display:inline-block}
+.troy-grad-silver{background:linear-gradient(135deg,#e5e7eb 0%,#9ca3af 50%,#6b7280 100%);-webkit-background-clip:text;background-clip:text;color:transparent;display:inline-block}
+.troy-hero__sub{font-size:clamp(1rem,.92rem + .5vw,1.18rem);color:var(--color-text-muted);max-width:58ch;line-height:1.7;margin:0}
+.troy-hero__sub strong{color:var(--color-text);font-weight:600}
+.troy-hero__pillars{display:flex;flex-wrap:wrap;gap:var(--space-2);margin-top:var(--space-2)}
+.troy-pill{display:inline-flex;align-items:center;gap:6px;font-size:11px;font-weight:700;letter-spacing:.06em;color:var(--color-text-muted);padding:7px 12px;border:1px solid var(--color-border);border-radius:var(--radius-full);background:var(--color-surface-offset);text-transform:uppercase}
+.troy-pill svg{color:var(--color-gold-bright);width:13px;height:13px;flex-shrink:0}
+
+/* Hero answer card */
+.troy-answer{position:relative;background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface)) 0%,color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface)) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-6) var(--space-5);text-align:center;overflow:hidden;backdrop-filter:blur(14px) saturate(140%);-webkit-backdrop-filter:blur(14px) saturate(140%);box-shadow:0 12px 40px color-mix(in oklch,var(--color-gold-bright) 12%,transparent)}
+@media(min-width:640px){.troy-answer{padding:var(--space-8) var(--space-6)}}
+.troy-answer::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at 50% 0%,var(--color-gold-bright) 0%,transparent 60%);opacity:.10;pointer-events:none}
+.troy-answer>*{position:relative;z-index:1}
+.troy-answer__label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.14em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.troy-answer__value{font-family:var(--font-display);font-size:clamp(3rem,2rem + 6vw,5.5rem);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:.95;letter-spacing:-.04em;margin-bottom:var(--space-2);text-shadow:0 4px 24px color-mix(in oklch,var(--color-gold-bright) 30%,transparent)}
+.troy-answer__unit{font-family:var(--font-display);font-size:clamp(.95rem,.85rem + .35vw,1.125rem);font-weight:600;color:var(--color-text);letter-spacing:.02em}
+.troy-answer__unit span{color:var(--color-text-muted);font-weight:500}
+.troy-answer__meta{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px dashed color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-divider));font-size:var(--text-xs);color:var(--color-text-muted);display:flex;justify-content:center;flex-wrap:wrap;gap:var(--space-2)}
+.troy-answer__meta strong{color:var(--color-text);font-weight:600;font-variant-numeric:tabular-nums}
+.troy-answer__meta-sep{color:var(--color-text-faint)}
+
+/* ── Live spot strip ── */
+.troy-spot-grid{max-width:1200px;margin:var(--space-2) auto var(--space-8);padding:0 var(--space-4);display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:640px){.troy-spot-grid{grid-template-columns:1fr 1fr}}
+@media(min-width:1024px){.troy-spot-grid{grid-template-columns:1fr 1fr auto;align-items:stretch}}
+.troy-spot{position:relative;background:color-mix(in oklch,var(--color-surface) 88%,transparent);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4) var(--space-5);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);box-shadow:var(--shadow-sm);display:flex;flex-direction:column;gap:6px;overflow:hidden;transition:border-color 220ms,box-shadow 220ms,transform 220ms}
+.troy-spot:hover{transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.troy-spot--gold:hover{border-color:var(--color-gold-bright)}
+.troy-spot--silver:hover{border-color:var(--color-silver)}
+.troy-spot::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at top right,currentColor 0%,transparent 60%);opacity:.05;pointer-events:none}
+.troy-spot--gold{color:var(--color-gold-bright)}
+.troy-spot--silver{color:var(--color-silver)}
+.troy-spot__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2);position:relative}
+.troy-spot__tag{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:currentColor;display:inline-flex;align-items:center;gap:6px}
+.troy-spot__tag .live-dot{background:#4ade80}
+.troy-spot__chip{font-size:10.5px;font-weight:600;color:var(--color-text-muted);padding:3px 9px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);letter-spacing:.04em;text-transform:uppercase}
+.troy-spot__value{font-family:var(--font-display);font-size:clamp(1.75rem,1.3rem + 1.8vw,2.5rem);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1.05;position:relative}
+.troy-spot__sub{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500;position:relative}
+.troy-spot__sub strong{color:var(--color-text);font-weight:600;font-variant-numeric:tabular-nums}
+
+.troy-spot__source{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4) var(--space-5);font-size:var(--text-xs);color:var(--color-text-muted);display:flex;flex-direction:column;justify-content:center;gap:6px}
+.troy-spot__source-head{font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-faint)}
+.troy-spot__source-body{line-height:1.55}
+.troy-spot__source a{color:var(--color-primary);text-decoration:none;font-weight:600}
+.troy-spot__source a:hover{text-decoration:underline}
+
+/* ── Section heads ── */
+.troy-section{max-width:1200px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+.troy-section-head{display:flex;flex-direction:column;gap:var(--space-2);margin:0 0 var(--space-5);max-width:780px}
+.troy-section-head__eyebrow{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright)}
+.troy-section-head__title{font-family:var(--font-display);font-size:clamp(1.5rem,1.15rem + 1.7vw,2.25rem);font-weight:700;color:var(--color-text);line-height:1.18;letter-spacing:-.015em}
+.troy-section-head__sub{font-size:var(--text-sm);color:var(--color-text-muted);max-width:65ch;line-height:1.65}
+
+/* ── TROY VS AVOIRDUPOIS comparison ── */
+.troy-vs__grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:768px){.troy-vs__grid{grid-template-columns:1fr auto 1fr;align-items:stretch;gap:var(--space-3)}}
+.troy-vs__card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;display:flex;flex-direction:column;gap:var(--space-3);transition:border-color 220ms,transform 220ms,box-shadow 220ms}
+.troy-vs__card:hover{transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.troy-vs__card--troy{border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface)) 0%,var(--color-surface) 80%)}
+.troy-vs__card--avoir{border-color:var(--color-border)}
+.troy-vs__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);flex-wrap:wrap}
+.troy-vs__symbol{display:grid;place-items:center;width:44px;height:44px;border-radius:var(--radius-lg);background:var(--color-surface-offset);border:1px solid var(--color-border);font-family:var(--font-display);font-size:18px;font-weight:700;color:var(--color-text);flex-shrink:0}
+.troy-vs__card--troy .troy-vs__symbol{background:color-mix(in oklch,var(--color-gold-bright) 16%,transparent);border-color:color-mix(in oklch,var(--color-gold-bright) 40%,transparent);color:var(--color-gold-bright)}
+.troy-vs__label{flex:1;min-width:0}
+.troy-vs__name{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);line-height:1.2}
+.troy-vs__abbr{font-size:11px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-top:2px}
+.troy-vs__weight{font-family:var(--font-display);font-size:clamp(1.75rem,1.25rem + 1.8vw,2.5rem);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1}
+.troy-vs__card--troy .troy-vs__weight{color:var(--color-gold-bright)}
+.troy-vs__weight-unit{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);margin-left:4px;letter-spacing:0}
+.troy-vs__use{display:flex;flex-wrap:wrap;gap:6px;margin-top:var(--space-2)}
+.troy-vs__use span{font-size:11px;font-weight:600;padding:4px 10px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);color:var(--color-text-muted)}
+.troy-vs__card--troy .troy-vs__use span{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border-color:color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));color:var(--color-text)}
+.troy-vs__note{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.55;margin-top:auto;padding-top:var(--space-3);border-top:1px dashed var(--color-divider)}
+.troy-vs__delta{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;padding:var(--space-4);background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-xl);text-align:center;min-height:120px}
+@media(max-width:767px){.troy-vs__delta{padding:var(--space-3) var(--space-5);min-height:auto;flex-direction:row;justify-content:space-between;text-align:left}}
+.troy-vs__delta-num{font-family:var(--font-display);font-size:clamp(1.5rem,1.1rem + 1.6vw,2rem);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1}
+.troy-vs__delta-label{font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted)}
+@media(max-width:767px){.troy-vs__delta-label{text-align:right}}
+
+/* Visual weight bar */
+.troy-vs__bars{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.troy-vs__bar-row{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3)}
+.troy-vs__bar-row:last-child{margin-bottom:0}
+.troy-vs__bar-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted);width:80px;flex-shrink:0}
+.troy-vs__bar-track{flex:1;height:18px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);overflow:hidden;position:relative}
+.troy-vs__bar-fill{position:absolute;inset:0 auto 0 0;background:linear-gradient(90deg,#9ca3af,#6b7280);border-radius:var(--radius-full);transition:width 600ms cubic-bezier(.4,0,.2,1)}
+.troy-vs__bar-fill--gold{background:linear-gradient(90deg,#f4c849,var(--color-gold-bright))}
+.troy-vs__bar-val{font-family:var(--font-display);font-size:13px;font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;width:74px;text-align:right;flex-shrink:0}
+
+/* ── PRECISION CONVERTER ── */
+.troy-conv{position:relative;background:color-mix(in oklch,var(--color-surface) 92%,transparent);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);box-shadow:var(--shadow-sm);overflow:hidden}
+@media(min-width:640px){.troy-conv{padding:var(--space-6) var(--space-6) var(--space-5)}}
+.troy-conv__head{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-5);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-divider);flex-wrap:wrap}
+.troy-conv__icon{width:44px;height:44px;display:grid;place-items:center;border-radius:var(--radius-lg);background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));color:var(--color-gold-bright);flex-shrink:0}
+.troy-conv__title{flex:1;min-width:0}
+.troy-conv__title h2{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);line-height:1.2;margin:0 0 2px}
+.troy-conv__title p{font-size:var(--text-xs);color:var(--color-text-muted);margin:0}
+.troy-conv__live{font-size:10.5px;font-weight:700;color:var(--color-text-muted);letter-spacing:.06em;text-transform:uppercase;display:inline-flex;align-items:center;gap:6px}
+.troy-conv__live .live-dot{background:#4ade80}
+.troy-conv__form{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin-bottom:var(--space-5)}
+@media(min-width:540px){.troy-conv__form{grid-template-columns:1.2fr 1fr}}
+.troy-field{display:flex;flex-direction:column;gap:6px}
+.troy-field__label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.troy-input{width:100%;padding:14px 16px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);font-variant-numeric:tabular-nums;font-weight:600;outline:none;min-height:50px;-moz-appearance:textfield;transition:border-color 180ms,box-shadow 180ms,background 180ms}
+.troy-input::-webkit-outer-spin-button,.troy-input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
+.troy-input:focus{border-color:var(--color-gold-bright);background:var(--color-surface);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+.troy-select{width:100%;padding:14px 40px 14px 16px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);font-weight:600;cursor:pointer;-webkit-appearance:none;-moz-appearance:none;appearance:none;background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%237a7974' stroke-width='2'><path d='M2 4l4 4 4-4'/></svg>");background-repeat:no-repeat;background-position:right 14px center;background-size:12px;outline:none;min-height:50px;transition:border-color 180ms,box-shadow 180ms}
+.troy-select:focus{border-color:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+
+/* Result tiles */
+.troy-conv__results{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin-bottom:var(--space-5)}
+@media(min-width:640px){.troy-conv__results{grid-template-columns:repeat(3,1fr)}}
+@media(min-width:1024px){.troy-conv__results{grid-template-columns:repeat(6,1fr)}}
+.troy-result{position:relative;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-3) var(--space-4);display:flex;flex-direction:column;gap:4px;min-height:78px;overflow:hidden;transition:border-color 180ms,transform 180ms}
+.troy-result:hover{transform:translateY(-1px);border-color:var(--color-gold-bright)}
+.troy-result__label{font-size:10.5px;font-weight:700;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em}
+.troy-result__value{font-family:var(--font-display);font-size:clamp(.95rem,.85rem + .4vw,1.125rem);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.01em;line-height:1.15;word-break:break-all}
+.troy-result__unit{font-size:10.5px;color:var(--color-text-faint);font-weight:600;text-transform:uppercase;letter-spacing:.04em;margin-top:auto}
+
+/* Live USD value cards */
+.troy-conv__values{display:grid;grid-template-columns:1fr;gap:var(--space-3);padding-top:var(--space-5);border-top:1px solid var(--color-divider)}
+@media(min-width:640px){.troy-conv__values{grid-template-columns:1fr 1fr}}
+.troy-value{position:relative;padding:var(--space-4);border:1px solid var(--color-border);border-radius:var(--radius-lg);background:color-mix(in oklch,var(--color-surface) 80%,transparent);display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);overflow:hidden}
+.troy-value::before{content:"";position:absolute;inset:0;background:radial-gradient(circle at left center,currentColor 0%,transparent 60%);opacity:.06;pointer-events:none}
+.troy-value--gold{color:var(--color-gold-bright)}
+.troy-value--silver{color:var(--color-silver)}
+.troy-value__left{position:relative;display:flex;flex-direction:column;gap:2px;min-width:0}
+.troy-value__label{font-size:10.5px;font-weight:700;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em}
+.troy-value__amount{font-family:var(--font-display);font-size:clamp(1.25rem,1rem + .9vw,1.6rem);font-weight:700;color:currentColor;font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1.1;text-shadow:0 2px 12px color-mix(in oklch,currentColor 20%,transparent)}
+.troy-value__sub{font-size:11px;color:var(--color-text-faint);font-weight:500}
+.troy-value__icon{position:relative;width:42px;height:42px;border-radius:50%;display:grid;place-items:center;background:color-mix(in oklch,currentColor 12%,transparent);border:1px solid color-mix(in oklch,currentColor 28%,transparent);color:currentColor;flex-shrink:0;font-family:var(--font-display);font-weight:700;font-size:14px;letter-spacing:.04em}
+
+/* ── CONVERSION TABLE (live USD) ── */
+.troy-table-wrap{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
+.troy-table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.troy-table{width:100%;min-width:560px;border-collapse:collapse;font-size:var(--text-sm)}
+.troy-table thead{background:var(--color-surface-offset)}
+.troy-table th{text-align:left;font-size:11px;font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:14px 16px;border-bottom:1px solid var(--color-border);white-space:nowrap}
+.troy-table th:first-child{padding-left:20px}
+.troy-table th:last-child{text-align:right;padding-right:20px}
+.troy-table th:not(:first-child){text-align:right}
+.troy-table td{padding:14px 16px;color:var(--color-text-muted);border-bottom:1px solid var(--color-divider);font-variant-numeric:tabular-nums;white-space:nowrap}
+.troy-table td:first-child{color:var(--color-text);font-weight:600;padding-left:20px}
+.troy-table td:not(:first-child){text-align:right}
+.troy-table td:last-child{padding-right:20px;color:var(--color-gold-bright);font-weight:700;font-family:var(--font-display)}
+.troy-table tr:last-child td{border-bottom:none}
+.troy-table tr:hover td{background:var(--color-surface-offset-2)}
+.troy-table tr.troy-table__highlight td{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface))}
+.troy-table tr.troy-table__highlight td:first-child{position:relative}
+.troy-table tr.troy-table__highlight td:first-child::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--color-gold-bright)}
+
+/* ── LIVE PRICES STRIP ── */
+.troy-prices{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3)}
+@media(min-width:768px){.troy-prices{grid-template-columns:repeat(4,1fr)}}
+.troy-price{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);position:relative;overflow:hidden;transition:border-color 220ms,transform 220ms,box-shadow 220ms}
+.troy-price:hover{transform:translateY(-2px);border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.troy-price__weight{font-size:11px;font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-bottom:6px}
+.troy-price__grams{font-size:11px;font-weight:600;color:var(--color-text-muted);font-variant-numeric:tabular-nums;margin-bottom:var(--space-3)}
+.troy-price__gold-label{font-size:10.5px;font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.06em;margin-bottom:2px}
+.troy-price__gold-val{font-family:var(--font-display);font-size:clamp(1.125rem,1rem + .5vw,1.4rem);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.01em;margin-bottom:var(--space-3);line-height:1.1}
+.troy-price__silver-label{font-size:10.5px;font-weight:700;color:var(--color-silver);text-transform:uppercase;letter-spacing:.06em;margin-bottom:2px}
+.troy-price__silver-val{font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text-muted);font-variant-numeric:tabular-nums;line-height:1.1}
+
+/* ── POUND OF GOLD CARD ── */
+.troy-pound{background:linear-gradient(135deg,color-mix(in oklch,var(--color-primary) 8%,var(--color-surface)) 0%,color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset)) 100%);border:1px solid color-mix(in oklch,var(--color-primary) 22%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-5);position:relative;overflow:hidden}
+@media(min-width:640px){.troy-pound{padding:var(--space-6)}}
+.troy-pound::before{content:"";position:absolute;inset:-30% auto auto -30%;width:60%;height:120%;background:radial-gradient(closest-side,color-mix(in oklch,var(--color-primary) 18%,transparent) 0%,transparent 70%);filter:blur(36px);pointer-events:none}
+.troy-pound__inner{position:relative;z-index:1;display:grid;grid-template-columns:1fr;gap:var(--space-4);align-items:center}
+@media(min-width:768px){.troy-pound__inner{grid-template-columns:1.3fr 1fr}}
+.troy-pound__text h3{font-family:var(--font-display);font-size:clamp(1.25rem,1rem + 1vw,1.75rem);font-weight:700;color:var(--color-text);line-height:1.2;margin:0 0 var(--space-2)}
+.troy-pound__text p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-3);max-width:48ch}
+.troy-pound__formula{display:inline-block;padding:8px 14px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);font-variant-numeric:tabular-nums;font-family:'IBM Plex Sans',monospace}
+.troy-pound__formula strong{color:var(--color-gold-bright)}
+.troy-pound__result{background:color-mix(in oklch,var(--color-surface) 85%,transparent);border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);text-align:center;backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px)}
+.troy-pound__result-label{font-size:11px;font-weight:700;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.1em;margin-bottom:6px}
+.troy-pound__result-value{font-family:var(--font-display);font-size:clamp(2rem,1.4rem + 2.4vw,2.75rem);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.025em;line-height:1;margin-bottom:6px}
+.troy-pound__result-sub{font-size:11.5px;color:var(--color-text-muted);font-variant-numeric:tabular-nums}
+
+/* ── HISTORY BENTO ── */
+.troy-bento{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+@media(min-width:640px){.troy-bento{grid-template-columns:repeat(2,1fr)}.troy-bento__card--feature{grid-column:1 / -1}}
+@media(min-width:1024px){.troy-bento{grid-template-columns:1.6fr 1fr 1fr;grid-template-rows:auto auto;grid-template-areas:"feat a b" "feat c d"}.troy-bento__card--feature{grid-area:feat;grid-column:auto}}
+.troy-bento__card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;transition:border-color 220ms,transform 220ms,box-shadow 220ms;display:flex;flex-direction:column;gap:var(--space-3)}
+.troy-bento__card:hover{transform:translateY(-2px);border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
+.troy-bento__card--feature{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 7%,var(--color-surface)) 0%,var(--color-surface) 85%);padding:var(--space-6) var(--space-5)}
+@media(min-width:640px){.troy-bento__card--feature{padding:var(--space-8) var(--space-6)}}
+.troy-bento__icon{width:44px;height:44px;display:grid;place-items:center;border-radius:var(--radius-lg);background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));color:var(--color-gold-bright);flex-shrink:0}
+.troy-bento__card--feature .troy-bento__icon{width:54px;height:54px}
+.troy-bento__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);line-height:1.2;margin:0}
+.troy-bento__card--feature .troy-bento__title{font-size:clamp(1.25rem,1rem + 1vw,1.75rem)}
+.troy-bento__text{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0}
+.troy-bento__text strong{color:var(--color-text);font-weight:600}
+.troy-bento__list{list-style:none;display:flex;flex-direction:column;gap:8px;margin:0;padding:0}
+.troy-bento__list li{display:flex;align-items:flex-start;gap:10px;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55}
+.troy-bento__list li::before{content:"";flex-shrink:0;width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);margin-top:7px;box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+.troy-bento__stat{display:flex;align-items:baseline;gap:8px;margin-top:auto;padding-top:var(--space-3);border-top:1px dashed var(--color-divider);font-size:var(--text-xs);color:var(--color-text-muted)}
+.troy-bento__stat strong{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+
+/* ── FORMULAS ── */
+.troy-formulas{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:640px){.troy-formulas{grid-template-columns:1fr 1fr}}
+@media(min-width:1024px){.troy-formulas{grid-template-columns:repeat(4,1fr)}}
+.troy-formula{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-2);transition:border-color 220ms,transform 220ms}
+.troy-formula:hover{border-color:var(--color-gold-bright);transform:translateY(-1px)}
+.troy-formula__from{font-size:10.5px;font-weight:700;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;display:flex;align-items:center;gap:6px}
+.troy-formula__from svg{color:var(--color-gold-bright)}
+.troy-formula__op{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.005em;line-height:1.3;word-break:break-word}
+.troy-formula__op strong{color:var(--color-gold-bright)}
+.troy-formula__ex{font-size:11.5px;color:var(--color-text-faint);font-variant-numeric:tabular-nums;line-height:1.4;margin-top:auto;padding-top:6px;border-top:1px dashed var(--color-divider)}
+
+/* ── TROY UNIT FAMILY ── */
+.troy-units{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3)}
+@media(min-width:768px){.troy-units{grid-template-columns:repeat(3,1fr)}}
+@media(min-width:1024px){.troy-units{grid-template-columns:repeat(5,1fr)}}
+.troy-unit{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);text-align:center;display:flex;flex-direction:column;gap:6px;transition:border-color 220ms,transform 220ms}
+.troy-unit:hover{border-color:var(--color-gold-bright);transform:translateY(-1px)}
+.troy-unit__abbr{font-family:var(--font-display);font-size:clamp(1.5rem,1.2rem + 1vw,2rem);font-weight:700;color:var(--color-gold-bright);line-height:1;letter-spacing:-.02em}
+.troy-unit__name{font-size:var(--text-sm);font-weight:700;color:var(--color-text);line-height:1.2}
+.troy-unit__weight{font-size:11.5px;color:var(--color-text-muted);font-variant-numeric:tabular-nums;line-height:1.4}
+.troy-unit__region{font-size:10.5px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-top:auto;padding-top:6px;border-top:1px dashed var(--color-divider)}
+
+/* ── FAQ ── */
+.troy-faq__list{display:flex;flex-direction:column;gap:var(--space-3);max-width:880px;margin:0 auto}
+.troy-faq__item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color 220ms}
+.troy-faq__item[open]{border-color:var(--color-gold-bright);box-shadow:var(--shadow-sm)}
+.troy-faq__q{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;background:transparent;transition:background 180ms;min-height:60px}
+.troy-faq__q:hover{background:var(--color-surface-offset)}
+.troy-faq__q::-webkit-details-marker,.troy-faq__q::marker{display:none}
+.troy-faq__q-icon{width:30px;height:30px;display:grid;place-items:center;border-radius:50%;border:1px solid var(--color-border);color:var(--color-text-muted);background:var(--color-surface-offset);transition:transform 240ms cubic-bezier(.4,0,.2,1),color 180ms,border-color 180ms;flex-shrink:0}
+.troy-faq__item[open] .troy-faq__q-icon{transform:rotate(45deg);color:var(--color-gold-bright);border-color:var(--color-gold-bright)}
+.troy-faq__a{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.75}
+.troy-faq__a p+p{margin-top:var(--space-3)}
+.troy-faq__a strong{color:var(--color-text);font-weight:600}
+.troy-faq__a .highlight{color:var(--color-gold-bright);font-weight:600}
+
+/* ── TRUST / DATA SOURCE ── */
+.troy-trust{display:flex;align-items:flex-start;gap:var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.troy-trust svg{flex-shrink:0;color:var(--color-gold-bright);margin-top:2px;width:18px;height:18px}
+.troy-trust strong{color:var(--color-text);font-weight:600}
+.troy-trust a{color:var(--color-primary);font-weight:600}
+.troy-trust a:hover{text-decoration:underline}
+
+/* ── RELATED CARDS ── */
+.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4)}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s,transform .15s;min-height:140px;color:var(--color-text)}
+.related-card:hover{border-color:var(--color-primary);box-shadow:var(--shadow-sm);transform:translateY(-2px)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+.related-card__tag{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.related-card__title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0;line-height:1.25}
+.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
+
+/* Share buttons */
+.share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) 0 var(--space-6);padding-top:var(--space-6);border-top:1px solid var(--color-border)}
+.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
+.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface)}
+.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset)}
+.share-buttons a svg{flex-shrink:0}
+
+/* Light mode adjustments */
+[data-theme="light"] .troy-spot,
+[data-theme="light"] .troy-conv,
+[data-theme="light"] .troy-answer{background:color-mix(in oklch,var(--color-surface) 95%,transparent)}
+[data-theme="light"] .troy-pound__result{background:color-mix(in oklch,var(--color-surface) 95%,transparent)}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce){
+  .troy-spot,.troy-bento__card,.troy-vs__card,.troy-result,.troy-formula,.troy-unit,.troy-price,.troy-vs__bar-fill,.troy-faq__q-icon{transition-duration:0ms!important;animation:none!important}
+}
+
+/* ── BLOG PREVIEW ── */
 .blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
 .blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
+.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6);flex-wrap:wrap;gap:var(--space-3)}
+.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-family:var(--font-display)}
 .blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
 .blog-preview-all:hover{color:var(--color-primary-hover)}
 .blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
 @media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
 @media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
+.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s,transform .15s;color:var(--color-text)}
+.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08);transform:translateY(-2px)}
+.blog-preview-card:hover h3{color:var(--color-primary)}
+.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:color-mix(in oklch,var(--color-primary) 12%,transparent);border-radius:99px;align-self:flex-start}
 .blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
 .blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+
 /* FOOTER */
+footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0 var(--space-6)}
 .footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
+.footer-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
+@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr}.footer-brand-col{grid-column:1/-1}}
+@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr;gap:var(--space-4)}}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
-.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4) 0;border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2);margin-top:var(--space-6)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
+#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
-
-
-/* ── Shared layout CSS ── */
-.breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"/";margin-right:var(--space-2);color:var(--color-text-faint)}
-.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
-.breadcrumb a:hover{color:var(--color-primary)}
-.breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.hero-tag{display:inline-block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-.hero-title{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero-title{font-size:var(--text-xl)}
-.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:72ch;line-height:1.7;margin-bottom:var(--space-6)}
-.price-card{display:inline-flex;flex-direction:column;gap:var(--space-1);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-2)}
-.price-card{width:100%}
-.price-label{font-size:var(--text-sm);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.price-value{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-gold-bright);font-weight:400;line-height:1}
-.price-usd{font-size:var(--text-base);color:var(--color-text-muted)}
-.price-purity{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-1)}
-.prose{max-width:72ch}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-1)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose{max-width:100%}
-.content{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
-.data-source{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.faq-answer-summary{font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4);cursor:pointer;list-style:none;background:var(--color-surface-offset);transition:background .15s}
-.faq-answer-summary:hover{background:var(--color-surface-dynamic)}
-.faq-answer-summary::marker,.faq-answer-summary::-webkit-details-marker{display:none}
-.faq-answer-summary::after{content:"＋";float:right;color:var(--color-text-faint)}
-.faq-answer-summary::after{content:"－"}
-.faq-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-4);border-top:1px solid var(--color-divider)}
-
-/* ── Hero left column ── */
-.hero-left{display:flex;flex-direction:column;justify-content:flex-start;gap:var(--space-3)}
-.hero-left .hero-title{margin-bottom:0}
-.hero-left .hero-tag{margin-bottom:var(--space-2)}
-@media(max-width:768px){.hero-left{margin-bottom:var(--space-4)}}
-
-/* ── Data Table ── */
-.data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
-.data-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-4) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.data-table td{padding:var(--space-3) var(--space-4) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.data-table td:first-child{color:var(--color-text);font-weight:500}
-.data-table td:not(:first-child){text-align:right;padding-right:0}
-.data-table th:not(:first-child){text-align:right;padding-right:0}
-.data-table tr:last-child td{border-bottom:none}
-.data-table tr:hover td{background:var(--color-surface)}
-.data-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border-radius:var(--radius-md)}
-
-/* ── Trust bar ── */
-.trust-bar{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset,var(--color-surface));border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.trust-bar a{color:var(--color-primary);text-decoration:none}
-.trust-bar a:hover{text-decoration:underline}
-
-/* ── Share buttons ── */
-.share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) 0 var(--space-6);padding-top:var(--space-6);border-top:1px solid var(--color-border)}
-.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
-.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface)}
-.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset)}
-.share-buttons a svg{flex-shrink:0}
-
-/* ── Related guides grid ── */
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin-top:var(--space-6)}
-.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface-offset,var(--color-surface));border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s;min-height:140px;color:var(--color-text)}
-.related-card:hover{border-color:var(--color-primary);box-shadow:var(--shadow-sm)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin:var(--space-1) 0}
-.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-
-/* ── Prose spacing ── */
-.prose p{margin-bottom:var(--space-4);line-height:1.7}
-.prose li{margin-bottom:var(--space-2);line-height:1.65}
-.prose h2{margin-top:var(--space-10);margin-bottom:var(--space-3)}
-.prose h3{margin-top:var(--space-6);margin-bottom:var(--space-2)}
+/* Hidden snippet answer (semantic SEO) */
+.snippet-answer{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 </style>
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org/",
-  "@type": "WebPage",
-  "name": "How Many Grams In Troy Ounce",
-  "url": "https://goldpricetools.com/how-many-grams-in-troy-ounce",
-  "speakable": {
-    "@type": "SpeakableSpecification",
-    "cssSelector": [".snippet-answer", ".faq-answer"]
-  }
-}
-</script>
 <link rel="stylesheet" href="/assets/site.css">
-<!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
 </head>
 <body>
+
+<!-- LIVE PRICE TICKER -->
+<div class="ticker-wrap" aria-label="Live precious metals prices">
+  <div class="ticker" id="troyTicker">
+    <span class="ticker-item"><span class="live-dot" aria-hidden="true"></span><span class="ticker-label">Live</span></span>
+    <span class="ticker-item"><span class="ticker-label">Gold (XAU/oz)</span> <span class="ticker-value" id="t-xau" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Gold /g</span> <span class="ticker-value" id="t-xau-g" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Gold /kg</span> <span class="ticker-value" id="t-xau-kg" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Silver (XAG/oz)</span> <span class="ticker-value" id="t-xag" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Silver /g</span> <span class="ticker-value" id="t-xag-g" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Gold/Silver Ratio</span> <span class="ticker-value" id="t-ratio" data-nosnippet>—</span></span>
+    <!-- duplicate for seamless loop -->
+    <span class="ticker-item"><span class="live-dot" aria-hidden="true"></span><span class="ticker-label">Live</span></span>
+    <span class="ticker-item"><span class="ticker-label">Gold (XAU/oz)</span> <span class="ticker-value" id="t-xau-2" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Gold /g</span> <span class="ticker-value" id="t-xau-g-2" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Gold /kg</span> <span class="ticker-value" id="t-xau-kg-2" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Silver (XAG/oz)</span> <span class="ticker-value" id="t-xag-2" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Silver /g</span> <span class="ticker-value" id="t-xag-g-2" data-nosnippet>$—</span></span>
+    <span class="ticker-item"><span class="ticker-label">Gold/Silver Ratio</span> <span class="ticker-value" id="t-ratio-2" data-nosnippet>—</span></span>
+  </div>
+</div>
+
 <nav class="site-nav" role="navigation" aria-label="Main navigation">
   <div class="nav-inner">
     <a href="/" class="nav-logo" aria-label="GoldPriceTools Home">
@@ -526,149 +578,681 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
     </div>
   </div>
 </nav>
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">How Many Grams in a Troy Ounce?</li></ol></div>
-<div class="hero">
-  <div class="prose">
-    <h1>How Many Grams in a Troy Ounce?</h1>
-    <h2 id="how-many-grams-is-1-oz-of-gold">How many grams is 1 oz of gold?</h2>
-    <p class="snippet-answer">There are exactly 31.1035 grams in 1 oz of gold. When trading precious metals like gold, the international standard is the troy ounce, which is roughly 10% heavier than a standard avoirdupois ounce (28.35 grams). All live spot prices and charts use the 31.1035g troy ounce.</p>
-  </div>
-  <div class="answer-box">
-    <div class="answer-num">31.1035</div>
-    <div class="answer-unit">grams per troy ounce</div>
-    <div class="answer-sub">Exact value: 31.10348 g (ISO 31-4)</div>
-  </div>
-</div>
-<div class="content">
-  <div class="prose">
-    <p>One troy ounce is exactly <strong>31.1035 grams</strong>. This is the unit used worldwide to price gold, silver, platinum, and palladium. It is heavier than a regular (avoirdupois) ounce, which weighs 28.3495 grams.</p>
 
-<div style="display:flex;gap:1rem;flex-wrap:wrap;margin:2rem 0;">
-  <div style="flex:1;min-width:min(300px, 100%);background:var(--color-surface);border:1px solid var(--color-border);border-radius:12px;padding:1.5rem;text-align:center;">
-    <h3 style="font-size:1.1rem;margin-bottom:0.5rem;">Live Gold Spot Price</h3>
-    <div style="font-size:1.75rem;font-weight:700;color:var(--color-gold-bright);" id="t-xau" data-nosnippet>Loading...</div>
-    <div style="font-size:0.9rem;color:var(--color-text-muted);">per troy ounce</div>
-  </div>
-  <div style="flex:1;min-width:min(300px, 100%);background:var(--color-surface);border:1px solid var(--color-border);border-radius:12px;padding:1.5rem;text-align:center;">
-    <h3 style="font-size:1.1rem;margin-bottom:0.5rem;">Live Silver Spot Price</h3>
-    <div style="font-size:1.75rem;font-weight:700;color:var(--color-text);" id="t-xag" data-nosnippet>Loading...</div>
-    <div style="font-size:0.9rem;color:var(--color-text-muted);">per troy ounce</div>
-  </div>
+<div class="breadcrumb-wrap">
+  <ol class="breadcrumb" aria-label="Breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/scrap-gold-calculator">Calculators</a></li>
+    <li aria-current="page">How Many Grams in a Troy Ounce?</li>
+  </ol>
 </div>
 
-<p class="data-source" style="text-align:center; font-size:0.8125rem; color:var(--color-text-muted); margin-bottom: 2rem;">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
-<h2 id="pound-of-gold-worth">How much is one pound of gold worth?</h2>
-<p class="snippet-answer">One pound of gold is worth approximately 14.58 troy ounces multiplied by the live gold spot price. There are 14.5833 troy ounces in a standard avoirdupois pound (453.59 grams). Use our weight converter below to find the exact live value of one pound of gold today.</p>
+<!-- Hidden semantic snippet -->
+<p class="snippet-answer">There are exactly 31.1035 grams in 1 troy ounce. The troy ounce is the international LBMA standard for pricing gold, silver, platinum and palladium, and is approximately 9.7% heavier than a regular avoirdupois ounce (28.3495 grams). All live spot prices and charts use the 31.1035g troy ounce.</p>
 
-<h2>Live Weight Converter</h2>
-<div style="background:var(--color-surface);border:1px solid var(--color-border);border-radius:12px;padding:1.5rem;margin-bottom:2rem;">
-  <div style="display:flex;gap:1rem;margin-bottom:1.5rem;flex-wrap:wrap;">
-    <div style="flex:1;min-width:min(150px, 100%);">
-      <label style="display:block;margin-bottom:0.5rem;font-size:0.9rem;color:var(--color-text-muted);">Amount</label>
-      <input type="number" id="convInput" value="1" min="0" step="any" style="width:100%;padding:0.75rem;background:var(--color-bg);border:1px solid var(--color-border);border-radius:8px;color:var(--color-text);font-size:1rem;">
+<!-- ═══════════════════════════════════════════════════════════════════
+     HERO — Editorial Power Moment
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-hero" aria-labelledby="troy-title">
+  <div class="troy-hero__pattern" aria-hidden="true">
+    <svg width="100%" height="100%" viewBox="0 0 1200 600" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <pattern id="ruler" x="0" y="0" width="60" height="60" patternUnits="userSpaceOnUse">
+          <g fill="none" stroke="currentColor" stroke-width="1" opacity="0.5">
+            <line x1="0" y1="30" x2="60" y2="30"/>
+            <line x1="30" y1="0" x2="30" y2="60"/>
+            <line x1="0" y1="0" x2="6" y2="0"/>
+            <line x1="0" y1="15" x2="3" y2="15"/>
+            <line x1="0" y1="45" x2="3" y2="45"/>
+            <line x1="0" y1="60" x2="6" y2="60"/>
+            <circle cx="30" cy="30" r="1.5" fill="currentColor"/>
+          </g>
+        </pattern>
+        <radialGradient id="heroGlow" cx="50%" cy="40%" r="60%">
+          <stop offset="0%" stop-color="currentColor" stop-opacity="0.22"/>
+          <stop offset="100%" stop-color="currentColor" stop-opacity="0"/>
+        </radialGradient>
+      </defs>
+      <rect width="100%" height="100%" fill="url(#ruler)"/>
+      <rect width="100%" height="100%" fill="url(#heroGlow)"/>
+    </svg>
+  </div>
+
+  <div class="troy-hero__inner">
+    <div class="troy-hero__left">
+      <span class="troy-hero__eyebrow">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2L4 7v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V7l-8-5z"/><path d="M9 12l2 2 4-4"/></svg>
+        International Standard · ISO 31-4
+      </span>
+      <h1 id="troy-title" class="troy-hero__title">
+        1 <span class="troy-grad-gold">Troy Ounce</span><br>
+        = 31.1035 grams.
+      </h1>
+      <p class="troy-hero__sub">The troy ounce is the <strong>global pricing unit for gold and silver</strong>. It's roughly 10% heavier than the regular kitchen-scale ounce — every LBMA, COMEX and Shanghai Gold Exchange spot price you see is quoted per troy ounce in <strong>US dollars</strong>.</p>
+      <div class="troy-hero__pillars" aria-hidden="true">
+        <span class="troy-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> Updated 60s</span>
+        <span class="troy-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12h18M12 3v18"/></svg> USD primary</span>
+        <span class="troy-pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12h6l2-7 4 14 2-7h6"/></svg> Exact: 31.10347680 g</span>
+      </div>
     </div>
-    <div style="flex:1;min-width:min(150px, 100%);">
-      <label style="display:block;margin-bottom:0.5rem;font-size:0.9rem;color:var(--color-text-muted);">From</label>
-      <select id="convFrom" style="width:100%;padding:0.75rem;background:var(--color-bg);border:1px solid var(--color-border);border-radius:8px;color:var(--color-text);font-size:1rem;appearance:none;">
-        <option value="31.1035" selected>Troy Ounce (oz t)</option>
-        <option value="1">Gram (g)</option>
-        <option value="1000">Kilogram (kg)</option>
-        <option value="1.55517">Pennyweight (dwt)</option>
-        <option value="0.0648">Grain (gr)</option>
-        <option value="11.664">Tola</option>
-      </select>
+
+    <aside class="troy-answer" aria-label="Troy ounce in grams">
+      <div class="troy-answer__label">Grams per troy ounce</div>
+      <div class="troy-answer__value" id="answerValue">31.1035</div>
+      <div class="troy-answer__unit">grams <span>(g)</span></div>
+      <div class="troy-answer__meta">
+        <span><strong>1 troy oz</strong> = 31.10347680 g</span>
+        <span class="troy-answer__meta-sep">·</span>
+        <span>20 dwt</span>
+        <span class="troy-answer__meta-sep">·</span>
+        <span>480 grains</span>
+      </div>
+    </aside>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     LIVE SPOT GRID — USD Primary
+     ═══════════════════════════════════════════════════════════════════ -->
+<div class="troy-spot-grid" role="group" aria-label="Live precious metals spot prices in USD">
+  <article class="troy-spot troy-spot--gold">
+    <div class="troy-spot__head">
+      <span class="troy-spot__tag"><span class="live-dot" aria-hidden="true"></span> Live Gold Spot</span>
+      <span class="troy-spot__chip">Per troy oz</span>
+    </div>
+    <div class="troy-spot__value" id="spotGoldOz" data-nosnippet>$—</div>
+    <div class="troy-spot__sub">Per gram <strong id="spotGoldG" data-nosnippet>$—</strong> · Per kg <strong id="spotGoldKg" data-nosnippet>$—</strong></div>
+  </article>
+
+  <article class="troy-spot troy-spot--silver">
+    <div class="troy-spot__head">
+      <span class="troy-spot__tag"><span class="live-dot" aria-hidden="true"></span> Live Silver Spot</span>
+      <span class="troy-spot__chip">Per troy oz</span>
+    </div>
+    <div class="troy-spot__value" id="spotSilverOz" data-nosnippet>$—</div>
+    <div class="troy-spot__sub">Per gram <strong id="spotSilverG" data-nosnippet>$—</strong> · Per kg <strong id="spotSilverKg" data-nosnippet>$—</strong></div>
+  </article>
+
+  <div class="troy-spot__source">
+    <span class="troy-spot__source-head">Data Source</span>
+    <span class="troy-spot__source-body">LBMA spot via <a href="https://www.gold-api.com" rel="noopener" target="_blank">gold-api.com</a>. Refreshed every <strong>60 seconds</strong>.</span>
+    <span class="troy-spot__source-body" style="font-size:10.5px;color:var(--color-text-faint)">Last updated: <span id="lastUpdated" data-nosnippet>—</span></span>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     TROY vs AVOIRDUPOIS comparison
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-vs-h">
+  <div class="troy-section-head">
+    <span class="troy-section-head__eyebrow">Standards Compared</span>
+    <h2 id="troy-vs-h" class="troy-section-head__title">Troy Ounce vs. Regular (Avoirdupois) Ounce</h2>
+    <p class="troy-section-head__sub">Two ounces, two histories. The troy ounce survived as the precious-metals standard while the avoirdupois ounce became the everyday weight at the grocery store. Here's exactly how they differ.</p>
+  </div>
+
+  <div class="troy-vs__grid">
+    <article class="troy-vs__card troy-vs__card--troy">
+      <div class="troy-vs__head">
+        <div class="troy-vs__symbol" aria-hidden="true">t oz</div>
+        <div class="troy-vs__label">
+          <div class="troy-vs__name">Troy Ounce</div>
+          <div class="troy-vs__abbr">oz t · ozt · t oz</div>
+        </div>
+      </div>
+      <div class="troy-vs__weight">31.1035<span class="troy-vs__weight-unit">g</span></div>
+      <div class="troy-vs__use">
+        <span>Gold</span><span>Silver</span><span>Platinum</span><span>Palladium</span><span>Gemstones</span>
+      </div>
+      <p class="troy-vs__note">Used by <strong>LBMA</strong>, <strong>COMEX</strong>, the Shanghai Gold Exchange, ISO 31-4 and every major precious-metals exchange worldwide. Equal to 480 grains.</p>
+    </article>
+
+    <div class="troy-vs__delta" aria-hidden="true">
+      <div class="troy-vs__delta-num">+9.7%</div>
+      <div class="troy-vs__delta-label">Troy is heavier<br>(+2.754 g)</div>
+    </div>
+
+    <article class="troy-vs__card troy-vs__card--avoir">
+      <div class="troy-vs__head">
+        <div class="troy-vs__symbol" aria-hidden="true">oz</div>
+        <div class="troy-vs__label">
+          <div class="troy-vs__name">Avoirdupois Ounce</div>
+          <div class="troy-vs__abbr">oz · "regular ounce"</div>
+        </div>
+      </div>
+      <div class="troy-vs__weight">28.3495<span class="troy-vs__weight-unit">g</span></div>
+      <div class="troy-vs__use">
+        <span>Food</span><span>Cooking</span><span>Postage</span><span>Consumer goods</span>
+      </div>
+      <p class="troy-vs__note">The "everyday" ounce defined by the international yard-and-pound agreement. 16 avoirdupois ounces make a 453.59 g pound. Equal to 437.5 grains.</p>
+    </article>
+  </div>
+
+  <div class="troy-vs__bars" aria-hidden="true">
+    <div class="troy-vs__bar-row">
+      <span class="troy-vs__bar-label">Troy oz</span>
+      <div class="troy-vs__bar-track"><div class="troy-vs__bar-fill troy-vs__bar-fill--gold" style="width:100%"></div></div>
+      <span class="troy-vs__bar-val">31.10 g</span>
+    </div>
+    <div class="troy-vs__bar-row">
+      <span class="troy-vs__bar-label">Avoir. oz</span>
+      <div class="troy-vs__bar-track"><div class="troy-vs__bar-fill" style="width:91.15%"></div></div>
+      <span class="troy-vs__bar-val">28.35 g</span>
     </div>
   </div>
-  <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:1rem;">
-    <div style="background:var(--color-bg);padding:1rem;border-radius:8px;border:1px solid var(--color-border);"><div style="font-size:0.8rem;color:var(--color-text-muted);margin-bottom:0.25rem;">Troy Ounces</div><div id="cv-ozt" style="font-weight:600;font-size:1.1rem;">—</div></div>
-    <div style="background:var(--color-bg);padding:1rem;border-radius:8px;border:1px solid var(--color-border);"><div style="font-size:0.8rem;color:var(--color-text-muted);margin-bottom:0.25rem;">Grams</div><div id="cv-g" style="font-weight:600;font-size:1.1rem;">—</div></div>
-    <div style="background:var(--color-bg);padding:1rem;border-radius:8px;border:1px solid var(--color-border);"><div style="font-size:0.8rem;color:var(--color-text-muted);margin-bottom:0.25rem;">Kilograms</div><div id="cv-kg" style="font-weight:600;font-size:1.1rem;">—</div></div>
-    <div style="background:var(--color-bg);padding:1rem;border-radius:8px;border:1px solid var(--color-border);"><div style="font-size:0.8rem;color:var(--color-text-muted);margin-bottom:0.25rem;">Pennyweight (dwt)</div><div id="cv-dwt" style="font-weight:600;font-size:1.1rem;">—</div></div>
-    <div style="background:var(--color-bg);padding:1rem;border-radius:8px;border:1px solid var(--color-border);"><div style="font-size:0.8rem;color:var(--color-text-muted);margin-bottom:0.25rem;">Grains</div><div id="cv-gr" style="font-weight:600;font-size:1.1rem;">—</div></div>
-    <div style="background:var(--color-bg);padding:1rem;border-radius:8px;border:1px solid var(--color-border);"><div style="font-size:0.8rem;color:var(--color-text-muted);margin-bottom:0.25rem;">Tola</div><div id="cv-tola" style="font-weight:600;font-size:1.1rem;">—</div></div>
-  </div>
-</div>
-<h2>Troy Ounce vs Regular Ounce</h2>
-    <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-    <div class="data-table-wrap"><table class="data-table" aria-label="Troy ounce vs avoirdupois ounce comparison"><thead><tr><th>Unit</th><th>Grams</th><th>Used For</th></tr></thead><tbody>
-      <tr class="highlight-row"><td>Troy ounce (t oz)</td><td>31.1035 g</td><td>Gold, silver, platinum</td></tr>
-      <tr><td>Avoirdupois ounce (oz)</td><td>28.3495 g</td><td>Food, general goods</td></tr>
-      <tr><td>Difference</td><td>+2.754 g (9.7%)</td><td>&mdash;</td></tr>
-    </tbody></table></div>
-    <h2>Troy Ounce Conversion Table</h2>
-    <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-    <div class="data-table-wrap"><table class="data-table" aria-label="Troy ounce to gram conversion"><thead><tr><th>Troy Ounces</th><th>Grams</th><th>Pennyweight (dwt)</th><th>Avoirdupois Ounces</th></tr></thead><tbody>
-      <tr><td>0.1 troy oz</td><td>3.1103 g</td><td>2 dwt</td><td>0.109 oz</td></tr>
-      <tr><td>0.5 troy oz</td><td>15.552 g</td><td>10 dwt</td><td>0.548 oz</td></tr>
-      <tr><td>1 troy oz</td><td>31.1035 g</td><td>20 dwt</td><td>1.097 oz</td></tr>
-      <tr><td>2 troy oz</td><td>62.207 g</td><td>40 dwt</td><td>2.194 oz</td></tr>
-      <tr><td>5 troy oz</td><td>155.517 g</td><td>100 dwt</td><td>5.482 oz</td></tr>
-      <tr><td>10 troy oz</td><td>311.035 g</td><td>200 dwt</td><td>10.971 oz</td></tr>
-      <tr><td>100 troy oz</td><td>3,110.35 g</td><td>2,000 dwt</td><td>109.714 oz</td></tr>
-    </tbody></table></div>
-    <h2>Why Does Gold Use Troy Ounces?</h2>
-    <p>The troy weight system dates to the trade fairs of Troyes in medieval France, where merchants established standardised weights for precious metals and gems. England adopted the troy system by statute in 1527, and it became the international standard for precious metal pricing. The London Bullion Market Association (LBMA) and the COMEX futures exchange both quote gold in US dollars per troy ounce.</p>
-    <h2>Converting Gold Price Per Troy Oz to Per Gram</h2>
-    <p>To find the gold price per gram in GBP: divide the spot price per troy ounce (USD) by 31.1035 to get USD/g, then multiply by the GBP/USD rate. Our <a href="/">live gold calculator</a> and <a href="/scrap-gold-calculator">scrap gold calculator</a> do this automatically.</p>
-  </div>
-</div>
-<div class="content" style="padding-bottom:1.5rem">
-<!-- Social share buttons (WP-34) -->
-<h2>Frequently Asked Questions</h2>
-<div class="faq-container">
-<div class="faq-card">
-  <h3 class="faq-answer-summary">How many grams are in a troy ounce?</h3>
-  <p class="faq-answer">There are exactly 31.1035 grams in one troy ounce. This is the internationally recognised unit used for pricing gold, silver, platinum and palladium on global commodity markets.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">What is the difference between a troy ounce and a regular ounce?</h3>
-  <p class="faq-answer">A troy ounce (31.1035 grams) is heavier than a regular avoirdupois ounce (28.3495 grams). The troy ounce is 9.7% heavier. Gold prices quoted per ounce always use the troy ounce, not the regular ounce.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">How many troy ounces are in a kilogram of gold?</h3>
-  <p class="faq-answer">There are 32.1507 troy ounces in one kilogram. To convert: 1000 grams ÷ 31.1035 grams/troy oz = 32.1507 troy oz.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">Why is gold measured in troy ounces?</h3>
-  <p class="faq-answer">Gold has been measured in troy ounces since the Middle Ages, originating from the trade fairs of Troyes, France. The troy weight system was formalised in England in the 15th century and has been the international standard for precious metals ever since.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">How do I convert troy ounces to grams?</h3>
-  <p class="faq-answer">Multiply troy ounces by 31.1035 to get grams. To convert grams to troy ounces, divide by 31.1035. Example: 2 troy oz = 2 × 31.1035 = 62.207 grams.</p>
-</div>
-</div>
-<div class="share-buttons">
-  <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/how-many-grams-in-troy-ounce&text=How+Many+Grams+in+a+Troy+Ounce%3F+%2831.1035g+Explained%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
-  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/how-many-grams-in-troy-ounce&title=How+Many+Grams+in+a+Troy+Ounce%3F+%2831.1035g+Explained%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=How+Many+Grams+in+a+Troy+Ounce%3F+%2831.1035g+Explained%29%20https%3A%2F%2Fgoldpricetools.com%2Fhow-many-grams-in-troy-ounce" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
-</div>
+</section>
 
+<!-- ═══════════════════════════════════════════════════════════════════
+     LIVE PRECISION CONVERTER
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-conv-h">
+  <div class="troy-section-head">
+    <span class="troy-section-head__eyebrow">The Tool</span>
+    <h2 id="troy-conv-h" class="troy-section-head__title">Live Precision Converter</h2>
+    <p class="troy-section-head__sub">Enter any weight and unit. Instantly see all six precious-metals weight equivalents — and the <strong>live USD value</strong> in gold and silver at today's spot price.</p>
+  </div>
 
-<h2>Related Gold &amp; Silver Guides</h2>
-<div class="related-guides-grid">
-  <a href="/scrap-gold-calculator" class="related-card">
-    <span class="related-card__tag">TOOL</span>
-    <span class="related-card__title">Scrap Gold Calculator</span>
-    <span class="related-card__desc">Calculate the melt value of your gold jewellery using today's live spot price.</span>
-  </a>
-  <a href="/gold-bar-value" class="related-card">
-    <span class="related-card__tag">TOOL</span>
-    <span class="related-card__title">Gold Bar Value Calculator</span>
-    <span class="related-card__desc">Calculate the real-time value of your gold bars at live LBMA spot prices.</span>
-  </a>
-  <a href="/gold-silver-ratio" class="related-card">
-    <span class="related-card__tag">LIVE TOOL</span>
-    <span class="related-card__title">Gold–Silver Ratio</span>
-    <span class="related-card__desc">Track the live gold-to-silver ratio and what it means for precious metals investors.</span>
-  </a>
-  <a href="/24k-gold-price-per-gram" class="related-card">
-    <span class="related-card__tag">LIVE PRICE</span>
-    <span class="related-card__title">24K Gold Price Per Gram</span>
-    <span class="related-card__desc">Live 24K (pure) gold price per gram — updated every 60 seconds from LBMA.</span>
-  </a>
-</div>
-</div>
+  <div class="troy-conv">
+    <div class="troy-conv__head">
+      <div class="troy-conv__icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M3 12h18M3 18h18"/><circle cx="8" cy="6" r="1.5" fill="currentColor"/><circle cx="16" cy="12" r="1.5" fill="currentColor"/><circle cx="10" cy="18" r="1.5" fill="currentColor"/></svg>
+      </div>
+      <div class="troy-conv__title">
+        <h3>Universal Weight Converter</h3>
+        <p>Troy oz · grams · kg · pennyweight · grain · tola</p>
+      </div>
+      <span class="troy-conv__live"><span class="live-dot" aria-hidden="true"></span> Live USD</span>
+    </div>
+
+    <div class="troy-conv__form">
+      <div class="troy-field">
+        <label class="troy-field__label" for="convInput">Amount</label>
+        <input class="troy-input" id="convInput" type="number" value="1" min="0" step="any" inputmode="decimal" aria-label="Weight amount">
+      </div>
+      <div class="troy-field">
+        <label class="troy-field__label" for="convFrom">Unit</label>
+        <select class="troy-select" id="convFrom" aria-label="From unit">
+          <option value="31.1034768" selected>Troy Ounce (oz t)</option>
+          <option value="1">Gram (g)</option>
+          <option value="1000">Kilogram (kg)</option>
+          <option value="1.55517384">Pennyweight (dwt)</option>
+          <option value="0.06479891">Grain (gr)</option>
+          <option value="11.6638">Tola (Indian)</option>
+          <option value="28.349523125">Avoirdupois ounce (oz)</option>
+          <option value="453.59237">Pound — avoirdupois (lb)</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="troy-conv__results">
+      <div class="troy-result">
+        <div class="troy-result__label">Troy Ounces</div>
+        <div class="troy-result__value" id="cv-ozt">—</div>
+        <div class="troy-result__unit">oz t</div>
+      </div>
+      <div class="troy-result">
+        <div class="troy-result__label">Grams</div>
+        <div class="troy-result__value" id="cv-g">—</div>
+        <div class="troy-result__unit">g</div>
+      </div>
+      <div class="troy-result">
+        <div class="troy-result__label">Kilograms</div>
+        <div class="troy-result__value" id="cv-kg">—</div>
+        <div class="troy-result__unit">kg</div>
+      </div>
+      <div class="troy-result">
+        <div class="troy-result__label">Pennyweight</div>
+        <div class="troy-result__value" id="cv-dwt">—</div>
+        <div class="troy-result__unit">dwt</div>
+      </div>
+      <div class="troy-result">
+        <div class="troy-result__label">Grains</div>
+        <div class="troy-result__value" id="cv-gr">—</div>
+        <div class="troy-result__unit">gr</div>
+      </div>
+      <div class="troy-result">
+        <div class="troy-result__label">Tola</div>
+        <div class="troy-result__value" id="cv-tola">—</div>
+        <div class="troy-result__unit">tola</div>
+      </div>
+    </div>
+
+    <div class="troy-conv__values" aria-label="Live USD value at today's spot price">
+      <div class="troy-value troy-value--gold">
+        <div class="troy-value__left">
+          <div class="troy-value__label">Worth in Gold (24K)</div>
+          <div class="troy-value__amount" id="cv-gold-usd" data-nosnippet>$—</div>
+          <div class="troy-value__sub" id="cv-gold-sub" data-nosnippet>At live spot price</div>
+        </div>
+        <div class="troy-value__icon" aria-hidden="true">Au</div>
+      </div>
+      <div class="troy-value troy-value--silver">
+        <div class="troy-value__left">
+          <div class="troy-value__label">Worth in Silver (.999)</div>
+          <div class="troy-value__amount" id="cv-silver-usd" data-nosnippet>$—</div>
+          <div class="troy-value__sub" id="cv-silver-sub" data-nosnippet>At live spot price</div>
+        </div>
+        <div class="troy-value__icon" aria-hidden="true">Ag</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     LIVE PRICE STRIP — 1, 5, 10, 100 troy oz
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-prices-h">
+  <div class="troy-section-head">
+    <span class="troy-section-head__eyebrow">Live USD Reference</span>
+    <h2 id="troy-prices-h" class="troy-section-head__title">How Much Is X Troy Ounces Worth Today?</h2>
+    <p class="troy-section-head__sub">Live USD valuations for popular bullion weights, recalculated every 60 seconds from the LBMA spot. Hover any card for the gram equivalent.</p>
+  </div>
+
+  <div class="troy-prices">
+    <article class="troy-price">
+      <div class="troy-price__weight">1 troy oz</div>
+      <div class="troy-price__grams">= 31.1035 g</div>
+      <div class="troy-price__gold-label">Gold</div>
+      <div class="troy-price__gold-val" id="px-1-gold" data-nosnippet>$—</div>
+      <div class="troy-price__silver-label">Silver</div>
+      <div class="troy-price__silver-val" id="px-1-silver" data-nosnippet>$—</div>
+    </article>
+    <article class="troy-price">
+      <div class="troy-price__weight">5 troy oz</div>
+      <div class="troy-price__grams">= 155.52 g</div>
+      <div class="troy-price__gold-label">Gold</div>
+      <div class="troy-price__gold-val" id="px-5-gold" data-nosnippet>$—</div>
+      <div class="troy-price__silver-label">Silver</div>
+      <div class="troy-price__silver-val" id="px-5-silver" data-nosnippet>$—</div>
+    </article>
+    <article class="troy-price">
+      <div class="troy-price__weight">10 troy oz</div>
+      <div class="troy-price__grams">= 311.03 g</div>
+      <div class="troy-price__gold-label">Gold</div>
+      <div class="troy-price__gold-val" id="px-10-gold" data-nosnippet>$—</div>
+      <div class="troy-price__silver-label">Silver</div>
+      <div class="troy-price__silver-val" id="px-10-silver" data-nosnippet>$—</div>
+    </article>
+    <article class="troy-price">
+      <div class="troy-price__weight">1 kilo bar</div>
+      <div class="troy-price__grams">= 32.15 oz t</div>
+      <div class="troy-price__gold-label">Gold</div>
+      <div class="troy-price__gold-val" id="px-kg-gold" data-nosnippet>$—</div>
+      <div class="troy-price__silver-label">Silver</div>
+      <div class="troy-price__silver-val" id="px-kg-silver" data-nosnippet>$—</div>
+    </article>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     POUND OF GOLD WORTH
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-pound-h">
+  <div class="troy-pound">
+    <div class="troy-pound__inner">
+      <div class="troy-pound__text">
+        <span class="troy-section-head__eyebrow" style="display:inline-block;margin-bottom:8px">Popular question</span>
+        <h2 id="troy-pound-h" style="font-family:var(--font-display);font-size:clamp(1.25rem,1rem + 1vw,1.75rem);font-weight:700;color:var(--color-text);line-height:1.2;margin:0 0 var(--space-2)">How much is one pound of gold worth?</h2>
+        <p>One avoirdupois pound = <strong>453.59 g</strong> = <strong>14.5833 troy oz</strong>. Multiply that by the live spot price for an exact USD value, updated below every 60 seconds.</p>
+        <div class="troy-pound__formula">453.59 g ÷ 31.1035 = <strong>14.5833 troy oz</strong></div>
+      </div>
+      <div class="troy-pound__result">
+        <div class="troy-pound__result-label">1 lb of Gold worth</div>
+        <div class="troy-pound__result-value" id="poundValue" data-nosnippet>$—</div>
+        <div class="troy-pound__result-sub">14.5833 troy oz × live spot</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     CONVERSION TABLE (live USD)
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-table-h">
+  <div class="troy-section-head">
+    <span class="troy-section-head__eyebrow">Quick Lookup</span>
+    <h2 id="troy-table-h" class="troy-section-head__title">Troy Ounce to Gram Conversion Table</h2>
+    <p class="troy-section-head__sub">Every row recalculates the live gold USD value at the LBMA spot price. The 1-troy-oz row is highlighted as your reference baseline.</p>
+  </div>
+
+  <div class="troy-table-wrap">
+    <div class="troy-table-scroll">
+      <table class="troy-table" aria-label="Troy ounce conversion table with live USD gold value">
+        <thead>
+          <tr>
+            <th scope="col">Troy Ounces</th>
+            <th scope="col">Grams</th>
+            <th scope="col">Pennyweight (dwt)</th>
+            <th scope="col">Avoirdupois oz</th>
+            <th scope="col">Live Gold (USD)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-troy="0.1"><td>0.1 troy oz</td><td>3.1103 g</td><td>2 dwt</td><td>0.1097 oz</td><td data-nosnippet>$—</td></tr>
+          <tr data-troy="0.25"><td>0.25 troy oz</td><td>7.7759 g</td><td>5 dwt</td><td>0.2743 oz</td><td data-nosnippet>$—</td></tr>
+          <tr data-troy="0.5"><td>0.5 troy oz</td><td>15.5517 g</td><td>10 dwt</td><td>0.5486 oz</td><td data-nosnippet>$—</td></tr>
+          <tr class="troy-table__highlight" data-troy="1"><td>1 troy oz</td><td>31.1035 g</td><td>20 dwt</td><td>1.0971 oz</td><td data-nosnippet>$—</td></tr>
+          <tr data-troy="2"><td>2 troy oz</td><td>62.2069 g</td><td>40 dwt</td><td>2.1943 oz</td><td data-nosnippet>$—</td></tr>
+          <tr data-troy="5"><td>5 troy oz</td><td>155.5174 g</td><td>100 dwt</td><td>5.4857 oz</td><td data-nosnippet>$—</td></tr>
+          <tr data-troy="10"><td>10 troy oz</td><td>311.0348 g</td><td>200 dwt</td><td>10.9714 oz</td><td data-nosnippet>$—</td></tr>
+          <tr data-troy="14.5833"><td>14.5833 troy oz (1 lb)</td><td>453.5924 g</td><td>291.67 dwt</td><td>16 oz</td><td data-nosnippet>$—</td></tr>
+          <tr data-troy="32.1507"><td>32.1507 troy oz (1 kg)</td><td>1,000 g</td><td>643.01 dwt</td><td>35.27 oz</td><td data-nosnippet>$—</td></tr>
+          <tr data-troy="100"><td>100 troy oz</td><td>3,110.35 g</td><td>2,000 dwt</td><td>109.71 oz</td><td data-nosnippet>$—</td></tr>
+          <tr data-troy="400"><td>400 troy oz (LBMA bar)</td><td>12,441.39 g</td><td>8,000 dwt</td><td>438.86 oz</td><td data-nosnippet>$—</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     WHY GOLD USES TROY OUNCES — Editorial bento
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-why-h">
+  <div class="troy-section-head">
+    <span class="troy-section-head__eyebrow">Origin Story</span>
+    <h2 id="troy-why-h" class="troy-section-head__title">Why is Gold Measured in Troy Ounces?</h2>
+    <p class="troy-section-head__sub">From a medieval French trade fair to the world's biggest commodity exchanges — the troy ounce survived because precision survived. Here's the abbreviated 600-year story.</p>
+  </div>
+
+  <div class="troy-bento">
+    <article class="troy-bento__card troy-bento__card--feature">
+      <div class="troy-bento__icon" aria-hidden="true">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21h18"/><path d="M5 21V8l7-5 7 5v13"/><path d="M9 21v-6h6v6"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/></svg>
+      </div>
+      <h3 class="troy-bento__title">Born at the Trade Fairs of Troyes, France</h3>
+      <p class="troy-bento__text">In the 12th century, the city of <strong>Troyes</strong> in northeastern France hosted Europe's most important medieval trade fairs. Merchants travelling from Italy, Flanders and the Hanseatic League needed a single, trusted weight standard for precious metals and gemstones. The "troy weight" system — based on a 480-grain ounce — emerged from those fairs and travelled across Europe in their saddlebags.</p>
+      <ul class="troy-bento__list">
+        <li>England formalised the troy system by statute in <strong>1527 under Henry VIII</strong></li>
+        <li>The US codified it in the <strong>Coinage Act of 1828</strong></li>
+        <li>Adopted as the international precious-metals standard well before metrication</li>
+      </ul>
+      <div class="troy-bento__stat"><strong>~1100 AD</strong> first documented use</div>
+    </article>
+
+    <article class="troy-bento__card">
+      <div class="troy-bento__icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="18" height="14" rx="2"/><path d="M3 10h18"/><path d="M8 14h3M14 14h2"/></svg>
+      </div>
+      <h3 class="troy-bento__title">LBMA Pricing Standard</h3>
+      <p class="troy-bento__text">The <strong>London Bullion Market Association</strong> sets the global benchmark gold and silver prices twice daily in USD per troy ounce — the LBMA Gold Price. Every "spot price" you see worldwide derives from this.</p>
+    </article>
+
+    <article class="troy-bento__card">
+      <div class="troy-bento__icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-5"/></svg>
+      </div>
+      <h3 class="troy-bento__title">COMEX Futures</h3>
+      <p class="troy-bento__text">The NYMEX/COMEX gold futures contract (symbol GC) trades in lots of <strong>100 troy ounces</strong>. The silver contract (SI) trades 5,000 troy oz lots. Settlement is always USD per troy oz.</p>
+    </article>
+
+    <article class="troy-bento__card">
+      <div class="troy-bento__icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M2 12h20M12 2a15 15 0 0 1 0 20M12 2a15 15 0 0 0 0 20"/></svg>
+      </div>
+      <h3 class="troy-bento__title">ISO 31-4 Standard</h3>
+      <p class="troy-bento__text">The international standard defines the troy ounce as exactly <strong>31.10347680 grams</strong>. ISO 4217 currency codes use XAU (gold) and XAG (silver) per troy ounce.</p>
+    </article>
+
+    <article class="troy-bento__card">
+      <div class="troy-bento__icon" aria-hidden="true">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="10" rx="2"/><path d="M6 11v2M10 10v4M14 11v2M18 10v4"/></svg>
+      </div>
+      <h3 class="troy-bento__title">Shanghai &amp; Dubai</h3>
+      <p class="troy-bento__text">The <strong>Shanghai Gold Exchange</strong> quotes the SGE Gold Benchmark in yuan per gram — but reports a troy-ounce USD equivalent. <strong>DMCC Dubai</strong> follows the same convention.</p>
+    </article>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     FORMULAS — Educational
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-formulas-h">
+  <div class="troy-section-head">
+    <span class="troy-section-head__eyebrow">The Math</span>
+    <h2 id="troy-formulas-h" class="troy-section-head__title">Conversion Formulas</h2>
+    <p class="troy-section-head__sub">Memorise these four and you can convert any precious-metals weight in your head.</p>
+  </div>
+
+  <div class="troy-formulas">
+    <article class="troy-formula">
+      <div class="troy-formula__from">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        Troy oz → grams
+      </div>
+      <div class="troy-formula__op">troy oz × <strong>31.1035</strong> = g</div>
+      <div class="troy-formula__ex">Example: 5 oz t × 31.1035 = 155.52 g</div>
+    </article>
+    <article class="troy-formula">
+      <div class="troy-formula__from">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        Grams → troy oz
+      </div>
+      <div class="troy-formula__op">g ÷ <strong>31.1035</strong> = troy oz</div>
+      <div class="troy-formula__ex">Example: 100 g ÷ 31.1035 = 3.2151 oz t</div>
+    </article>
+    <article class="troy-formula">
+      <div class="troy-formula__from">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        Kilogram → troy oz
+      </div>
+      <div class="troy-formula__op">kg × <strong>32.1507</strong> = troy oz</div>
+      <div class="troy-formula__ex">Example: 1 kg = 32.1507 oz t</div>
+    </article>
+    <article class="troy-formula">
+      <div class="troy-formula__from">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        USD/oz → USD/g
+      </div>
+      <div class="troy-formula__op">spot $ ÷ <strong>31.1035</strong> = $/g</div>
+      <div class="troy-formula__ex">Example: $2,400/oz ÷ 31.1035 = $77.16/g</div>
+    </article>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     TROY UNIT FAMILY
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-units-h">
+  <div class="troy-section-head">
+    <span class="troy-section-head__eyebrow">The Family Tree</span>
+    <h2 id="troy-units-h" class="troy-section-head__title">Other Precious-Metals Weight Units</h2>
+    <p class="troy-section-head__sub">Beyond troy ounces and grams, jewellers, refiners and regional markets use these specialised units. All convert cleanly back to grams or troy oz.</p>
+  </div>
+
+  <div class="troy-units">
+    <article class="troy-unit">
+      <div class="troy-unit__abbr">dwt</div>
+      <div class="troy-unit__name">Pennyweight</div>
+      <div class="troy-unit__weight">1.5552 g<br>1/20 troy oz</div>
+      <div class="troy-unit__region">UK / Jewellers</div>
+    </article>
+    <article class="troy-unit">
+      <div class="troy-unit__abbr">gr</div>
+      <div class="troy-unit__name">Grain</div>
+      <div class="troy-unit__weight">0.0648 g<br>1/480 troy oz</div>
+      <div class="troy-unit__region">Original troy unit</div>
+    </article>
+    <article class="troy-unit">
+      <div class="troy-unit__abbr">tola</div>
+      <div class="troy-unit__name">Tola</div>
+      <div class="troy-unit__weight">11.6638 g<br>0.375 troy oz</div>
+      <div class="troy-unit__region">India / Pakistan</div>
+    </article>
+    <article class="troy-unit">
+      <div class="troy-unit__abbr">tael</div>
+      <div class="troy-unit__name">Hong Kong Tael</div>
+      <div class="troy-unit__weight">37.4290 g<br>1.2034 troy oz</div>
+      <div class="troy-unit__region">East Asia</div>
+    </article>
+    <article class="troy-unit">
+      <div class="troy-unit__abbr">m</div>
+      <div class="troy-unit__name">Mithqal</div>
+      <div class="troy-unit__weight">4.6082 g<br>0.1481 troy oz</div>
+      <div class="troy-unit__region">Middle East</div>
+    </article>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     DATA SOURCE TRUST BAR
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-label="Data accuracy disclaimer">
+  <div class="troy-trust">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2L4 7v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V7l-8-5z"/><path d="M9 12l2 2 4-4"/></svg>
+    <div>
+      <strong>Live data accuracy.</strong> All USD prices on this page derive from a single source — <a href="https://www.gold-api.com" rel="noopener" target="_blank">gold-api.com</a> (LBMA spot, refreshed every 60 seconds) — so the ticker, hero cards, converter, table and live values stay in lock-step. ISO 4217 currency codes used: <strong>XAU</strong> (gold) and <strong>XAG</strong> (silver). Conversion constants follow ISO 31-4 (1 troy oz = 31.10347680 g exactly). Indicative pricing only — not financial advice.
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     FAQ — Premium accordion
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-faq-h">
+  <div class="troy-section-head" style="max-width:100%;text-align:center;align-items:center;margin-left:auto;margin-right:auto">
+    <span class="troy-section-head__eyebrow">Common Questions</span>
+    <h2 id="troy-faq-h" class="troy-section-head__title" style="margin-left:auto;margin-right:auto">Frequently Asked Questions</h2>
+  </div>
+
+  <div class="troy-faq__list">
+    <details class="troy-faq__item">
+      <summary class="troy-faq__q">How many grams are in a troy ounce?<span class="troy-faq__q-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 5v14M5 12h14"/></svg></span></summary>
+      <div class="troy-faq__a">
+        <p>There are exactly <span class="highlight">31.1035 grams</span> in one troy ounce. The precise ISO 31-4 value is 31.10347680 g. This is the internationally recognised unit used for pricing gold, silver, platinum and palladium on the LBMA, COMEX, Shanghai Gold Exchange and every other global commodity market.</p>
+      </div>
+    </details>
+
+    <details class="troy-faq__item">
+      <summary class="troy-faq__q">What is the difference between a troy ounce and a regular ounce?<span class="troy-faq__q-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 5v14M5 12h14"/></svg></span></summary>
+      <div class="troy-faq__a">
+        <p>A <strong>troy ounce</strong> (31.1035 g) is heavier than a regular <strong>avoirdupois ounce</strong> (28.3495 g). The troy ounce is about <span class="highlight">9.7% heavier</span> — a difference of 2.754 g per ounce.</p>
+        <p>Gold and silver prices quoted "per ounce" <strong>always</strong> mean the troy ounce. Your kitchen scale uses the avoirdupois ounce. This is why spot gold at "$2,400 an ounce" gives 31.1035 g of gold, not 28.35 g.</p>
+      </div>
+    </details>
+
+    <details class="troy-faq__item">
+      <summary class="troy-faq__q">How many troy ounces are in a kilogram of gold?<span class="troy-faq__q-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 5v14M5 12h14"/></svg></span></summary>
+      <div class="troy-faq__a">
+        <p>There are <span class="highlight">32.1507 troy ounces</span> in one kilogram. The math: 1,000 g ÷ 31.1035 g/troy oz = 32.1507 troy oz. A standard 1-kg gold bar — the dominant form factor in Switzerland, Singapore and the Middle East — therefore contains 32.1507 troy oz of pure gold.</p>
+      </div>
+    </details>
+
+    <details class="troy-faq__item">
+      <summary class="troy-faq__q">Why is gold measured in troy ounces?<span class="troy-faq__q-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 5v14M5 12h14"/></svg></span></summary>
+      <div class="troy-faq__a">
+        <p>Gold has been measured in troy ounces since the Middle Ages, originating from the merchant fairs of <strong>Troyes</strong> in northeastern France. The troy weight system was formalised in England by Henry VIII in 1527 and has been the international standard for precious metals ever since.</p>
+        <p>The standard survived metrication because every major bullion market — LBMA, COMEX, the Shanghai Gold Exchange, DMCC Dubai — settles contracts in USD per troy ounce. Changing it would mean rewriting decades of contracts and price history.</p>
+      </div>
+    </details>
+
+    <details class="troy-faq__item">
+      <summary class="troy-faq__q">How do I convert troy ounces to grams?<span class="troy-faq__q-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 5v14M5 12h14"/></svg></span></summary>
+      <div class="troy-faq__a">
+        <p><strong>Multiply troy ounces by 31.1035 to get grams.</strong> To convert grams to troy ounces, divide by 31.1035. Example: 2 troy oz × 31.1035 = <span class="highlight">62.207 grams</span>. Use the Live Precision Converter above for any weight — it shows all six unit conversions plus the live USD gold and silver value instantly.</p>
+      </div>
+    </details>
+
+    <details class="troy-faq__item">
+      <summary class="troy-faq__q">How much is one pound of gold worth?<span class="troy-faq__q-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 5v14M5 12h14"/></svg></span></summary>
+      <div class="troy-faq__a">
+        <p>One avoirdupois pound of gold is <strong>453.59 grams = 14.5833 troy ounces</strong>. Multiply 14.5833 by today's gold spot price in USD per troy ounce — that's the live USD value. The "Pound of Gold" card above shows the current number automatically.</p>
+        <p>Note: bullion is never traded by the avoirdupois pound. This conversion is purely educational. There is also a "troy pound" (12 troy oz = 373.24 g), but it has been obsolete since the 19th century.</p>
+      </div>
+    </details>
+
+    <details class="troy-faq__item">
+      <summary class="troy-faq__q">Are troy ounces used for anything other than precious metals?<span class="troy-faq__q-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 5v14M5 12h14"/></svg></span></summary>
+      <div class="troy-faq__a">
+        <p>Today, almost exclusively just <strong>gold, silver, platinum, palladium and gemstones</strong>. Historically the troy system was also used for apothecary measurements and gunpowder — that's why "grain" is also a unit for bullets and gunpowder loads (1 grain = 0.0648 g) — but those uses have been displaced by SI units.</p>
+      </div>
+    </details>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════════════════════════════
+     RELATED GUIDES + SHARE
+     ═══════════════════════════════════════════════════════════════════ -->
+<section class="troy-section" aria-labelledby="troy-related-h">
+  <div class="troy-section-head">
+    <span class="troy-section-head__eyebrow">Keep Reading</span>
+    <h2 id="troy-related-h" class="troy-section-head__title">Related Gold &amp; Silver Tools</h2>
+    <p class="troy-section-head__sub">Use the live spot price you just looked up to value real-world precious-metals holdings.</p>
+  </div>
+
+  <div class="related-guides-grid">
+    <a href="/scrap-gold-calculator" class="related-card">
+      <span class="related-card__tag">TOOL</span>
+      <span class="related-card__title">Scrap Gold Calculator</span>
+      <span class="related-card__desc">Calculate the melt value of your gold jewellery using today's live spot price in USD.</span>
+    </a>
+    <a href="/gold-bar-value" class="related-card">
+      <span class="related-card__tag">TOOL</span>
+      <span class="related-card__title">Gold Bar Value Calculator</span>
+      <span class="related-card__desc">Live USD value of every common bar size from 1 g up to the 400 oz LBMA Good Delivery bar.</span>
+    </a>
+    <a href="/gold-silver-ratio" class="related-card">
+      <span class="related-card__tag">LIVE TOOL</span>
+      <span class="related-card__title">Gold–Silver Ratio</span>
+      <span class="related-card__desc">Track the live gold-to-silver ratio and what it means for precious metals investors.</span>
+    </a>
+    <a href="/24k-gold-price-per-gram" class="related-card">
+      <span class="related-card__tag">LIVE PRICE</span>
+      <span class="related-card__title">24K Gold Price Per Gram</span>
+      <span class="related-card__desc">Live 24K (pure) gold price per gram — updated every 60 seconds from LBMA in USD.</span>
+    </a>
+    <a href="/silver-price-per-kilo" class="related-card">
+      <span class="related-card__tag">LIVE PRICE</span>
+      <span class="related-card__title">Silver Price Per Kilo</span>
+      <span class="related-card__desc">Live silver price per kilogram converted from XAG troy-ounce spot. USD primary.</span>
+    </a>
+    <a href="/zakat-gold-silver-calculator" class="related-card">
+      <span class="related-card__tag">TOOL</span>
+      <span class="related-card__title">Zakat Calculator</span>
+      <span class="related-card__desc">Calculate your 2.5% Zakat due on precious-metals wealth at live spot prices.</span>
+    </a>
+  </div>
+
+  <div class="share-buttons">
+    <span>Share:</span>
+    <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/how-many-grams-in-troy-ounce&text=How+Many+Grams+in+a+Troy+Ounce%3F+%2831.1035g+Explained%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+    <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/how-many-grams-in-troy-ounce&title=How+Many+Grams+in+a+Troy+Ounce%3F+%2831.1035g+Explained%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+    <a href="https://api.whatsapp.com/send?text=How+Many+Grams+in+a+Troy+Ounce%3F+%2831.1035g+Explained%29%20https%3A%2F%2Fgoldpricetools.com%2Fhow-many-grams-in-troy-ounce" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+    <a href="mailto:?subject=How+Many+Grams+in+a+Troy+Ounce%3F&amp;body=https%3A%2F%2Fgoldpricetools.com%2Fhow-many-grams-in-troy-ounce" rel="nofollow" data-platform="email" aria-label="Share via Email"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6 9-6"/></svg> Email</a>
+  </div>
+</section>
+
+<!-- BLOG PREVIEW -->
+<section class="blog-preview-section">
+  <div class="blog-preview-inner">
+    <div class="blog-preview-header">
+      <h2 class="blog-preview-title">Latest from the Blog</h2>
+      <a href="/blog/" class="blog-preview-all">View all articles &rarr;</a>
+    </div>
+    <div class="blog-preview-grid">
+      <a href="/blog/gold-vs-bitcoin-2026" class="blog-preview-card">
+        <span class="blog-preview-tag">Markets</span>
+        <h3>Gold vs Bitcoin 2026</h3>
+        <p>Which store of value won the year? Performance, volatility and correlation compared.</p>
+      </a>
+      <a href="/blog/best-uk-gold-dealers-2026" class="blog-preview-card">
+        <span class="blog-preview-tag">Dealers</span>
+        <h3>Best UK Gold Dealers 2026</h3>
+        <p>Premium, buyback spread and CGT-exempt coin selection ranked across 12 dealers.</p>
+      </a>
+      <a href="/blog/uk-gold-cgt-guide" class="blog-preview-card">
+        <span class="blog-preview-tag">Tax</span>
+        <h3>Gold CGT UK Guide</h3>
+        <p>Which gold is Capital Gains Tax-free in the UK and how to structure a tax-efficient stack.</p>
+      </a>
+      <a href="/blog/is-gold-overpriced-2026" class="blog-preview-card">
+        <span class="blog-preview-tag">Analysis</span>
+        <h3>Is Gold Overpriced in 2026?</h3>
+        <p>Inflation-adjusted highs, central-bank demand and what the gold/silver ratio is signalling.</p>
+      </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">
@@ -689,7 +1273,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -719,17 +1302,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Blog</h4>
-      <ul>
-        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
-        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
-        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
-        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
-        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
-        <li><a href="/blog/">All Articles</a></li>
-      </ul>
-    </div>
-    <div class="footer-col">
       <h4>Info</h4>
       <ul>
         <li><a href="/about">About</a></li>
@@ -747,74 +1319,213 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 </footer>
 
 <script>
-let goldSpotOz = null;
-let silverSpotOz = null;
-let fxRates = { GBP: 1 };
-const TROY_OZ_TO_GRAM = 31.1035;
+/* ════════════════════════════════════════════════════════════════════
+   TROY OUNCE PAGE — Live data engine
+   Sources: gold-api.com (LBMA spot). USD primary.
+   Refresh: 60s. Conversion constants: ISO 31-4.
+   ════════════════════════════════════════════════════════════════════ */
+(function(){
+  'use strict';
 
-async function fetchFxRates() {
-  try {
-    const res = await fetch('https://open.er-api.com/v6/latest/USD');
-    const data = await res.json();
-    if(data && data.rates) fxRates = data.rates;
-  } catch(e) { console.warn('FX unavailable', e); }
-}
+  // Exact conversion constants (ISO 31-4 / international yard-and-pound agreement)
+  const G_PER_TROY_OZ = 31.1034768;
+  const G_PER_AVOIR_OZ = 28.349523125;
+  const G_PER_AVOIR_LB = 453.59237;
+  const G_PER_DWT = 1.55517384;
+  const G_PER_GRAIN = 0.06479891;
+  const G_PER_TOLA = 11.6638;
 
-async function fetchPrices() {
-  try {
-    const [gRes, sRes] = await Promise.all([
-      fetch('https://api.gold-api.com/price/XAU'),
-      fetch('https://api.gold-api.com/price/XAG')
-    ]);
-    const gData = await gRes.json();
-    const sData = await sRes.json();
-    if (gData && gData.price) goldSpotOz = parseFloat(gData.price);
-    if (sData && sData.price) silverSpotOz = parseFloat(sData.price);
-    updatePrices();
-  } catch(e) {
-    console.error('Failed to fetch prices', e);
+  const TROY_OZ_PER_LB = G_PER_AVOIR_LB / G_PER_TROY_OZ; // 14.5833333...
+  const TROY_OZ_PER_KG = 1000 / G_PER_TROY_OZ; // 32.1507466...
+
+  const REFRESH_MS = 60000;
+  let goldSpotOz = null;
+  let silverSpotOz = null;
+  let lastFetchTs = null;
+
+  function $(id){ return document.getElementById(id); }
+
+  function fmtUSD(val, minFrac, maxFrac){
+    if(val == null || !isFinite(val)) return '$—';
+    return new Intl.NumberFormat('en-US', {
+      style:'currency', currency:'USD',
+      minimumFractionDigits: minFrac != null ? minFrac : 2,
+      maximumFractionDigits: maxFrac != null ? maxFrac : 2
+    }).format(val);
   }
-}
 
-function fmtUSD(val) {
-  return new Intl.NumberFormat('en-US', {style:'currency',currency:'USD',minimumFractionDigits:2}).format(val);
-}
+  function fmtNum(val, dec){
+    if(val == null || !isFinite(val)) return '—';
+    const d = dec != null ? dec : 4;
+    return val.toLocaleString('en-US', {minimumFractionDigits:d, maximumFractionDigits:d});
+  }
 
-function setText(id, val) {
-  const el = document.getElementById(id);
-  if(el) el.textContent = val;
-}
+  function setText(id, txt){
+    const el = $(id);
+    if(el) el.textContent = txt;
+  }
 
-function updatePrices() {
-  if(goldSpotOz) setText('t-xau', fmtUSD(goldSpotOz));
-  if(silverSpotOz) setText('t-xag', fmtUSD(silverSpotOz));
-}
+  // ── Fetch prices ──────────────────────────────────────────────
+  async function fetchPrices(){
+    try {
+      const [gRes, sRes] = await Promise.all([
+        fetch('https://api.gold-api.com/price/XAU', {cache:'no-store'}),
+        fetch('https://api.gold-api.com/price/XAG', {cache:'no-store'}).catch(()=>null)
+      ]);
+      if(!gRes.ok) throw new Error('XAU HTTP '+gRes.status);
+      const gData = await gRes.json();
+      if(gData && gData.price) goldSpotOz = parseFloat(gData.price);
+      if(sRes && sRes.ok){
+        const sData = await sRes.json();
+        if(sData && sData.price) silverSpotOz = parseFloat(sData.price);
+      }
+      lastFetchTs = new Date();
+      paintAll();
+      if(typeof gtag !== 'undefined') gtag('event','price_view',{metal:'gold',page:'troy-ounce'});
+    } catch(e){
+      console.warn('[troy] price fetch failed', e);
+    }
+  }
 
-function calcConverter() {
-  const amount = parseFloat(document.getElementById('convInput').value) || 0;
-  const from = parseFloat(document.getElementById('convFrom').value);
-  const grams = amount * from;
-  const fmt = (v, dec) => v.toLocaleString('en-US', {minimumFractionDigits:dec||4, maximumFractionDigits:dec||4});
+  function lastUpdatedString(){
+    if(!lastFetchTs) return '—';
+    return lastFetchTs.toLocaleTimeString('en-US', {hour12:false, hour:'2-digit', minute:'2-digit', second:'2-digit'}) + ' UTC';
+  }
 
-  setText('cv-g', fmt(grams, 4) + ' g');
-  setText('cv-ozt', fmt(grams/31.1035, 4) + ' oz t');
-  setText('cv-kg', fmt(grams/1000, 6) + ' kg');
-  setText('cv-dwt', fmt(grams/1.55517, 4) + ' dwt');
-  setText('cv-gr', fmt(grams/0.0648, 2) + ' gr');
-  setText('cv-tola', fmt(grams/11.664, 4) + ' tola');
-}
+  // ── Paint all live elements ───────────────────────────────────
+  function paintAll(){
+    const g = goldSpotOz, s = silverSpotOz;
 
-['convInput','convFrom'].forEach(id => {
-  const el = document.getElementById(id);
-  if (el) el.addEventListener('input', calcConverter);
-});
+    // Hero spot cards
+    setText('spotGoldOz', fmtUSD(g, 2, 2));
+    setText('spotGoldG', g ? fmtUSD(g / G_PER_TROY_OZ, 2, 2) : '$—');
+    setText('spotGoldKg', g ? fmtUSD(g * TROY_OZ_PER_KG, 0, 0) : '$—');
+    setText('spotSilverOz', fmtUSD(s, 2, 2));
+    setText('spotSilverG', s ? fmtUSD(s / G_PER_TROY_OZ, 3, 3) : '$—');
+    setText('spotSilverKg', s ? fmtUSD(s * TROY_OZ_PER_KG, 0, 0) : '$—');
 
-Promise.all([fetchFxRates(), fetchPrices()]).then(() => {
-  calcConverter();
-});
+    // Last updated
+    setText('lastUpdated', lastUpdatedString());
+
+    // Ticker
+    const tickerVals = {
+      't-xau':    g ? fmtUSD(g, 2, 2) : '$—',
+      't-xau-g':  g ? fmtUSD(g / G_PER_TROY_OZ, 2, 2) : '$—',
+      't-xau-kg': g ? fmtUSD(g * TROY_OZ_PER_KG, 0, 0) : '$—',
+      't-xag':    s ? fmtUSD(s, 2, 2) : '$—',
+      't-xag-g':  s ? fmtUSD(s / G_PER_TROY_OZ, 3, 3) : '$—',
+      't-ratio':  (g && s) ? (g/s).toFixed(1) : '—'
+    };
+    Object.keys(tickerVals).forEach(k => {
+      setText(k, tickerVals[k]);
+      setText(k+'-2', tickerVals[k]);
+    });
+
+    // Live price strip (1, 5, 10 troy oz, 1 kg)
+    if(g){
+      setText('px-1-gold',  fmtUSD(g * 1, 2, 2));
+      setText('px-5-gold',  fmtUSD(g * 5, 2, 2));
+      setText('px-10-gold', fmtUSD(g * 10, 0, 0));
+      setText('px-kg-gold', fmtUSD(g * TROY_OZ_PER_KG, 0, 0));
+    }
+    if(s){
+      setText('px-1-silver',  fmtUSD(s * 1, 2, 2));
+      setText('px-5-silver',  fmtUSD(s * 5, 2, 2));
+      setText('px-10-silver', fmtUSD(s * 10, 2, 2));
+      setText('px-kg-silver', fmtUSD(s * TROY_OZ_PER_KG, 0, 0));
+    }
+
+    // Pound of gold value
+    if(g) setText('poundValue', fmtUSD(g * TROY_OZ_PER_LB, 0, 0));
+
+    // Conversion table — live gold value column
+    document.querySelectorAll('.troy-table tr[data-troy]').forEach(tr => {
+      const ozt = parseFloat(tr.getAttribute('data-troy'));
+      const cell = tr.querySelector('td:last-child');
+      if(!cell) return;
+      if(g && isFinite(ozt)){
+        const val = g * ozt;
+        cell.textContent = val >= 10000 ? fmtUSD(val, 0, 0) : fmtUSD(val, 2, 2);
+      } else {
+        cell.textContent = '$—';
+      }
+    });
+
+    // Re-run converter so its live USD values update too
+    calcConverter();
+  }
+
+  // ── Converter ─────────────────────────────────────────────────
+  function calcConverter(){
+    const amountEl = $('convInput');
+    const fromEl = $('convFrom');
+    if(!amountEl || !fromEl) return;
+
+    const amount = parseFloat(amountEl.value);
+    const gramsPerUnit = parseFloat(fromEl.value);
+    const grams = (isFinite(amount) && isFinite(gramsPerUnit)) ? amount * gramsPerUnit : NaN;
+
+    if(!isFinite(grams)){
+      ['cv-ozt','cv-g','cv-kg','cv-dwt','cv-gr','cv-tola'].forEach(id => setText(id, '—'));
+      setText('cv-gold-usd', '$—');
+      setText('cv-silver-usd', '$—');
+      setText('cv-gold-sub', 'Enter a valid weight');
+      setText('cv-silver-sub', 'Enter a valid weight');
+      return;
+    }
+
+    setText('cv-ozt',  fmtNum(grams / G_PER_TROY_OZ, 4));
+    setText('cv-g',    fmtNum(grams, 4));
+    setText('cv-kg',   fmtNum(grams / 1000, 6));
+    setText('cv-dwt',  fmtNum(grams / G_PER_DWT, 4));
+    setText('cv-gr',   fmtNum(grams / G_PER_GRAIN, 2));
+    setText('cv-tola', fmtNum(grams / G_PER_TOLA, 4));
+
+    // Live USD value
+    const troyOz = grams / G_PER_TROY_OZ;
+    if(goldSpotOz){
+      const goldVal = goldSpotOz * troyOz;
+      setText('cv-gold-usd', goldVal >= 10000 ? fmtUSD(goldVal, 0, 0) : fmtUSD(goldVal, 2, 2));
+      setText('cv-gold-sub', troyOz.toLocaleString('en-US',{maximumFractionDigits:4}) + ' oz t × ' + fmtUSD(goldSpotOz, 0, 0) + '/oz');
+    } else {
+      setText('cv-gold-usd', '$—');
+      setText('cv-gold-sub', 'Loading live spot…');
+    }
+    if(silverSpotOz){
+      const sVal = silverSpotOz * troyOz;
+      setText('cv-silver-usd', sVal >= 10000 ? fmtUSD(sVal, 0, 0) : fmtUSD(sVal, 2, 2));
+      setText('cv-silver-sub', troyOz.toLocaleString('en-US',{maximumFractionDigits:4}) + ' oz t × ' + fmtUSD(silverSpotOz, 2, 2) + '/oz');
+    } else {
+      setText('cv-silver-usd', '$—');
+      setText('cv-silver-sub', 'Loading live spot…');
+    }
+  }
+
+  // ── Bind events ───────────────────────────────────────────────
+  function bindConverter(){
+    ['convInput','convFrom'].forEach(id => {
+      const el = $(id);
+      if(el){
+        el.addEventListener('input', calcConverter);
+        el.addEventListener('change', calcConverter);
+      }
+    });
+  }
+
+  // ── Init ──────────────────────────────────────────────────────
+  function init(){
+    bindConverter();
+    calcConverter(); // initial paint without prices
+    fetchPrices();
+    setInterval(fetchPrices, REFRESH_MS);
+  }
+  if(document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();
 </script>
 
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+
 <script>
 let _deepReadFired = false;
 window.addEventListener('scroll', () => {
@@ -822,22 +1533,23 @@ window.addEventListener('scroll', () => {
   const scrollTop = window.scrollY || document.documentElement.scrollTop;
   const scrollHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
   if (scrollHeight > 0 && (scrollTop / scrollHeight) > 0.75) {
-    gtag('event', 'guide_deep_read');
+    if(typeof gtag !== 'undefined') gtag('event', 'guide_deep_read');
     _deepReadFired = true;
   }
 }, { passive: true });
 </script>
+
 <script>(function(){
   const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
   let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
   root.setAttribute('data-theme',theme);
-  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);localStorage.setItem('gpt-theme',theme);themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
   const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
   if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
   document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
   document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
-  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
 })();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Complete UI/UX overhaul of `/how-many-grams-in-troy-ounce` using the recent liquid-glass + bento + editorial pattern (matches the `zk-`, `gcb-`, and 24K redesigns). Mobile-first sections that scale accurately to every viewport with WCAG-compliant touch targets, focus states, and `prefers-reduced-motion` support.

### Highlights
- **Editorial hero** with massive `31.1035` gradient answer card and ruler-pattern SVG
- **Live USD spot strip** — gold + silver per troy oz, per gram, per kg from `gold-api.com`
- **Live ticker** at the top matching the site convention (XAU, XAG, /g, /kg, ratio)
- **Troy vs Avoirdupois** visual comparison with `+9.7%` delta callout and weight bars
- **New Live Precision Converter** — 8 input units → 6 result tiles + **live Au & Ag USD value at the entered weight**
- **Conversion table** now shows live USD gold value per row (0.1 → 400 troy oz LBMA bar)
- **"How much is X troy oz worth?"** live USD price strip (1, 5, 10 oz, 1 kg)
- **Pound of gold worth** section with live $/lb calculation
- **5-card editorial bento** on troy ounce history (Troyes 1100 AD, LBMA, COMEX, ISO 31-4, Shanghai/Dubai)
- 4 conversion formulas + 5-unit troy family reference (dwt, grain, tola, tael, mithqal)
- **Premium FAQ accordion** — 7 questions (expanded from 5) with smooth `+ → ×` icon
- Trust-bar disclaimer with data source and ISO references
- 6 related-guide cards + share buttons + blog preview + preserved footer

### Data accuracy
- All conversion constants follow ISO 31-4 exactly (1 troy oz = `31.10347680` g)
- Single LBMA spot source (`gold-api.com`) feeds ticker, hero, table, converter, prices, and pound card — values stay in lock-step
- 60-second refresh interval matches site standard
- USD is the primary currency throughout; values formatted with `Intl.NumberFormat`
- Adaptive precision (≥ $10k uses no decimals, smaller amounts show 2 decimals)
- `data-nosnippet` on all live price elements
- `WebApplication` JSON-LD schema added for the converter tool

## Test plan
- [ ] Open page on iPhone 14 Pro profile and verify hero, spot cards, converter, and bento all stack cleanly with no horizontal overflow
- [ ] Verify live ticker, hero spot cards, conversion table USD column, live price strip, and pound-of-gold card all show the same gold spot value within a single refresh cycle
- [ ] Type into the converter (try 5 oz t, 100 g, 1 kg, 1 lb) and verify all 6 unit tiles update and both live USD value cards update with correct math
- [ ] Test light/dark mode toggle and check contrast on glass cards in both
- [ ] Verify FAQ accordion expands/collapses with `+ → ×` icon animation
- [ ] Run `python3 tools/playwright_audit.py https://goldpricetools.com/how-many-grams-in-troy-ounce` after deploy and review every 400 px screenshot strip
- [ ] Confirm no console errors and no failed network requests in DevTools

https://claude.ai/code/session_01JNVigg6NiYj61jhb589AmN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNVigg6NiYj61jhb589AmN)_