### PR TITLE
Redesign 800-silver-price-per-gram with premium editorial UI (USD primary)

### DIFF
--- a/800-silver-price-per-gram.html
+++ b/800-silver-price-per-gram.html
@@ -2,53 +2,52 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
-  <script>
-(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
+<script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
 </script>
-    <meta name="cf-no-email-obfuscation">
+<meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>.800 European Silver Price Per Gram Today (Live) — GoldPriceTools</title>
-  <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Live .800 European silver price per gram in GBP & USD. Also shows price per troy ounce and per 100g. Updated every 60 seconds from LBMA spot market.">>
+<title>.800 European Silver Price Per Gram Today (Live USD) — Continental Heritage | GoldPriceTools</title>
+<meta name="google-adsense-account" content="ca-pub-8849494330640880">
+<meta name="description" content="Live .800 European silver price per gram in USD, GBP and EUR. Free .800 silver calculator, hallmark identification, antique German &amp; Italian flatware melt value. Updated every 60 seconds from LBMA spot data — USD primary.">
 <meta name="robots" content="index, follow">
-<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/800-silver-price-per-gram">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/800-silver-price-per-gram">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/800-silver-price-per-gram">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/800-silver-price-per-gram">
 <link rel="canonical" href="https://goldpricetools.com/800-silver-price-per-gram">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":".800 European Silver Price Per Gram","item":"https://goldpricetools.com/800-silver-price-per-gram"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is .800 silver worth per gram today?","acceptedAnswer":{"@type":"Answer","text":"The value of .800 silver per gram is calculated by multiplying the live silver spot price per gram by 0.800 (80% purity). The live price is shown on this page."}},{"@type":"Question","name":"Is .800 silver worth anything?","acceptedAnswer":{"@type":"Answer","text":"Yes, .800 silver contains 80% pure silver, giving it significant intrinsic melt value based on the current silver spot price."}},{"@type":"Question","name":"How do I identify .800 European silver?","acceptedAnswer":{"@type":"Answer","text":".800 silver is typically identified by an '800' hallmark stamp. German pieces often feature a crescent moon and crown mark alongside the 800 stamp."}},{"@type":"Question","name":"What is the difference between .800 silver and sterling silver?","acceptedAnswer":{"@type":"Answer","text":".800 silver is 80% pure silver, commonly used in continental Europe for cutlery and holloware. Sterling silver (.925) is purer, containing 92.5% silver, and is the standard in the UK and US."}}]}</script>
-<!-- Dataset JSON-LD (WP-53) -->
-<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Dataset","name":"Live .800 European Silver Price Per Gram \u2014 Daily Historical Data","description":"Daily silver spot price data per gram and troy ounce in GBP and USD. Updated daily from LBMA spot market via gold-api.com. Covers 1 month, 3 months, 1 year, 5 years, and 10 years of historical silver price data.","url":"https://goldpricetools.com/800-silver-price-per-gram","keywords":["silver price","silver price per kilo","silver price per gram","LBMA spot price","precious metals data","XAG/GBP","XAG/USD"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"temporalCoverage":"2016-06-01/..","variableMeasured":"Silver spot price per troy ounce in USD (XAG/USD) and GBP (XAG/GBP)"}</script>
-<meta property="og:title" content=".800 European Silver Price Per Gram Today (Live)">
-<meta property="og:description" content="Live .800 European silver price per gram in GBP & USD. Also shows price per troy ounce and per 100g. Updated every 60 seconds from LBMA spot market.">>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Silver Guides","item":"https://goldpricetools.com/guides/silver-guides/"},{"@type":"ListItem","position":3,"name":".800 European Silver Price Per Gram","item":"https://goldpricetools.com/800-silver-price-per-gram"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is .800 silver worth per gram today?","acceptedAnswer":{"@type":"Answer","text":"The live .800 European silver price per gram is calculated by multiplying the live silver spot price per troy ounce (USD) by 0.800 (80% purity) and dividing by 31.1035 (grams per troy ounce). USD is the primary currency on this page; GBP and EUR conversions use live ECB reference rates. Updated every 60 seconds from LBMA spot data."}},{"@type":"Question","name":"How do I identify .800 European silver?","acceptedAnswer":{"@type":"Answer","text":".800 silver is identified by an '800' hallmark stamp. German pieces (1888 onwards) feature a crescent moon (Halbmond) and crown (Krone) mark alongside the 800 stamp. Italian, French, Austrian and Dutch antique silverware also commonly use the 800 fineness."}},{"@type":"Question","name":"What is the difference between .800 silver and sterling silver (.925)?","acceptedAnswer":{"@type":"Answer","text":".800 silver is 80% pure silver and 20% copper, used historically across Continental Europe for cutlery and holloware. Sterling silver (.925) is purer at 92.5% silver and is the UK/US standard. Per gram, .800 silver is worth roughly 86.5% of sterling's melt value (0.800 ÷ 0.925)."}},{"@type":"Question","name":"What common items are made from .800 silver?","acceptedAnswer":{"@type":"Answer","text":"Common .800 silver items include German and Italian cutlery flatware sets, antique tea and coffee services, decorative trays, cake servers, pre-1940 pocket watch cases, cigarette cases, and small decorative boxes. Many WMF, Wilkens, Bruckmann and Koch &amp; Bergfeld pieces are .800 fineness."}},{"@type":"Question","name":"Is .800 silver worth selling for scrap?","acceptedAnswer":{"@type":"Answer","text":"Yes — .800 silver contains 80% pure silver with significant melt value. Dealers typically pay 75–88% of melt for .800 scrap. For items by sought-after makers (WMF, Christofle, Buccellati), antique value can be 2×–5× melt. Always weigh accurately and deduct non-silver components (resin bases, glass inserts, wooden handles) before calculating."}},{"@type":"Question","name":"Why is silver priced in USD globally?","acceptedAnswer":{"@type":"Answer","text":"Silver is quoted globally in US dollars per troy ounce on the COMEX futures exchange and via the LBMA Silver Price benchmark in London. USD is the world's reserve currency and the most liquid quote unit for precious metals. All conversions to GBP, EUR or INR on this page are derived from the live USD spot using ECB reference rates."}},{"@type":"Question","name":"Is .800 silver magnetic?","acceptedAnswer":{"@type":"Answer","text":"No — genuine .800 silver is non-magnetic. Silver and copper (its main alloying metal) are both non-ferromagnetic. If your item is attracted to a magnet it is silver-plated over a steel or iron base, not solid .800 silver."}},{"@type":"Question","name":"How accurate are these live .800 silver prices?","acceptedAnswer":{"@type":"Answer","text":"Spot prices come direct from the LBMA via gold-api.com and refresh every 60 seconds. Currency conversion from USD to GBP and EUR uses the Frankfurter API's live ECB reference rates. These figures are melt values — the raw .800 silver content. Dealer buy prices are typically 75–88% of melt; antique value can exceed melt for collector pieces."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Dataset","name":"Live .800 European Silver Price Per Gram — Daily Historical Data","description":"Daily silver spot price data per gram and troy ounce in USD (primary), GBP and EUR for .800 European (Continental antique) silver fineness. Updated every 60 seconds from LBMA spot market via gold-api.com.","url":"https://goldpricetools.com/800-silver-price-per-gram","keywords":["800 silver","european silver","continental silver","silver price per gram","LBMA spot","XAG/USD","german silver","800 hallmark"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"temporalCoverage":"2016-06-01/..","variableMeasured":"Silver spot price per troy ounce in USD (XAG/USD) multiplied by 0.800 purity factor"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"WebPage","name":".800 European Silver Price Per Gram Today","url":"https://goldpricetools.com/800-silver-price-per-gram","speakable":{"@type":"SpeakableSpecification","cssSelector":[".snippet-answer",".faq-pro__body"]}}</script>
+<meta property="og:title" content=".800 European Silver Price Per Gram Today (Live USD)">
+<meta property="og:description" content="Real-time .800 Continental silver price per gram in USD, GBP, EUR. Free calculator for antique German &amp; Italian flatware. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/800-silver-price-per-gram">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
-<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
 <script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
 <script>
 (adsbygoogle = window.adsbygoogle || []).push({
   google_ad_client: "ca-pub-8849494330640880",
   enable_page_level_ads: true,
   overlays: {bottom: false},
-  vignette: {
-    new_triggers: false
-  }
+  vignette: { new_triggers: false }
 });
 </script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
-<style>
-
+<link rel="manifest" href="/manifest.json">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
+<meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://api.gold-api.com">
+<link rel="preconnect" href="https://api.frankfurter.dev">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:wght@500;600;700;800&display=swap" rel="stylesheet"><style>
 /* ── Guides mega panel — category links ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
@@ -58,28 +57,16 @@
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#5a5953;--color-text-faint:#8a8983;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#c08a00;--color-silver:#6b7280;--color-silver-bright:#4b5563;--color-silver-deep:#374151;--color-silver-luxe:#9ca3af;--color-platinum:#d1d5db;--color-heritage:#8c6a2f;--color-heritage-bright:#a98443;--color-success:#0f7a3d;--color-danger:#b91c1c;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--shadow-silver:0 8px 32px -8px oklch(0.6 0.02 250/0.3);--shadow-luxe:0 20px 50px -20px oklch(0.55 0.02 250/0.35);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--space-20:5rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--text-3xl:clamp(2.5rem,1.5rem + 4vw,5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-editorial:'Playfair Display',Georgia,serif;--font-mono:'IBM Plex Mono',ui-monospace,monospace;--transition:180ms cubic-bezier(0.16,1,0.3,1);--transition-slow:400ms cubic-bezier(0.16,1,0.3,1);--gradient-silver:linear-gradient(135deg,#e5e7eb 0%,#cbd5e1 35%,#94a3b8 70%,#475569 100%);--gradient-silver-luxe:linear-gradient(135deg,#f1f5f9 0%,#e2e8f0 25%,#cbd5e1 55%,#94a3b8 100%);--gradient-silver-deep:linear-gradient(135deg,#cbd5e1 0%,#94a3b8 30%,#64748b 65%,#334155 100%);--gradient-silver-soft:linear-gradient(135deg,oklch(0.78 0.01 250/0.18) 0%,oklch(0.65 0.01 250/0.06) 100%);--gradient-heritage:linear-gradient(135deg,#a98443 0%,#8c6a2f 50%,#6b4f1f 100%);--silver-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.78 0.02 250/0.16),transparent 60%);--silver-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.78 0.02 250/0.22),transparent 65%)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#e8e6e0;--color-text-muted:#a09e98;--color-text-faint:#6a6864;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#cbd5e1;--color-silver-bright:#e2e8f0;--color-silver-deep:#94a3b8;--color-silver-luxe:#f1f5f9;--color-platinum:#f8fafc;--color-heritage:#c69a4f;--color-heritage-bright:#dab170;--color-success:#4ade80;--color-danger:#f87171;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5);--shadow-silver:0 8px 32px -4px oklch(0.75 0.02 250/0.32);--shadow-luxe:0 30px 60px -20px oklch(0.7 0.03 250/0.42);--gradient-silver:linear-gradient(135deg,#f1f5f9 0%,#cbd5e1 35%,#94a3b8 70%,#475569 100%);--gradient-silver-luxe:linear-gradient(135deg,#f8fafc 0%,#e2e8f0 30%,#cbd5e1 55%,#64748b 100%);--gradient-silver-deep:linear-gradient(135deg,#f1f5f9 0%,#cbd5e1 25%,#94a3b8 55%,#475569 100%);--gradient-silver-soft:linear-gradient(135deg,oklch(0.78 0.02 250/0.16) 0%,oklch(0.55 0.02 250/0.04) 100%);--gradient-heritage:linear-gradient(135deg,#dab170 0%,#c69a4f 50%,#9b7833 100%);--silver-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.78 0.03 250/0.18),transparent 60%);--silver-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.82 0.03 250/0.22),transparent 70%)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-/* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
 .article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
 .article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
 
-
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:calc(var(--space-16) + var(--space-2))}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
@@ -87,194 +74,283 @@ input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+:focus-visible{outline:2px solid var(--color-silver);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-
-/* TICKER */
-.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
-.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
-.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
-.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
-.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
-.ticker:hover{animation-play-state:paused}
-@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
-.ticker-label{color:var(--color-text-muted)}
-.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
-.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
-@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
-
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
 
 /* AD SLOTS */
 .ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
 .ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
 
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
+/* ═════ PREMIUM HERO ═════ */
+.hero-premium{position:relative;overflow:hidden;border-bottom:1px solid var(--color-border)}
+.hero-premium::before{content:'';position:absolute;inset:0;background:var(--silver-glow-deep);pointer-events:none;z-index:0}
+.hero-premium::after{content:'';position:absolute;top:-20%;right:-10%;width:60%;height:140%;background:radial-gradient(ellipse 50% 70% at 30% 30%,oklch(0.78 0.03 250/0.12),transparent 60%);pointer-events:none;z-index:0}
+.hero-premium__inner{position:relative;z-index:1;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-10)}
+@media(min-width:768px){.hero-premium__inner{padding:var(--space-12) var(--space-6) var(--space-12)}}
+@media(min-width:1024px){.hero-premium__inner{padding:var(--space-16) var(--space-8) var(--space-12)}}
+.hero-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);padding:6px var(--space-3);background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--color-silver) 35%,transparent);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--color-silver);margin-bottom:var(--space-5)}
+.hero-eyebrow__pulse{width:6px;height:6px;border-radius:50%;background:var(--color-silver);box-shadow:0 0 8px var(--color-silver);animation:heroPulse 2.4s ease-in-out infinite}
+@keyframes heroPulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+.hero-premium__title{font-family:var(--font-editorial);font-weight:600;color:var(--color-text);line-height:.98;letter-spacing:-.025em;margin-bottom:var(--space-5);font-size:clamp(2.25rem,1.35rem + 5vw,5rem)}
+.hero-premium__title-em{display:inline-block;background:var(--gradient-silver-deep);-webkit-background-clip:text;background-clip:text;color:transparent;font-style:italic;font-weight:500}
+.hero-premium__sub{font-size:clamp(1rem,.95rem + .35vw,1.25rem);color:var(--color-text-muted);line-height:1.6;max-width:62ch;margin-bottom:var(--space-8)}
+.hero-premium__sub strong{color:var(--color-silver);font-weight:600}
 
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+/* PRICE TILES */
+.price-tiles{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-6)}
+@media(min-width:560px){.price-tiles{grid-template-columns:repeat(3,1fr);gap:var(--space-3)}}
+@media(min-width:1024px){.price-tiles{gap:var(--space-4)}}
+.price-tile{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.price-tile::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,transparent,var(--color-silver),transparent);opacity:.6}
+.price-tile:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-silver)}
+.price-tile--primary{background:linear-gradient(135deg,var(--color-surface) 0%,var(--color-surface-offset) 100%);border-color:color-mix(in oklch,var(--color-silver) 30%,var(--color-border))}
+.price-tile--primary::before{background:var(--gradient-silver-deep);opacity:1;height:4px}
+.price-tile__head{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-3);gap:var(--space-2)}
+.price-tile__label{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--color-text-muted)}
+.price-tile--primary .price-tile__label{color:var(--color-silver)}
+.price-tile__flag{display:inline-flex;align-items:center;gap:6px;font-size:11px;color:var(--color-text-faint);font-weight:600;font-family:var(--font-mono);letter-spacing:.04em}
+.price-tile__value{font-family:var(--font-display);font-size:clamp(1.75rem,1.2rem + 2.2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.02em;line-height:1;font-variant-numeric:tabular-nums;margin-bottom:var(--space-2)}
+.price-tile--primary .price-tile__value{color:var(--color-silver)}
+.price-tile__sub{font-size:var(--text-xs);color:var(--color-text-muted);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.price-tile__purity-dot{width:6px;height:6px;border-radius:50%;background:var(--color-silver);flex-shrink:0}
 
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+/* LIVE STATUS */
+.live-status{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2) var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted)}
+.live-status__dot{width:8px;height:8px;border-radius:50%;background:var(--color-success);box-shadow:0 0 8px color-mix(in oklch,var(--color-success) 80%,transparent);animation:heroPulse 2s ease-in-out infinite;flex-shrink:0}
+.live-status__label{font-weight:600;color:var(--color-text)}
+.live-status__divider{color:var(--color-text-faint);user-select:none}
+.live-status__meta{font-variant-numeric:tabular-nums}
+.live-status__meta strong{color:var(--color-silver);font-weight:600}
+.live-status__cta{margin-left:auto;display:inline-flex;align-items:center;gap:6px;padding:8px var(--space-3);background:var(--gradient-silver-luxe);color:#0f172a;border-radius:var(--radius-md);font-weight:700;font-size:11px;letter-spacing:.06em;text-transform:uppercase;text-decoration:none;min-height:36px}
+.live-status__cta:hover{filter:brightness(1.08);text-decoration:none;color:#0f172a}
 
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+/* TRUST STRIP */
+.trust-strip{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4);display:flex;flex-wrap:wrap;gap:var(--space-3);align-items:center;border-bottom:1px solid var(--color-divider)}
+.trust-strip__item{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+.trust-strip__item svg{width:14px;height:14px;color:var(--color-silver);flex-shrink:0}
+.trust-strip__item--link{margin-left:auto;color:var(--color-primary);font-weight:600;text-decoration:none}
+.trust-strip__item--link:hover{color:var(--color-primary-hover);text-decoration:underline}
+@media(max-width:540px){.trust-strip__item--link{margin-left:0}}
 
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
+/* ═════ LIVE CALCULATOR ═════ */
+.calc-pro{max-width:1200px;margin:var(--space-10) auto;padding:0 var(--space-4)}
+@media(min-width:768px){.calc-pro{margin:var(--space-12) auto}}
+.calc-pro__card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden;box-shadow:var(--shadow-md)}
+.calc-pro__card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-silver) 30%,var(--color-silver) 70%,transparent 100%);opacity:.5}
+.calc-pro__head{padding:var(--space-6) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-4);flex-wrap:wrap}
+@media(min-width:768px){.calc-pro__head{padding:var(--space-8) var(--space-8) var(--space-5)}}
+.calc-pro__head-left{flex:1;min-width:200px}
+.calc-pro__title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);display:flex;align-items:center;gap:var(--space-2)}
+.calc-pro__title-icon{width:24px;height:24px;color:var(--color-silver);flex-shrink:0}
+.calc-pro__sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;max-width:56ch}
+.calc-pro__head-badge{display:inline-flex;align-items:center;gap:6px;padding:6px var(--space-3);background:color-mix(in oklch,var(--color-success) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-success) 30%,transparent);color:var(--color-success);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase}
+.calc-pro__head-badge .live-dot{width:6px;height:6px;border-radius:50%;background:var(--color-success);animation:heroPulse 2s ease-in-out infinite}
+.calc-pro__body{padding:var(--space-5)}
+@media(min-width:768px){.calc-pro__body{padding:var(--space-6) var(--space-8) var(--space-8)}}
+.calc-pro__row{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-4)}
+@media(min-width:560px){.calc-pro__row{grid-template-columns:1.4fr .8fr .8fr;gap:var(--space-4)}}
+.calc-pro__field{display:flex;flex-direction:column;gap:var(--space-2)}
+.calc-pro__field-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__input,.calc-pro__select{width:100%;min-height:48px;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none;transition:border-color var(--transition),background var(--transition),box-shadow var(--transition)}
+.calc-pro__input:focus,.calc-pro__select:focus{border-color:var(--color-silver);background:var(--color-surface);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-silver) 18%,transparent);outline:none}
+.calc-pro__input{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;font-variant-numeric:tabular-nums}
+.calc-pro__select-wrap{position:relative}
+.calc-pro__select-wrap::after{content:'';position:absolute;right:var(--space-4);top:50%;width:8px;height:8px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:translateY(-70%) rotate(45deg);pointer-events:none}
+.calc-pro__purity-locked{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px dashed color-mix(in oklch,var(--color-silver) 30%,var(--color-border));border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text)}
+.calc-pro__purity-locked strong{font-family:var(--font-editorial);font-style:italic;color:var(--color-silver);font-weight:600;font-size:1.125em}
+.calc-pro__purity-locked .lock-icon{width:14px;height:14px;color:var(--color-text-faint);flex-shrink:0}
+.calc-pro__chips{display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-5);align-items:center}
+.calc-pro__chips-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-right:var(--space-2);width:100%}
+@media(min-width:560px){.calc-pro__chips-label{width:auto;margin-right:var(--space-1)}}
+.calc-chip{min-height:36px;padding:6px var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);cursor:pointer;transition:all var(--transition);white-space:nowrap}
+.calc-chip:hover{border-color:var(--color-silver);color:var(--color-silver);background:color-mix(in oklch,var(--color-silver) 8%,var(--color-surface-offset))}
+.calc-chip:focus-visible{outline:2px solid var(--color-silver);outline-offset:2px}
+.calc-chip.active{background:var(--gradient-silver-luxe);color:#0f172a;border-color:transparent}
+.calc-pro__result{background:linear-gradient(135deg,color-mix(in oklch,var(--color-silver) 10%,var(--color-surface)) 0%,var(--color-surface) 100%);border:1px solid color-mix(in oklch,var(--color-silver) 25%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-5);position:relative;overflow:hidden}
+.calc-pro__result::before{content:'';position:absolute;top:-50%;right:-20%;width:280px;height:280px;background:radial-gradient(circle,color-mix(in oklch,var(--color-silver) 18%,transparent) 0%,transparent 60%);pointer-events:none}
+.calc-pro__result-primary{position:relative;display:flex;align-items:baseline;justify-content:space-between;padding-bottom:var(--space-4);margin-bottom:var(--space-4);border-bottom:1px solid color-mix(in oklch,var(--color-silver) 18%,var(--color-border));flex-wrap:wrap;gap:var(--space-2)}
+.calc-pro__result-label-main{font-size:var(--text-sm);font-weight:700;color:var(--color-text);text-transform:uppercase;letter-spacing:.08em}
+.calc-pro__result-main{font-family:var(--font-display);font-size:clamp(2rem,1.5rem + 2vw,3rem);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;letter-spacing:-.025em;line-height:1}
+.calc-pro__result-grid{position:relative;display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3) var(--space-4)}
+.calc-pro__result-item{display:flex;flex-direction:column;gap:var(--space-1)}
+.calc-pro__result-item-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__result-item-value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+.calc-pro__hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-4);line-height:1.6;max-width:62ch}
+.calc-pro__hint code{font-family:var(--font-mono);font-size:11px;background:var(--color-surface-offset-2);padding:2px 6px;border-radius:4px;color:var(--color-silver);border:1px solid var(--color-divider)}
 
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
+/* ═════ STAT CARDS ═════ */
+.stat-cards{max-width:1200px;margin:0 auto var(--space-12);padding:0 var(--space-4);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+@media(min-width:768px){.stat-cards{grid-template-columns:repeat(4,1fr);gap:var(--space-4)}}
+.stat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);position:relative;overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.stat-card:hover{border-color:color-mix(in oklch,var(--color-silver) 35%,var(--color-border));transform:translateY(-2px)}
+.stat-card__icon{width:32px;height:32px;color:var(--color-silver);margin-bottom:var(--space-3)}
+.stat-card__value{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);letter-spacing:-.02em;line-height:1;margin-bottom:var(--space-2);font-variant-numeric:tabular-nums}
+.stat-card__label{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.4}
 
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+/* ═════ SECTION COMMON ═════ */
+.section{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
+.section--narrow{max-width:920px}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:var(--space-5);flex-wrap:wrap;gap:var(--space-3)}
+.section-head__left{flex:1;min-width:200px}
+.section-eyebrow{display:inline-block;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-silver);margin-bottom:var(--space-2)}
+.section-title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);line-height:1.2;margin-bottom:var(--space-2);letter-spacing:-.015em}
+.section-sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;max-width:60ch}
 
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+/* ═════ PRICE TABLE ═════ */
+.price-table-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.price-table-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden}
+.price-table-card__head{padding:var(--space-5) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3)}
+@media(min-width:768px){.price-table-card__head{padding:var(--space-6) var(--space-8) var(--space-5)}}
+.price-table-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1)}
+.price-table-card__sub{font-size:var(--text-xs);color:var(--color-text-muted)}
+.price-table-card__sub strong{color:var(--color-success);font-weight:700}
+.currency-switch{display:inline-flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px;gap:2px;flex-wrap:wrap}
+.currency-switch__btn{min-height:32px;padding:6px var(--space-3);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);border-radius:var(--radius-full);cursor:pointer;transition:all var(--transition);letter-spacing:.04em}
+.currency-switch__btn:hover{color:var(--color-text)}
+.currency-switch__btn.active{background:var(--gradient-silver-luxe);color:#0f172a}
+.price-table-card__body{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.price-table-pro{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums;min-width:520px}
+.price-table-pro th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-5);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);white-space:nowrap}
+.price-table-pro th:not(:first-child){text-align:right}
+.price-table-pro td{padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.price-table-pro td:first-child{color:var(--color-text);font-weight:600;font-family:var(--font-display)}
+.price-table-pro td:not(:first-child){text-align:right;color:var(--color-text);font-weight:500}
+.price-table-pro td.price-table-pro__primary{color:var(--color-silver);font-weight:700}
+.price-table-pro tr:last-child td{border-bottom:none}
+.price-table-pro tr:hover td{background:color-mix(in oklch,var(--color-silver) 4%,var(--color-surface))}
+.price-table-pro .weight-label-sub{color:var(--color-text-faint);font-size:11px;font-weight:400;display:block;margin-top:2px;font-family:var(--font-body)}
 
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+/* ═════ PURITY GRID ═════ */
+.purity-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.purity-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.purity-cards{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:900px){.purity-cards{grid-template-columns:repeat(4,1fr);gap:var(--space-3)}}
+.purity-card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4);text-decoration:none;transition:all var(--transition);overflow:hidden;display:flex;flex-direction:column;gap:var(--space-2);color:var(--color-text)}
+.purity-card:hover{border-color:color-mix(in oklch,var(--color-silver) 50%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-md);color:var(--color-text);text-decoration:none}
+.purity-card--featured{background:linear-gradient(135deg,color-mix(in oklch,var(--color-silver) 14%,var(--color-surface)) 0%,var(--color-surface) 100%);border-color:var(--color-silver);box-shadow:0 0 0 1px var(--color-silver),var(--shadow-silver)}
+.purity-card--featured::before{content:'YOU ARE HERE';position:absolute;top:8px;right:8px;font-size:9px;font-weight:700;letter-spacing:.1em;color:var(--color-silver);background:color-mix(in oklch,var(--color-silver) 14%,transparent);padding:2px 6px;border-radius:4px;font-family:var(--font-mono)}
+.purity-card__purity{font-family:var(--font-editorial);font-size:clamp(2rem,1.4rem + 2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.025em;line-height:1}
+.purity-card--featured .purity-card__purity{color:var(--color-silver);font-style:italic}
+.purity-card__grade{font-size:var(--text-sm);color:var(--color-silver);font-weight:700;font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+.purity-card__pct{font-size:11px;font-weight:600;color:var(--color-text-faint);font-family:var(--font-mono);letter-spacing:.1em;text-transform:uppercase}
+.purity-card__price{font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;padding-top:var(--space-2);border-top:1px solid var(--color-divider);margin-top:auto}
+.purity-card__price-label{display:block;font-size:10px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-bottom:2px}
+.purity-card__use{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
 
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+/* ═════ FORMULA BLOCK ═════ */
+.formula-block{max-width:920px;margin:var(--space-10) auto var(--space-8);padding:0 var(--space-4)}
+.formula-card{background:linear-gradient(180deg,var(--color-surface-offset) 0%,var(--color-surface) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6) var(--space-5);position:relative;overflow:hidden}
+@media(min-width:768px){.formula-card{padding:var(--space-8)}}
+.formula-card__eyebrow{font-size:11px;font-weight:700;color:var(--color-silver);text-transform:uppercase;letter-spacing:.12em;margin-bottom:var(--space-3)}
+.formula-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-4)}
+.formula-card__equation{font-family:var(--font-mono);font-size:clamp(.875rem,.8rem + .5vw,1.125rem);color:var(--color-text);background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);overflow-x:auto;-webkit-overflow-scrolling:touch;white-space:nowrap;font-variant-numeric:tabular-nums;line-height:1.6}
+.formula-card__equation .op{color:var(--color-silver);font-weight:600}
+.formula-card__equation .var{color:var(--color-primary);font-weight:600}
+.formula-card__steps{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:768px){.formula-card__steps{grid-template-columns:repeat(3,1fr)}}
+.formula-step{display:flex;gap:var(--space-3);padding:var(--space-3);background:var(--color-surface);border:1px solid var(--color-divider);border-radius:var(--radius-md)}
+.formula-step__num{flex-shrink:0;width:28px;height:28px;border-radius:50%;background:var(--gradient-silver-luxe);color:#0f172a;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
+.formula-step__text{font-size:var(--text-sm);color:var(--color-text);line-height:1.5}
+.formula-step__text strong{color:var(--color-silver);font-variant-numeric:tabular-nums}
 
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+/* ═════ HERITAGE / USE CASE CARDS ═════ */
+.luxe-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.luxe-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.luxe-cards{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:1024px){.luxe-cards{grid-template-columns:repeat(3,1fr)}}
+.luxe-card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-5) var(--space-6);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.luxe-card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-silver) 50%,transparent 100%);opacity:.7}
+.luxe-card::after{content:'';position:absolute;top:-30%;right:-30%;width:200px;height:200px;background:radial-gradient(circle,color-mix(in oklch,var(--color-silver) 12%,transparent) 0%,transparent 65%);pointer-events:none;transition:opacity var(--transition)}
+.luxe-card:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-luxe)}
+.luxe-card__icon{width:48px;height:48px;color:var(--color-silver);margin-bottom:var(--space-4)}
+.luxe-card__category{font-size:11px;font-weight:700;color:var(--color-silver);text-transform:uppercase;letter-spacing:.14em;margin-bottom:var(--space-2);font-family:var(--font-mono)}
+.luxe-card__title{font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:600;color:var(--color-text);line-height:1.25;margin-bottom:var(--space-3);font-style:italic}
+.luxe-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin-bottom:var(--space-4)}
+.luxe-card__stat{display:flex;align-items:baseline;gap:var(--space-2);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.luxe-card__stat-val{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.luxe-card__stat-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
 
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+/* ═════ HALLMARK GALLERY ═════ */
+.hallmark-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.hallmark-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.hallmark-grid{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:1024px){.hallmark-grid{grid-template-columns:repeat(4,1fr)}}
+.hallmark-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);text-align:center;display:flex;flex-direction:column;align-items:center;gap:var(--space-3);transition:border-color var(--transition),transform var(--transition)}
+.hallmark-card:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border));transform:translateY(-2px)}
+.hallmark-card__mark{font-family:var(--font-editorial);font-size:clamp(2rem,1.5rem + 2vw,3rem);line-height:1;color:var(--color-silver);letter-spacing:.05em;padding:var(--space-3) var(--space-5);background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--color-silver) 30%,var(--color-border));border-radius:var(--radius-md);font-variant-numeric:tabular-nums;font-weight:600;display:flex;align-items:center;gap:8px;min-height:64px}
+.hallmark-card__mark svg{width:24px;height:24px;color:var(--color-silver)}
+.hallmark-card__country{font-size:var(--text-sm);font-weight:700;color:var(--color-text);font-family:var(--font-display)}
+.hallmark-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.5}
+
+/* ═════ EDITORIAL PROSE ═════ */
+.content-section{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-12)}
+.prose-pro{max-width:760px;margin:0 auto}
+.prose-pro h2{font-family:var(--font-display);font-size:clamp(1.5rem,1.1rem + 1.5vw,2rem);font-weight:700;color:var(--color-text);margin:var(--space-12) 0 var(--space-4);line-height:1.2;letter-spacing:-.015em;position:relative;padding-top:var(--space-3)}
+.prose-pro h2::before{content:'';position:absolute;top:0;left:0;width:48px;height:3px;background:var(--gradient-silver-deep);border-radius:2px}
+.prose-pro h2:first-child{margin-top:0}
+.prose-pro h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-8) 0 var(--space-3);letter-spacing:-.01em}
+.prose-pro p{font-size:var(--text-base);color:var(--color-text);line-height:1.75;margin-bottom:var(--space-4)}
+.prose-pro ul,.prose-pro ol{padding-left:var(--space-5);margin-bottom:var(--space-5)}
+.prose-pro li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:var(--space-2)}
+.prose-pro li::marker{color:var(--color-silver)}
+.prose-pro strong{color:var(--color-text);font-weight:700}
+.prose-pro a{color:var(--color-primary);text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;transition:color var(--transition)}
+.prose-pro a:hover{color:var(--color-primary-hover);text-decoration-thickness:2px}
+.prose-pro blockquote{margin:var(--space-5) 0;padding:var(--space-4) var(--space-5);background:var(--color-surface);border-left:3px solid var(--color-silver);border-radius:var(--radius-md);font-family:var(--font-editorial);font-size:var(--text-lg);font-style:italic;color:var(--color-text);font-weight:500;line-height:1.5}
+.prose-pro blockquote strong{font-style:normal;font-family:var(--font-mono);color:var(--color-silver);font-size:var(--text-base);font-weight:600}
+.snippet-answer{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-silver);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);margin:var(--space-4) 0;font-size:var(--text-base);color:var(--color-text);line-height:1.7}
+.snippet-answer strong{color:var(--color-silver)}
+.callout{background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--color-silver) 30%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-5) 0;display:flex;gap:var(--space-3);align-items:flex-start}
+.callout__icon{flex-shrink:0;width:32px;height:32px;color:var(--color-silver);margin-top:2px}
+.callout__title{font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);font-family:var(--font-display)}
+.callout__body{font-size:var(--text-sm);color:var(--color-text);line-height:1.6}
+
+/* MARKET / TIMELINE TABLE */
+.market-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px solid var(--color-border);border-radius:var(--radius-lg);margin:var(--space-5) 0}
+.market-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:480px}
+.market-table th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-4);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
+.market-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text);vertical-align:top}
+.market-table td:first-child{font-weight:600;font-family:var(--font-display);white-space:nowrap}
+.market-table td:nth-child(2){color:var(--color-silver);font-family:var(--font-mono);font-size:11px;letter-spacing:.06em;white-space:nowrap}
+.market-table tr:last-child td{border-bottom:none}
+
+/* FAQ ACCORDION */
+.faq-pro{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+.faq-pro__item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.faq-pro__item:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
+.faq-pro__item[open]{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
+.faq-pro__summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;min-height:60px}
+.faq-pro__summary::-webkit-details-marker{display:none}
+.faq-pro__summary:hover{background:var(--color-surface-offset)}
+.faq-pro__summary:focus-visible{outline:2px solid var(--color-silver);outline-offset:-2px}
+.faq-pro__plus{flex-shrink:0;width:24px;height:24px;border:1px solid var(--color-border);border-radius:50%;display:flex;align-items:center;justify-content:center;position:relative;transition:transform var(--transition),border-color var(--transition),background var(--transition)}
+.faq-pro__plus::before,.faq-pro__plus::after{content:'';position:absolute;background:var(--color-text-muted);transition:transform var(--transition),background var(--transition)}
+.faq-pro__plus::before{width:10px;height:2px}
+.faq-pro__plus::after{width:2px;height:10px}
+.faq-pro__item[open] .faq-pro__plus{background:var(--color-silver);border-color:var(--color-silver);transform:rotate(45deg)}
+.faq-pro__item[open] .faq-pro__plus::before,.faq-pro__item[open] .faq-pro__plus::after{background:#0f172a}
+.faq-pro__body{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;border-top:1px solid var(--color-divider);padding-top:var(--space-4)}
+.faq-pro__body strong{color:var(--color-text)}
+
+/* STICKY MOBILE PRICE BAR */
+.sticky-price{position:fixed;bottom:0;left:0;right:0;background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-3) var(--space-4);z-index:80;display:none;align-items:center;gap:var(--space-3);box-shadow:0 -8px 24px rgba(0,0,0,.2);backdrop-filter:blur(12px);transform:translateY(100%);transition:transform .3s ease-out;padding-bottom:max(var(--space-3),env(safe-area-inset-bottom))}
+.sticky-price.visible{transform:translateY(0)}
+@media(max-width:768px){.sticky-price{display:flex}body{padding-bottom:80px}}
+.sticky-price__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.sticky-price__value{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;line-height:1.1}
+.sticky-price__info{flex:1;min-width:0}
+.sticky-price__cta{display:inline-flex;align-items:center;gap:6px;padding:10px var(--space-4);background:var(--gradient-silver-luxe);color:#0f172a;border-radius:var(--radius-md);font-size:var(--text-xs);font-weight:700;text-decoration:none;letter-spacing:.04em;text-transform:uppercase;min-height:44px;white-space:nowrap}
+.sticky-price__cta:hover{filter:brightness(1.08);color:#0f172a;text-decoration:none}
+
+/* DISCLAIMER */
+.disclaimer{margin-top:var(--space-8);padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--color-text-faint);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+.disclaimer strong{color:var(--color-text)}
 
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
-.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
 .mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
@@ -327,22 +403,6 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
 .footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
@@ -352,135 +412,38 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
+footer{background:var(--color-surface);border-top:1px solid var(--color-border)}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
-
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
-
-
-/* ── Shared layout CSS ── */
+/* Breadcrumb */
 .breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted)}
+.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted);flex-wrap:wrap}
 .breadcrumb li+li::before{content:"/";margin-right:var(--space-2);color:var(--color-text-faint)}
 .breadcrumb a{color:var(--color-text-muted);text-decoration:none}
 .breadcrumb a:hover{color:var(--color-primary)}
 .breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.hero-tag{display:inline-block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-.hero-title{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero-title{font-size:var(--text-xl)}
-.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:72ch;line-height:1.7;margin-bottom:var(--space-6)}
-.price-card{display:inline-flex;flex-direction:column;gap:var(--space-1);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-2)}
-.price-card{width:100%}
-.price-label{font-size:var(--text-sm);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.price-value{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-gold-bright);font-weight:400;line-height:1}
-.price-usd{font-size:var(--text-base);color:var(--color-text-muted)}
-.price-purity{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-1)}
-.prose{max-width:72ch}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-1)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose{max-width:100%}
-.content{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
-.data-source{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.faq-answer-summary{font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4);cursor:pointer;list-style:none;background:var(--color-surface-offset);transition:background .15s}
-.faq-answer-summary:hover{background:var(--color-surface-dynamic)}
-.faq-answer-summary::marker,.faq-answer-summary::-webkit-details-marker{display:none}
-.faq-answer-summary::after{content:"＋";float:right;color:var(--color-text-faint)}
-.faq-answer-summary::after{content:"－"}
-.faq-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-4);border-top:1px solid var(--color-divider)}
-
-/* ═══════════════════════════════════════════════
-   .800 SILVER PAGE — LAYOUT & COMPONENT FIXES
-   ═══════════════════════════════════════════════ */
-
-/* Hero: single column, centred */
-.hero{grid-template-columns:1fr!important;max-width:860px;padding:var(--space-8) var(--space-4) var(--space-6);align-items:start}
-.hero-title{font-size:clamp(1.75rem,3.5vw,2.75rem)!important;line-height:1.15!important;margin-bottom:var(--space-3)!important}
-
-/* Trust bar */
-.trust-bar{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.trust-bar a{color:var(--color-primary);text-decoration:underline}
-
-/* Prose reading width */
-.prose{max-width:860px!important}
-
-/* Data tables */
-.data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-2) 0 var(--space-8);max-width:860px}
-.data-table thead tr{border-bottom:2px solid var(--color-border)}
-.data-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-4) var(--space-2) 0;white-space:nowrap}
-.data-table th:first-child{padding-left:0}
-.data-table td{padding:var(--space-3) var(--space-4) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle;white-space:nowrap}
-.data-table td:first-child{color:var(--color-text);font-weight:600;padding-left:0}
-.data-table tr:last-child td{border-bottom:none}
-.data-table td:nth-child(2),.data-table td:nth-child(3),.data-table td:nth-child(4),.data-table td:nth-child(5){font-variant-numeric:tabular-nums;color:var(--color-text)}
-
-/* Blockquote */
-blockquote{background:color-mix(in oklch,var(--color-silver) 6%,var(--color-surface-offset));border-left:3px solid var(--color-silver);border-radius:0 var(--radius-md) var(--radius-md) 0;padding:var(--space-4) var(--space-5);margin:var(--space-4) 0 var(--space-6);font-size:var(--text-base);color:var(--color-text-muted);max-width:860px}
-blockquote strong{color:var(--color-text)}
-
-/* Snippet / highlighted answer paragraphs */
-.snippet-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);margin-bottom:var(--space-6);max-width:860px;border-left:3px solid color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
-.snippet-answer span{font-weight:600;color:var(--color-text)}
-
-/* FAQ accordion */
-.faq-container{display:flex;flex-direction:column;gap:var(--space-2);margin:var(--space-2) 0 var(--space-6);max-width:860px}
-.prose details,.faq-container details{border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;margin-bottom:0}
-.faq-answer-summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5)!important;background:var(--color-surface)!important;user-select:none}
-.faq-answer-summary::after{content:"＋"!important;margin-left:var(--space-3);flex-shrink:0}
-details[open]>.faq-answer-summary{background:var(--color-surface-offset)!important}
-details[open]>.faq-answer-summary::after{content:"－"!important}
-.faq-answer,.prose details p{padding:var(--space-4) var(--space-5)!important;font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;border-top:1px solid var(--color-border);margin:0!important}
 
 /* Share buttons */
