### PR TITLE
Redesign silver-price-per-kilo with premium editorial UI (USD primary)

### DIFF
--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -2,53 +2,52 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
-  <script>
+<script>
 (function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
 </script>
-    <meta name="cf-no-email-obfuscation">
+<meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Silver Price Per Kilo Today (Live UK) — Per Gram & Troy Oz | GoldPriceTools</title>
-  <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Live silver price per kilogram in GBP and USD. Also shows price per gram, per troy ounce, and per 100g. Free silver calculator for any weight. Updated every 60 seconds from LBMA.">
+<title>Silver Price Per Kilo Today (Live USD) — Per Gram, Troy Oz &amp; 1kg Bar | GoldPriceTools</title>
+<meta name="google-adsense-account" content="ca-pub-8849494330640880">
+<meta name="description" content="Live silver price per kilogram in USD, GBP and EUR — also per gram and per troy ounce. Free silver calculator, .999 fine silver, 1kg bullion bars and purity grades. Updated every 60 seconds from LBMA spot data.">
 <meta name="robots" content="index, follow">
-<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/silver-price-per-kilo">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/silver-price-per-kilo">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/silver-price-per-kilo">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/silver-price-per-kilo">
 <link rel="canonical" href="https://goldpricetools.com/silver-price-per-kilo">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Silver Price Per Kilo","item":"https://goldpricetools.com/silver-price-per-kilo"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the silver price per kilo today?","acceptedAnswer":{"@type":"Answer","text":"The silver price per kilogram is calculated by multiplying the spot price per troy ounce by 32.1507 (troy ounces per kilogram). The live price in GBP and USD is shown above, updated every 60 seconds."}},{"@type":"Question","name":"How many troy ounces are in a kilogram of silver?","acceptedAnswer":{"@type":"Answer","text":"There are 32.1507 troy ounces in one kilogram of silver. One troy ounce equals 31.1035 grams, so 1000 \u00f7 31.1035 = 32.1507 troy oz/kg."}},{"@type":"Question","name":"What is the silver price per gram in GBP?","acceptedAnswer":{"@type":"Answer","text":"The silver price per gram in GBP equals the spot price per troy ounce \u00f7 31.1035, then converted at the live GBP/USD exchange rate. The current live price is shown on this page."}}]}</script>
-<!-- Dataset JSON-LD (WP-53) -->
-<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Dataset","name":"Live Silver Price Per Kilogram \u2014 Daily Historical Data","description":"Daily silver spot price data per kilogram, gram, and troy ounce in GBP and USD. Updated daily from LBMA spot market via gold-api.com. Covers 1 month, 3 months, 1 year, 5 years, and 10 years of historical silver price data.","url":"https://goldpricetools.com/silver-price-per-kilo","keywords":["silver price","silver price per kilo","silver price per gram","LBMA spot price","precious metals data","XAG/GBP","XAG/USD"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"temporalCoverage":"2016-06-01/..","variableMeasured":"Silver spot price per troy ounce in USD (XAG/USD) and GBP (XAG/GBP)"}</script>
-<meta property="og:title" content="Silver Price Per Kilo Today (Live)">
-<meta property="og:description" content="Real-time silver price per kilogram, gram and troy ounce in GBP and USD. Updated every 60 seconds.">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is the silver price per kilo today?","acceptedAnswer":{"@type":"Answer","text":"The live silver price per kilogram is calculated by multiplying the spot price per troy ounce (in USD) by 32.1507 (troy ounces per kilogram). USD is the primary currency on this page; GBP and EUR conversions use live ECB reference rates. Updated every 60 seconds from LBMA spot data."}},{"@type":"Question","name":"How many troy ounces are in a kilogram of silver?","acceptedAnswer":{"@type":"Answer","text":"There are exactly 32.1507 troy ounces in one kilogram of silver. One troy ounce equals 31.1035 grams, so 1,000 ÷ 31.1035 = 32.1507 troy oz/kg."}},{"@type":"Question","name":"What is the silver price per gram in USD?","acceptedAnswer":{"@type":"Answer","text":"The live silver price per gram in USD equals the spot price per troy ounce divided by 31.1035. For .999 fine silver this is the raw spot value; for sterling (.925), coin (.900) or European (.800) silver, multiply by the purity factor."}},{"@type":"Question","name":"How much does a 1kg silver bar cost?","acceptedAnswer":{"@type":"Answer","text":"A 1kg silver bar contains 32.1507 troy ounces of pure silver, with melt value equal to the live spot price per oz × 32.1507. Physical bars typically carry a premium of $20–$60 over spot depending on brand. UK buyers also pay 20% VAT on silver bullion."}},{"@type":"Question","name":"Is silver priced in USD or GBP globally?","acceptedAnswer":{"@type":"Answer","text":"Silver is quoted globally in US dollars per troy ounce on the COMEX futures exchange and via the LBMA Silver Price benchmark in London. All conversions to GBP, EUR or INR are derived from the USD spot price using live FX rates."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Dataset","name":"Live Silver Price Per Kilogram — Daily Historical Data","description":"Daily silver spot price data per kilogram, gram and troy ounce in USD (primary), GBP and EUR. Updated every 60 seconds from LBMA spot market via gold-api.com. Covers 1 month, 3 months, 1 year, 5 years, and 10 years of historical silver price data.","url":"https://goldpricetools.com/silver-price-per-kilo","keywords":["silver price","silver price per kilo","silver price per gram","LBMA spot price","precious metals data","XAG/USD","XAG/GBP"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"temporalCoverage":"2016-06-01/..","variableMeasured":"Silver spot price per troy ounce in USD (XAG/USD), GBP (XAG/GBP) and EUR (XAG/EUR)"}</script>
+<meta property="og:title" content="Silver Price Per Kilo Today (Live USD)">
+<meta property="og:description" content="Real-time silver price per kilogram in USD, GBP, EUR — per gram and troy ounce included. 1kg bullion, .999 fine silver. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/silver-price-per-kilo">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
-<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
 <script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
 <script>
 (adsbygoogle = window.adsbygoogle || []).push({
   google_ad_client: "ca-pub-8849494330640880",
   enable_page_level_ads: true,
   overlays: {bottom: false},
-  vignette: {
-    new_triggers: false
-  }
+  vignette: { new_triggers: false }
 });
 </script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link rel="manifest" href="/manifest.json">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
+<meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://api.gold-api.com">
+<link rel="preconnect" href="https://api.frankfurter.dev">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:wght@500;600;700;800&display=swap" rel="stylesheet">
 <style>
-
 /* ── Guides mega panel — category links ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
@@ -58,28 +57,22 @@
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#5a5953;--color-text-faint:#8a8983;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#c08a00;--color-silver:#6b7280;--color-silver-bright:#4b5563;--color-silver-deep:#374151;--color-silver-luxe:#9ca3af;--color-platinum:#d1d5db;--color-success:#0f7a3d;--color-danger:#b91c1c;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--shadow-silver:0 8px 32px -8px oklch(0.6 0.02 250/0.3);--shadow-luxe:0 20px 50px -20px oklch(0.55 0.02 250/0.35);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--space-20:5rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--text-3xl:clamp(2.5rem,1.5rem + 4vw,5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-editorial:'Playfair Display',Georgia,serif;--font-mono:'IBM Plex Mono',ui-monospace,monospace;--transition:180ms cubic-bezier(0.16,1,0.3,1);--transition-slow:400ms cubic-bezier(0.16,1,0.3,1);--gradient-silver:linear-gradient(135deg,#e5e7eb 0%,#cbd5e1 35%,#94a3b8 70%,#475569 100%);--gradient-silver-luxe:linear-gradient(135deg,#f1f5f9 0%,#e2e8f0 25%,#cbd5e1 55%,#94a3b8 100%);--gradient-silver-deep:linear-gradient(135deg,#cbd5e1 0%,#94a3b8 30%,#64748b 65%,#334155 100%);--gradient-silver-soft:linear-gradient(135deg,oklch(0.78 0.01 250/0.18) 0%,oklch(0.65 0.01 250/0.06) 100%);--silver-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.78 0.02 250/0.16),transparent 60%);--silver-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.78 0.02 250/0.22),transparent 65%)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#e8e6e0;--color-text-muted:#a09e98;--color-text-faint:#6a6864;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#cbd5e1;--color-silver-bright:#e2e8f0;--color-silver-deep:#94a3b8;--color-silver-luxe:#f1f5f9;--color-platinum:#f8fafc;--color-success:#4ade80;--color-danger:#f87171;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5);--shadow-silver:0 8px 32px -4px oklch(0.75 0.02 250/0.32);--shadow-luxe:0 30px 60px -20px oklch(0.7 0.03 250/0.42);--gradient-silver:linear-gradient(135deg,#f1f5f9 0%,#cbd5e1 35%,#94a3b8 70%,#475569 100%);--gradient-silver-luxe:linear-gradient(135deg,#f8fafc 0%,#e2e8f0 30%,#cbd5e1 55%,#64748b 100%);--gradient-silver-deep:linear-gradient(135deg,#f1f5f9 0%,#cbd5e1 25%,#94a3b8 55%,#475569 100%);--gradient-silver-soft:linear-gradient(135deg,oklch(0.78 0.02 250/0.16) 0%,oklch(0.55 0.02 250/0.04) 100%);--silver-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.78 0.03 250/0.18),transparent 60%);--silver-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.82 0.03 250/0.22),transparent 70%)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-/* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
 .article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
 .article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
 .article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
 .article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
 .article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
 .article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
 .blog-preview-card:hover h3{color:var(--color-primary)}
 .related-card:hover .related-card__title{color:var(--color-primary)}
 
-
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:calc(var(--space-16) + var(--space-2))}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
@@ -87,194 +80,289 @@ input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+:focus-visible{outline:2px solid var(--color-silver);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-
-/* TICKER */
-.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
-.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
-.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
-.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
-.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
-.ticker:hover{animation-play-state:paused}
-@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
-.ticker-label{color:var(--color-text-muted)}
-.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
-.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
-@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
-
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
 
 /* AD SLOTS */
 .ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
 .ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
 
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
+/* ═════ PREMIUM HERO ═════ */
+.hero-premium{position:relative;overflow:hidden;border-bottom:1px solid var(--color-border)}
+.hero-premium::before{content:'';position:absolute;inset:0;background:var(--silver-glow-deep);pointer-events:none;z-index:0}
+.hero-premium::after{content:'';position:absolute;top:-20%;right:-10%;width:60%;height:140%;background:radial-gradient(ellipse 50% 70% at 30% 30%,oklch(0.78 0.03 250/0.12),transparent 60%);pointer-events:none;z-index:0}
+.hero-premium__inner{position:relative;z-index:1;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-10)}
+@media(min-width:768px){.hero-premium__inner{padding:var(--space-12) var(--space-6) var(--space-12)}}
+@media(min-width:1024px){.hero-premium__inner{padding:var(--space-16) var(--space-8) var(--space-12)}}
+.hero-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);padding:6px var(--space-3);background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--color-silver) 35%,transparent);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--color-silver);margin-bottom:var(--space-5)}
+.hero-eyebrow__pulse{width:6px;height:6px;border-radius:50%;background:var(--color-silver);box-shadow:0 0 8px var(--color-silver);animation:heroPulse 2.4s ease-in-out infinite}
+@keyframes heroPulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+.hero-premium__title{font-family:var(--font-editorial);font-weight:600;color:var(--color-text);line-height:.98;letter-spacing:-.025em;margin-bottom:var(--space-5);font-size:clamp(2.5rem,1.5rem + 5.5vw,5.5rem)}
+.hero-premium__title-em{display:inline-block;background:var(--gradient-silver-deep);-webkit-background-clip:text;background-clip:text;color:transparent;font-style:italic;font-weight:500}
+.hero-premium__sub{font-size:clamp(1rem,.95rem + .35vw,1.25rem);color:var(--color-text-muted);line-height:1.6;max-width:62ch;margin-bottom:var(--space-8)}
+.hero-premium__sub strong{color:var(--color-silver);font-weight:600}
 
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+/* PRICE TILES */
+.price-tiles{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-6)}
+@media(min-width:560px){.price-tiles{grid-template-columns:repeat(3,1fr);gap:var(--space-3)}}
+@media(min-width:1024px){.price-tiles{gap:var(--space-4)}}
+.price-tile{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.price-tile::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,transparent,var(--color-silver),transparent);opacity:.6}
+.price-tile:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-silver)}
+.price-tile--primary{background:linear-gradient(135deg,var(--color-surface) 0%,var(--color-surface-offset) 100%);border-color:color-mix(in oklch,var(--color-silver) 30%,var(--color-border))}
+.price-tile--primary::before{background:var(--gradient-silver-deep);opacity:1;height:4px}
+.price-tile__head{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-3)}
+.price-tile__label{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--color-text-muted)}
+.price-tile--primary .price-tile__label{color:var(--color-silver)}
+.price-tile__flag{display:inline-flex;align-items:center;gap:6px;font-size:11px;color:var(--color-text-faint);font-weight:600;font-family:var(--font-mono);letter-spacing:.04em}
+.price-tile__value{font-family:var(--font-display);font-size:clamp(1.75rem,1.2rem + 2.2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.02em;line-height:1;font-variant-numeric:tabular-nums;margin-bottom:var(--space-2)}
+.price-tile--primary .price-tile__value{color:var(--color-silver)}
+.price-tile__sub{font-size:var(--text-xs);color:var(--color-text-muted);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.price-tile__purity-dot{width:6px;height:6px;border-radius:50%;background:var(--color-silver);flex-shrink:0}
 
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+/* LIVE STATUS */
+.live-status{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2) var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted)}
+.live-status__dot{width:8px;height:8px;border-radius:50%;background:var(--color-success);box-shadow:0 0 8px color-mix(in oklch,var(--color-success) 80%,transparent);animation:heroPulse 2s ease-in-out infinite;flex-shrink:0}
+.live-status__label{font-weight:600;color:var(--color-text)}
+.live-status__divider{color:var(--color-text-faint);user-select:none}
+.live-status__meta{font-variant-numeric:tabular-nums}
+.live-status__meta strong{color:var(--color-silver);font-weight:600}
+.live-status__cta{margin-left:auto;display:inline-flex;align-items:center;gap:6px;padding:8px var(--space-3);background:var(--gradient-silver-luxe);color:#0f172a;border-radius:var(--radius-md);font-weight:700;font-size:11px;letter-spacing:.06em;text-transform:uppercase;text-decoration:none;min-height:36px}
+.live-status__cta:hover{filter:brightness(1.08);text-decoration:none;color:#0f172a}
 
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+/* TRUST STRIP */
+.trust-strip{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4);display:flex;flex-wrap:wrap;gap:var(--space-3);align-items:center;border-bottom:1px solid var(--color-divider)}
+.trust-strip__item{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+.trust-strip__item svg{width:14px;height:14px;color:var(--color-silver);flex-shrink:0}
+.trust-strip__item--link{margin-left:auto;color:var(--color-primary);font-weight:600;text-decoration:none}
+.trust-strip__item--link:hover{color:var(--color-primary-hover);text-decoration:underline}
+@media(max-width:540px){.trust-strip__item--link{margin-left:0}}
 
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
+/* ═════ LIVE CALCULATOR ═════ */
+.calc-pro{max-width:1200px;margin:var(--space-10) auto;padding:0 var(--space-4)}
+@media(min-width:768px){.calc-pro{margin:var(--space-12) auto}}
+.calc-pro__card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden;box-shadow:var(--shadow-md)}
+.calc-pro__card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-silver) 30%,var(--color-silver) 70%,transparent 100%);opacity:.5}
+.calc-pro__head{padding:var(--space-6) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-4);flex-wrap:wrap}
+@media(min-width:768px){.calc-pro__head{padding:var(--space-8) var(--space-8) var(--space-5)}}
+.calc-pro__head-left{flex:1;min-width:200px}
+.calc-pro__title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);display:flex;align-items:center;gap:var(--space-2)}
+.calc-pro__title-icon{width:24px;height:24px;color:var(--color-silver);flex-shrink:0}
+.calc-pro__sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;max-width:56ch}
+.calc-pro__head-badge{display:inline-flex;align-items:center;gap:6px;padding:6px var(--space-3);background:color-mix(in oklch,var(--color-success) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-success) 30%,transparent);color:var(--color-success);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase}
+.calc-pro__head-badge .live-dot{width:6px;height:6px;border-radius:50%;background:var(--color-success);animation:heroPulse 2s ease-in-out infinite}
+.calc-pro__body{padding:var(--space-5)}
+@media(min-width:768px){.calc-pro__body{padding:var(--space-6) var(--space-8) var(--space-8)}}
+.calc-pro__row{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-4)}
+@media(min-width:560px){.calc-pro__row{grid-template-columns:1.4fr .8fr .8fr;gap:var(--space-4)}}
+.calc-pro__field{display:flex;flex-direction:column;gap:var(--space-2)}
+.calc-pro__field-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__input,.calc-pro__select{width:100%;min-height:48px;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none;transition:border-color var(--transition),background var(--transition),box-shadow var(--transition)}
+.calc-pro__input:focus,.calc-pro__select:focus{border-color:var(--color-silver);background:var(--color-surface);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-silver) 18%,transparent);outline:none}
+.calc-pro__input{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;font-variant-numeric:tabular-nums}
+.calc-pro__select-wrap{position:relative}
+.calc-pro__select-wrap::after{content:'';position:absolute;right:var(--space-4);top:50%;width:8px;height:8px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:translateY(-70%) rotate(45deg);pointer-events:none}
+.calc-pro__chips{display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-5);align-items:center}
+.calc-pro__chips-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-right:var(--space-2);width:100%}
+@media(min-width:560px){.calc-pro__chips-label{width:auto;margin-right:var(--space-1)}}
+.calc-chip{min-height:36px;padding:6px var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);cursor:pointer;transition:all var(--transition);white-space:nowrap}
+.calc-chip:hover{border-color:var(--color-silver);color:var(--color-silver);background:color-mix(in oklch,var(--color-silver) 8%,var(--color-surface-offset))}
+.calc-chip:focus-visible{outline:2px solid var(--color-silver);outline-offset:2px}
+.calc-chip.active{background:var(--gradient-silver-luxe);color:#0f172a;border-color:transparent}
+.calc-pro__result{background:linear-gradient(135deg,color-mix(in oklch,var(--color-silver) 10%,var(--color-surface)) 0%,var(--color-surface) 100%);border:1px solid color-mix(in oklch,var(--color-silver) 25%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-5);position:relative;overflow:hidden}
+.calc-pro__result::before{content:'';position:absolute;top:-50%;right:-20%;width:280px;height:280px;background:radial-gradient(circle,color-mix(in oklch,var(--color-silver) 18%,transparent) 0%,transparent 60%);pointer-events:none}
+.calc-pro__result-primary{position:relative;display:flex;align-items:baseline;justify-content:space-between;padding-bottom:var(--space-4);margin-bottom:var(--space-4);border-bottom:1px solid color-mix(in oklch,var(--color-silver) 18%,var(--color-border));flex-wrap:wrap;gap:var(--space-2)}
+.calc-pro__result-label-main{font-size:var(--text-sm);font-weight:700;color:var(--color-text);text-transform:uppercase;letter-spacing:.08em}
+.calc-pro__result-main{font-family:var(--font-display);font-size:clamp(2rem,1.5rem + 2vw,3rem);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;letter-spacing:-.025em;line-height:1}
+.calc-pro__result-grid{position:relative;display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3) var(--space-4)}
+.calc-pro__result-item{display:flex;flex-direction:column;gap:var(--space-1)}
+.calc-pro__result-item-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__result-item-value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+.calc-pro__hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-4);line-height:1.6;max-width:62ch}
+.calc-pro__hint code{font-family:var(--font-mono);font-size:11px;background:var(--color-surface-offset-2);padding:2px 6px;border-radius:4px;color:var(--color-silver);border:1px solid var(--color-divider)}
 
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
+/* ═════ STAT CARDS ═════ */
+.stat-cards{max-width:1200px;margin:0 auto var(--space-12);padding:0 var(--space-4);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+@media(min-width:768px){.stat-cards{grid-template-columns:repeat(4,1fr);gap:var(--space-4)}}
+.stat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);position:relative;overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.stat-card:hover{border-color:color-mix(in oklch,var(--color-silver) 35%,var(--color-border));transform:translateY(-2px)}
+.stat-card__icon{width:32px;height:32px;color:var(--color-silver);margin-bottom:var(--space-3)}
+.stat-card__value{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);letter-spacing:-.02em;line-height:1;margin-bottom:var(--space-2);font-variant-numeric:tabular-nums}
+.stat-card__label{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.4}
 
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+/* ═════ SECTION COMMON ═════ */
+.section{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
+.section--narrow{max-width:920px}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:var(--space-5);flex-wrap:wrap;gap:var(--space-3)}
+.section-head__left{flex:1;min-width:200px}
+.section-eyebrow{display:inline-block;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-silver);margin-bottom:var(--space-2)}
+.section-title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);line-height:1.2;margin-bottom:var(--space-2);letter-spacing:-.015em}
+.section-sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;max-width:60ch}
 
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+/* ═════ PRICE TABLE ═════ */
+.price-table-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.price-table-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden}
+.price-table-card__head{padding:var(--space-5) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3)}
+@media(min-width:768px){.price-table-card__head{padding:var(--space-6) var(--space-8) var(--space-5)}}
+.price-table-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1)}
+.price-table-card__sub{font-size:var(--text-xs);color:var(--color-text-muted)}
+.price-table-card__sub strong{color:var(--color-success);font-weight:700}
+.currency-switch{display:inline-flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px;gap:2px;flex-wrap:wrap}
+.currency-switch__btn{min-height:32px;padding:6px var(--space-3);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);border-radius:var(--radius-full);cursor:pointer;transition:all var(--transition);letter-spacing:.04em}
+.currency-switch__btn:hover{color:var(--color-text)}
+.currency-switch__btn.active{background:var(--gradient-silver-luxe);color:#0f172a}
+.price-table-card__body{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.price-table-pro{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums;min-width:520px}
+.price-table-pro th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-5);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);white-space:nowrap}
+.price-table-pro th:not(:first-child){text-align:right}
+.price-table-pro td{padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.price-table-pro td:first-child{color:var(--color-text);font-weight:600;font-family:var(--font-display)}
+.price-table-pro td:not(:first-child){text-align:right;color:var(--color-text);font-weight:500}
+.price-table-pro td.price-table-pro__primary{color:var(--color-silver);font-weight:700}
+.price-table-pro tr:last-child td{border-bottom:none}
+.price-table-pro tr:hover td{background:color-mix(in oklch,var(--color-silver) 4%,var(--color-surface))}
+.price-table-pro .weight-label-sub{color:var(--color-text-faint);font-size:11px;font-weight:400;display:block;margin-top:2px;font-family:var(--font-body)}
 
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+/* ═════ PURITY GRID ═════ */
+.purity-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.purity-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.purity-cards{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:900px){.purity-cards{grid-template-columns:repeat(4,1fr);gap:var(--space-3)}}
+.purity-card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4);text-decoration:none;transition:all var(--transition);overflow:hidden;display:flex;flex-direction:column;gap:var(--space-2);color:var(--color-text)}
+.purity-card:hover{border-color:color-mix(in oklch,var(--color-silver) 50%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-md);color:var(--color-text);text-decoration:none}
+.purity-card--featured{background:linear-gradient(135deg,color-mix(in oklch,var(--color-silver) 14%,var(--color-surface)) 0%,var(--color-surface) 100%);border-color:var(--color-silver);box-shadow:0 0 0 1px var(--color-silver),var(--shadow-silver)}
+.purity-card--featured::before{content:'.999 FINE';position:absolute;top:8px;right:8px;font-size:9px;font-weight:700;letter-spacing:.1em;color:var(--color-silver);background:color-mix(in oklch,var(--color-silver) 14%,transparent);padding:2px 6px;border-radius:4px;font-family:var(--font-mono)}
+.purity-card__purity{font-family:var(--font-editorial);font-size:clamp(2rem,1.4rem + 2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.025em;line-height:1}
+.purity-card--featured .purity-card__purity{color:var(--color-silver);font-style:italic}
+.purity-card__grade{font-size:var(--text-sm);color:var(--color-silver);font-weight:700;font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+.purity-card__pct{font-size:11px;font-weight:600;color:var(--color-text-faint);font-family:var(--font-mono);letter-spacing:.1em;text-transform:uppercase}
+.purity-card__price{font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;padding-top:var(--space-2);border-top:1px solid var(--color-divider);margin-top:auto}
+.purity-card__price-label{display:block;font-size:10px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-bottom:2px}
+.purity-card__use{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
 
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+/* ═════ FORMULA BLOCK ═════ */
+.formula-block{max-width:920px;margin:var(--space-10) auto var(--space-8);padding:0 var(--space-4)}
+.formula-card{background:linear-gradient(180deg,var(--color-surface-offset) 0%,var(--color-surface) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6) var(--space-5);position:relative;overflow:hidden}
+@media(min-width:768px){.formula-card{padding:var(--space-8)}}
+.formula-card__eyebrow{font-size:11px;font-weight:700;color:var(--color-silver);text-transform:uppercase;letter-spacing:.12em;margin-bottom:var(--space-3)}
+.formula-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-4)}
+.formula-card__equation{font-family:var(--font-mono);font-size:clamp(.875rem,.8rem + .5vw,1.125rem);color:var(--color-text);background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);overflow-x:auto;-webkit-overflow-scrolling:touch;white-space:nowrap;font-variant-numeric:tabular-nums;line-height:1.6}
+.formula-card__equation .op{color:var(--color-silver);font-weight:600}
+.formula-card__equation .var{color:var(--color-primary);font-weight:600}
+.formula-card__steps{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:768px){.formula-card__steps{grid-template-columns:repeat(3,1fr)}}
+.formula-step{display:flex;gap:var(--space-3);padding:var(--space-3);background:var(--color-surface);border:1px solid var(--color-divider);border-radius:var(--radius-md)}
+.formula-step__num{flex-shrink:0;width:28px;height:28px;border-radius:50%;background:var(--gradient-silver-luxe);color:#0f172a;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
+.formula-step__text{font-size:var(--text-sm);color:var(--color-text);line-height:1.5}
+.formula-step__text strong{color:var(--color-silver);font-variant-numeric:tabular-nums}
 
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+/* ═════ USE CASE CARDS (Industrial / Investment / Heritage) ═════ */
+.luxe-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.luxe-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.luxe-cards{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:1024px){.luxe-cards{grid-template-columns:repeat(3,1fr)}}
+.luxe-card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-5) var(--space-6);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.luxe-card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-silver) 50%,transparent 100%);opacity:.7}
+.luxe-card::after{content:'';position:absolute;top:-30%;right:-30%;width:200px;height:200px;background:radial-gradient(circle,color-mix(in oklch,var(--color-silver) 12%,transparent) 0%,transparent 65%);pointer-events:none;transition:opacity var(--transition)}
+.luxe-card:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-luxe)}
+.luxe-card__icon{width:48px;height:48px;color:var(--color-silver);margin-bottom:var(--space-4)}
+.luxe-card__category{font-size:11px;font-weight:700;color:var(--color-silver);text-transform:uppercase;letter-spacing:.14em;margin-bottom:var(--space-2);font-family:var(--font-mono)}
+.luxe-card__title{font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:600;color:var(--color-text);line-height:1.25;margin-bottom:var(--space-3);font-style:italic}
+.luxe-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin-bottom:var(--space-4)}
+.luxe-card__stat{display:flex;align-items:baseline;gap:var(--space-2);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.luxe-card__stat-val{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.luxe-card__stat-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
 
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+/* ═════ DEMAND CHART (Industrial Silver Demand) ═════ */
+.seasonal{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.seasonal-card{background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);padding:var(--space-6) var(--space-5);position:relative;overflow:hidden}
+@media(min-width:768px){.seasonal-card{padding:var(--space-8)}}
+.seasonal-card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-silver) 50%,transparent 100%);opacity:.6}
+.seasonal-chart{display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:8px;margin-top:var(--space-5);align-items:end;min-height:200px}
+.seasonal-bar{position:relative;background:var(--color-surface-offset);border-radius:6px 6px 0 0;min-height:32px;transition:transform var(--transition);cursor:default;display:flex;align-items:flex-end;justify-content:center;padding-bottom:6px}
+.seasonal-bar::after{content:attr(data-cat);position:absolute;bottom:-36px;left:50%;transform:translateX(-50%);font-size:10px;font-weight:600;color:var(--color-text-faint);font-family:var(--font-mono);letter-spacing:.05em;text-transform:uppercase;white-space:nowrap;text-align:center;width:max-content;max-width:120%}
+.seasonal-bar--peak{background:var(--gradient-silver-luxe)}
+.seasonal-bar--high{background:linear-gradient(180deg,color-mix(in oklch,var(--color-silver) 70%,var(--color-surface)) 0%,color-mix(in oklch,var(--color-silver) 45%,var(--color-surface)) 100%)}
+.seasonal-bar--mid{background:linear-gradient(180deg,color-mix(in oklch,var(--color-silver) 35%,var(--color-surface)) 0%,color-mix(in oklch,var(--color-silver) 18%,var(--color-surface)) 100%)}
+.seasonal-bar:hover{transform:translateY(-2px)}
+.seasonal-bar__pct{font-size:11px;font-weight:700;color:#0f172a;background:rgba(255,255,255,.9);padding:2px 6px;border-radius:3px;font-family:var(--font-mono);letter-spacing:.04em}
+.seasonal-bar--mid .seasonal-bar__pct,.seasonal-bar--high .seasonal-bar__pct{background:rgba(15,23,42,.85);color:#f1f5f9}
+.seasonal-legend{display:flex;flex-wrap:wrap;gap:var(--space-3);margin-top:var(--space-10);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.seasonal-legend__item{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);color:var(--color-text-muted)}
+.seasonal-legend__swatch{width:14px;height:14px;border-radius:3px;flex-shrink:0}
+.seasonal-legend__swatch--peak{background:var(--gradient-silver-luxe)}
+.seasonal-legend__swatch--high{background:color-mix(in oklch,var(--color-silver) 60%,var(--color-surface))}
+.seasonal-legend__swatch--mid{background:color-mix(in oklch,var(--color-silver) 30%,var(--color-surface))}
+
+/* ═════ EDITORIAL PROSE ═════ */
+.content-section{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-12)}
+.prose-pro{max-width:760px;margin:0 auto}
+.prose-pro h2{font-family:var(--font-display);font-size:clamp(1.5rem,1.1rem + 1.5vw,2rem);font-weight:700;color:var(--color-text);margin:var(--space-12) 0 var(--space-4);line-height:1.2;letter-spacing:-.015em;position:relative;padding-top:var(--space-3)}
+.prose-pro h2::before{content:'';position:absolute;top:0;left:0;width:48px;height:3px;background:var(--gradient-silver-deep);border-radius:2px}
+.prose-pro h2:first-child{margin-top:0}
+.prose-pro h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-8) 0 var(--space-3);letter-spacing:-.01em}
+.prose-pro p{font-size:var(--text-base);color:var(--color-text);line-height:1.75;margin-bottom:var(--space-4)}
+.prose-pro ul,.prose-pro ol{padding-left:var(--space-5);margin-bottom:var(--space-5)}
+.prose-pro li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:var(--space-2)}
+.prose-pro li::marker{color:var(--color-silver)}
+.prose-pro strong{color:var(--color-text);font-weight:700}
+.prose-pro a{color:var(--color-primary);text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;transition:color var(--transition)}
+.prose-pro a:hover{color:var(--color-primary-hover);text-decoration-thickness:2px}
+.prose-pro blockquote{margin:var(--space-5) 0;padding:var(--space-4) var(--space-5);background:var(--color-surface);border-left:3px solid var(--color-silver);border-radius:var(--radius-md);font-family:var(--font-editorial);font-size:var(--text-lg);font-style:italic;color:var(--color-text);font-weight:500;line-height:1.5}
+.prose-pro blockquote strong{font-style:normal;font-family:var(--font-mono);color:var(--color-silver);font-size:var(--text-base);font-weight:600}
+.snippet-answer{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-silver);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);margin:var(--space-4) 0;font-size:var(--text-base);color:var(--color-text);line-height:1.7}
+.snippet-answer strong{color:var(--color-silver)}
+.callout{background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--color-silver) 30%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-5) 0;display:flex;gap:var(--space-3);align-items:flex-start}
+.callout__icon{flex-shrink:0;width:32px;height:32px;color:var(--color-silver);margin-top:2px}
+.callout__title{font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);font-family:var(--font-display)}
+.callout__body{font-size:var(--text-sm);color:var(--color-text);line-height:1.6}
+
+/* MARKET / TIMELINE TABLE */
+.market-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px solid var(--color-border);border-radius:var(--radius-lg);margin:var(--space-5) 0}
+.market-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:480px}
+.market-table th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-4);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
+.market-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text);vertical-align:top}
+.market-table td:first-child{font-weight:600;font-family:var(--font-display);white-space:nowrap}
+.market-table td:nth-child(2){color:var(--color-silver);font-family:var(--font-mono);font-size:11px;letter-spacing:.06em;white-space:nowrap}
+.market-table tr:last-child td{border-bottom:none}
+
+/* FAQ ACCORDION */
+.faq-pro{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+.faq-pro__item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.faq-pro__item:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
+.faq-pro__item[open]{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
+.faq-pro__summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;min-height:60px}
+.faq-pro__summary::-webkit-details-marker{display:none}
+.faq-pro__summary:hover{background:var(--color-surface-offset)}
+.faq-pro__summary:focus-visible{outline:2px solid var(--color-silver);outline-offset:-2px}
+.faq-pro__plus{flex-shrink:0;width:24px;height:24px;border:1px solid var(--color-border);border-radius:50%;display:flex;align-items:center;justify-content:center;position:relative;transition:transform var(--transition),border-color var(--transition),background var(--transition)}
+.faq-pro__plus::before,.faq-pro__plus::after{content:'';position:absolute;background:var(--color-text-muted);transition:transform var(--transition),background var(--transition)}
+.faq-pro__plus::before{width:10px;height:2px}
+.faq-pro__plus::after{width:2px;height:10px}
+.faq-pro__item[open] .faq-pro__plus{background:var(--color-silver);border-color:var(--color-silver);transform:rotate(45deg)}
+.faq-pro__item[open] .faq-pro__plus::before,.faq-pro__item[open] .faq-pro__plus::after{background:#0f172a}
+.faq-pro__body{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;border-top:1px solid var(--color-divider);padding-top:var(--space-4)}
+.faq-pro__body strong{color:var(--color-text)}
+
+/* STICKY MOBILE PRICE BAR */
+.sticky-price{position:fixed;bottom:0;left:0;right:0;background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-3) var(--space-4);z-index:80;display:none;align-items:center;gap:var(--space-3);box-shadow:0 -8px 24px rgba(0,0,0,.2);backdrop-filter:blur(12px);transform:translateY(100%);transition:transform .3s ease-out;padding-bottom:max(var(--space-3),env(safe-area-inset-bottom))}
+.sticky-price.visible{transform:translateY(0)}
+@media(max-width:768px){.sticky-price{display:flex}body{padding-bottom:80px}}
+.sticky-price__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.sticky-price__value{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;line-height:1.1}
+.sticky-price__info{flex:1;min-width:0}
+.sticky-price__cta{display:inline-flex;align-items:center;gap:6px;padding:10px var(--space-4);background:var(--gradient-silver-luxe);color:#0f172a;border-radius:var(--radius-md);font-size:var(--text-xs);font-weight:700;text-decoration:none;letter-spacing:.04em;text-transform:uppercase;min-height:44px;white-space:nowrap}
+.sticky-price__cta:hover{filter:brightness(1.08);color:#0f172a;text-decoration:none}
+
+/* DISCLAIMER */
+.disclaimer{margin-top:var(--space-8);padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--color-text-faint);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+.disclaimer strong{color:var(--color-text)}
 
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
-.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
 .mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
@@ -327,22 +415,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
 .footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
@@ -352,147 +424,47 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
+footer{background:var(--color-surface);border-top:1px solid var(--color-border)}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
-
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
-
-
-/* ── Shared layout CSS ── */
+/* Breadcrumb */
 .breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted)}
+.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted);flex-wrap:wrap}
 .breadcrumb li+li::before{content:"/";margin-right:var(--space-2);color:var(--color-text-faint)}
 .breadcrumb a{color:var(--color-text-muted);text-decoration:none}
 .breadcrumb a:hover{color:var(--color-primary)}
 .breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.hero-tag{display:inline-block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-.hero-title{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero-title{font-size:var(--text-xl)}
-.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:72ch;line-height:1.7;margin-bottom:var(--space-6)}
-.price-card{display:inline-flex;flex-direction:column;gap:var(--space-1);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-2)}
-.price-card{width:100%}
-.price-label{font-size:var(--text-sm);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.price-value{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-gold-bright);font-weight:400;line-height:1}
-.price-usd{font-size:var(--text-base);color:var(--color-text-muted)}
-.price-purity{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-1)}
-.prose{max-width:72ch}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-1)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose{max-width:100%}
-.content{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
-.data-source{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.faq-answer-summary{font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4);cursor:pointer;list-style:none;background:var(--color-surface-offset);transition:background .15s}
-.faq-answer-summary:hover{background:var(--color-surface-dynamic)}
-.faq-answer-summary::marker,.faq-answer-summary::-webkit-details-marker{display:none}
-.faq-answer-summary::after{content:"＋";float:right;color:var(--color-text-faint)}
-.faq-answer-summary::after{content:"－"}
-.faq-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-4);border-top:1px solid var(--color-divider)}
 