-.share-buttons{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2);margin:var(--space-6) 0}
-.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);margin-right:var(--space-1)}
-.share-buttons a{display:inline-flex;align-items:center;gap:var(--space-2);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:var(--space-2) var(--space-4);text-decoration:none;transition:border-color .15s,color .15s,background .15s}
-.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:color-mix(in oklch,var(--color-primary) 6%,var(--color-surface))}
-.share-buttons svg{flex-shrink:0}
+.share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) 0 var(--space-6);padding-top:var(--space-6);border-top:1px solid var(--color-border)}
+.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
+.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface);min-height:44px}
+.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset);text-decoration:none}
+.share-buttons a svg{flex-shrink:0}
 
-/* Related guides grid & cards */
-.related-guides-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-4);margin-top:var(--space-4)}
-@media(max-width:900px){.related-guides-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:540px){.related-guides-grid{grid-template-columns:1fr}}
-
-.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s}
-.related-card:hover{border-color:color-mix(in oklch,var(--color-primary) 40%,var(--color-border));box-shadow:var(--shadow-sm)}
-.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright)}
-.related-card__title{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.3}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin-top:auto}
-
-/* Related guides section container */
-.related-guides{background:var(--color-surface-offset);padding:var(--space-10) var(--space-4)}
-.related-guides .container,.container{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
-.related-guides h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-
-@media(max-width:640px){.hero{padding:var(--space-6) var(--space-4) var(--space-4)}}
+/* Related guides */
+.related-guides{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.related-guides-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.related-guides-grid{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:900px){.related-guides-grid{grid-template-columns:repeat(4,1fr)}}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,transform .15s,box-shadow .15s;color:var(--color-text)}
+.related-card:hover{border-color:var(--color-silver);box-shadow:var(--shadow-md);transform:translateY(-2px);text-decoration:none;color:var(--color-text)}
+.related-card:hover .related-card__title{color:var(--color-silver)}
+.related-card__tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-silver);align-self:flex-start;padding:2px 8px;background:color-mix(in oklch,var(--color-silver) 10%,transparent);border-radius:99px}
+.related-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0;line-height:1.3;transition:color var(--transition)}
+.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
 </style>
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org/",
-  "@type": "WebPage",
-  "name": ".800 European Silver Price Per Gram",
-  "url": "https://goldpricetools.com/800-silver-price-per-gram",
-  "speakable": {
-    "@type": "SpeakableSpecification",
-    "cssSelector": [".snippet-answer", ".faq-answer"]
-  }
-}
-</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is .800 silver worth per gram today?","acceptedAnswer":{"@type":"Answer","text":"The value of .800 silver per gram is calculated by multiplying the live silver spot price per gram by 0.800 (80% purity). The live price is shown on this page."}},{"@type":"Question","name":"Is .800 silver worth anything?","acceptedAnswer":{"@type":"Answer","text":"Yes, .800 silver contains 80% pure silver, giving it significant intrinsic melt value based on the current silver spot price."}},{"@type":"Question","name":"How do I identify .800 European silver?","acceptedAnswer":{"@type":"Answer","text":".800 silver is typically identified by an '800' hallmark stamp. German pieces often feature a crescent moon and crown mark alongside the 800 stamp."}},{"@type":"Question","name":"What is the difference between .800 silver and sterling silver?","acceptedAnswer":{"@type":"Answer","text":".800 silver is 80% pure silver, commonly used in continental Europe for cutlery and holloware. Sterling silver (.925) is purer, containing 92.5% silver, and is the standard in the UK and US."}},{"@type":"Question","name":"What common items are made from .800 silver?","acceptedAnswer":{"@type":"Answer","text":"Common .800 silver items include Continental European cutlery sets (especially German and Italian), antique tea services, decorative trays, cake servers, older pocket watch cases, cigarette cases, and small decorative boxes. Many pre-1940 German silverware sets marked with the crescent moon and crown are .800 silver."}},{"@type":"Question","name":"Can I sell .800 silver at a UK pawnbroker?","acceptedAnswer":{"@type":"Answer","text":"Yes, most UK pawnbrokers accept .800 silver, but they typically pay less per gram than specialist precious metal dealers because of the lower purity. For the best price, use a weight-based online buyer or specialist silver dealer who evaluates items purely on metal content."}},{"@type":"Question","name":"Is .800 silver magnetic?","acceptedAnswer":{"@type":"Answer","text":"No, genuine .800 silver is not magnetic. Silver and copper (its main alloying metal) are both non-magnetic. If your item is attracted to a magnet, it is likely silver-plated over a ferromagnetic base metal, not solid .800 silver."}}]}</script>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
@@ -553,240 +516,644 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
     </div>
   </div>
 </nav>
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">.800 European Silver Price Per Gram</li></ol></div>
-<div class="hero">
-  <div class="hero-tag">Live .800 European Silver Price</div>
-  <h1 class="hero-title">.800 European Silver Price Per Gram Today</h1>
-  <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Live silver spot price in multiple weights. Updated every 60 seconds.</p>
-  </div>
-<div class="content">
-  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about">About our data</a></div>
 