-/* ═══════════════════════════════════════════════
-   SILVER PER KILO — LAYOUT & COMPONENT FIXES
-   ═══════════════════════════════════════════════ */
+/* Share buttons */
+.share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) 0 var(--space-6);padding-top:var(--space-6);border-top:1px solid var(--color-border)}
+.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
+.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface);min-height:44px}
+.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset);text-decoration:none}
+.share-buttons a svg{flex-shrink:0}
 
-/* Hero: fix H1 size override, single-col flow */
-.hero{grid-template-columns:1fr;max-width:860px;padding:var(--space-8) var(--space-4) var(--space-6);align-items:start}
-.hero-title{font-size:clamp(1.75rem,3.5vw,2.75rem)!important;line-height:1.15!important;margin-bottom:var(--space-3)!important}
-
-/* Price tiles */
-.price-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin:var(--space-5) 0}
-.price-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);display:flex;flex-direction:column;gap:var(--space-1);transition:border-color .15s}
-.price-tile:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
-.price-tile-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-faint)}
-.price-tile-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;line-height:1.2}
-
-/* Content wrapper */
-.content{max-width:1200px;margin:0 auto;padding:var(--space-6) var(--space-4) var(--space-16)}
-
-/* Prose reading width (fix 100% override) */
-.prose{max-width:860px!important}
-
-/* Data tables */
-.data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-2) 0 var(--space-8)}
-.data-table thead tr{border-bottom:2px solid var(--color-border)}
-.data-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-4) var(--space-2) 0;white-space:nowrap}
-.data-table th:first-child{padding-left:0}
-.data-table td{padding:var(--space-3) var(--space-4) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle;white-space:nowrap}
-.data-table td:first-child{color:var(--color-text);font-weight:600;padding-left:0}
-.data-table tr:last-child td{border-bottom:none}
-.data-table td:nth-child(2),.data-table td:nth-child(3),.data-table td:nth-child(4),.data-table td:nth-child(5){font-variant-numeric:tabular-nums;color:var(--color-text)}
-
-/* Blockquote */
-blockquote{background:color-mix(in oklch,var(--color-silver) 6%,var(--color-surface-offset));border-left:3px solid var(--color-silver);border-radius:0 var(--radius-md) var(--radius-md) 0;padding:var(--space-4) var(--space-5);margin:var(--space-4) 0 var(--space-6);font-size:var(--text-base);color:var(--color-text-muted);max-width:860px}
-blockquote strong{color:var(--color-text)}
-
-/* Snippet answer */
-.snippet-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);margin-bottom:var(--space-6);max-width:860px;border-left:3px solid color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
-.snippet-answer span{font-weight:600;color:var(--color-text)}
-
-/* FAQ accordion */
-.faq-container{display:flex;flex-direction:column;gap:var(--space-2);margin:var(--space-2) 0 var(--space-6);max-width:860px}
-.prose details,.faq-container details{border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;margin-bottom:0}
-.faq-answer-summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5)!important;background:var(--color-surface)!important;user-select:none}
-.faq-answer-summary::after{content:"＋"!important;margin-left:var(--space-3);flex-shrink:0}
-details[open]>.faq-answer-summary{background:var(--color-surface-offset)!important}
-details[open]>.faq-answer-summary::after{content:"－"!important}
-.faq-answer,.prose details p{padding:var(--space-4) var(--space-5)!important;font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;border-top:1px solid var(--color-border);margin:0!important}
-
-/* Related guides container */
-.container{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4) var(--space-16)}
-.container h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-
-/* Breadcrumb alignment with content */
-ul.breadcrumb{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-
-@media(max-width:640px){
-  .price-grid{grid-template-columns:1fr}
-  .hero{padding:var(--space-6) var(--space-4) var(--space-4)}
-}
-
-/* ── Related guides grid ── */
-.related-guides-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-4);margin-top:var(--space-4)}
-@media(max-width:900px){.related-guides-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:540px){.related-guides-grid{grid-template-columns:1fr}}
-
-.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s}
-.related-card:hover{border-color:color-mix(in oklch,var(--color-primary) 40%,var(--color-border));box-shadow:var(--shadow-sm)}
-.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright)}
-.related-card__title{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.3}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin-top:auto}
-
-/* ── Share buttons ── */
-.share-buttons{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2);margin:var(--space-6) 0}
-.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);margin-right:var(--space-1)}
-.share-buttons a{display:inline-flex;align-items:center;gap:var(--space-2);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:var(--space-2) var(--space-4);text-decoration:none;transition:border-color .15s,color .15s,background .15s}
-.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:color-mix(in oklch,var(--color-primary) 6%,var(--color-surface))}
-.share-buttons svg{flex-shrink:0}
-
-/* ── Related Guides prose section (bottom) ── */
-.prose .related-guides-prose{margin:var(--space-6) 0}
-.prose .related-guides-prose ul{list-style:none;padding:0;display:flex;flex-direction:column;gap:var(--space-2)}
-.prose .related-guides-prose li a{color:var(--color-primary);font-weight:500;text-decoration:underline}
+/* Related guides */
+.related-guides{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.related-guides-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.related-guides-grid{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:900px){.related-guides-grid{grid-template-columns:repeat(4,1fr)}}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,transform .15s,box-shadow .15s;color:var(--color-text)}
+.related-card:hover{border-color:var(--color-silver);box-shadow:var(--shadow-md);transform:translateY(-2px);text-decoration:none;color:var(--color-text)}
+.related-card:hover .related-card__title{color:var(--color-silver)}
+.related-card__tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-silver);align-self:flex-start;padding:2px 8px;background:color-mix(in oklch,var(--color-silver) 10%,transparent);border-radius:99px}
+.related-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0;line-height:1.3;transition:color var(--transition)}
+.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
 </style>
-
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",
   "@type": "WebPage",
-  "name": "Silver Price Per Kilo",
+  "name": "Silver Price Per Kilo Today",
   "url": "https://goldpricetools.com/silver-price-per-kilo",
   "speakable": {
     "@type": "SpeakableSpecification",
-    "cssSelector": [".snippet-answer", ".faq-answer"]
+    "cssSelector": [".snippet-answer", ".faq-pro__body"]
   }
 }
 </script>
@@ -568,197 +540,620 @@ ul.breadcrumb{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-
     </div>
   </div>
 </nav>
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">Silver Price Per Kilo</li></ol></div>
-<div class="hero">
-  <div class="hero-tag">Live Silver Price</div>
-  <h1 class="hero-title">Silver Price Per Kilo Today</h1>
-  <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Live silver spot price in multiple weights. Updated every 60 seconds.</p>
-  <div class="price-grid">
-    <div class="price-tile"><div class="price-tile-label">Per Kilo (GBP)</div><div class="price-tile-value" id="p-kg-gbp" data-nosnippet>&mdash;</div></div>
-    <div class="price-tile"><div class="price-tile-label">Per Kilo (USD)</div><div class="price-tile-value" id="p-kg-usd" data-nosnippet>&mdash;</div></div>
-    <div class="price-tile"><div class="price-tile-label">Per Troy Oz (GBP)</div><div class="price-tile-value" id="p-oz-gbp" data-nosnippet>&mdash;</div></div>
-    <div class="price-tile"><div class="price-tile-label">Per Gram (GBP)</div><div class="price-tile-value" id="p-g-gbp" data-nosnippet>&mdash;</div></div>
+
+<div class="breadcrumb-wrap">
+  <ol class="breadcrumb" aria-label="Breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/guides/silver-guides/">Silver Guides</a></li>
+    <li aria-current="page">Silver Price Per Kilo</li>
+  </ol>
+</div>
+
+<!-- ═════════════ PREMIUM HERO ═════════════ -->
+<section class="hero-premium" aria-labelledby="hero-title">
+  <div class="hero-premium__inner">
+    <div class="hero-eyebrow">
+      <span class="hero-eyebrow__pulse" aria-hidden="true"></span>
+      <span>Live · LBMA Spot · XAG/USD</span>
+    </div>
+    <h1 class="hero-premium__title" id="hero-title">
+      Silver Price <span class="hero-premium__title-em">per kilo</span> today
+    </h1>
+    <p class="hero-premium__sub">Real-time <strong>.999 fine silver</strong> spot valuation in <strong>USD</strong>, GBP and EUR — refreshed every 60 seconds direct from LBMA London spot data. Per gram, per troy ounce, per 100g and per kilogram, plus a free 1kg bullion bar calculator.</p>
+
+    <!-- 3-currency live price tiles — USD primary -->
+    <div class="price-tiles" role="region" aria-label="Live silver prices per kilogram">
+      <article class="price-tile price-tile--primary">
+        <div class="price-tile__head">
+          <span class="price-tile__label">USD / kilo</span>
+          <span class="price-tile__flag">US · Primary</span>
+        </div>
+        <div class="price-tile__value" id="hero-usd" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>.999 fine · 32.1507 troy oz</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">GBP / kilo</span>
+          <span class="price-tile__flag">UK</span>
+        </div>
+        <div class="price-tile__value" id="hero-gbp" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>.999 fine · ex-VAT</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">EUR / kilo</span>
+          <span class="price-tile__flag">EU</span>
+        </div>
+        <div class="price-tile__value" id="hero-eur" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>.999 fine · ECB ref rate</div>
+      </article>
+    </div>
+
+    <!-- Live status bar -->
+    <div class="live-status" role="status" aria-live="polite">
+      <span class="live-status__dot" aria-hidden="true"></span>
+      <span class="live-status__label">Live</span>
+      <span class="live-status__divider" aria-hidden="true">·</span>
+      <span class="live-status__meta">Spot: <strong id="spot-usd" data-nosnippet>&mdash;</strong></span>
+      <span class="live-status__divider" aria-hidden="true">·</span>
+      <span class="live-status__meta">Updated <span id="updated-time">just now</span></span>
+      <span class="live-status__divider" aria-hidden="true">·</span>
+      <span class="live-status__meta">Refresh in <span id="refresh-counter">60s</span></span>
+      <a href="#calculator" class="live-status__cta">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>
+        Calculate
+      </a>
+    </div>
   </div>
-</div>
-<div class="content">
-  <p class="data-source">Live prices sourced from LBMA spot market via gold-api.com. Updated every 60 seconds. <a href="/about">About our data</a></p>
-  <div class="prose">
-    <h2>Silver Price by Weight</h2>
-    <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-    <table class="data-table" aria-label="Live silver price by weight">
-      <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
-      <tbody>
-        <tr><td>1 gram</td><td id="t-1g-gbp" data-nosnippet>&mdash;</td><td id="t-1g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>10 grams</td><td id="t-10g-gbp" data-nosnippet>&mdash;</td><td id="t-10g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>100 grams</td><td id="t-100g-gbp" data-nosnippet>&mdash;</td><td id="t-100g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>1 troy ounce (31.1g)</td><td id="t-oz-gbp" data-nosnippet>&mdash;</td><td id="t-oz-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>500 grams</td><td id="t-500g-gbp" data-nosnippet>&mdash;</td><td id="t-500g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>1 kilogram</td><td id="t-1k-gbp" data-nosnippet>&mdash;</td><td id="t-1k-usd" data-nosnippet>&mdash;</td></tr>
-      </tbody>
-    </table>
-    <h2>Silver Purity Grades</h2>
-<table class="data-table" aria-label="Silver purity grades and indicative prices">
-  <thead><tr><th>Purity</th><th>Grade</th><th>Price per Gram</th><th>Price per Kg</th><th>Price per Troy Oz</th></tr></thead>
-  <tbody>
-    <tr><td>.999</td><td>Fine</td><td id="t-ag999g">--</td><td id="t-ag999kg">--</td><td id="t-ag999oz">--</td></tr>
-    <tr><td>.925</td><td>Sterling</td><td id="t-ag925g">--</td><td id="t-ag925kg">--</td><td id="t-ag925oz">--</td></tr>
-    <tr><td>.900</td><td>Coin</td><td id="t-ag900g">--</td><td id="t-ag900kg">--</td><td id="t-ag900oz">--</td></tr>
-    <tr><td>.800</td><td>European</td><td id="t-ag800g">--</td><td id="t-ag800kg">--</td><td id="t-ag800oz">--</td></tr>
-  </tbody>
-</table>
+</section>
 
-<h2>About Silver Pricing</h2>
-    <p>Silver is priced per troy ounce on global spot markets. One troy ounce equals 31.1035 grams, so one kilogram of silver contains <strong>32.1507 troy ounces</strong>. The silver spot price is set continuously on exchanges including COMEX (New York) and LBMA (London).</p>
-    <h2 id="what-is-silver-price-per-kilo">What is the silver price per kilogram?</h2>
-<p class="snippet-answer">The silver price per kilogram is currently <span id="snippet-price" data-nosnippet>[current spot price]</span> today. This value is calculated by multiplying the live silver spot price per troy ounce by 32.1507. There are exactly 32.1507 troy ounces in one kilogram of silver. Use our live silver calculator below for current prices.</p>
-
-<h2 id="how-many-troy-oz-in-kilo-silver">How many troy ounces are in a kilogram of silver?</h2>
-<p class="snippet-answer">There are exactly 32.1507 troy ounces in one kilogram of silver. Because one troy ounce is equal to 31.1035 grams, you calculate this by dividing 1,000 grams by 31.1035, yielding the 32.1507 conversion factor.</p>
-
-<h2>Frequently Asked Questions</h2>
-<div class="faq-container">
-<div class="faq-card">
-  <h3 class="faq-answer-summary">What is the silver price per kilo today?</h3>
-  <p class="faq-answer">The silver price per kilogram is calculated by multiplying the spot price per troy ounce by 32.1507 (troy ounces per kilogram). The live price in GBP and USD is shown above, updated every 60 seconds.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">How many troy ounces are in a kilogram of silver?</h3>
-  <p class="faq-answer">There are 32.1507 troy ounces in one kilogram of silver. One troy ounce equals 31.1035 grams, so 1000 ÷ 31.1035 = 32.1507 troy oz/kg.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">What is the silver price per gram in GBP?</h3>
-  <p class="faq-answer">The silver price per gram in GBP equals the spot price per troy ounce ÷ 31.1035, then converted at the live GBP/USD exchange rate. The current live price is shown on this page.</p>
-</div>
+<!-- Trust strip -->
+<div class="trust-strip">
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    LBMA-sourced XAG spot
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+    60-second refresh
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/><circle cx="12" cy="12" r="10"/></svg>
+    USD · GBP · EUR
+  </span>
+  <a href="/about" class="trust-strip__item trust-strip__item--link">About our data &rarr;</a>
 </div>
 
-    <h2>What Is the Silver Price Per Kilogram?</h2>
-    <p>The silver price per kilogram is calculated directly from the global silver spot price, which is quoted in US dollars per troy ounce on the COMEX futures exchange and the LBMA in London. Because there are <strong>32.1507 troy ounces in one kilogram</strong> (not 31.1035 — that is per gram), the formula is:</p>
-    <blockquote><strong>Silver price per kg = Spot price (USD/troy oz) × 32.1507</strong></blockquote>
-    <p>For example, at a spot price of $33.00/oz, the silver price per kg = $33.00 × 32.1507 = <strong>$1,060.97 per kg</strong>. Our calculator above converts this to GBP, EUR, and INR in real time using live exchange rates.</p>
-
-    <h2>Why Track Silver Price Per Kilo?</h2>
-    <p>The per-kilogram price is most useful for:</p>
-    <ul>
-      <li><strong>Industrial buyers</strong> — manufacturers of solar panels, electronics, and medical devices purchase silver in kilograms or tonnes.</li>
-      <li><strong>Bulk scrap dealers</strong> — recyclers and refineries price silver by the kilo rather than gram.</li>
-      <li><strong>Large investors</strong> — 1 kg silver bars (such as those produced by the Royal Mint or PAMP Suisse) are a popular investment vehicle with lower premiums per ounce than smaller bars or coins.</li>
-    </ul>
-
-    <h2>Silver Spot Price Sources</h2>
-    <p>The global silver benchmark is set by the <strong>LBMA Silver Price</strong>, published once daily at noon London time by ICE Benchmark Administration. Throughout the trading day, the live price is determined by COMEX (New York) futures, with significant activity also in Shanghai (SHFE). GoldPriceTools sources live silver prices from gold-api.com, updated every 60 seconds during market hours.</p>
-
-    <h2>1 kg Silver Bar Prices in the UK</h2>
-    <p>A 1 kg silver bar typically carries a <em>premium over spot</em> of £30–£80 depending on the brand and retailer. Well-known brands available in the UK include Royal Mint, PAMP Suisse, Metalor, Umicore, and Baird & Co. Key points for UK buyers:</p>
-    <ul>
-      <li><strong>VAT</strong>: Silver bullion (bars and coins) is subject to 20% VAT in the UK, unlike gold which is VAT-exempt. Factor this into your cost basis.</li>
-      <li><strong>CGT</strong>: Profits on silver bullion are subject to Capital Gains Tax. Some silver coins (legal tender) may qualify for CGT exemption — check with HMRC or a tax adviser.</li>
-      <li><strong>Storage</strong>: 1 kg bars are practical to store at home or in a specialist bullion vault. Professional vault storage typically costs 0.5%–1% of asset value per year.</li>
-    </ul>
-
-    <h2>Silver Price History: Key Milestones</h2>
-    <p>Understanding historical context helps interpret current silver prices:</p>
-    <ul>
-      <li><strong>1980</strong>: Silver hit an all-time high of ~$50/oz driven by the Hunt Brothers' attempted cornering of the market.</li>
-      <li><strong>2011</strong>: Silver reached $49.80/oz during the commodity supercycle and QE-driven precious metals rally.</li>
-      <li><strong>2020</strong>: Pandemic-era monetary stimulus pushed silver to ~$29/oz.</li>
-      <li><strong>2021</strong>: The "Silver Squeeze" Reddit-driven event briefly spiked prices above $30/oz.</li>
-      <li><strong>2024–2026</strong>: Strong industrial demand (solar photovoltaic, EV batteries) and central bank gold buying (which supports the gold/silver ratio) have kept prices elevated.</li>
-    </ul>
-
-    <h2>Factors Driving the Silver Price</h2>
-    <p>Silver has a dual role as both a monetary metal and an industrial commodity, making its price dynamics more complex than gold:</p>
-    <ul>
-      <li><strong>Solar panel demand</strong> — Silver paste is a critical component in photovoltaic cells. The global solar energy build-out is a structural tailwind for silver demand.</li>
-      <li><strong>Electronics and EVs</strong> — Silver is used in EV battery management systems, 5G infrastructure, and semiconductor manufacturing.</li>
-      <li><strong>Investment demand</strong> — Silver ETFs, coins, and bars attract investment flows during periods of monetary uncertainty.</li>
-      <li><strong>Gold/silver ratio</strong> — Many investors monitor this ratio to assess relative value between the two metals.</li>
-      <li><strong>Mine supply</strong> — Approximately 70% of silver is produced as a by-product of copper, lead, and zinc mining, making supply relatively inelastic.</li>
-    </ul>
-
-    <h2>Frequently Asked Questions</h2>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">How many troy ounces are in a kilogram of silver?</h3>
-      <p class="faq-answer">There are exactly 32.1507 troy ounces in one kilogram. This is slightly different from avoirdupois ounces (35.274 oz/kg) — precious metals are always measured in troy ounces, not regular ounces.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Is silver a good investment in 2026?</h3>
-      <p class="faq-answer">Silver has structural industrial demand tailwinds from solar energy and electrification, and typically benefits from the same macroeconomic factors as gold (low real rates, dollar weakness, geopolitical risk). However, silver is significantly more volatile than gold and has higher industrial exposure, making it higher risk. Consult a qualified financial adviser before making investment decisions.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">What is the difference between the spot price and what I pay for a 1 kg silver bar?</h3>
-      <p class="faq-answer">The spot price is the theoretical price for immediate delivery of unallocated silver. Physical bars carry a premium to cover refining, fabrication, dealer margin, and VAT (in the UK). A 1 kg bar typically trades at spot plus £40–£80, plus 20% VAT, so the all-in cost is substantially above the spot price shown on our calculator.</p>
+<!-- ═════════════ LIVE CALCULATOR ═════════════ -->
+<section class="calc-pro" id="calculator" aria-labelledby="calc-title">
+  <div class="calc-pro__card">
+    <div class="calc-pro__head">
+      <div class="calc-pro__head-left">
+        <h2 class="calc-pro__title" id="calc-title">
+          <svg class="calc-pro__title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M12 14h.01M16 14h.01M8 18h2M12 18h.01M16 18h.01"/></svg>
+          Silver Calculator
+        </h2>
+        <p class="calc-pro__sub">Enter weight and choose a purity — get live melt value, dealer payout estimate and retail price for any silver bar, coin or scrap lot. <strong>USD primary</strong>, GBP and EUR conversions live.</p>
+      </div>
+      <span class="calc-pro__head-badge">
+        <span class="live-dot" aria-hidden="true"></span>
+        Live · 60s refresh
+      </span>
     </div>
 
-    <div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative spot values and do not include dealer premiums. Physical silver coins and bars typically sell at 5&ndash;20% above spot. Not financial advice.</div>
+    <div class="calc-pro__body">
+      <div class="calc-pro__row">
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-weight">Weight</label>
+          <input class="calc-pro__input" type="number" id="calc-weight" inputmode="decimal" placeholder="e.g. 1000" min="0" step="0.01" value="1000" aria-label="Weight value">
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-unit">Unit</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-unit" aria-label="Weight unit">
+              <option value="1" selected>grams</option>
+              <option value="0.001">kilograms</option>
+              <option value="31.1035">troy ounces</option>
+              <option value="28.3495">ounces (oz)</option>
+            </select>
+          </div>
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-currency">Currency</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-currency" aria-label="Display currency">
+              <option value="USD" selected>USD ($)</option>
+              <option value="GBP">GBP (£)</option>
+              <option value="EUR">EUR (€)</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class="calc-pro__row" style="grid-template-columns:1fr;margin-top:calc(-1 * var(--space-2))">
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-purity">Purity</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-purity" aria-label="Silver purity">
+              <option value="0.999" selected>.999 Fine Silver (bullion)</option>
+              <option value="0.925">.925 Sterling Silver</option>
+              <option value="0.900">.900 Coin Silver (US 1837–1964)</option>
+              <option value="0.800">.800 European Silver</option>
+              <option value="0.835">.835 Continental Silver</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class="calc-pro__chips" role="group" aria-label="Quick weight presets">
+        <span class="calc-pro__chips-label">Quick weights:</span>
+        <button class="calc-chip" type="button" data-weight="1" data-unit="1">1g</button>
+        <button class="calc-chip" type="button" data-weight="10" data-unit="1">10g</button>
+        <button class="calc-chip" type="button" data-weight="100" data-unit="1">100g</button>
+        <button class="calc-chip" type="button" data-weight="31.1035" data-unit="1">1 troy oz</button>
+        <button class="calc-chip" type="button" data-weight="500" data-unit="1">500g</button>
+        <button class="calc-chip active" type="button" data-weight="1000" data-unit="1">1kg bar</button>
+        <button class="calc-chip" type="button" data-weight="5000" data-unit="1">5kg</button>
+      </div>
+
+      <div class="calc-pro__result">
+        <div class="calc-pro__result-primary">
+          <span class="calc-pro__result-label-main">Melt value</span>
+          <span class="calc-pro__result-main" id="calc-melt" data-nosnippet>&mdash;</span>
+        </div>
+        <div class="calc-pro__result-grid">
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Dealer pays (~85%)</span>
+            <span class="calc-pro__result-item-value" id="calc-dealer" data-nosnippet>&mdash;</span>
+          </div>
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Retail + premium (~+5%)</span>
+            <span class="calc-pro__result-item-value" id="calc-retail" data-nosnippet>&mdash;</span>
+          </div>
+        </div>
+      </div>
+      <p class="calc-pro__hint">Formula: <code>weight (g) × (spot USD/oz ÷ 31.1035) × purity</code>. Silver dealer payouts typically sit at 82–90% of melt; 1kg bullion bars carry a $20–$60 premium over spot. <strong>UK buyers pay 20% VAT</strong> on silver bullion (unlike gold). <a href="/where-to-sell-gold-silver">Find the best dealers&nbsp;&rarr;</a></p>
+    </div>
   </div>
+</section>
+
+<!-- ═════════════ STAT CARDS ═════════════ -->
+<section class="stat-cards" aria-label="Silver key facts">
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 21h18M5 21V10l7-5 7 5v11M9 13h6M9 17h6"/></svg>
+    <div class="stat-card__value">32.1507</div>
+    <div class="stat-card__label">Troy ounces per kilogram of silver</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M9 12l2 2 4-4"/></svg>
+    <div class="stat-card__value">.999</div>
+    <div class="stat-card__label">Fine silver — the LBMA bullion standard</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2"/></svg>
+    <div class="stat-card__value">~50%</div>
+    <div class="stat-card__label">Of annual silver demand is industrial use</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+    <div class="stat-card__value">12:00 GMT</div>
+    <div class="stat-card__label">LBMA Silver Price daily benchmark fix</div>
+  </article>
+</section>
+
+<!-- ═════════════ LIVE PRICE TABLE ═════════════ -->
+<section class="price-table-section" aria-labelledby="price-table-title">
+  <div class="price-table-card">
+    <div class="price-table-card__head">
+      <div>
+        <h2 class="price-table-card__title" id="price-table-title">Silver Price by Weight</h2>
+        <p class="price-table-card__sub"><strong>Live</strong> · .999 fine silver · 1g to 1kg · USD primary</p>
+      </div>
+      <div class="currency-switch" role="tablist" aria-label="Choose currency to highlight">
+        <button class="currency-switch__btn active" role="tab" data-currency="USD" aria-selected="true">USD</button>
+        <button class="currency-switch__btn" role="tab" data-currency="GBP" aria-selected="false">GBP</button>
+        <button class="currency-switch__btn" role="tab" data-currency="EUR" aria-selected="false">EUR</button>
+      </div>
+    </div>
+    <div class="price-table-card__body">
+      <figure itemscope itemtype="https://schema.org/Table" style="margin:0">
+        <figcaption class="sr-only">Live .999 fine silver price by weight in USD, GBP and EUR — updated every 60 seconds</figcaption>
+        <table class="price-table-pro" aria-label="Silver price by weight">
+          <thead><tr><th>Weight</th><th data-col="USD">USD</th><th data-col="GBP">GBP</th><th data-col="EUR">EUR</th></tr></thead>
+          <tbody>
+            <tr><td>1g <span class="weight-label-sub">Per-gram benchmark</span></td><td id="t-1g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-1g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-1g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>10g <span class="weight-label-sub">Small ingot</span></td><td id="t-10g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-10g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-10g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>100g <span class="weight-label-sub">Small bar / scrap lot</span></td><td id="t-100g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-100g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-100g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1 <a href="/how-many-grams-in-troy-ounce">troy oz</a> <span class="weight-label-sub">31.1035g · Spot quote unit</span></td><td id="t-oz-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-oz-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-oz-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>500g <span class="weight-label-sub">Half kilo bar</span></td><td id="t-500g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-500g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-500g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1 kg <span class="weight-label-sub">32.1507 troy oz · bullion standard</span></td><td id="t-1k-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-1k-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-1k-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+          </tbody>
+        </table>
+      </figure>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ PURITY GRID ═════════════ -->
+<section class="purity-section" aria-labelledby="purity-section-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Purity grades</span>
+      <h2 class="section-title" id="purity-section-title">Silver Purity Compared</h2>
+      <p class="section-sub">All four grades use the same silver spot price as a base, multiplied by the purity ratio. .999 fine silver is the LBMA bullion standard; .925 sterling is the global jewellery benchmark. Live USD prices below.</p>
+    </div>
+  </div>
+  <div class="purity-cards">
+    <div class="purity-card purity-card--featured">
+      <div class="purity-card__purity">.999</div>
+      <div class="purity-card__grade">Fine Silver</div>
+      <div class="purity-card__pct">99.9% pure</div>
+      <div class="purity-card__use">Investment bullion · LBMA standard · 1kg bars</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / kilo</span><span id="purity-999-usd" data-nosnippet>&mdash;</span></div>
+    </div>
+    <a href="/800-silver-price-per-gram" class="purity-card">
+      <div class="purity-card__purity">.925</div>
+      <div class="purity-card__grade">Sterling</div>
+      <div class="purity-card__pct">92.5% pure</div>
+      <div class="purity-card__use">Jewellery, flatware, hallmarked global standard</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / kilo</span><span id="purity-925-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/900-silver-price-per-gram" class="purity-card">
+      <div class="purity-card__purity">.900</div>
+      <div class="purity-card__grade">Coin Silver</div>
+      <div class="purity-card__pct">90.0% pure</div>
+      <div class="purity-card__use">US pre-1965 dimes, quarters, half dollars</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / kilo</span><span id="purity-900-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/800-silver-price-per-gram" class="purity-card">
+      <div class="purity-card__purity">.800</div>
+      <div class="purity-card__grade">European</div>
+      <div class="purity-card__pct">80.0% pure</div>
+      <div class="purity-card__use">Continental European antique silverware</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / kilo</span><span id="purity-800-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+  </div>
+</section>
+
+<!-- ═════════════ FORMULA BLOCK ═════════════ -->
+<section class="formula-block" aria-labelledby="formula-title">
+  <div class="formula-card">
+    <div class="formula-card__eyebrow">The Math</div>
+    <h2 class="formula-card__title" id="formula-title">How the silver price per kilo is calculated</h2>
+    <p style="color:var(--color-text-muted);font-size:var(--text-sm);margin-bottom:var(--space-4);line-height:1.7">Silver is quoted globally in <strong style="color:var(--color-silver)">USD per troy ounce</strong> on COMEX (New York) and via the LBMA Silver Price benchmark in London. Because a kilogram contains <strong style="color:var(--color-silver)">32.1507 troy ounces</strong>, the per-kilo price is a direct multiplication of the spot price.</p>
+    <div class="formula-card__equation"><span class="var">silver USD/kg</span> <span class="op">=</span> <span class="var">spot USD/oz</span> <span class="op">×</span> 32.1507</div>
+    <div class="formula-card__steps">
+      <div class="formula-step">
+        <div class="formula-step__num">1</div>
+        <div class="formula-step__text">Take the live LBMA spot price (<strong>USD per troy oz</strong> of .999 fine silver)</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">2</div>
+        <div class="formula-step__text">Multiply by <strong>32.1507</strong> — troy ounces in 1 kilogram (1,000 ÷ 31.1035)</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">3</div>
+        <div class="formula-step__text">For lower purities, multiply by purity factor (e.g. <strong>0.925</strong> for sterling)</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ USE CASES ═════════════ -->
+<section class="luxe-section" aria-labelledby="usecase-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Why silver matters</span>
+      <h2 class="section-title" id="usecase-title">Industrial demand &amp; investment uses</h2>
+      <p class="section-sub">Unlike gold, silver carries a dual identity: ~50% of demand is industrial (solar, electronics, EVs) and ~50% is investment/jewellery. Three live USD valuations below cover the full spectrum.</p>
+    </div>
+  </div>
+  <div class="luxe-cards">
+    <article class="luxe-card">
+      <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <rect x="6" y="8" width="36" height="28" rx="2"/>
+        <path d="M6 16h36M14 16v20M24 16v20M34 16v20M6 24h36M6 30h36"/>
+        <circle cx="20" cy="42" r="2"/>
+        <circle cx="28" cy="42" r="2"/>
+      </svg>
+      <div class="luxe-card__category">Solar PV</div>
+      <h3 class="luxe-card__title">The silver in every solar panel</h3>
+      <p class="luxe-card__desc">Solar photovoltaic cells use silver paste in their conductive contacts — each standard panel consumes ~20g of silver. The global solar build-out absorbs <strong>~165 million troy oz/year</strong>, the single largest industrial silver demand sector.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-solar-stat" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">20g of silver per solar panel</span>
+      </div>
+    </article>
+    <article class="luxe-card">
+      <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <rect x="8" y="14" width="32" height="22" rx="2"/>
+        <path d="M14 14v-4M22 14v-4M30 14v-4M14 36v4M22 36v4M30 36v4"/>
+        <circle cx="16" cy="25" r="1.5" fill="currentColor"/>
+        <circle cx="24" cy="25" r="1.5" fill="currentColor"/>
+        <circle cx="32" cy="25" r="1.5" fill="currentColor"/>
+        <path d="M12 19h24M12 31h24"/>
+      </svg>
+      <div class="luxe-card__category">Electronics &amp; EVs</div>
+      <h3 class="luxe-card__title">Silver in 5G &amp; battery management</h3>
+      <p class="luxe-card__desc">Every EV uses 25–50g of silver across battery management systems and power electronics. 5G base stations, semiconductors and contact switches push electronics demand toward <strong>250 million troy oz/year</strong> — and supply is largely inelastic.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-ev-stat" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">~40g per EV (industry avg.)</span>
+      </div>
+    </article>
+    <article class="luxe-card">
+      <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path d="M10 14h28v20H10z"/>
+        <path d="M14 14v20M22 14v20M30 14v20"/>
+        <path d="M12 14l-4-4h32l-4 4"/>
+        <text x="24" y="29" text-anchor="middle" font-size="9" fill="currentColor" stroke="none" font-family="ui-monospace,monospace">1kg</text>
+      </svg>
+      <div class="luxe-card__category">1kg Bullion Bars</div>
+      <h3 class="luxe-card__title">The investment-grade benchmark</h3>
+      <p class="luxe-card__desc">A 1kg <strong>.999 fine</strong> silver bar is the global investment benchmark — produced by Royal Mint, PAMP Suisse, Metalor, Heraeus and Umicore. Premium over spot is typically <strong>$20–$60</strong>. UK buyers pay 20% VAT; US buyers pay sales tax in most states.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-bar-stat" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">1kg bar melt value (USD)</span>
+      </div>
+    </article>
+  </div>
+</section>
+
+<!-- ═════════════ SILVER DEMAND BREAKDOWN ═════════════ -->
+<section class="seasonal" aria-labelledby="demand-title">
+  <div class="seasonal-card">
+    <span class="section-eyebrow">Demand mix</span>
+    <h2 class="section-title" id="demand-title" style="margin-top:var(--space-2)">Where the world's silver demand goes</h2>
+    <p class="section-sub">Total annual silver demand is ~1.2 billion troy ounces. Roughly half is industrial — that share is rising as solar PV and EV adoption scale. Hover any bar to see the share.</p>
+    <div class="seasonal-chart" role="img" aria-label="Silver demand breakdown chart showing industrial demand at 48%, jewellery at 17%, coins and bars at 22%, silverware at 5%, photography at 3%, other at 5%">
+      <div class="seasonal-bar seasonal-bar--peak" style="height:96%" data-cat="Industrial"><span class="seasonal-bar__pct">48%</span></div>
+      <div class="seasonal-bar seasonal-bar--high" style="height:44%" data-cat="Coins &amp; Bars"><span class="seasonal-bar__pct">22%</span></div>
+      <div class="seasonal-bar seasonal-bar--high" style="height:34%" data-cat="Jewellery"><span class="seasonal-bar__pct">17%</span></div>
+      <div class="seasonal-bar seasonal-bar--mid" style="height:14%" data-cat="Silverware"><span class="seasonal-bar__pct">5%</span></div>
+      <div class="seasonal-bar seasonal-bar--mid" style="height:10%" data-cat="Photography"><span class="seasonal-bar__pct">3%</span></div>
+      <div class="seasonal-bar seasonal-bar--mid" style="height:10%" data-cat="Other"><span class="seasonal-bar__pct">5%</span></div>
+    </div>
+    <div class="seasonal-legend">
+      <span class="seasonal-legend__item"><span class="seasonal-legend__swatch seasonal-legend__swatch--peak"></span>Industrial (solar PV, EVs, electronics, 5G)</span>
+      <span class="seasonal-legend__item"><span class="seasonal-legend__swatch seasonal-legend__swatch--high"></span>Investment &amp; jewellery</span>
+      <span class="seasonal-legend__item"><span class="seasonal-legend__swatch seasonal-legend__swatch--mid"></span>Silverware, photography &amp; other</span>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ EDITORIAL CONTENT ═════════════ -->
+<div class="content-section">
+  <article class="prose-pro">
+    <h2 id="what-is-silver-price-per-kilo">What is the silver price per kilogram today?</h2>
+    <div class="snippet-answer">The live silver price per kilogram is approximately <strong><span id="snippet-price" data-nosnippet>[live USD value]</span></strong> today. This is calculated by multiplying the live silver spot price per troy ounce (USD) by <strong>32.1507</strong>, the number of troy ounces in one kilogram. USD is the primary currency on this page since silver is globally quoted in US dollars on COMEX and the LBMA. GBP and EUR conversions use live ECB reference rates and refresh every 60 seconds.</div>
+
+    <h2 id="how-many-troy-oz-in-kilo-silver">How many troy ounces are in a kilogram of silver?</h2>
+    <div class="snippet-answer">There are exactly <strong>32.1507 troy ounces</strong> in one kilogram of silver. Because one troy ounce equals 31.1035 grams, you compute this by dividing 1,000 grams by 31.1035. Note this differs from the avoirdupois ounce (≈35.274 oz/kg) — precious metals are always measured in troy ounces, never regular ounces.</div>
+
+    <h2>The LBMA Silver Price &amp; how the spot is set</h2>
+    <p>Silver's global benchmark is the <strong>LBMA Silver Price</strong>, an electronic auction conducted at <strong>12:00 GMT daily</strong> by ICE Benchmark Administration. Throughout the trading day, the live spot price is set by COMEX (New York) silver futures, with significant activity in Shanghai (SHFE) and London OTC markets. GoldPriceTools sources live XAG/USD spot prices from <code style="font-family:var(--font-mono);background:var(--color-surface-offset);padding:2px 6px;border-radius:4px;font-size:90%">gold-api.com</code> (LBMA-derived), updated every 60 seconds. Currency conversion to GBP and EUR uses the <strong>Frankfurter API</strong> (ECB reference rates).</p>
+
+    <h2>Why track the silver price per kilo?</h2>
+    <p>The per-kilogram price is the most relevant unit for several distinct audiences:</p>
+    <ul>
+      <li><strong>Industrial buyers</strong> — Manufacturers of solar panels, EVs, electronics, brazing alloys and medical devices purchase silver in kilograms or tonnes. Their procurement teams hedge against the kilo price.</li>
+      <li><strong>Bulk scrap dealers</strong> — Recyclers and refineries price silver scrap by the kilo rather than gram, particularly for industrial e-waste streams.</li>
+      <li><strong>Investors in 1kg bars</strong> — A 1kg .999 silver bar (Royal Mint, PAMP Suisse, Metalor, Umicore, Heraeus, Baird &amp; Co) is one of the most cost-efficient ways to hold silver, with lower premiums per ounce than smaller bars or coins.</li>
+      <li><strong>Estate &amp; antique valuers</strong> — Inherited sterling tea services, candelabras and flatware are typically several kilos of silver content — the per-kilo benchmark is essential.</li>
+    </ul>
+
+    <h2>1kg silver bars: premium, VAT &amp; storage</h2>
+    <p>A 1kg silver bar contains <strong>32.1507 troy ounces</strong> of pure silver. Premiums over spot vary by brand and retailer:</p>
+    <div class="market-table-wrap">
+      <table class="market-table" aria-label="1kg silver bar brand comparison">
+        <thead><tr><th>Brand</th><th>Origin</th><th>Typical premium / kg</th></tr></thead>
+        <tbody>
+          <tr><td>The Royal Mint</td><td>LBMA-accredited UK</td><td>$40–$60 over spot</td></tr>
+          <tr><td>PAMP Suisse</td><td>LBMA-accredited Swiss</td><td>$35–$55 over spot</td></tr>
+          <tr><td>Metalor</td><td>LBMA-accredited Swiss</td><td>$30–$50 over spot</td></tr>
+          <tr><td>Heraeus</td><td>LBMA-accredited German</td><td>$30–$50 over spot</td></tr>
+          <tr><td>Umicore</td><td>LBMA-accredited Belgian</td><td>$25–$45 over spot</td></tr>
+          <tr><td>Generic / private mint</td><td>Various</td><td>$20–$35 over spot</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="callout">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg>
+      <div>
+        <div class="callout__title">UK VAT &amp; CGT</div>
+        <div class="callout__body">Silver bullion is subject to <strong>20% VAT</strong> in the UK (gold is exempt). Profits are subject to <strong>Capital Gains Tax</strong>, though Royal Mint silver coins that are UK legal tender (e.g. Britannias) qualify for CGT exemption. Always confirm with HMRC or a qualified tax adviser before significant purchases.</div>
+      </div>
+    </div>
+    <p>Professional vault storage runs at 0.5–1% of asset value per year and includes full insurance. Home storage is viable for 1–5 kg holdings; beyond that the insurance premium typically exceeds vault fees. Reputable UK vaults include Brink's, Loomis, and the Royal Mint's own Vault Service.</p>
+
+    <h2>Silver price history: key milestones</h2>
+    <p>Understanding historical context helps interpret current silver levels. The metal has experienced four major price events in the modern era:</p>
+    <ul>
+      <li><strong>1980 — The Hunt Brothers</strong>: Silver hit an all-time peak of ~$50/oz as the Hunt family attempted to corner the market. The crash that followed wiped out fortunes and led to the New York COMEX raising margin requirements ("Silver Thursday", 27 March 1980).</li>
+      <li><strong>2011 — Post-GFC peak</strong>: Silver reached $49.80/oz during the commodity supercycle and QE-driven precious metals rally. It came within $0.20 of the 1980 high before reversing.</li>
+      <li><strong>2020 — Pandemic stimulus</strong>: COVID-era monetary stimulus pushed silver from a March 2020 low of $11.94 to ~$29/oz by August — one of the sharpest 5-month rallies in history.</li>
+      <li><strong>2021 — The Silver Squeeze</strong>: A Reddit-driven retail movement briefly pushed prices above $30/oz before institutional flows reasserted control.</li>
+      <li><strong>2024–2026 — Industrial supercycle</strong>: Strong solar PV demand, EV adoption, central bank gold buying (lifting the silver-to-gold ratio), and persistent supply deficits have kept silver elevated and increasingly correlated with energy transition stocks.</li>
+    </ul>
+
+    <h2>Factors driving the silver price</h2>
+    <p>Silver's dual role as both a monetary metal and an industrial commodity makes its price dynamics more complex than gold. The major drivers in 2026 are:</p>
+    <ul>
+      <li><strong>Solar PV demand</strong> — Silver paste is critical to crystalline silicon photovoltaic cells. The global solar build-out absorbs ~165 million oz/year and rising. Any thrifting (silver-per-cell reduction) is more than offset by gigawatt growth.</li>
+      <li><strong>EV &amp; electronics</strong> — Silver is used in EV battery management systems, 5G infrastructure, semiconductors and contact switches. Industrial demand has overtaken jewellery as the largest single category.</li>
+      <li><strong>Investment demand</strong> — Silver ETFs (SLV, SIVR, PHAG), coins (American Silver Eagle, Britannia, Maple Leaf) and bars attract investment flows during periods of monetary uncertainty.</li>
+      <li><strong>Gold/silver ratio</strong> — Many investors monitor this ratio (currently ~80–85) to time relative-value trades. See our live <a href="/gold-silver-ratio">gold-silver ratio tracker</a>.</li>
+      <li><strong>Mine supply</strong> — ~70% of mined silver is a by-product of copper, lead, and zinc mining, making supply relatively inelastic to silver price. This is structurally bullish in deficit periods.</li>
+      <li><strong>USD strength</strong> — Silver is priced in USD globally. Dollar weakness typically lifts the silver price for non-USD buyers; dollar strength compresses it.</li>
+    </ul>
+
+    <div class="callout">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/><path d="M9 12l2 2 4-4"/></svg>
+      <div>
+        <div class="callout__title">Volatility note</div>
+        <div class="callout__body">Silver typically exhibits <strong>1.5×–2× the volatility of gold</strong> because of its smaller market size and industrial-demand cyclicality. A 1% move in gold often corresponds to a 2% move in silver. Plan position sizing accordingly.</div>
+      </div>
+    </div>
+
+    <h2>How to calculate the silver price per kilogram</h2>
+    <p>The formula is straightforward:</p>
+    <blockquote><strong>Silver USD/kg = Spot USD/oz × 32.1507</strong></blockquote>
+    <p>For example, at a spot price of $33.00/troy oz:</p>
+    <ul>
+      <li>Silver per kg (.999 fine) = $33.00 × 32.1507 = <strong>$1,060.97 / kg</strong></li>
+      <li>Sterling silver (.925) per kg = $1,060.97 × 0.925 = <strong>$981.40 / kg</strong></li>
+      <li>Coin silver (.900) per kg = $1,060.97 × 0.900 = <strong>$954.87 / kg</strong></li>
+    </ul>
+    <p>These are <em>melt values</em> — the intrinsic silver content value. Dealers typically pay <strong>82–90% of melt</strong> for scrap (higher for .999 bullion, lower for low-purity flatware). Retail bullion bars trade at melt + brand premium ($20–$60 per kg). UK retail prices additionally include 20% VAT.</p>
+
+    <h2>Silver vs gold: which is better in 2026?</h2>
+    <p>Silver and gold often correlate but diverge in important ways:</p>
+    <ul>
+      <li><strong>Industrial exposure</strong> — Silver benefits from solar &amp; EV growth; gold does not. In bull cycles silver typically outperforms.</li>
+      <li><strong>Volatility</strong> — Silver swings 1.5–2× gold. Higher upside, higher downside.</li>
+      <li><strong>Tax treatment (UK)</strong> — Gold bullion is VAT-exempt; silver attracts 20% VAT. This is a meaningful entry-cost difference.</li>
+      <li><strong>Storage density</strong> — Gold is ~80× more valuable per gram. A $50,000 gold position fits in your hand; the equivalent silver position weighs ~50 kg.</li>
+      <li><strong>Liquidity</strong> — Both are highly liquid, but gold has a deeper investment bid; silver has stronger industrial bid.</li>
+    </ul>
+    <p>Many investors hold both, with silver weighted toward growth and gold toward defensive monetary hedging. Track the live ratio on our <a href="/gold-silver-ratio">gold-silver ratio page</a>.</p>
+
+    <h2>Frequently asked questions</h2>
+    <div class="faq-pro">
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What is the silver price per kilo today in USD?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">The live silver price per kilogram in USD is shown in the hero tile at the top of this page and refreshes every 60 seconds. It is calculated by multiplying the live LBMA-derived spot price (USD per troy ounce) by <strong>32.1507</strong> — the number of troy ounces in a kilogram. USD is the primary currency on this page because silver is quoted globally in US dollars.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How many troy ounces are in a kilogram of silver?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">There are exactly <strong>32.1507 troy ounces</strong> in one kilogram. This is slightly different from avoirdupois ounces (≈35.274 oz/kg) — precious metals are always measured in troy ounces, not regular ounces. The conversion: 1,000 grams ÷ 31.1035 grams per troy oz = 32.1507.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How much does a 1kg silver bar cost?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">A 1kg .999 silver bar has a <strong>melt value equal to the live spot price × 32.1507</strong> (use the calculator above for the live figure). Physical bars from LBMA-accredited refiners carry a premium of <strong>$20–$60 over spot</strong>, depending on brand. UK buyers also pay 20% VAT; US buyers pay sales tax in most states.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Why is silver priced in USD globally?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Silver is quoted in US dollars per troy ounce on the COMEX futures exchange and via the LBMA Silver Price daily auction in London. USD is the world's reserve currency and the most liquid quote unit for precious metals globally. All conversions to GBP, EUR, INR or any other currency are mathematically derived from the live USD spot using ECB or live FX rates.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Why does the silver price vary between websites?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Small differences reflect the timing of each site's data feed, the spot price source (LBMA, COMEX OTC, or composite), and FX conversion timestamps. GoldPriceTools fetches USD spot from <strong>gold-api.com</strong> (LBMA-sourced) and FX rates from the <strong>Frankfurter API</strong> (ECB reference rates), both updated every 60 seconds — and applied uniformly across every page on this site for cross-page consistency.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Is silver a good investment in 2026?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Silver has structural industrial tailwinds from solar PV and EV adoption, and typically benefits from the same macroeconomic factors as gold (low real rates, dollar weakness, geopolitical risk). However, silver is significantly more volatile than gold (1.5–2×) and has higher industrial exposure. UK silver bullion is also subject to 20% VAT. Consult a qualified financial adviser before making investment decisions.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What is the difference between .999, .925, .900 and .800 silver?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body"><strong>.999 fine silver</strong> is investment-grade bullion (99.9% pure). <strong>.925 sterling</strong> is the global jewellery and flatware standard (92.5% pure, balance copper). <strong>.900 coin silver</strong> was used in US dimes, quarters, half dollars and silver dollars 1837–1964. <strong>.800 European silver</strong> is the historical Continental antique silverware standard. To compute melt value: multiply the silver spot price by the purity factor.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How accurate are these live prices?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Spot prices come direct from the LBMA via gold-api.com and refresh every 60 seconds. Currency conversion from USD to GBP and EUR uses the Frankfurter API's live ECB reference rates. These figures are <em>melt values</em> — the raw silver content. Dealer buy prices for silver are typically 82–90% of melt; retail bars include brand premium and (in the UK) 20% VAT.</div>
+      </details>
+    </div>
+
+    <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Dealer buy prices are typically 82–90% of melt. Brand premiums, taxes (UK 20% VAT, US sales tax) and shop margins apply at retail. Always verify with your dealer before transacting.</div>
+  </article>
 </div>
-<div class="content" style="padding-bottom:1.5rem">
-<!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
+
+<!-- Social share buttons -->
+<div class="content-section" style="padding-top:0;padding-bottom:1.5rem">
+<div class="share-buttons" style="max-width:760px;margin:0 auto">
   <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/silver-price-per-kilo&text=Silver+Price+Per+Kilo+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
-  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/silver-price-per-kilo&title=Silver+Price+Per+Kilo+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=Silver+Price+Per+Kilo+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fsilver-price-per-kilo" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/silver-price-per-kilo&text=Silver+Price+Per+Kilo+Today+%28Live+USD%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/silver-price-per-kilo&title=Silver+Price+Per+Kilo+Today+%28Live+USD%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=Silver+Price+Per+Kilo+Today+%28Live+USD%29%20https%3A%2F%2Fgoldpricetools.com%2Fsilver-price-per-kilo" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
 </div>
 </div>
 
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
-    <h2>Related Gold &amp; Silver Guides</h2>
-    <div class="related-guides-grid">
-      <a href="/800-silver-price-per-gram" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">.800 Silver Price Per Gram</div>
-        <div class="related-card__desc">Today's .800 silver price per gram — European silver standard.</div>
-      </a>
-      <a href="/900-silver-price-per-gram" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">.900 Silver Price Per Gram</div>
-        <div class="related-card__desc">Live .900 silver price per gram — common in US coins and antique silverware.</div>
-      </a>
-      <a href="/gold-silver-ratio" class="related-card">
-        <div class="related-card__tag">Live Tool</div>
-        <div class="related-card__title">Gold-Silver Ratio</div>
-        <div class="related-card__desc">Track the live gold-to-silver ratio to time your silver purchases.</div>
-      </a>
-      <a href="/guides/silver-price-per-gram-explained" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Silver Price Per Gram Explained</div>
-        <div class="related-card__desc">How the silver spot price translates to per-gram and per-kilo rates.</div>
-      </a>
-      <a href="/guides/gold-vs-silver-investment" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold vs Silver Investment</div>
-        <div class="related-card__desc">Compare silver kilobars vs gold bars as long-term stores of value.</div>
-      </a>
-      <a href="/guides/what-is-925-sterling-silver" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">What is 925 Sterling Silver?</div>
-        <div class="related-card__desc">Understanding silver purity grades — .800, .900, .925 and .999 fine silver.</div>
-      </a>
+<!-- Related Guides -->
+<section class="related-guides" aria-labelledby="related-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Keep reading</span>
+      <h2 class="section-title" id="related-title">Related Silver &amp; Gold Guides</h2>
     </div>
+  </div>
+  <div class="related-guides-grid">
+    <a href="/800-silver-price-per-gram" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">.800 Silver Price Per Gram</div>
+      <div class="related-card__desc">Today's .800 silver per gram — the European Continental silver standard.</div>
+    </a>
+    <a href="/900-silver-price-per-gram" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">.900 Silver Price Per Gram</div>
+      <div class="related-card__desc">Live .900 silver per gram — used in US pre-1965 coinage and silverware.</div>
+    </a>
+    <a href="/silver-coins-calculator" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">Silver Coins Calculator</div>
+      <div class="related-card__desc">Calculate live USD melt value of US silver coins, Eagles and Britannias.</div>
+    </a>
+    <a href="/gold-silver-ratio" class="related-card">
+      <span class="related-card__tag">Live Tool</span>
+      <div class="related-card__title">Gold-Silver Ratio</div>
+      <div class="related-card__desc">Track the live gold-to-silver ratio — a key precious metals timing indicator.</div>
+    </a>
+    <a href="/us-silver-dollar-values" class="related-card">
+      <span class="related-card__tag">Live Tool</span>
+      <div class="related-card__title">US Silver Dollar Values</div>
+      <div class="related-card__desc">Morgan, Peace and Eisenhower dollar melt values at live USD spot.</div>
+    </a>
+    <a href="/guides/silver-price-per-gram-explained" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Silver Per Gram Explained</div>
+      <div class="related-card__desc">How spot price translates to per-gram, per-kilo and per-troy-oz rates.</div>
+    </a>
+    <a href="/guides/what-is-925-sterling-silver" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">What is 925 Sterling Silver?</div>
+      <div class="related-card__desc">Understanding silver purity grades — .800, .900, .925 and .999 fine silver.</div>
+    </a>
+    <a href="/scrap-gold-calculator" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">Scrap Gold Calculator</div>
+      <div class="related-card__desc">Live USD melt value for gold scrap by karat — complementary to silver.</div>
+    </a>
   </div>
 </section>
 
-
-<section class="related-guides">
-  <div class="container" style="padding-top:0">
-    <h2>More Silver Guides</h2>
-    <div class="related-guides-grid">
-      <a href="/guides/silver-price-guide" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Silver Price Guide</div>
-        <div class="related-card__desc">Everything about silver spot prices, 925 sterling value and investing.</div>
-      </a>
-      <a href="/guides/indian-gold-silver-prices" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Indian Silver Prices</div>
-        <div class="related-card__desc">Live silver rates in INR — today's price per gram, tola and kilogram.</div>
-      </a>
-    </div>
+<!-- Sticky mobile price bar -->
+<div class="sticky-price" id="stickyPrice" role="complementary" aria-label="Live price quick access">
+  <div class="sticky-price__info">
+    <div class="sticky-price__label">Silver · USD/kg</div>
+    <div class="sticky-price__value" id="sticky-usd" data-nosnippet>&mdash;</div>
   </div>
-</section>
+  <a href="#calculator" class="sticky-price__cta">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M8 18h2"/></svg>
+    Calculate
+  </a>
+</div>
 
 <footer>
   <div class="footer-inner">
@@ -767,7 +1162,7 @@ ul.breadcrumb{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds. USD primary currency.</p>
       <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
@@ -780,7 +1175,6 @@ ul.breadcrumb{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -810,17 +1204,6 @@ ul.breadcrumb{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Blog</h4>
-      <ul>
-        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
-        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
-        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
-        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
-        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
-        <li><a href="/blog/">All Articles</a></li>
-      </ul>
-    </div>
-    <div class="footer-col">
       <h4>Info</h4>
       <ul>
         <li><a href="/about">About</a></li>
@@ -833,34 +1216,275 @@ ul.breadcrumb{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-
   </div>
   <div class="footer-bottom">
     <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
-    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com. USD primary.</span>
   </div>
 </footer>
-<script>
-async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
-async function fetchSpot(){try{const r=await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();const ozUSD=d.price;const gbpusd=window._gbpusd||0.79;const perG_USD=ozUSD/31.1035;const perG_GBP=perG_USD*gbpusd;const perKg_USD=perG_USD*1000;const perKg_GBP=perG_GBP*1000;document.getElementById('p-kg-gbp').textContent='£'+perKg_GBP.toFixed(2);document.getElementById('p-kg-usd').textContent='$'+perKg_USD.toFixed(2);document.getElementById('p-oz-gbp').textContent='£'+(ozUSD*gbpusd).toFixed(2);document.getElementById('p-g-gbp').textContent='£'+perG_GBP.toFixed(3);
-    const snippetEl = document.getElementById('snippet-price');
-    if(snippetEl) snippetEl.textContent='£'+perKg_GBP.toFixed(2)+' ($'+perKg_USD.toFixed(2)+' USD)';[[1,'1g'],[10,'10g'],[100,'100g'],[31.1035,'oz'],[500,'500g'],[1000,'1k']].forEach(([w,id])=>{const g=document.getElementById('t-'+id+'-gbp');const u=document.getElementById('t-'+id+'-usd');if(g)g.textContent='£'+(perG_GBP*w).toFixed(2);if(u)u.textContent='$'+(perG_USD*w).toFixed(2);});gtag('event','price_view',{metal:'silver',unit:'kilo'});
 
-    // Purity Table logic
-    const purities = [0.999, 0.925, 0.900, 0.800];
-    const pure_oz = ozUSD;
-    const pure_g = pure_oz / 31.1035;
-    const tbody = document.querySelector('.data-table:nth-of-type(2) tbody');
-    if (tbody) {
-      const rows = tbody.querySelectorAll('tr');
-      purities.forEach((p, i) => {
-        if (rows[i]) {
-          const p_g = pure_g * p;
-          rows[i].cells[2].textContent = '£' + (p_g * gbpusd).toFixed(2);
-          rows[i].cells[3].textContent = '£' + (p_g * 1000 * gbpusd).toFixed(2);
-          rows[i].cells[4].textContent = '£' + (pure_oz * p * gbpusd).toFixed(2);
+<script>
+/* ───────── Live silver price engine — USD primary, multi-currency ─────────
+   Sources:
+     • Silver spot: https://api.gold-api.com/price/XAG  (LBMA-derived USD/oz)
+     • FX rates:    https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR
+   Refresh: 60s — DO NOT change interval (keeps cross-page consistency)
+*/
+(function(){
+  const G_PER_OZ = 31.1035;
+  const OZ_PER_KG = 32.1507;
+  const REFRESH_MS = 60000;
+  const PURITIES = {'999':0.999, '925':0.925, '900':0.900, '800':0.800};
+  let lastFetchTs = 0;
+  let countdownTimer = null;
+
+  // Currency formatters — USD is primary
+  const fmtUSD = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
+  const fmtGBP = new Intl.NumberFormat('en-GB',{style:'currency',currency:'GBP',maximumFractionDigits:2});
+  const fmtEUR = new Intl.NumberFormat('en-IE',{style:'currency',currency:'EUR',maximumFractionDigits:2});
+  const fmtSpot = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
+
+  function $(id){return document.getElementById(id);}
+
+  async function fetchFx(){
+    try{
+      const r = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR',{cache:'no-store'});
+      if(!r.ok) throw new Error('FX fetch failed');
+      const d = await r.json();
+      window._gbpusd = d.rates.GBP || 0.79;
+      window._eurusd = d.rates.EUR || 0.92;
+    }catch(e){
+      console.warn('FX fallback used',e);
+      window._gbpusd = window._gbpusd || 0.79;
+      window._eurusd = window._eurusd || 0.92;
+    }
+  }
+
+  async function fetchSpot(){
+    try{
+      const r = await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});
+      if(!r.ok) throw new Error('Spot fetch failed');
+      const d = await r.json();
+      const spotUSD = d.price;
+      window._spotUSD = spotUSD;
+      lastFetchTs = Date.now();
+      render(spotUSD);
+      gtag('event','price_view',{metal:'silver',unit:'kilo'});
+    }catch(e){
+      console.warn('Silver spot fetch failed',e);
+    }
+  }
+
+  function render(spotUSD){
+    const gbp = window._gbpusd || 0.79;
+    const eur = window._eurusd || 0.92;
+
+    // Pure silver USD baselines
+    const perG_USD = spotUSD / G_PER_OZ;
+    const perKg_USD = spotUSD * OZ_PER_KG;
+    const perOz_USD = spotUSD;
+    // Currency conversions
+    const perKg_GBP = perKg_USD * gbp;
+    const perKg_EUR = perKg_USD * eur;
+
+    // Hero tiles — USD primary
+    if($('hero-usd')) $('hero-usd').textContent = fmtUSD.format(perKg_USD);
+    if($('hero-gbp')) $('hero-gbp').textContent = fmtGBP.format(perKg_GBP);
+    if($('hero-eur')) $('hero-eur').textContent = fmtEUR.format(perKg_EUR);
+
+    // Sticky mobile bar (USD)
+    if($('sticky-usd')) $('sticky-usd').textContent = fmtUSD.format(perKg_USD);
+
+    // Spot reference
+    if($('spot-usd')) $('spot-usd').textContent = fmtSpot.format(spotUSD) + ' /oz';
+
+    // Snippet inline price (USD primary)
+    if($('snippet-price')) $('snippet-price').textContent = fmtUSD.format(perKg_USD) + ' / kg (' + fmtGBP.format(perKg_GBP) + ' / kg)';
+
+    // Weight table — 1g, 10g, 100g, 1 troy oz, 500g, 1kg (all USD/GBP/EUR)
+    const rows = [
+      {id:'1g', mult:1},
+      {id:'10g', mult:10},
+      {id:'100g', mult:100},
+      {id:'oz', mult:G_PER_OZ},
+      {id:'500g', mult:500},
+      {id:'1k', mult:1000},
+    ];
+    rows.forEach(r => {
+      const u = $('t-'+r.id+'-usd');
+      const g = $('t-'+r.id+'-gbp');
+      const e = $('t-'+r.id+'-eur');
+      const v = perG_USD * r.mult;
+      if(u) u.textContent = fmtUSD.format(v);
+      if(g) g.textContent = fmtGBP.format(v * gbp);
+      if(e) e.textContent = fmtEUR.format(v * eur);
+    });
+
+    // Purity grid — USD per kilo for each purity grade
+    Object.keys(PURITIES).forEach(k => {
+      const el = $('purity-'+k+'-usd');
+      if(el) el.textContent = fmtUSD.format(perKg_USD * PURITIES[k]);
+    });
+
+    // Use-case card stats (USD)
+    const solarEl = $('luxe-solar-stat');     // 20g per solar panel
+    const evEl    = $('luxe-ev-stat');        // ~40g per EV
+    const barEl   = $('luxe-bar-stat');       // 1kg bar
+    if(solarEl) solarEl.textContent = fmtUSD.format(perG_USD * 20);
+    if(evEl)    evEl.textContent    = fmtUSD.format(perG_USD * 40);
+    if(barEl)   barEl.textContent   = fmtUSD.format(perKg_USD);
+
+    // Calculator — update live
+    updateCalculator();
+
+    // Update timestamp
+    updateTimestamp();
+    startCountdown();
+  }
+
+  function updateTimestamp(){
+    const el = $('updated-time');
+    if(!el) return;
+    el.textContent = 'just now';
+  }
+
+  function startCountdown(){
+    if(countdownTimer) clearInterval(countdownTimer);
+    const counterEl = $('refresh-counter');
+    const updatedEl = $('updated-time');
+    countdownTimer = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - lastFetchTs) / 1000);
+      const remaining = Math.max(0, 60 - elapsed);
+      if(counterEl) counterEl.textContent = remaining + 's';
+      if(updatedEl){
+        if(elapsed < 10) updatedEl.textContent = 'just now';
+        else if(elapsed < 60) updatedEl.textContent = elapsed + 's ago';
+        else updatedEl.textContent = Math.floor(elapsed/60) + 'm ago';
+      }
+    }, 1000);
+  }
+
+  // ───────── Calculator interaction ─────────
+  function updateCalculator(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD) return;
+    const weightEl = $('calc-weight');
+    const unitEl = $('calc-unit');
+    const currencyEl = $('calc-currency');
+    const purityEl = $('calc-purity');
+    if(!weightEl || !unitEl || !currencyEl || !purityEl) return;
+    const rawWeight = parseFloat(weightEl.value) || 0;
+    const unitMult = parseFloat(unitEl.value) || 1;     // multiplier to grams
+    const grams = rawWeight * unitMult;
+    const purity = parseFloat(purityEl.value) || 0.999;
+    const currency = currencyEl.value;
+
+    const perG_USD = spotUSD / G_PER_OZ;
+    const meltUSD = perG_USD * grams * purity;
+    let melt, fmt;
+    if(currency === 'GBP'){
+      melt = meltUSD * (window._gbpusd || 0.79);
+      fmt = fmtGBP;
+    }else if(currency === 'EUR'){
+      melt = meltUSD * (window._eurusd || 0.92);
+      fmt = fmtEUR;
+    }else{
+      melt = meltUSD;
+      fmt = fmtUSD;
+    }
+
+    const dealer = melt * 0.85;   // silver dealer payout midpoint (82-90%)
+    const retail = melt * 1.05;   // bullion premium (~5% small-bar avg)
+
+    if($('calc-melt')) $('calc-melt').textContent = fmt.format(melt);
+    if($('calc-dealer')) $('calc-dealer').textContent = fmt.format(dealer);
+    if($('calc-retail')) $('calc-retail').textContent = fmt.format(retail);
+  }
+
+  function bindCalculator(){
+    ['calc-weight','calc-unit','calc-currency','calc-purity'].forEach(id=>{
+      const el = $(id);
+      if(el) el.addEventListener('input', updateCalculator);
+      if(el) el.addEventListener('change', updateCalculator);
+    });
+    document.querySelectorAll('.calc-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const w = chip.getAttribute('data-weight');
+        const u = chip.getAttribute('data-unit');
+        const weightEl = $('calc-weight');
+        const unitEl = $('calc-unit');
+        if(weightEl){
+          weightEl.value = w;
+          if(u && unitEl) unitEl.value = u;
+          updateCalculator();
+        }
+        document.querySelectorAll('.calc-chip').forEach(c => c.classList.remove('active'));
+        chip.classList.add('active');
+        gtag('event','calc_chip_click',{metal:'silver',weight:w});
+      });
+    });
+  }
+
+  // Currency switch (highlights column in price table + drives calculator)
+  function bindCurrencySwitch(){
+    const btns = document.querySelectorAll('.currency-switch__btn');
+    btns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const cur = btn.getAttribute('data-currency');
+        btns.forEach(b => {
+          b.classList.toggle('active', b === btn);
+          b.setAttribute('aria-selected', b === btn ? 'true' : 'false');
+        });
+        document.querySelectorAll('.price-table-pro td, .price-table-pro th').forEach(c => {
+          c.classList.toggle('price-table-pro__primary', c.getAttribute('data-col') === cur);
+        });
+        const calcCur = $('calc-currency');
+        if(calcCur && calcCur.value !== cur){
+          calcCur.value = cur;
+          updateCalculator();
         }
       });
-    }
-}catch(e){console.warn('Silver price fetch failed',e);}}
-Promise.all([fetchFx(),fetchSpot()]);setInterval(fetchSpot,60000);
+    });
+    // Set initial highlight — USD default
+    document.querySelectorAll('.price-table-pro td[data-col="USD"], .price-table-pro th[data-col="USD"]').forEach(c => c.classList.add('price-table-pro__primary'));
+  }
+
+  // Sticky mobile bar — show after scroll past hero
+  function bindStickyBar(){
+    const bar = $('stickyPrice');
+    if(!bar) return;
+    let visible = false;
+    window.addEventListener('scroll', () => {
+      const show = window.scrollY > 400;
+      if(show !== visible){
+        bar.classList.toggle('visible', show);
+        visible = show;
+      }
+    }, {passive: true});
+  }
+
+  // Init
+  document.addEventListener('DOMContentLoaded', () => {
+    bindCalculator();
+    bindCurrencySwitch();
+    bindStickyBar();
+  });
+
+  // Boot
+  Promise.all([fetchFx(), fetchSpot()]).catch(e => console.warn('init',e));
+  setInterval(fetchSpot, REFRESH_MS);
+})();
 </script>