-      <div class="calc-panel" id="panel-silver" role="tabpanel" style="display:block; max-width: 600px; margin: 2rem auto; border: 1px solid var(--color-border); border-radius: 12px; padding: 1.5rem;">
-        <div class="calc-row" style="display:grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem;">
-          <div class="form-group">
-            <label class="form-label" for="silverPurity" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Silver Purity</label>
-            <div class="form-select-wrap">
-              <select class="form-select" id="silverPurity" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);" disabled>
-                <option value="0.800" selected>.800 European Silver</option>
-              </select>
-            </div>
-            <p style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: 0.25rem;">Locked to .800 European Silver</p>
-          </div>
-          <div class="form-group">
-            <label class="form-label" for="silverWeight" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Weight</label>
-            <input class="form-input" type="number" id="silverWeight" value="1" min="0" step="0.01" placeholder="Enter weight" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
-          </div>
-        </div>
-        <div class="calc-row" style="display:grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem;">
-          <div class="form-group">
-            <label class="form-label" for="silverUnit" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Weight Unit</label>
-            <div class="form-select-wrap">
-              <select class="form-select" id="silverUnit" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
-                <option value="1" selected>Grams (g)</option>
-                <option value="31.1035">Troy Ounces (oz t)</option>
-                <option value="1000">Kilograms (kg)</option>
-                <option value="1.55517">Pennyweight (dwt)</option>
-              </select>
-            </div>
-          </div>
-          <div class="form-group">
-            <label class="form-label" for="silverCurrency" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Currency</label>
-            <div class="form-select-wrap">
-              <select class="form-select" id="silverCurrency" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
-                <option value="USD" selected>USD ($)</option>
-                <option value="GBP">GBP (£)</option>
-                <option value="EUR">EUR (€)</option>
-                <option value="INR">INR (₹)</option>
-              </select>
-            </div>
-          </div>
-        </div>
-        <div class="calc-result" style="text-align:center; padding: 1.5rem; background: var(--color-surface); border-radius: 8px;">
-          <div class="calc-result-label" style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--color-text-muted); margin-bottom: 0.5rem;">Estimated Value</div>
-          <div class="calc-result-value" id="silverResult" style="font-family: var(--font-display); font-size: 2.5rem; font-weight: 700; color: var(--color-gold-bright);">—</div>
-          <div class="calc-result-meta" id="silverResultMeta" style="font-size: 0.875rem; color: var(--color-text-muted); margin-top: 0.5rem;"></div>
-        </div>
-      </div>
-
-  <div class="prose">
-    <h2>Silver Price by Weight</h2>
-    <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-    <table class="data-table" aria-label="Live silver price by weight">
-      <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
-      <tbody>
-        <tr><td>1 gram</td><td id="t-1g-gbp" data-nosnippet>&mdash;</td><td id="t-1g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>10 grams</td><td id="t-10g-gbp" data-nosnippet>&mdash;</td><td id="t-10g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>100 grams</td><td id="t-100g-gbp" data-nosnippet>&mdash;</td><td id="t-100g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>1 troy ounce (31.1g)</td><td id="t-oz-gbp" data-nosnippet>&mdash;</td><td id="t-oz-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>500 grams</td><td id="t-500g-gbp" data-nosnippet>&mdash;</td><td id="t-500g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>1 kilogram</td><td id="t-1k-gbp" data-nosnippet>&mdash;</td><td id="t-1k-usd" data-nosnippet>&mdash;</td></tr>
-      </tbody>
-    </table>
-    <h2>Silver Purity Grades</h2>
-<table class="data-table" aria-label="Silver purity grades and indicative prices">
-  <thead><tr><th>Purity</th><th>Grade</th><th>Price per Gram</th><th>Price per Kg</th><th>Price per Troy Oz</th></tr></thead>
-  <tbody>
-    <tr><td>.999</td><td>Fine</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
-    <tr><td>.925</td><td>Sterling</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
-    <tr><td>.900</td><td>Coin</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
-    <tr><td>.800</td><td>European</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
-  </tbody>
-</table>
-
-
-    <h2>What is .800 European Silver?</h2>
-    <p>.800 silver is an alloy composed of 80% pure silver and 20% other metals, usually copper. This purity grade is most strongly associated with continental Europe, particularly Germany, Italy, France, and the Netherlands, where it was historically the standard for silverware, flatware, and holloware.</p>
-
-    <h2>Where is .800 Silver Found?</h2>
-    <p>You will frequently find .800 silver in antique European cutlery sets, tea services, decorative trays, and some older pocket watches. Because it contains more copper than sterling silver, it is harder and more durable, which made it ideal for functional household items that saw daily use.</p>
-
-    <h2>How to Identify .800 Silver</h2>
-    <p>.800 silver is identified by its hallmark. Look for a stamp that simply reads "800". In Germany, following the unification hallmark laws of 1888, the "800" stamp is often accompanied by a crescent moon (Halbmond) and a crown (Krone). Italian pieces may also have regional assay marks next to the 800 stamp.</p>
-
-    <h2>.800 Silver vs Sterling Silver</h2>
-    <p>Sterling silver (.925) contains 92.5% pure silver, making it significantly purer than .800 European silver. For an extensive breakdown of silver purities, read our <a href="/guides/gold-purity-guide">Purity Guide</a>. Because .800 silver has a lower silver content, its melt value per gram is lower than that of sterling.</p>
-
-    <h2>Selling .800 Silver in the UK</h2>
-    <p>While the UK standard is sterling, antique dealers and scrap buyers in the UK readily purchase .800 silver. Since it is below the UK standard, it cannot legally be described simply as "silver" in trade without specifying the fineness, and it is usually valued purely on its 80% silver melt content rather than antique value, unless it is a particularly rare or desirable piece.</p>
-
-<h2>Frequently Asked Questions</h2>
-
-<div class="faq-container">
-<div class="faq-card">
-  <h3 class="faq-answer-summary">What is .800 silver worth per gram today?</h3>
-  <p class="faq-answer">The value of .800 silver per gram is calculated by multiplying the live silver spot price per gram by 0.800 (80% purity). The live price is shown on this page.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">Is .800 silver worth anything?</h3>
-  <p class="faq-answer">Yes, .800 silver contains 80% pure silver, giving it significant intrinsic melt value based on the current silver spot price.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">How do I identify .800 European silver?</h3>
-  <p class="faq-answer">.800 silver is typically identified by an '800' hallmark stamp. German pieces often feature a crescent moon and crown mark alongside the 800 stamp.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">What is the difference between .800 silver and sterling silver?</h3>
-  <p class="faq-answer">.800 silver is 80% pure silver, commonly used in continental Europe for cutlery and holloware. Sterling silver (.925) is purer, containing 92.5% silver, and is the standard in the UK and US.</p>
-</div>
+<div class="breadcrumb-wrap">
+  <ol class="breadcrumb" aria-label="Breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/guides/silver-guides/">Silver Guides</a></li>
+    <li aria-current="page">.800 European Silver Per Gram</li>
+  </ol>
 </div>
 