+
+<script>(function(){
+  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
+  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+  root.setAttribute('data-theme',theme);
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);try{localStorage.setItem('gpt-theme',theme);}catch(e){}themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
+  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
+  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
+  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
+  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
+})();</script>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>
 let _deepReadFired = false;
@@ -874,17 +1498,5 @@ window.addEventListener('scroll', () => {
   }
 }, { passive: true });
 </script>
-<script>(function(){
-  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
-  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
-  root.setAttribute('data-theme',theme);
-  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
-  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
-  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
-  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
-  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
-  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
-  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}};});
-})();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Full mobile-first redesign of `silver-price-per-kilo.html` using the flagship editorial pattern proven on the 22K gold page, generated via the `ui-ux-pro-max` design system. **USD is now the primary currency** across hero, calculator, tables, purity grid, sticky bar, snippet and meta tags — silver is quoted in USD on COMEX/LBMA globally.

## What's new

- **Premium hero** — Playfair Display headline with italic "per kilo" emphasis, eyebrow pulse pill, 3 live USD-primary tiles (USD / GBP / EUR), live status bar with last-updated time + 60s countdown, and a "Calculate" CTA scrolling to the calculator.
- **Trust strip** — LBMA-sourced XAG · 60s refresh · USD/GBP/EUR.
- **Flagship calculator** — weight + unit (g / kg / troy oz / oz) + purity (.999 / .925 / .900 / .800 / .835) + currency selectors, plus 7 quick-weight chips (1g → 5kg). Outputs melt value, dealer payout (~85%), and retail (~+5%).
- **4 stat cards** — 32.1507 troy oz/kg, .999 LBMA standard, ~50% industrial demand, LBMA 12:00 GMT fix.
- **Live price table** — 6 weights (1g → 1kg) × 3 currencies with USD/GBP/EUR toggle.
- **Purity grid** — .999 (featured) / .925 / .900 / .800 cards with live USD/kg.
- **Formula card** — 3-step monospace equation.
- **Use-case cards** — Solar PV, Electronics & EVs, 1kg Bullion Bars (each with a live USD stat tied to spot).
- **Demand-mix bar chart** — Industrial 48 / Coins&Bars 22 / Jewellery 17 / Silverware 5 / Photography 3 / Other 5.
- **Editorial prose** — LBMA price source, why-track-kilo, 1kg bar premiums table, **UK 20% VAT + CGT callout**, price history (1980 / 2011 / 2020 / 2021 / 2024–26), volatility callout, silver vs gold comparison.
- **`faq-pro` accordion**, share buttons, sticky mobile USD/kg bar, related guides.

## Data accuracy

Live price math is identical to the other silver pages on the site so cross-page numbers stay consistent:

- Spot: `api.gold-api.com/price/XAG` (LBMA-derived USD/oz) — same endpoint as `800-silver-price-per-gram.html` and `900-silver-price-per-gram.html`.
- FX: `api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR` (ECB reference rates) — same endpoint as `22k-gold-price-per-gram.html`.
- Constants: `31.1035` g/troy oz, `32.1507` troy oz/kg.
- Refresh: `60000` ms — matches every other live-price page.
- Purity factors: `0.999 / 0.925 / 0.900 / 0.800`.

## Mobile-first design

- Stacked single column at <560px, 2-col at 560px, 3-col at 768px, 4–5-col at 900–1024px.
- All inputs `min-height: 48px`; CTAs `min-height: 44px`; share buttons `min-height: 44px`.
- `aria-live="polite"` on the live status region; 27× `aria-label`, 18× `aria-expanded`, 32× `aria-hidden`.
- `prefers-reduced-motion` respected.
- Sticky mobile USD/kg bar appears after 400px scroll with safe-area-inset bottom padding.

## Validation

- 4 JSON-LD blocks (BreadcrumbList, FAQPage, Dataset, WebPage) all pass `scripts/validate-jsonld.js` Rich Results checks.
- All 38 JS-referenced IDs are present in markup.
- All `var(--*)` tokens resolve against either the local `<style>` block or `assets/site.css`.
- HTML tag balance verified, USD verified as first hero tile.

## Test plan

- [ ] Visual check at 375 / 768 / 1024 / 1440 px in Chromium and iPhone 14 Pro device profile.
- [ ] Confirm hero/calculator/table all populate within ~1s of page load on live XAG fetch.
- [ ] Confirm 60s countdown ticks down and the spot/derived values refresh at zero.
- [ ] Confirm currency switch in price table also drives the calculator currency.
- [ ] Confirm quick-weight chips set both weight and unit correctly and update the result.
- [ ] Confirm sticky bar appears past 400px scroll on mobile and links to `#calculator`.
- [ ] Run `tools/playwright_audit.py` per `DEVELOPMENT_RULES.md` and review every 400px strip.

https://claude.ai/code/session_018d2MmzfTRkmEQKXkvSUdug

---
_Generated by [Claude Code](https://claude.ai/code/session_018d2MmzfTRkmEQKXkvSUdug)_