-
-    <h2>What is 800 Silver?</h2>
-    <p>800 silver (also called <em>European silver or German silver</em>) contains <strong>80.0% pure silver</strong>, with the remaining 20.0% made up of copper or other base metals. The hallmark <strong>800</strong> indicates 800 parts per thousand of silver. 800 silver was the dominant standard across Continental Europe and remains common in antique markets. Many French and Italian sterling-equivalent items carry the 800 mark.</p>
-    <p>It is commonly found in Continental European silverware, older cutlery sets, and antique items. It was widely used in Germany, France, and Eastern Europe before the 20th century. Understanding its silver content is essential when calculating scrap or melt value.</p>
-
-    <h2>How to Calculate the 800 Silver Price Per Gram</h2>
-    <p>The melt value formula for 800 silver is:</p>
-    <blockquote><strong>800 silver price per gram = (Spot price per troy oz ÷ 31.1035) × 0.8</strong></blockquote>
-    <p>For example, if silver spot is $33.00 per troy ounce:</p>
-    <ul>
-      <li>Price per gram of pure silver = $33.00 ÷ 31.1035 = <strong>$1.061</strong></li>
-      <li>800 silver price per gram = $1.061 × 0.8 = <strong>$0.849</strong></li>
-    </ul>
-    <p>The melt value is the maximum intrinsic value. Dealers will pay a percentage of this — typically 70%–90% for scrap silver, depending on quantity and condition. Our live calculator above applies the current spot price automatically.</p>
-
-    <h2>The 800 Hallmark</h2>
-    <p>In the UK, the Hallmarking Act 1973 requires independent assay of precious metals above certain weight thresholds. A <strong>800 mark</strong> on silverware or jewellery confirms a silver purity of 80.0%. Unlike 925 sterling silver (the most common UK standard) or 999 fine silver (used in bullion), 800 silver has a slightly warmer, slightly duller appearance due to its higher copper content.</p>
-    <p>When valuing antique 800 silver items, always weigh them accurately (deducting any non-silver components such as resin-filled bases or glass inserts) before calculating melt value.</p>
-
-    <h2>800 vs 925 Sterling Silver</h2>
-    <table class="data-table" aria-label="Silver purity comparison">
-      <thead><tr><th>Standard</th><th>Purity</th><th>Hallmark</th><th>Common Use</th></tr></thead>
-      <tbody>
-        <tr><td>999 Fine</td><td>99.9%</td><td>999</td><td>Bullion bars and coins</td></tr>
-        <tr><td>958 Britannia</td><td>95.8%</td><td>958</td><td>UK commemorative silver</td></tr>
-        <tr><td>925 Sterling</td><td>92.5%</td><td>925</td><td>Most UK/US jewellery and silverware</td></tr>
-        <tr><td>900 Coin Silver</td><td>90.0%</td><td>900</td><td>Pre-1965 US coins, Scandinavian silverware</td></tr>
-        <tr><td><strong>800</strong></td><td><strong>80.0%</strong></td><td><strong>800</strong></td><td><strong>Antique Continental silverware</strong></td></tr>
-      </tbody>
-    </table>
-
-    <h2>Selling 800 Silver in the UK</h2>
-    <p>Scrap 800 silver is accepted by most UK precious metal dealers and some pawnbrokers. Because its purity is below 925 sterling, some dealers apply a slightly lower buy rate. The best prices are typically offered by weight-based online buyers who evaluate items purely on metal content rather than craftsmanship.</p>
-    <p>For antique 800 silver items in good condition (e.g. Continental tea sets, cutlery, or decorative pieces), specialist antique silver dealers or auction houses may offer significantly more than melt value — sometimes 2×–5× melt for sought-after makers or patterns.</p>
-
-    <h2>Frequently Asked Questions</h2>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Is 800 silver worth buying as an investment?</h3>
-      <p class="faq-answer">800 silver has real silver content and tracks the silver price, so it retains intrinsic value. However, for pure investment purposes, 999 fine silver bullion (bars or coins) has a lower premium over spot and is more liquid. 800 silver is best viewed as a store of value you may also use or display.</p>
+<!-- ═════════════ PREMIUM HERO ═════════════ -->
+<section class="hero-premium" aria-labelledby="hero-title">
+  <div class="hero-premium__inner">
+    <div class="hero-eyebrow">
+      <span class="hero-eyebrow__pulse" aria-hidden="true"></span>
+      <span>Live · LBMA Spot · XAG/USD · .800 Fineness</span>
     </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">How can I identify 800 silver at home?</h3>
-      <p class="faq-answer">Look for the stamped 800 mark, often accompanied by other hallmarks (maker's mark, assay office symbol, or date letter). A jeweller's loupe helps with small items. Acid testing kits available online can confirm silver purity. Genuine 800 silver will not be magnetic.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Does 800 silver tarnish?</h3>
-      <p class="faq-answer">Yes — all silver alloys tarnish over time through oxidation of the copper content. 800 silver tarnishes slightly faster than 925 sterling due to its higher base metal content. Regular polishing with a silver cloth and proper storage in anti-tarnish pouches will maintain its appearance.</p>
+    <h1 class="hero-premium__title" id="hero-title">
+      .800 European Silver <span class="hero-premium__title-em">per gram</span> today
+    </h1>
+    <p class="hero-premium__sub">Real-time melt valuation for <strong>Continental European antique silver</strong> — German Halbmond &amp; Krone hallmarks, Italian and French .800 flatware. Quoted in <strong>USD</strong>, GBP and EUR, refreshed every 60 seconds from LBMA London spot data.</p>
+
+    <!-- 3-currency live price tiles — USD primary -->
+    <div class="price-tiles" role="region" aria-label="Live .800 silver prices per gram">
+      <article class="price-tile price-tile--primary">
+        <div class="price-tile__head">
+          <span class="price-tile__label">USD / gram</span>
+          <span class="price-tile__flag">US · Primary</span>
+        </div>
+        <div class="price-tile__value" id="hero-usd" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>.800 fineness · 80% pure Ag</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">GBP / gram</span>
+          <span class="price-tile__flag">UK</span>
+        </div>
+        <div class="price-tile__value" id="hero-gbp" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>.800 fineness · ex-VAT</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">EUR / gram</span>
+          <span class="price-tile__flag">EU</span>
+        </div>
+        <div class="price-tile__value" id="hero-eur" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>.800 fineness · ECB ref rate</div>
+      </article>
     </div>
 
-    <h2>Common .800 Silver Items and Their Value</h2>
-    <p>If you've inherited or collected silverware, knowing which items are commonly made from .800 silver can help you identify pieces worth valuing:</p>
-    <table class="data-table" aria-label="Common .800 silver items">
-      <thead><tr><th>Item</th><th>Typical Weight</th><th>Notes</th></tr></thead>
-      <tbody>
-        <tr><td>6-piece cutlery set</td><td>300–500g</td><td>German/Italian flatware sets; check for 800 stamp on each piece</td></tr>
-        <tr><td>Tea/coffee pot</td><td>400–800g</td><td>Deduct weight of non-silver handles and resin bases</td></tr>
-        <tr><td>Cake server/serving spoon</td><td>50–120g</td><td>Common estate sale find; often undervalued</td></tr>
-        <tr><td>Cigarette case</td><td>80–150g</td><td>Pre-war German cases frequently .800; check hinge mechanism</td></tr>
-        <tr><td>Decorative tray</td><td>200–1,000g</td><td>Larger trays can have significant melt value; weigh accurately</td></tr>
-        <tr><td>Pocket watch case</td><td>20–60g</td><td>Case only (movement is not silver); look for 800 stamp inside back cover</td></tr>
-      </tbody>
-    </table>
-    <p>To calculate the melt value of any .800 silver item, use our calculator above or the <a href="/scrap-gold-calculator">scrap metal calculator</a>. For items with potential antique or collector value (especially marked pieces from makers like WMF, Wilkens, or Bruckmann), consider getting a specialist valuation before selling for scrap.</p>
-    <p>For more on silver purity grades, see our <a href="/silver-purity-grades">silver purity grades</a> page, or compare with <a href="/900-silver-price-per-gram">.900 coin silver</a> and <a href="/guides/what-is-925-sterling-silver">925 sterling silver</a>. If you're looking at silver coins specifically, use our <a href="/silver-coins-calculator">silver coins calculator</a>.</p>
-
-    <div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative spot values and do not include dealer premiums. Physical silver coins and bars typically sell at 5&ndash;20% above spot. Not financial advice.</div>
-  </div>
-</div>
-<div class="content" style="padding-bottom:1.5rem">
-<!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
-  <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/800-silver-price-per-gram&text=.800+European+Silver+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
-  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/800-silver-price-per-gram&title=Silver+Price+Per+Kilo+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=.800+European+Silver+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fsilver-price-per-kilo" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
-</div>
-</div>
-
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
-    <h2>Related Gold &amp; Silver Guides</h2>
-    <div class="related-guides-grid">
-      <a href="/900-silver-price-per-gram" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">.900 Silver Price Per Gram</div>
-        <div class="related-card__desc">Today's .900 silver price per gram — commonly found in US coins and European flatware.</div>
-      </a>
-      <a href="/silver-price-per-kilo" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">Silver Price Per Kilo</div>
-        <div class="related-card__desc">Live silver price per kilogram — the standard unit for wholesale silver trading.</div>
-      </a>
-      <a href="/guides/what-is-925-sterling-silver" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">What is 925 Sterling Silver?</div>
-        <div class="related-card__desc">Learn how .925 sterling silver compares to .800 and .900 silver in purity and value.</div>
-      </a>
-      <a href="/guides/silver-price-per-gram-explained" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Silver Price Per Gram Explained</div>
-        <div class="related-card__desc">How silver spot prices are converted to a per-gram rate and what affects daily prices.</div>
-      </a>
-      <a href="/scrap-gold-calculator" class="related-card">
-        <div class="related-card__tag">Tool</div>
-        <div class="related-card__title">Scrap Metal Calculator</div>
-        <div class="related-card__desc">Calculate the melt value of .800 silver flatware, coins or jewellery at today's price.</div>
-      </a>
-      <a href="/gold-silver-ratio" class="related-card">
-        <div class="related-card__tag">Live Tool</div>
-        <div class="related-card__title">Gold-Silver Ratio</div>
-        <div class="related-card__desc">Track the live gold-to-silver ratio — a key metric for silver investors.</div>
+    <!-- Live status bar -->
+    <div class="live-status" role="status" aria-live="polite">
+      <span class="live-status__dot" aria-hidden="true"></span>
+      <span class="live-status__label">Live</span>
+      <span class="live-status__divider" aria-hidden="true">·</span>
+      <span class="live-status__meta">Spot: <strong id="spot-usd" data-nosnippet>&mdash;</strong></span>
+      <span class="live-status__divider" aria-hidden="true">·</span>
+      <span class="live-status__meta">Updated <span id="updated-time">just now</span></span>
+      <span class="live-status__divider" aria-hidden="true">·</span>
+      <span class="live-status__meta">Refresh in <span id="refresh-counter">60s</span></span>
+      <a href="#calculator" class="live-status__cta">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>
+        Calculate
       </a>
     </div>
   </div>
 </section>
+
+<!-- Trust strip -->
+<div class="trust-strip">
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    LBMA-sourced XAG spot
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+    60-second refresh
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/><circle cx="12" cy="12" r="10"/></svg>
+    USD · GBP · EUR
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2v20M2 12h20"/><circle cx="12" cy="12" r="3"/></svg>
+    .800 fineness locked
+  </span>
+  <a href="/about" class="trust-strip__item trust-strip__item--link">About our data &rarr;</a>
+</div>
+
+<!-- ═════════════ LIVE CALCULATOR ═════════════ -->
+<section class="calc-pro" id="calculator" aria-labelledby="calc-title">
+  <div class="calc-pro__card">
+    <div class="calc-pro__head">
+      <div class="calc-pro__head-left">
+        <h2 class="calc-pro__title" id="calc-title">
+          <svg class="calc-pro__title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M12 14h.01M16 14h.01M8 18h2M12 18h.01M16 18h.01"/></svg>
+          .800 Silver Calculator
+        </h2>
+        <p class="calc-pro__sub">Enter the weight of your German, Italian or French .800 silverware — get live melt value, dealer payout estimate and antique-market premium guidance. <strong>USD primary</strong>, GBP and EUR conversions live.</p>
+      </div>
+      <span class="calc-pro__head-badge">
+        <span class="live-dot" aria-hidden="true"></span>
+        Live · 60s refresh
+      </span>
+    </div>
+
+    <div class="calc-pro__body">
+      <div class="calc-pro__row">
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-weight">Weight</label>
+          <input class="calc-pro__input" type="number" id="calc-weight" inputmode="decimal" placeholder="e.g. 100" min="0" step="0.01" value="100" aria-label="Weight value">
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-unit">Unit</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-unit" aria-label="Weight unit">
+              <option value="1" selected>grams</option>
+              <option value="1000">kilograms</option>
+              <option value="31.1035">troy ounces</option>
+              <option value="1.55517">pennyweight (dwt)</option>
+            </select>
+          </div>
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-currency">Currency</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-currency" aria-label="Display currency">
+              <option value="USD" selected>USD ($)</option>
+              <option value="GBP">GBP (£)</option>
+              <option value="EUR">EUR (€)</option>
+              <option value="INR">INR (₹)</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class="calc-pro__row" style="grid-template-columns:1fr;margin-top:calc(-1 * var(--space-2))">
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-purity">Purity</label>
+          <div class="calc-pro__purity-locked">
+            <span>
+              <strong>.800 European Silver</strong> &nbsp;·&nbsp; 80.0% pure Ag &nbsp;·&nbsp; locked
+            </span>
+            <svg class="lock-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 018 0v4"/></svg>
+          </div>
+          <input type="hidden" id="calc-purity" value="0.800">
+        </div>
+      </div>
+
+      <div class="calc-pro__chips" role="group" aria-label="Quick weight presets">
+        <span class="calc-pro__chips-label">Quick weights:</span>
+        <button class="calc-chip" type="button" data-weight="1" data-unit="1">1g</button>
+        <button class="calc-chip" type="button" data-weight="10" data-unit="1">10g</button>
+        <button class="calc-chip active" type="button" data-weight="100" data-unit="1">100g</button>
+        <button class="calc-chip" type="button" data-weight="31.1035" data-unit="1">1 troy oz</button>
+        <button class="calc-chip" type="button" data-weight="250" data-unit="1">250g cutlery set</button>
+        <button class="calc-chip" type="button" data-weight="500" data-unit="1">500g tea pot</button>
+        <button class="calc-chip" type="button" data-weight="1000" data-unit="1">1kg</button>
+      </div>
+
+      <div class="calc-pro__result">
+        <div class="calc-pro__result-primary">
+          <span class="calc-pro__result-label-main">Melt value (.800)</span>
+          <span class="calc-pro__result-main" id="calc-melt" data-nosnippet>&mdash;</span>
+        </div>
+        <div class="calc-pro__result-grid">
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Dealer pays (~80%)</span>
+            <span class="calc-pro__result-item-value" id="calc-dealer" data-nosnippet>&mdash;</span>
+          </div>
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Antique premium (2×–5× melt)</span>
+            <span class="calc-pro__result-item-value" id="calc-antique" data-nosnippet>&mdash;</span>
+          </div>
+        </div>
+      </div>
+      <p class="calc-pro__hint">Formula: <code>weight (g) × (spot USD/oz ÷ 31.1035) × 0.800</code>. Scrap-grade .800 silver payouts typically sit at <strong>75–88% of melt</strong>; antique pieces by makers like WMF, Wilkens, Christofle or Buccellati can fetch <strong>2×–5× melt</strong> at auction. Deduct non-silver components (resin bases, glass inserts, wooden handles) before weighing. <a href="/where-to-sell-gold-silver">Find specialist silver buyers&nbsp;&rarr;</a></p>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ STAT CARDS ═════════════ -->
+<section class="stat-cards" aria-label=".800 silver key facts">
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+    <div class="stat-card__value">80.0%</div>
+    <div class="stat-card__label">Pure silver content — balance 20% copper</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 18a9 9 0 1 0 0-13"/><path d="M9 9l3 3-3 3M9 3l3 3-3 3M9 15l3 3-3 3"/></svg>
+    <div class="stat-card__value">☾ ♛</div>
+    <div class="stat-card__label">Halbmond &amp; Krone — German 1888+ standard mark</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 9h18M8 14h2M8 17h2"/></svg>
+    <div class="stat-card__value">86.5%</div>
+    <div class="stat-card__label">Of sterling .925 melt value, gram-for-gram</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    <div class="stat-card__value">5 countries</div>
+    <div class="stat-card__label">Germany, Italy, France, Austria, Netherlands</div>
+  </article>
+</section>
+
+<!-- ═════════════ LIVE PRICE TABLE ═════════════ -->
+<section class="price-table-section" aria-labelledby="price-table-title">
+  <div class="price-table-card">
+    <div class="price-table-card__head">
+      <div>
+        <h2 class="price-table-card__title" id="price-table-title">.800 Silver Price by Weight</h2>
+        <p class="price-table-card__sub"><strong>Live</strong> · 80% pure silver · 1g to 1kg · USD primary</p>
+      </div>
+      <div class="currency-switch" role="tablist" aria-label="Choose currency to highlight">
+        <button class="currency-switch__btn active" role="tab" data-currency="USD" aria-selected="true">USD</button>
+        <button class="currency-switch__btn" role="tab" data-currency="GBP" aria-selected="false">GBP</button>
+        <button class="currency-switch__btn" role="tab" data-currency="EUR" aria-selected="false">EUR</button>
+      </div>
+    </div>
+    <div class="price-table-card__body">
+      <figure itemscope itemtype="https://schema.org/Table" style="margin:0">
+        <figcaption class="sr-only">Live .800 European silver price by weight in USD, GBP and EUR — updated every 60 seconds</figcaption>
+        <table class="price-table-pro" aria-label=".800 silver price by weight">
+          <thead><tr><th>Weight</th><th data-col="USD">USD</th><th data-col="GBP">GBP</th><th data-col="EUR">EUR</th></tr></thead>
+          <tbody>
+            <tr><td>1g <span class="weight-label-sub">Per-gram benchmark</span></td><td id="t-1g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-1g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-1g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>10g <span class="weight-label-sub">Small spoon / coin lot</span></td><td id="t-10g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-10g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-10g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1 <a href="/how-many-grams-in-troy-ounce">troy oz</a> <span class="weight-label-sub">31.1035g · Spot quote unit</span></td><td id="t-oz-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-oz-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-oz-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>100g <span class="weight-label-sub">Cake server / cigarette case</span></td><td id="t-100g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-100g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-100g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>250g <span class="weight-label-sub">6-piece cutlery set</span></td><td id="t-250g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-250g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-250g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>500g <span class="weight-label-sub">Tea pot / decorative tray</span></td><td id="t-500g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-500g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-500g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1 kg <span class="weight-label-sub">Tea service / large tray</span></td><td id="t-1k-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-1k-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-1k-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+          </tbody>
+        </table>
+      </figure>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ PURITY GRID ═════════════ -->
+<section class="purity-section" aria-labelledby="purity-section-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Silver purity grades compared</span>
+      <h2 class="section-title" id="purity-section-title">Where .800 fits in the silver hierarchy</h2>
+      <p class="section-sub">All four grades use the same XAG/USD spot price as a base, multiplied by the purity ratio. .999 fine is the LBMA bullion standard; .800 is the historic Continental European antique standard. Live USD prices below.</p>
+    </div>
+  </div>
+  <div class="purity-cards">
+    <a href="/silver-price-per-kilo" class="purity-card">
+      <div class="purity-card__purity">.999</div>
+      <div class="purity-card__grade">Fine Silver</div>
+      <div class="purity-card__pct">99.9% pure</div>
+      <div class="purity-card__use">Investment bullion · LBMA standard · 1kg bars</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / gram</span><span id="purity-999-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/guides/what-is-925-sterling-silver" class="purity-card">
+      <div class="purity-card__purity">.925</div>
+      <div class="purity-card__grade">Sterling</div>
+      <div class="purity-card__pct">92.5% pure</div>
+      <div class="purity-card__use">Jewellery, flatware, UK/US hallmarked standard</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / gram</span><span id="purity-925-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/900-silver-price-per-gram" class="purity-card">
+      <div class="purity-card__purity">.900</div>
+      <div class="purity-card__grade">Coin Silver</div>
+      <div class="purity-card__pct">90.0% pure</div>
+      <div class="purity-card__use">US pre-1965 dimes, quarters, half dollars</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / gram</span><span id="purity-900-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <div class="purity-card purity-card--featured">
+      <div class="purity-card__purity">.800</div>
+      <div class="purity-card__grade">European</div>
+      <div class="purity-card__pct">80.0% pure</div>
+      <div class="purity-card__use">Continental antique silverware · German Halbmond &amp; Krone</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / gram</span><span id="purity-800-usd" data-nosnippet>&mdash;</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ FORMULA BLOCK ═════════════ -->
+<section class="formula-block" aria-labelledby="formula-title">
+  <div class="formula-card">
+    <div class="formula-card__eyebrow">The Math</div>
+    <h2 class="formula-card__title" id="formula-title">How the .800 silver price per gram is calculated</h2>
+    <p style="color:var(--color-text-muted);font-size:var(--text-sm);margin-bottom:var(--space-4);line-height:1.7">Silver is quoted globally in <strong style="color:var(--color-silver)">USD per troy ounce</strong> on COMEX (New York) and via the LBMA Silver Price benchmark in London. To get the .800 European silver gram value, divide the spot by 31.1035 (grams in a troy ounce), then multiply by the <strong style="color:var(--color-silver)">0.800 purity ratio</strong>.</p>
+    <div class="formula-card__equation"><span class="var">.800 USD/g</span> <span class="op">=</span> ( <span class="var">spot USD/oz</span> <span class="op">÷</span> 31.1035 ) <span class="op">×</span> 0.800</div>
+    <div class="formula-card__steps">
+      <div class="formula-step">
+        <div class="formula-step__num">1</div>
+        <div class="formula-step__text">Take the live LBMA spot price (<strong>USD per troy oz</strong> of .999 fine silver)</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">2</div>
+        <div class="formula-step__text">Divide by <strong>31.1035</strong> — grams in one troy ounce — to get pure silver USD/g</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">3</div>
+        <div class="formula-step__text">Multiply by the <strong>0.800 purity ratio</strong> to get the .800 silver USD/g melt value</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ HERITAGE USE CASES ═════════════ -->
+<section class="luxe-section" aria-labelledby="usecase-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Continental heritage</span>
+      <h2 class="section-title" id="usecase-title">Where you'll find .800 European silver</h2>
+      <p class="section-sub">From pre-1940 German cutlery flatware to Italian antique tea services and French Belle Époque holloware — .800 was the working standard of Continental craftsmen. Live USD melt values below.</p>
+    </div>
+  </div>
+  <div class="luxe-cards">
+    <article class="luxe-card">
+      <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path d="M16 4l-2 14h4l-2-14zM24 4l-2 14h4l-2-14zM32 4l-2 14h4l-2-14z"/>
+        <path d="M14 18h4v22h-4zM22 18h4v22h-4zM30 18h4v22h-4z"/>
+        <path d="M10 44h28"/>
+      </svg>
+      <div class="luxe-card__category">German Flatware</div>
+      <h3 class="luxe-card__title">WMF, Wilkens &amp; Koch &amp; Bergfeld</h3>
+      <p class="luxe-card__desc">From 1888 onwards, German silverware bearing the <strong>Halbmond &amp; Krone</strong> mark with "800" was the household standard. WMF, Wilkens, Bruckmann and Koch &amp; Bergfeld 6-piece cutlery sets weigh 250–500g per set. Pre-1940 pieces often carry significant antique premium.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-cutlery-stat" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">Melt value, 250g set</span>
+      </div>
+    </article>
+    <article class="luxe-card">
+      <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path d="M14 10h20v6c0 8-5 14-10 14s-10-6-10-14V10z"/>
+        <path d="M34 14c4 0 6 2 6 5s-2 5-6 5"/>
+        <path d="M8 38h32v4H8zM18 30v8M30 30v8"/>
+      </svg>
+      <div class="luxe-card__category">Italian Tea Services</div>
+      <h3 class="luxe-card__title">Antique Continental holloware</h3>
+      <p class="luxe-card__desc">Italian, French and Austrian tea and coffee services from 1880–1930 commonly used the <strong>.800 fineness</strong> for its workability and durability. A 5-piece tea service weighs 1.2–2.5kg of silver content — even at scrap rate this is substantial melt value, with antique premium often 3×–5× melt for desirable makers.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-tea-stat" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">Melt value, 1.5kg tea set</span>
+      </div>
+    </article>
+    <article class="luxe-card">
+      <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <circle cx="24" cy="26" r="14"/>
+        <path d="M24 18v8l5 5M24 12v-4M20 8h8"/>
+        <circle cx="24" cy="26" r="1.5" fill="currentColor"/>
+      </svg>
+      <div class="luxe-card__category">Pocket Watch Cases</div>
+      <h3 class="luxe-card__title">Pre-1940 European mechanical movements</h3>
+      <p class="luxe-card__desc">Continental European pocket watches from the late 19th and early 20th centuries frequently used .800 silver cases — look for the <strong>"800" stamp inside the back cover</strong>. Case-only weight is typically 20–60g. The movement is brass/steel, not silver, so weigh the case separately for accurate melt value.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-watch-stat" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">Melt value, 40g case</span>
+      </div>
+    </article>
+  </div>
+</section>
+
+<!-- ═════════════ HALLMARK GALLERY ═════════════ -->
+<section class="hallmark-section" aria-labelledby="hallmark-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Identification</span>
+      <h2 class="section-title" id="hallmark-title">.800 hallmarks by region</h2>
+      <p class="section-sub">Each Continental European country marked .800 silver differently. Use a jeweller's loupe (10× magnification) to inspect the underside, base, or inside lip of any piece you suspect is .800 European silver.</p>
+    </div>
+  </div>
+  <div class="hallmark-grid">
+    <div class="hallmark-card">
+      <div class="hallmark-card__mark">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/></svg>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M5 16l2-6 5 4 5-4 2 6M5 19h14"/></svg>
+        <span>800</span>
+      </div>
+      <div class="hallmark-card__country">Germany (1888+)</div>
+      <div class="hallmark-card__desc">Crescent moon (Halbmond) + crown (Krone) + 800. Often with maker's mark.</div>
+    </div>
+    <div class="hallmark-card">
+      <div class="hallmark-card__mark">
+        <span>800</span>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="2"/><circle cx="12" cy="12" r="5"/></svg>
+      </div>
+      <div class="hallmark-card__country">Italy (1934+)</div>
+      <div class="hallmark-card__desc">"800" stamp + regional province assay number (e.g. 1AL for Alessandria).</div>
+    </div>
+    <div class="hallmark-card">
+      <div class="hallmark-card__mark">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2l10 10-10 10L2 12z"/><path d="M12 8v8M8 12h8"/></svg>
+        <span>800</span>
+      </div>
+      <div class="hallmark-card__country">France (1838+)</div>
+      <div class="hallmark-card__desc">Boar's head (Paris) or crab (provinces) + "800" minerve mark below 950 standard.</div>
+    </div>
+    <div class="hallmark-card">
+      <div class="hallmark-card__mark">
+        <span>800</span>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v10M7 12h10"/></svg>
+      </div>
+      <div class="hallmark-card__country">Netherlands / Austria</div>
+      <div class="hallmark-card__desc">Dutch lion or Austrian Diana head + "800" — common pre-1953.</div>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ EDITORIAL CONTENT ═════════════ -->
+<div class="content-section">
+  <article class="prose-pro">
+    <h2 id="what-is-800-silver">What is .800 European silver?</h2>
+    <div class="snippet-answer">.800 European silver is an alloy of <strong>80.0% pure silver</strong> and 20.0% copper (or other base metals), historically the dominant fineness for Continental European silverware. The "800" hallmark indicates 800 parts of pure silver per 1,000 parts alloy. It was the working standard in Germany, Italy, France, Austria and the Netherlands from the mid-19th century through World War II — encompassing cutlery flatware, tea and coffee services, pocket watch cases, cigarette cases and decorative holloware.</div>
+
+    <h2 id="todays-800-silver-price">What is .800 silver worth per gram today?</h2>
+    <div class="snippet-answer">The live .800 silver price per gram is approximately <strong><span id="snippet-price" data-nosnippet>[live USD value]</span></strong> today. This is calculated by multiplying the live LBMA spot price (USD per troy ounce) by <strong>0.800</strong> (the purity ratio) and dividing by <strong>31.1035</strong> (grams in a troy ounce). <strong>USD is the primary currency</strong> on this page because silver is quoted globally in US dollars on COMEX and via the LBMA London benchmark. GBP and EUR conversions use live ECB reference rates and refresh every 60 seconds.</div>
+
+    <h2>How the LBMA spot price drives .800 silver value</h2>
+    <p>Silver's global benchmark is the <strong>LBMA Silver Price</strong>, an electronic auction conducted at <strong>12:00 GMT daily</strong> by ICE Benchmark Administration. Throughout the trading day, the live spot price is set by COMEX (New York) silver futures, with significant activity in Shanghai (SHFE) and London OTC markets. GoldPriceTools sources live XAG/USD spot prices from <code style="font-family:var(--font-mono);background:var(--color-surface-offset);padding:2px 6px;border-radius:4px;font-size:90%">gold-api.com</code> (LBMA-derived), updated every 60 seconds. Currency conversion to GBP and EUR uses the <strong>Frankfurter API</strong> (ECB reference rates). The same USD spot is applied uniformly across every page on this site to ensure cross-page consistency — your .800 gram value here matches the .999 kilo value on our <a href="/silver-price-per-kilo">silver price per kilo</a> page, scaled only by purity and weight.</p>
+
+    <h2>How to identify .800 European silver</h2>
+    <p>Authentic .800 silver carries a clear hallmark. Look on the underside of trays, the back of spoon handles, inside the lip of bowls, or the inner back cover of pocket watches. Use a <strong>10× jeweller's loupe</strong> for small marks. The five most common markings are:</p>
+    <ul>
+      <li><strong>Germany (post-1888)</strong> — Crescent moon (<em>Halbmond</em>) and crown (<em>Krone</em>) symbols stamped alongside "800", often with a maker's mark. This is the Imperial Hallmarking Act standard.</li>
+      <li><strong>Italy (post-1934)</strong> — "800" inside a lozenge with the provincial assay office number (e.g. "1AL" for Alessandria, "27MI" for Milan, "1313FI" for Florence).</li>
+      <li><strong>France (post-1838)</strong> — Boar's head (Paris assay) or crab (provincial) Minerve hallmark with the "2nd standard" classification (silver ≥800/1000).</li>
+      <li><strong>Austria-Hungary &amp; successor states</strong> — Diana head (1872–1922), or "A" inside a triangle, accompanied by "800".</li>
+      <li><strong>Netherlands</strong> — Lion passant + "800" — used 1814–1953, before the introduction of the Dutch sword mark system.</li>
+    </ul>
+
+    <h2>How to calculate .800 silver melt value step-by-step</h2>
+    <p>The formula is:</p>
+    <blockquote><strong>.800 silver USD/g = (Spot USD/oz ÷ 31.1035) × 0.800</strong></blockquote>
+    <p>For example, at a silver spot price of $33.00 per troy ounce:</p>
+    <ul>
+      <li>Pure silver USD/g = $33.00 ÷ 31.1035 = <strong>$1.061 / gram</strong></li>
+      <li>.800 silver USD/g = $1.061 × 0.800 = <strong>$0.849 / gram</strong></li>
+      <li>A 250g German cutlery set = $0.849 × 250 = <strong>$212.27 melt value</strong></li>
+      <li>A 1.5kg Italian tea service = $0.849 × 1500 = <strong>$1,273.65 melt value</strong></li>
+    </ul>
+    <p>Use the calculator above for live figures — the maths refreshes every 60 seconds with the current LBMA spot.</p>
+
+    <div class="callout">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg>
+      <div>
+        <div class="callout__title">UK VAT &amp; CGT considerations</div>
+        <div class="callout__body">Silver scrap and antique silver are subject to <strong>20% VAT</strong> in the UK at retail (gold is exempt). Profits on antique silver can be subject to <strong>Capital Gains Tax</strong>; second-hand antique silver may also qualify for the VAT margin scheme depending on dealer registration. Always confirm with HMRC or a qualified tax adviser before significant transactions.</div>
+      </div>
+    </div>
+
+    <h2>Selling .800 silver: scrap vs antique value</h2>
+    <p>A key decision when valuing .800 silver is whether to sell at scrap rate or pursue antique market premium:</p>
+    <div class="market-table-wrap">
+      <table class="market-table" aria-label=".800 silver selling channels comparison">
+        <thead><tr><th>Channel</th><th>Typical payout</th><th>Best for</th></tr></thead>
+        <tbody>
+          <tr><td>Bullion scrap dealer</td><td>75–85% of melt</td><td>Damaged, unmarked or generic pieces</td></tr>
+          <tr><td>Specialist silver buyer</td><td>82–88% of melt</td><td>Hallmarked, intact, weighable</td></tr>
+          <tr><td>UK pawnbroker</td><td>60–75% of melt</td><td>Quick liquidity, lower priority</td></tr>
+          <tr><td>Antique auction house</td><td>Hammer + 80–90%</td><td>Maker-marked Wilkens, Christofle, WMF, Buccellati</td></tr>
+          <tr><td>Direct collector sale</td><td>Up to 5× melt</td><td>Complete services, rare patterns, Belle Époque</td></tr>
+          <tr><td>Online marketplace</td><td>Variable; 1.5–3× melt</td><td>Documented provenance, photos, full descriptions</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p>For most household estate-clearance pieces, weight-based online silver buyers offer the best balance of price and convenience. For documented antique services by sought-after makers, an auction valuation is worth the wait. Use our <a href="/where-to-sell-gold-silver">where to sell gold &amp; silver guide</a> for vetted dealer recommendations.</p>
+
+    <h2>.800 silver vs sterling .925 — the math</h2>
+    <p>Sterling silver (.925) contains 92.5% pure silver, making it 15.6% richer in silver content per gram than .800. The melt-value ratio is straightforward: <strong>0.800 ÷ 0.925 = 86.5%</strong>. So .800 silver is worth about 86.5% of sterling per gram. Other differences:</p>
+    <ul>
+      <li><strong>Hardness &amp; durability</strong> — .800 contains more copper, making it harder and slightly more wear-resistant. Ideal for daily-use cutlery.</li>
+      <li><strong>Tarnish rate</strong> — .800 tarnishes faster than .925 due to higher copper content. Regular polishing required.</li>
+      <li><strong>Colour</strong> — .800 has a subtle warmer, slightly duller hue. Side-by-side comparison reveals the copper undertone.</li>
+      <li><strong>Geography</strong> — .925 is the UK/US standard; .800 is the Continental European standard. Hallmarks reveal the origin.</li>
+      <li><strong>Antique value</strong> — Both grades carry premium for collector pieces. Sterling Georgian silver and Continental .800 Belle Époque both command 3×–10× melt for the best examples.</li>
+    </ul>
+
+    <div class="callout">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/><path d="M9 12l2 2 4-4"/></svg>
+      <div>
+        <div class="callout__title">Verifying authenticity</div>
+        <div class="callout__body">Genuine .800 silver is <strong>non-magnetic</strong>. If your piece sticks to a magnet, it's silver-plated over a ferrous base — worth only the value of the thin silver layer (typically pennies). For ambiguous pieces, a <strong>silver acid test kit</strong> or XRF analysis at a specialist dealer can confirm purity. Acid testing is destructive at a tiny spot; XRF is non-destructive but requires specialist equipment.</div>
+      </div>
+    </div>
+
+    <h2>What weight of .800 silver is each common item?</h2>
+    <p>Knowing typical weights helps you estimate melt value before weighing — particularly useful when scouting estate sales or flea markets:</p>
+    <div class="market-table-wrap">
+      <table class="market-table" aria-label="Common .800 silver items and weights">
+        <thead><tr><th>Item</th><th>Typical weight</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td>Spoon (teaspoon/dessert)</td><td>20–40g</td><td>Stamp on the back of the handle near the bowl</td></tr>
+          <tr><td>Fork / knife handle</td><td>30–80g</td><td>Knives often have steel blades — weigh handle only</td></tr>
+          <tr><td>6-piece cutlery set</td><td>250–500g</td><td>Cased German/Italian sets common at estate sales</td></tr>
+          <tr><td>Cake server / serving spoon</td><td>50–120g</td><td>Frequently undervalued at house clearances</td></tr>
+          <tr><td>Cigarette case</td><td>80–150g</td><td>Pre-war German cases often .800; check hinge interior</td></tr>
+          <tr><td>Pocket watch case</td><td>20–60g</td><td>Movement is brass/steel; weigh case only</td></tr>
+          <tr><td>Tea / coffee pot</td><td>400–800g</td><td>Deduct ebony or ivory handle and resin base weight</td></tr>
+          <tr><td>5-piece tea service</td><td>1,200–2,500g</td><td>Sugar bowl, milk jug, tea pot, coffee pot, tray</td></tr>
+          <tr><td>Decorative tray</td><td>200–1,000g</td><td>Larger trays can hold substantial melt value</td></tr>
+          <tr><td>Picture frame</td><td>100–400g</td><td>Often silver foil over wood — verify with magnet test</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h2>Frequently asked questions</h2>
+    <div class="faq-pro">
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What is .800 silver worth per gram today in USD?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">The live .800 European silver price per gram in USD is shown in the hero tile at the top of this page and refreshes every 60 seconds. It is calculated as <strong>(LBMA spot USD/oz ÷ 31.1035) × 0.800</strong>. USD is the primary currency on this page because silver is quoted globally in US dollars; GBP and EUR conversions use live ECB reference rates.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How do I identify .800 European silver?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Look for an "800" hallmark stamp. German pieces (post-1888) feature a <strong>crescent moon (Halbmond) and crown (Krone)</strong> with the 800 mark. Italian pieces show "800" inside a lozenge with a provincial number. French pieces use a Minerve hallmark with the 2nd standard. Use a 10× jeweller's loupe and inspect the underside, base, or inside lip of any piece.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What is the difference between .800 silver and sterling silver (.925)?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">.800 silver is 80.0% pure silver, used historically across Continental Europe for cutlery and holloware. Sterling silver (.925) is 92.5% pure and is the UK/US hallmarked standard. By melt value, <strong>.800 is worth roughly 86.5% of sterling per gram</strong> (0.800 ÷ 0.925). .800 is harder due to higher copper content but tarnishes slightly faster.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What common items are made from .800 silver?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Common .800 items include German and Italian cutlery flatware sets, antique tea and coffee services, decorative trays, cake servers, pre-1940 pocket watch cases, cigarette cases, and small decorative boxes. Many <strong>WMF, Wilkens, Bruckmann, Koch &amp; Bergfeld, Christofle and Buccellati</strong> pieces are .800 fineness.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Is .800 silver worth selling for scrap?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Yes — .800 silver contains 80% pure silver with significant melt value. Dealers typically pay <strong>75–88% of melt</strong> for .800 scrap. For items by sought-after makers, antique value can be 2×–5× melt at auction. Always weigh accurately and deduct non-silver components (resin bases, glass inserts, wooden handles, steel blades) before calculating.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Is .800 silver magnetic?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">No — genuine .800 silver is <strong>non-magnetic</strong>. Silver and copper (its main alloying metal) are both non-ferromagnetic. If your item is attracted to a magnet, it is silver-plated over a steel or iron base, not solid .800 silver. The magnet test is the fastest first-pass authenticity check.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Why is silver priced in USD globally?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Silver is quoted in US dollars per troy ounce on the COMEX futures exchange and via the LBMA Silver Price daily auction in London. USD is the world's reserve currency and the most liquid quote unit for precious metals globally. All conversions to GBP, EUR or INR are mathematically derived from the live USD spot using ECB reference rates from the Frankfurter API.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How accurate are these live .800 silver prices?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Spot prices come direct from the LBMA via gold-api.com and refresh every 60 seconds. Currency conversion from USD to GBP and EUR uses the Frankfurter API's live ECB reference rates. These figures are <em>melt values</em> — the raw silver content. Dealer buy prices for .800 are typically 75–88% of melt; antique-market premiums for documented maker-marked pieces can exceed 3×–5× melt at auction.</div>
+      </details>
+    </div>
+
+    <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Dealer buy prices for .800 silver scrap are typically 75–88% of melt. Antique value for maker-marked Continental pieces can exceed 3×–5× melt at auction. UK retail purchases are subject to 20% VAT. Always verify with your dealer or auction house before transacting.</div>
+  </article>
+</div>
+
+<!-- Social share buttons -->
+<div class="content-section" style="padding-top:0;padding-bottom:1.5rem">
+<div class="share-buttons" style="max-width:760px;margin:0 auto">
+  <span>Share:</span>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/800-silver-price-per-gram&text=.800+European+Silver+Price+Per+Gram+Today+%28Live+USD%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/800-silver-price-per-gram&title=.800+European+Silver+Price+Per+Gram+Today+%28Live+USD%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=.800+European+Silver+Price+Per+Gram+Today+%28Live+USD%29%20https%3A%2F%2Fgoldpricetools.com%2F800-silver-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+</div>
+</div>
+
+<!-- Related Guides -->
+<section class="related-guides" aria-labelledby="related-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Keep reading</span>
+      <h2 class="section-title" id="related-title">Related Silver &amp; Gold Guides</h2>
+    </div>
+  </div>
+  <div class="related-guides-grid">
+    <a href="/900-silver-price-per-gram" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">.900 Silver Price Per Gram</div>
+      <div class="related-card__desc">Today's .900 coin silver per gram — US pre-1965 coinage and Scandinavian silverware.</div>
+    </a>
+    <a href="/silver-price-per-kilo" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">Silver Price Per Kilo</div>
+      <div class="related-card__desc">Live .999 fine silver per kilogram — bullion bars and wholesale silver trading.</div>
+    </a>
+    <a href="/guides/what-is-925-sterling-silver" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">What is 925 Sterling Silver?</div>
+      <div class="related-card__desc">How .925 sterling compares to .800 and .900 in purity, hallmarking and value.</div>
+    </a>
+    <a href="/silver-purity-grades" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Silver Purity Grades</div>
+      <div class="related-card__desc">Complete guide to .999, .958, .925, .900, .835 and .800 — fineness, hallmarks and uses.</div>
+    </a>
+    <a href="/scrap-gold-calculator" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">Scrap Metal Calculator</div>
+      <div class="related-card__desc">Calculate live USD melt value of mixed precious metal scrap at today's spot.</div>
+    </a>
+    <a href="/silver-coins-calculator" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">Silver Coins Calculator</div>
+      <div class="related-card__desc">Live USD melt value for US silver coins, Eagles, Britannias and pre-1965 dimes.</div>
+    </a>
+    <a href="/gold-silver-ratio" class="related-card">
+      <span class="related-card__tag">Live Tool</span>
+      <div class="related-card__title">Gold-Silver Ratio</div>
+      <div class="related-card__desc">Track the live gold-to-silver ratio — a key precious metals timing indicator.</div>
+    </a>
+    <a href="/where-to-sell-gold-silver" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Where to Sell Gold &amp; Silver</div>
+      <div class="related-card__desc">Vetted UK and US dealers, auction houses and online buyers for antique silver.</div>
+    </a>
+  </div>
+</section>
+
+<!-- Sticky mobile price bar -->
+<div class="sticky-price" id="stickyPrice" role="complementary" aria-label="Live price quick access">
+  <div class="sticky-price__info">
+    <div class="sticky-price__label">.800 Silver · USD/g</div>
+    <div class="sticky-price__value" id="sticky-usd" data-nosnippet>&mdash;</div>
+  </div>
+  <a href="#calculator" class="sticky-price__cta">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M8 18h2"/></svg>
+    Calculate
+  </a>
+</div>
 
 <footer>
   <div class="footer-inner">
@@ -795,7 +1162,7 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz, kilo and per gram by purity. Prices sourced from LBMA via gold-api.com, updated every 60 seconds. USD primary currency.</p>
       <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
@@ -808,7 +1175,6 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -838,17 +1204,6 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Blog</h4>
-      <ul>
-        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
-        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
-        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
-        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
-        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
-        <li><a href="/blog/">All Articles</a></li>
-      </ul>
-    </div>
-    <div class="footer-col">
       <h4>Info</h4>
       <ul>
         <li><a href="/about">About</a></li>
@@ -861,57 +1216,281 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
   </div>
   <div class="footer-bottom">
     <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
-    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com. USD primary.</span>
   </div>
 </footer>
+
 <script>
-async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
+/* ───────── Live .800 silver price engine — USD primary, multi-currency ─────────
+   Sources:
+     • Silver spot: https://api.gold-api.com/price/XAG  (LBMA-derived USD/oz)
+     • FX rates:    https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR
+   Refresh: 60s — DO NOT change interval (keeps cross-page consistency)
+   Purity: 0.800 (locked — this is the .800 European silver page)
+*/
+(function(){
+  const G_PER_OZ = 31.1035;
+  const PURITY = 0.800;
+  const REFRESH_MS = 60000;
+  const PURITIES = {'999':0.999, '925':0.925, '900':0.900, '800':0.800};
+  let lastFetchTs = 0;
+  let countdownTimer = null;
 
+  // Currency formatters — USD is primary
+  const fmtUSD = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:4,minimumFractionDigits:2});
+  const fmtGBP = new Intl.NumberFormat('en-GB',{style:'currency',currency:'GBP',maximumFractionDigits:4,minimumFractionDigits:2});
+  const fmtEUR = new Intl.NumberFormat('en-IE',{style:'currency',currency:'EUR',maximumFractionDigits:4,minimumFractionDigits:2});
+  const fmtINR = new Intl.NumberFormat('en-IN',{style:'currency',currency:'INR',maximumFractionDigits:2});
+  const fmtSpot = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
 
-function fmtCurr(val, cur) {
-  if (cur==='USD') return '$'+val.toFixed(2);
-  if (cur==='GBP') return '£'+(val*window._gbpusd).toFixed(2);
-  if (cur==='EUR') return '€'+(val*1.16).toFixed(2);
-  if (cur==='INR') return '₹'+(val*83.0).toFixed(2);
-  return val.toFixed(2);
-}
-function calcSilver(spotOz) {
-  if (!spotOz) return;
-  const purity=0.800, weight=parseFloat(document.getElementById('silverWeight').value)||0, unit=parseFloat(document.getElementById('silverUnit').value), currency=document.getElementById('silverCurrency').value;
-  const grams = weight * unit;
-  const usdVal = (spotOz / 31.1035) * purity * grams;
-  document.getElementById('silverResult').textContent = fmtCurr(usdVal, currency);
-  document.getElementById('silverResultMeta').textContent = `${grams.toFixed(4)}g × $80.0% purity × $${(spotOz/31.1035).toFixed(2)}/g spot`;
-}
+  function $(id){return document.getElementById(id);}
 
-async function fetchSpot(){try{const r=await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();const ozUSD=d.price;const gbpusd=window._gbpusd||0.79;const perG_USD=(ozUSD/31.1035)*0.800;const perG_GBP=perG_USD*gbpusd;
-    [[1,'1g'],[10,'10g'],[100,'100g'],[31.1035,'oz'],[500,'500g'],[1000,'1k']].forEach(([w,id])=>{const g=document.getElementById('t-'+id+'-gbp');const u=document.getElementById('t-'+id+'-usd');if(g)g.textContent='£'+(perG_GBP*w).toFixed(2);if(u)u.textContent='$'+(perG_USD*w).toFixed(2);});
+  async function fetchFx(){
+    try{
+      const r = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR',{cache:'no-store'});
+      if(!r.ok) throw new Error('FX fetch failed');
+      const d = await r.json();
+      window._gbpusd = d.rates.GBP || 0.79;
+      window._eurusd = d.rates.EUR || 0.92;
+      window._inrusd = d.rates.INR || 83.0;
+    }catch(e){
+      console.warn('FX fallback used',e);
+      window._gbpusd = window._gbpusd || 0.79;
+      window._eurusd = window._eurusd || 0.92;
+      window._inrusd = window._inrusd || 83.0;
+    }
+  }
 
-    // Purity Table logic
-    const purities = [0.999, 0.925, 0.900, 0.800];
-    const pure_oz = ozUSD;
-    const pure_g = pure_oz / 31.1035;
-    const tbody = document.querySelector('.data-table:nth-of-type(2) tbody');
-    if (tbody) {
-      const rows = tbody.querySelectorAll('tr');
-      purities.forEach((p, i) => {
-        if (rows[i]) {
-          const p_g = pure_g * p;
-          rows[i].cells[2].textContent = '£' + (p_g * gbpusd).toFixed(2);
-          rows[i].cells[3].textContent = '£' + (p_g * 1000 * gbpusd).toFixed(2);
-          rows[i].cells[4].textContent = '£' + (pure_oz * p * gbpusd).toFixed(2);
-        }
-      });
+  async function fetchSpot(){
+    try{
+      const r = await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});
+      if(!r.ok) throw new Error('Spot fetch failed');
+      const d = await r.json();
+      const spotUSD = d.price;
+      window._spotUSD = spotUSD;
+      lastFetchTs = Date.now();
+      render(spotUSD);
+      gtag('event','price_view',{metal:'silver',unit:'0.800'});
+    }catch(e){
+      console.warn('Silver spot fetch failed',e);
+    }
+  }
+
+  function render(spotUSD){
+    const gbp = window._gbpusd || 0.79;
+    const eur = window._eurusd || 0.92;
+
+    // Pure silver USD baselines
+    const pureG_USD = spotUSD / G_PER_OZ;             // .999 fine USD/g
+    const eightG_USD = pureG_USD * PURITY;            // .800 USD/g
+    const eightG_GBP = eightG_USD * gbp;
+    const eightG_EUR = eightG_USD * eur;
+
+    // Hero tiles — USD primary, .800 per gram
+    if($('hero-usd')) $('hero-usd').textContent = fmtUSD.format(eightG_USD);
+    if($('hero-gbp')) $('hero-gbp').textContent = fmtGBP.format(eightG_GBP);
+    if($('hero-eur')) $('hero-eur').textContent = fmtEUR.format(eightG_EUR);
+
+    // Sticky mobile bar (USD)
+    if($('sticky-usd')) $('sticky-usd').textContent = fmtUSD.format(eightG_USD);
+
+    // Spot reference (per troy oz, pure silver)
+    if($('spot-usd')) $('spot-usd').textContent = fmtSpot.format(spotUSD) + ' /oz';
+
+    // Snippet inline price (USD primary, .800 per gram)
+    if($('snippet-price')) $('snippet-price').textContent = fmtUSD.format(eightG_USD) + ' / g (' + fmtGBP.format(eightG_GBP) + ' / g)';
+
+    // Weight table — 1g, 10g, troy oz, 100g, 250g, 500g, 1kg — .800 silver
+    const rows = [
+      {id:'1g', mult:1},
+      {id:'10g', mult:10},
+      {id:'oz', mult:G_PER_OZ},
+      {id:'100g', mult:100},
+      {id:'250g', mult:250},
+      {id:'500g', mult:500},
+      {id:'1k', mult:1000},
+    ];
+    rows.forEach(r => {
+      const u = $('t-'+r.id+'-usd');
+      const g = $('t-'+r.id+'-gbp');
+      const e = $('t-'+r.id+'-eur');
+      const v = eightG_USD * r.mult;
+      if(u) u.textContent = fmtUSD.format(v);
+      if(g) g.textContent = fmtGBP.format(v * gbp);
+      if(e) e.textContent = fmtEUR.format(v * eur);
+    });
+
+    // Purity grid — USD per gram for each purity grade (pure_g × purity)
+    Object.keys(PURITIES).forEach(k => {
+      const el = $('purity-'+k+'-usd');
+      if(el) el.textContent = fmtUSD.format(pureG_USD * PURITIES[k]);
+    });
+
+    // Heritage use-case card stats (USD)
+    const cutleryEl = $('luxe-cutlery-stat');        // 250g 6-piece cutlery set
+    const teaEl     = $('luxe-tea-stat');            // 1.5kg tea service
+    const watchEl   = $('luxe-watch-stat');          // 40g pocket watch case
+    if(cutleryEl) cutleryEl.textContent = fmtUSD.format(eightG_USD * 250);
+    if(teaEl)     teaEl.textContent     = fmtUSD.format(eightG_USD * 1500);
+    if(watchEl)   watchEl.textContent   = fmtUSD.format(eightG_USD * 40);
+
+    // Calculator — update live
+    updateCalculator();
+
+    // Update timestamp
+    updateTimestamp();
+    startCountdown();
+  }
+
+  function updateTimestamp(){
+    const el = $('updated-time');
+    if(!el) return;
+    el.textContent = 'just now';
+  }
+
+  function startCountdown(){
+    if(countdownTimer) clearInterval(countdownTimer);
+    const counterEl = $('refresh-counter');
+    const updatedEl = $('updated-time');
+    countdownTimer = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - lastFetchTs) / 1000);
+      const remaining = Math.max(0, 60 - elapsed);
+      if(counterEl) counterEl.textContent = remaining + 's';
+      if(updatedEl){
+        if(elapsed < 10) updatedEl.textContent = 'just now';
+        else if(elapsed < 60) updatedEl.textContent = elapsed + 's ago';
+        else updatedEl.textContent = Math.floor(elapsed/60) + 'm ago';
+      }
+    }, 1000);
+  }
+
+  // ───────── Calculator interaction ─────────
+  function updateCalculator(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD) return;
+    const weightEl = $('calc-weight');
+    const unitEl = $('calc-unit');
+    const currencyEl = $('calc-currency');
+    const purityEl = $('calc-purity');
+    if(!weightEl || !unitEl || !currencyEl) return;
+    const rawWeight = parseFloat(weightEl.value) || 0;
+    const unitMult = parseFloat(unitEl.value) || 1;       // multiplier to grams
+    const grams = rawWeight * unitMult;
+    const purity = parseFloat(purityEl ? purityEl.value : PURITY) || PURITY;
+    const currency = currencyEl.value;
+
+    const pureG_USD = spotUSD / G_PER_OZ;
+    const meltUSD = pureG_USD * grams * purity;
+    let melt, fmt;
+    if(currency === 'GBP'){
+      melt = meltUSD * (window._gbpusd || 0.79);
+      fmt = fmtGBP;
+    }else if(currency === 'EUR'){
+      melt = meltUSD * (window._eurusd || 0.92);
+      fmt = fmtEUR;
+    }else if(currency === 'INR'){
+      melt = meltUSD * (window._inrusd || 83.0);
+      fmt = fmtINR;
+    }else{
+      melt = meltUSD;
+      fmt = fmtUSD;
     }
 
-    calcSilver(ozUSD);
+    const dealer = melt * 0.80;     // .800 silver dealer payout midpoint (75–88%)
+    const antique = melt * 3.5;     // antique market premium midpoint (2×–5×)
 
-    ['silverWeight','silverUnit','silverCurrency'].forEach(id=>document.getElementById(id)?.addEventListener('input',() => calcSilver(ozUSD)));
+    if($('calc-melt')) $('calc-melt').textContent = fmt.format(melt);
+    if($('calc-dealer')) $('calc-dealer').textContent = fmt.format(dealer);
+    if($('calc-antique')) $('calc-antique').textContent = fmt.format(antique);
+  }
 
-    gtag('event','price_view',{metal:'silver',unit:'0.800'});}catch(e){console.warn('Silver price fetch failed',e);}}
+  function bindCalculator(){
+    ['calc-weight','calc-unit','calc-currency'].forEach(id=>{
+      const el = $(id);
+      if(el) el.addEventListener('input', updateCalculator);
+      if(el) el.addEventListener('change', updateCalculator);
+    });
+    document.querySelectorAll('.calc-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const w = chip.getAttribute('data-weight');
+        const u = chip.getAttribute('data-unit');
+        const weightEl = $('calc-weight');
+        const unitEl = $('calc-unit');
+        if(weightEl){
+          weightEl.value = w;
+          if(u && unitEl) unitEl.value = u;
+          updateCalculator();
+        }
+        document.querySelectorAll('.calc-chip').forEach(c => c.classList.remove('active'));
+        chip.classList.add('active');
+        gtag('event','calc_chip_click',{metal:'silver-800',weight:w});
+      });
+    });
+  }
 
-Promise.all([fetchFx(),fetchSpot()]);setInterval(fetchSpot,60000);
+  // Currency switch (highlights column in price table + drives calculator)
+  function bindCurrencySwitch(){
+    const btns = document.querySelectorAll('.currency-switch__btn');
+    btns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const cur = btn.getAttribute('data-currency');
+        btns.forEach(b => {
+          b.classList.toggle('active', b === btn);
+          b.setAttribute('aria-selected', b === btn ? 'true' : 'false');
+        });
+        document.querySelectorAll('.price-table-pro td, .price-table-pro th').forEach(c => {
+          c.classList.toggle('price-table-pro__primary', c.getAttribute('data-col') === cur);
+        });
+        const calcCur = $('calc-currency');
+        if(calcCur && calcCur.value !== cur){
+          calcCur.value = cur;
+          updateCalculator();
+        }
+      });
+    });
+    // Set initial highlight — USD default
+    document.querySelectorAll('.price-table-pro td[data-col="USD"], .price-table-pro th[data-col="USD"]').forEach(c => c.classList.add('price-table-pro__primary'));
+  }
+
+  // Sticky mobile bar — show after scroll past hero
+  function bindStickyBar(){
+    const bar = $('stickyPrice');
+    if(!bar) return;
+    let visible = false;
+    window.addEventListener('scroll', () => {
+      const show = window.scrollY > 400;
+      if(show !== visible){
+        bar.classList.toggle('visible', show);
+        visible = show;
+      }
+    }, {passive: true});
+  }
+
+  // Init
+  document.addEventListener('DOMContentLoaded', () => {
+    bindCalculator();
+    bindCurrencySwitch();
+    bindStickyBar();
+  });
+
+  // Boot
+  Promise.all([fetchFx(), fetchSpot()]).catch(e => console.warn('init',e));
+  setInterval(fetchSpot, REFRESH_MS);
+})();
 </script>
+
+<script>(function(){
+  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
+  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+  root.setAttribute('data-theme',theme);
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);try{localStorage.setItem('gpt-theme',theme);}catch(e){}themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
+  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
+  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
+  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
+  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
+})();</script>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>
 let _deepReadFired = false;


### PR DESCRIPTION
## Summary

Applies the existing premium editorial design language (Playfair Display + IBM Plex Sans + silver gradient) from `silver-price-per-kilo.html` to the `.800` European silver page. Mobile-first responsive with USD as the primary currency, and live LBMA spot pricing preserved across the calculator, weight table, purity grid, and heritage cards.

## Design highlights

- **Premium hero** — editorial italic headline ("per gram today"), live status with refresh countdown, 3 price tiles (USD primary · GBP · EUR)
- **Trust strip** — LBMA-sourced, 60s refresh, multi-currency, .800-locked
- **Live calculator** — purity locked to 0.800, 7 quick-weight chips including ".800-relevant" presets (250g cutlery set, 500g tea pot, 1 troy oz), dual-results panel (melt + dealer payout @ 80% + antique premium @ 3.5×)
- **4 stat cards** — 80.0% purity, German Halbmond & Krone hallmark, 86.5% of sterling melt, 5 source countries
- **Live weight table** — USD/GBP/EUR currency switcher with primary-column highlighting; rows for 1g, 10g, 1 troy oz, 100g, 250g, 500g, 1kg
- **Purity comparison grid** — .999 / .925 / .900 / **.800 (YOU ARE HERE)** with live USD/gram for each
- **Formula block** — `(spot USD/oz ÷ 31.1035) × 0.800` with 3-step explanation
- **3 heritage luxe cards** — German flatware (WMF/Wilkens), Italian tea services, pocket-watch cases — each with live USD melt valuation tile
- **Hallmark identification grid** — Germany / Italy / France / Netherlands+Austria with regional marking details
- **Editorial prose** — history, identification, formula walkthrough, UK VAT/CGT callout, selling-channels comparison table, .800 vs .925 maths, authenticity callout, common-item weights table
- **FAQ Pro accordion** — 8 questions with custom plus/minus toggle
- **Sticky mobile price bar** — appears after 400px scroll, shows .800 USD/g + jump-to-calculator CTA
- **Related guides** + share buttons + footer (consistent with site-wide template)

## Data integrity (matches silver-price-per-kilo.html exactly)

| Constant / source | Value |
|---|---|
| Silver spot | `https://api.gold-api.com/price/XAG` (LBMA-derived USD/oz) |
| FX rates | `https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR` (ECB ref rates) |
| Grams per troy oz | 31.1035 |
| Purity factor | 0.800 (locked) |
| Refresh interval | 60,000 ms |

Sample at $33/oz spot:
- pure_g_usd = $1.0610
- .800 g_usd = $0.8488
- 250g cutlery set melt = $212.19
- 1.5kg tea service melt = $1,273.17

## Accessibility & responsive

- 21 `min-width` mobile-first queries vs 6 `max-width` overrides
- Breakpoints: 540, 560, 600, 768, 900, 1024
- 15 responsive `clamp()` font sizes
- 35 aria-labels, 39 aria-hidden on decorative SVGs
- 38 SVG icons (no emojis)
- `prefers-reduced-motion` respected
- 4 JSON-LD schemas (BreadcrumbList, FAQPage, Dataset, WebPage+SpeakableSpecification)
- 37 `data-nosnippet` markers on live price elements

## Test plan

- [ ] Run `python3 tools/playwright_audit.py https://goldpricetools.com/800-silver-price-per-gram` against the deployed branch
- [ ] Verify Chromium desktop @ 1440px renders hero, calculator, and table without horizontal scroll
- [ ] Verify iPhone 14 Pro renders mobile stack with sticky price bar appearing on scroll
- [ ] Confirm live USD/GBP/EUR prices populate within 5s of page load
- [ ] Confirm 60s refresh countdown ticks and re-fetches
- [ ] Verify calculator quick-weight chips update result with no flicker
- [ ] Confirm currency switcher highlights correct table column and drives calculator currency
- [ ] Cross-check `.800` USD/g value matches `(spot ÷ 31.1035) × 0.800` to 2 decimal places
- [ ] Confirm purity-grid `.999` USD/g matches `silver-price-per-kilo` calc (cross-page consistency)

https://claude.ai/code/session_015qpoq3DFMneJty5Rp6uUYi

---
_Generated by [Claude Code](https://claude.ai/code/session_015qpoq3DFMneJty5Rp6uUYi)_