### PR TITLE
Redesign 900-silver-price-per-gram with premium editorial UI (USD primary)

### DIFF
--- a/900-silver-price-per-gram.html
+++ b/900-silver-price-per-gram.html
@@ -2,54 +2,54 @@
 <html lang="en" dir="ltr" data-theme="dark">
 <head>
 <meta charset="UTF-8">
-  <script>
-(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
+<script>
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
 </script>
-    <meta name="cf-no-email-obfuscation">
+<meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>.900 Coin Silver Price Per Gram Today (Live) — GoldPriceTools</title>
-  <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Live .900 coin silver price per gram in GBP & USD. Also shows price per troy ounce and per 100g. Updated every 60 seconds from LBMA spot market.">>
+<title>.900 Coin Silver Price Per Gram Today (Live USD) — US Pre-1965 Junk Silver | GoldPriceTools</title>
+<meta name="google-adsense-account" content="ca-pub-8849494330640880">
+<meta name="description" content="Live .900 coin silver price per gram in USD, GBP and EUR. Free Morgan Dollar, pre-1965 quarter, dime &amp; half dollar melt calculator. Junk silver bag values. Updated every 60 seconds from LBMA spot — USD primary.">
 <meta name="robots" content="index, follow">
-<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/900-silver-price-per-gram">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/900-silver-price-per-gram">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/900-silver-price-per-gram">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/900-silver-price-per-gram">
 <link rel="canonical" href="https://goldpricetools.com/900-silver-price-per-gram">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":".900 Coin Silver Price Per Gram","item":"https://goldpricetools.com/900-silver-price-per-gram"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is .900 coin silver worth today?","acceptedAnswer":{"@type":"Answer","text":"The value of .900 coin silver is calculated by multiplying the live silver spot price per troy ounce by 0.900 (90% purity). The live price in GBP and USD is shown above, updated every 60 seconds."}},{"@type":"Question","name":"How do I calculate the melt value of .900 silver coins?","acceptedAnswer":{"@type":"Answer","text":"You can calculate the melt value by weighing your coins in grams, multiplying by 0.900 to find the pure silver weight, and then multiplying by the live silver spot price per gram."}},{"@type":"Question","name":"Is .900 silver the same as sterling silver?","acceptedAnswer":{"@type":"Answer","text":"No, .900 silver is 90% pure silver and 10% copper (often called coin silver). Sterling silver is .925, meaning it is slightly purer at 92.5% silver."}},{"@type":"Question","name":"What US coins are made of .900 silver?","acceptedAnswer":{"@type":"Answer","text":"Most US silver coins minted before 1965, including Morgan and Peace Dollars, Washington Quarters, and Roosevelt Dimes, are made of .900 coin silver."}}]}</script>
-<!-- Dataset JSON-LD (WP-53) -->
-<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Dataset","name":"Live .900 Coin Silver Price Per Gram \u2014 Daily Historical Data","description":"Daily silver spot price data per gram and troy ounce in GBP and USD. Updated daily from LBMA spot market via gold-api.com. Covers 1 month, 3 months, 1 year, 5 years, and 10 years of historical silver price data.","url":"https://goldpricetools.com/900-silver-price-per-gram","keywords":["silver price","silver price per kilo","silver price per gram","LBMA spot price","precious metals data","XAG/GBP","XAG/USD"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"temporalCoverage":"2016-06-01/..","variableMeasured":"Silver spot price per troy ounce in USD (XAG/USD) and GBP (XAG/GBP)"}</script>
-<meta property="og:title" content=".900 Coin Silver Price Per Gram Today (Live)">
-<meta property="og:description" content="Live .900 coin silver price per gram in GBP & USD. Also shows price per troy ounce and per 100g. Updated every 60 seconds from LBMA spot market.">>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Silver Guides","item":"https://goldpricetools.com/guides/silver-guides/"},{"@type":"ListItem","position":3,"name":".900 Coin Silver Price Per Gram","item":"https://goldpricetools.com/900-silver-price-per-gram"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What is .900 coin silver worth per gram today in USD?","acceptedAnswer":{"@type":"Answer","text":"The live .900 US coin silver price per gram in USD is calculated by multiplying the live LBMA silver spot price (USD per troy ounce) by 0.900 (the purity ratio) and dividing by 31.1035 (grams per troy ounce). USD is the primary currency on this page because silver is quoted globally in US dollars; GBP and EUR conversions use live ECB reference rates. Updated every 60 seconds."}},{"@type":"Question","name":"How much silver is in a pre-1965 US quarter, dime or half dollar?","acceptedAnswer":{"@type":"Answer","text":"Pre-1965 US 90% silver coins contain: Roosevelt/Mercury Dime — 2.25g pure silver (0.07234 troy oz), Washington Quarter — 5.625g (0.18084 troy oz), Walking Liberty/Franklin/Kennedy Half Dollar — 11.25g (0.36169 troy oz), Morgan/Peace Dollar — 24.057g (0.77344 troy oz). The trade convention for $1 face value of junk silver is 0.715 troy oz of pure silver content accounting for typical circulation wear."}},{"@type":"Question","name":"How do I identify .900 US silver coins?","acceptedAnswer":{"@type":"Answer","text":"US coins do not carry a hallmark stamp. Identify .900 coin silver by date: any Roosevelt or Mercury Dime, Washington Quarter, or Walking Liberty/Franklin/Kennedy Half Dollar minted 1964 or earlier is 90% silver. Morgan (1878–1904, 1921) and Peace Dollars (1921–1935) are also 90% silver. 1965–1970 Kennedy Halves are 40% silver — a distinct intermediate alloy. Post-1971 dimes and quarters are copper-nickel clad with no silver content."}},{"@type":"Question","name":"What is junk silver and how do I calculate $1 face value?","acceptedAnswer":{"@type":"Answer","text":"Junk silver refers to circulated pre-1965 US 90% silver coins with no numismatic premium — valued purely for silver content. $1 face value of any 90% combination (10 dimes, 4 quarters, 2 halves) contains approximately 0.715 troy oz of pure silver (the trade-standard figure accounting for normal coin wear; uncirculated coins technically hold 0.7234 oz). At today's spot, a $1,000 face value bag holds about 715 troy oz of silver."}},{"@type":"Question","name":"Is .900 coin silver the same as sterling silver (.925)?","acceptedAnswer":{"@type":"Answer","text":"No. .900 coin silver is 90.0% pure silver with 10.0% copper, historically used for US circulating coinage. Sterling silver (.925) is 92.5% pure and is the UK/US jewellery and flatware standard. By melt value, .900 coin silver is worth approximately 97.3% of sterling per gram (0.900 ÷ 0.925). The added copper in .900 produced harder, more wear-resistant coinage."}},{"@type":"Question","name":"What is the difference between Morgan and Peace silver dollars?","acceptedAnswer":{"@type":"Answer","text":"Both Morgan (1878–1904, 1921) and Peace (1921–1935) Dollars are .900 silver with identical 26.73g total weight and 24.057g (0.77344 troy oz) pure silver content. Morgan Dollars feature Lady Liberty's portrait by George T. Morgan; Peace Dollars feature Anthony de Francisci's Liberty commemorating the end of WWI. Both share identical melt value — numismatic premium for rare dates can multiply melt value 5×–100× for collector pieces."}},{"@type":"Question","name":"Why is silver priced in USD globally?","acceptedAnswer":{"@type":"Answer","text":"Silver is quoted globally in US dollars per troy ounce on the COMEX futures exchange and via the LBMA Silver Price daily auction in London. USD is the world's reserve currency and the most liquid quote unit for precious metals. All conversions on this page to GBP, EUR or INR are mathematically derived from the live USD spot using ECB reference rates from the Frankfurter API."}},{"@type":"Question","name":"How accurate are these live .900 coin silver prices?","acceptedAnswer":{"@type":"Answer","text":"Spot prices come direct from the LBMA via gold-api.com and refresh every 60 seconds. Currency conversion from USD to GBP, EUR and INR uses the Frankfurter API's live ECB reference rates. The figures shown are melt values — the raw silver content. Junk silver dealer buy prices typically sit at 85–100% of spot (sometimes above spot for cleaner lots); rare-date or BU-graded Morgan Dollars can command 5×–100× melt at auction."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Dataset","name":"Live .900 US Coin Silver Price Per Gram — Daily Historical Data","description":"Daily silver spot price data per gram and troy ounce in USD (primary), GBP and EUR for .900 US coin silver fineness (pre-1965 dimes, quarters, half dollars, Morgan and Peace Dollars). Updated every 60 seconds from LBMA spot market via gold-api.com.","url":"https://goldpricetools.com/900-silver-price-per-gram","keywords":["900 silver","coin silver","junk silver","US silver coins","Morgan Dollar","Peace Dollar","Walking Liberty Half","Mercury Dime","pre-1965 silver","LBMA spot","XAG/USD","silver price per gram"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"temporalCoverage":"2016-06-01/..","variableMeasured":"Silver spot price per troy ounce in USD (XAG/USD) multiplied by 0.900 purity factor"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"WebPage","name":".900 Coin Silver Price Per Gram Today","url":"https://goldpricetools.com/900-silver-price-per-gram","speakable":{"@type":"SpeakableSpecification","cssSelector":[".snippet-answer",".faq-pro__body"]}}</script>
+<meta property="og:title" content=".900 Coin Silver Price Per Gram Today (Live USD)">
+<meta property="og:description" content="Real-time .900 US coin silver price per gram in USD, GBP, EUR. Free Morgan Dollar, pre-1965 quarter, dime &amp; junk silver bag calculator. Updated every 60 seconds.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/900-silver-price-per-gram">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
-<!-- Google Funding Choices — CMP loader for EU/UK consent banner (#2) -->
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
 <script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
-<!-- Auto Ads config: vignette new triggers disabled, overlays off -->
 <script>
 (adsbygoogle = window.adsbygoogle || []).push({
   google_ad_client: "ca-pub-8849494330640880",
   enable_page_level_ads: true,
   overlays: {bottom: false},
-  vignette: {
-    new_triggers: false
-  }
+  vignette: { new_triggers: false }
 });
 </script>
-<link rel="manifest" href="/manifest.json"><link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg"><meta name="theme-color" content="#0f0e0c">
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link rel="manifest" href="/manifest.json">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
+<meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://api.gold-api.com">
+<link rel="preconnect" href="https://api.frankfurter.dev">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:wght@500;600;700;800&display=swap" rel="stylesheet">
 <style>
-
-/* ── Guides mega panel — category links ── */
+/* ── Guides mega panel ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
 .mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
@@ -58,28 +58,67 @@
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+/* ═════ DESIGN TOKENS — .900 Coin Silver edition ═════ */
+:root,[data-theme="light"]{
+  --color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;
+  --color-text:#28251d;--color-text-muted:#5a5953;--color-text-faint:#8a8983;--color-text-inverse:#f9f8f4;
+  --color-primary:#01696f;--color-primary-hover:#0c4e54;
+  --color-gold:#b07a00;--color-gold-bright:#c08a00;
+  --color-silver:#6b7280;--color-silver-bright:#4b5563;--color-silver-deep:#374151;--color-silver-luxe:#9ca3af;--color-platinum:#d1d5db;
+  /* Heritage copper — .900 personality */
+  --color-copper:#a05a2c;--color-copper-bright:#c47339;--color-copper-deep:#7a4220;--color-patina:#5e7d6e;
+  --color-success:#0f7a3d;--color-danger:#b91c1c;
+  --shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);
+  --shadow-silver:0 8px 32px -8px oklch(0.6 0.02 250/0.3);--shadow-luxe:0 20px 50px -20px oklch(0.55 0.02 250/0.35);
+  --shadow-copper:0 8px 32px -8px oklch(0.55 0.12 50/0.25);
+  --radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;
+  --space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--space-20:5rem;
+  --text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--text-3xl:clamp(2.5rem,1.5rem + 4vw,5rem);
+  --font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-editorial:'Playfair Display',Georgia,serif;--font-mono:'IBM Plex Mono',ui-monospace,monospace;
+  --transition:180ms cubic-bezier(0.16,1,0.3,1);--transition-slow:400ms cubic-bezier(0.16,1,0.3,1);
+  --gradient-silver:linear-gradient(135deg,#e5e7eb 0%,#cbd5e1 35%,#94a3b8 70%,#475569 100%);
+  --gradient-silver-luxe:linear-gradient(135deg,#f1f5f9 0%,#e2e8f0 25%,#cbd5e1 55%,#94a3b8 100%);
+  --gradient-silver-deep:linear-gradient(135deg,#cbd5e1 0%,#94a3b8 30%,#64748b 65%,#334155 100%);
+  --gradient-silver-soft:linear-gradient(135deg,oklch(0.78 0.01 250/0.18) 0%,oklch(0.65 0.01 250/0.06) 100%);
+  --gradient-coin:linear-gradient(135deg,#e5e7eb 0%,#cbd5e1 30%,#c47339 70%,#7a4220 100%);
+  --gradient-coin-soft:linear-gradient(135deg,oklch(0.78 0.02 250/0.16) 0%,oklch(0.65 0.10 55/0.10) 100%);
+  --gradient-copper:linear-gradient(135deg,#d4915c 0%,#c47339 45%,#a05a2c 100%);
+  --gradient-heritage:linear-gradient(135deg,#dab170 0%,#c69a4f 50%,#9b7833 100%);
+  --silver-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.78 0.02 250/0.16),transparent 60%);
+  --silver-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.78 0.02 250/0.22),transparent 65%);
+  --copper-glow:radial-gradient(ellipse 70% 55% at 30% 0%,oklch(0.65 0.10 55/0.14),transparent 65%)
+}
+[data-theme="dark"]{
+  --color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;
+  --color-text:#e8e6e0;--color-text-muted:#a09e98;--color-text-faint:#6a6864;--color-text-inverse:#1a1917;
+  --color-primary:#4f98a3;--color-primary-hover:#6ab3be;
+  --color-gold:#b07a00;--color-gold-bright:#e8af34;
+  --color-silver:#cbd5e1;--color-silver-bright:#e2e8f0;--color-silver-deep:#94a3b8;--color-silver-luxe:#f1f5f9;--color-platinum:#f8fafc;
+  --color-copper:#d4915c;--color-copper-bright:#e8a87c;--color-copper-deep:#a05a2c;--color-patina:#82a292;
+  --color-success:#4ade80;--color-danger:#f87171;
+  --shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5);
+  --shadow-silver:0 8px 32px -4px oklch(0.75 0.02 250/0.32);--shadow-luxe:0 30px 60px -20px oklch(0.7 0.03 250/0.42);
+  --shadow-copper:0 8px 32px -4px oklch(0.7 0.10 55/0.30);
+  --gradient-silver:linear-gradient(135deg,#f1f5f9 0%,#cbd5e1 35%,#94a3b8 70%,#475569 100%);
+  --gradient-silver-luxe:linear-gradient(135deg,#f8fafc 0%,#e2e8f0 30%,#cbd5e1 55%,#64748b 100%);
+  --gradient-silver-deep:linear-gradient(135deg,#f1f5f9 0%,#cbd5e1 25%,#94a3b8 55%,#475569 100%);
+  --gradient-silver-soft:linear-gradient(135deg,oklch(0.78 0.02 250/0.16) 0%,oklch(0.55 0.02 250/0.04) 100%);
+  --gradient-coin:linear-gradient(135deg,#f1f5f9 0%,#cbd5e1 30%,#d4915c 75%,#a05a2c 100%);
+  --gradient-coin-soft:linear-gradient(135deg,oklch(0.78 0.03 250/0.16) 0%,oklch(0.70 0.12 55/0.12) 100%);
+  --gradient-copper:linear-gradient(135deg,#e8a87c 0%,#d4915c 45%,#a05a2c 100%);
+  --gradient-heritage:linear-gradient(135deg,#dab170 0%,#c69a4f 50%,#9b7833 100%);
+  --silver-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.78 0.03 250/0.18),transparent 60%);
+  --silver-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.82 0.03 250/0.22),transparent 70%);
+  --copper-glow:radial-gradient(ellipse 70% 55% at 30% 0%,oklch(0.70 0.12 55/0.20),transparent 65%)
+}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-/* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
 .article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
 .article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
 
-
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:calc(var(--space-16) + var(--space-2))}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
@@ -87,199 +126,313 @@ input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+:focus-visible{outline:2px solid var(--color-silver);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
-@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-
-/* TICKER */
-.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
-.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
-.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
-.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
-.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
-.ticker:hover{animation-play-state:paused}
-@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
-.ticker-label{color:var(--color-text-muted)}
-.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
-.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
-@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
-
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important;scroll-behavior:auto!important}}
 
 /* AD SLOTS */
 .ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
 .ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
 
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
+/* ═════ PREMIUM HERO — silver × copper ═════ */
+.hero-premium{position:relative;overflow:hidden;border-bottom:1px solid var(--color-border)}
+.hero-premium::before{content:'';position:absolute;inset:0;background:var(--silver-glow-deep);pointer-events:none;z-index:0}
+.hero-premium::after{content:'';position:absolute;top:-20%;right:-10%;width:60%;height:140%;background:var(--copper-glow);pointer-events:none;z-index:0}
+.hero-premium__inner{position:relative;z-index:1;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-10)}
+@media(min-width:768px){.hero-premium__inner{padding:var(--space-12) var(--space-6) var(--space-12)}}
+@media(min-width:1024px){.hero-premium__inner{padding:var(--space-16) var(--space-8) var(--space-12)}}
+.hero-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);padding:6px var(--space-3);background:var(--gradient-coin-soft);border:1px solid color-mix(in oklch,var(--color-silver) 35%,transparent);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--color-silver);margin-bottom:var(--space-5);min-height:32px}
+.hero-eyebrow__pulse{width:6px;height:6px;border-radius:50%;background:var(--color-silver);box-shadow:0 0 8px var(--color-silver);animation:heroPulse 2.4s ease-in-out infinite;flex-shrink:0}
+@keyframes heroPulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+.hero-premium__title{font-family:var(--font-editorial);font-weight:600;color:var(--color-text);line-height:.98;letter-spacing:-.025em;margin-bottom:var(--space-5);font-size:clamp(2.25rem,1.35rem + 5vw,5rem)}
+.hero-premium__title-em{display:inline-block;background:var(--gradient-coin);-webkit-background-clip:text;background-clip:text;color:transparent;font-style:italic;font-weight:500}
+.hero-premium__sub{font-size:clamp(1rem,.95rem + .35vw,1.25rem);color:var(--color-text-muted);line-height:1.6;max-width:62ch;margin-bottom:var(--space-8)}
+.hero-premium__sub strong{color:var(--color-silver);font-weight:600}
+.hero-premium__sub .em-copper{color:var(--color-copper)}
 
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+/* PRICE TILES — USD primary */
+.price-tiles{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-6)}
+@media(min-width:560px){.price-tiles{grid-template-columns:repeat(3,1fr);gap:var(--space-3)}}
+@media(min-width:1024px){.price-tiles{gap:var(--space-4)}}
+.price-tile{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.price-tile::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,transparent,var(--color-silver),transparent);opacity:.6}
+.price-tile:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-silver)}
+.price-tile--primary{background:linear-gradient(135deg,var(--color-surface) 0%,var(--color-surface-offset) 100%);border-color:color-mix(in oklch,var(--color-silver) 30%,var(--color-border))}
+.price-tile--primary::before{background:var(--gradient-coin);opacity:1;height:4px}
+.price-tile__head{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-3);gap:var(--space-2)}
+.price-tile__label{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--color-text-muted)}
+.price-tile--primary .price-tile__label{color:var(--color-silver)}
+.price-tile__flag{display:inline-flex;align-items:center;gap:6px;font-size:11px;color:var(--color-text-faint);font-weight:600;font-family:var(--font-mono);letter-spacing:.04em}
+.price-tile__value{font-family:var(--font-display);font-size:clamp(1.75rem,1.2rem + 2.2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.02em;line-height:1;font-variant-numeric:tabular-nums;margin-bottom:var(--space-2)}
+.price-tile--primary .price-tile__value{color:var(--color-silver)}
+.price-tile__sub{font-size:var(--text-xs);color:var(--color-text-muted);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.price-tile__purity-dot{width:6px;height:6px;border-radius:50%;background:var(--color-silver);flex-shrink:0;box-shadow:0 0 0 1px color-mix(in oklch,var(--color-copper) 50%,transparent)}
 
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+/* LIVE STATUS */
+.live-status{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2) var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted)}
+.live-status__dot{width:8px;height:8px;border-radius:50%;background:var(--color-success);box-shadow:0 0 8px color-mix(in oklch,var(--color-success) 80%,transparent);animation:heroPulse 2s ease-in-out infinite;flex-shrink:0}
+.live-status__label{font-weight:600;color:var(--color-text)}
+.live-status__divider{color:var(--color-text-faint);user-select:none}
+.live-status__meta{font-variant-numeric:tabular-nums}
+.live-status__meta strong{color:var(--color-silver);font-weight:600}
+.live-status__cta{margin-left:auto;display:inline-flex;align-items:center;gap:6px;padding:8px var(--space-3);background:var(--gradient-silver-luxe);color:#0f172a;border-radius:var(--radius-md);font-weight:700;font-size:11px;letter-spacing:.06em;text-transform:uppercase;text-decoration:none;min-height:36px;transition:filter var(--transition),box-shadow var(--transition)}
+.live-status__cta:hover{filter:brightness(1.08);text-decoration:none;color:#0f172a;box-shadow:var(--shadow-silver)}
 
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+/* TRUST STRIP */
+.trust-strip{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4);display:flex;flex-wrap:wrap;gap:var(--space-3);align-items:center;border-bottom:1px solid var(--color-divider)}
+.trust-strip__item{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+.trust-strip__item svg{width:14px;height:14px;color:var(--color-silver);flex-shrink:0}
+.trust-strip__item--link{margin-left:auto;color:var(--color-primary);font-weight:600;text-decoration:none}
+.trust-strip__item--link:hover{color:var(--color-primary-hover);text-decoration:underline}
+@media(max-width:540px){.trust-strip__item--link{margin-left:0}}
 
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
+/* ═════ LIVE CALCULATOR ═════ */
+.calc-pro{max-width:1200px;margin:var(--space-10) auto;padding:0 var(--space-4)}
+@media(min-width:768px){.calc-pro{margin:var(--space-12) auto}}
+.calc-pro__card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden;box-shadow:var(--shadow-md)}
+.calc-pro__card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-silver) 30%,var(--color-copper) 70%,transparent 100%);opacity:.5}
+.calc-pro__head{padding:var(--space-6) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-4);flex-wrap:wrap}
+@media(min-width:768px){.calc-pro__head{padding:var(--space-8) var(--space-8) var(--space-5)}}
+.calc-pro__head-left{flex:1;min-width:200px}
+.calc-pro__title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);display:flex;align-items:center;gap:var(--space-2)}
+.calc-pro__title-icon{width:24px;height:24px;color:var(--color-silver);flex-shrink:0}
+.calc-pro__sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;max-width:56ch}
+.calc-pro__head-badge{display:inline-flex;align-items:center;gap:6px;padding:6px var(--space-3);background:color-mix(in oklch,var(--color-success) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-success) 30%,transparent);color:var(--color-success);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase}
+.calc-pro__head-badge .live-dot{width:6px;height:6px;border-radius:50%;background:var(--color-success);animation:heroPulse 2s ease-in-out infinite}
+.calc-pro__body{padding:var(--space-5)}
+@media(min-width:768px){.calc-pro__body{padding:var(--space-6) var(--space-8) var(--space-8)}}
+.calc-pro__row{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-4)}
+@media(min-width:560px){.calc-pro__row{grid-template-columns:1.4fr .8fr .8fr;gap:var(--space-4)}}
+.calc-pro__field{display:flex;flex-direction:column;gap:var(--space-2)}
+.calc-pro__field-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__input,.calc-pro__select{width:100%;min-height:48px;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none;transition:border-color var(--transition),background var(--transition),box-shadow var(--transition)}
+.calc-pro__input:focus,.calc-pro__select:focus{border-color:var(--color-silver);background:var(--color-surface);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-silver) 18%,transparent);outline:none}
+.calc-pro__input{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;font-variant-numeric:tabular-nums}
+.calc-pro__select-wrap{position:relative}
+.calc-pro__select-wrap::after{content:'';position:absolute;right:var(--space-4);top:50%;width:8px;height:8px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:translateY(-70%) rotate(45deg);pointer-events:none}
+.calc-pro__purity-locked{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px dashed color-mix(in oklch,var(--color-silver) 30%,var(--color-border));border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text);min-height:48px}
+.calc-pro__purity-locked strong{font-family:var(--font-editorial);font-style:italic;color:var(--color-silver);font-weight:600;font-size:1.125em}
+.calc-pro__purity-locked .lock-icon{width:14px;height:14px;color:var(--color-text-faint);flex-shrink:0}
+.calc-pro__chips{display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-5);align-items:center}
+.calc-pro__chips-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-right:var(--space-2);width:100%}
+@media(min-width:560px){.calc-pro__chips-label{width:auto;margin-right:var(--space-1)}}
+.calc-chip{min-height:36px;padding:6px var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);cursor:pointer;transition:all var(--transition);white-space:nowrap;font-family:var(--font-body)}
+.calc-chip:hover{border-color:var(--color-silver);color:var(--color-silver);background:color-mix(in oklch,var(--color-silver) 8%,var(--color-surface-offset))}
+.calc-chip:focus-visible{outline:2px solid var(--color-silver);outline-offset:2px}
+.calc-chip.active{background:var(--gradient-silver-luxe);color:#0f172a;border-color:transparent;font-weight:700}
+.calc-chip--copper.active{background:var(--gradient-copper);color:#fff}
+.calc-pro__result{background:linear-gradient(135deg,color-mix(in oklch,var(--color-silver) 10%,var(--color-surface)) 0%,var(--color-surface) 100%);border:1px solid color-mix(in oklch,var(--color-silver) 25%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-5);position:relative;overflow:hidden}
+.calc-pro__result::before{content:'';position:absolute;top:-50%;right:-20%;width:280px;height:280px;background:radial-gradient(circle,color-mix(in oklch,var(--color-silver) 18%,transparent) 0%,transparent 60%);pointer-events:none}
+.calc-pro__result::after{content:'';position:absolute;bottom:-40%;left:-20%;width:240px;height:240px;background:radial-gradient(circle,color-mix(in oklch,var(--color-copper) 14%,transparent) 0%,transparent 60%);pointer-events:none}
+.calc-pro__result-primary{position:relative;display:flex;align-items:baseline;justify-content:space-between;padding-bottom:var(--space-4);margin-bottom:var(--space-4);border-bottom:1px solid color-mix(in oklch,var(--color-silver) 18%,var(--color-border));flex-wrap:wrap;gap:var(--space-2)}
+.calc-pro__result-label-main{font-size:var(--text-sm);font-weight:700;color:var(--color-text);text-transform:uppercase;letter-spacing:.08em}
+.calc-pro__result-main{font-family:var(--font-display);font-size:clamp(2rem,1.5rem + 2vw,3rem);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;letter-spacing:-.025em;line-height:1}
+.calc-pro__result-grid{position:relative;display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3) var(--space-4)}
+.calc-pro__result-item{display:flex;flex-direction:column;gap:var(--space-1)}
+.calc-pro__result-item-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__result-item-value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+.calc-pro__hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-4);line-height:1.6;max-width:62ch}
+.calc-pro__hint code{font-family:var(--font-mono);font-size:11px;background:var(--color-surface-offset-2);padding:2px 6px;border-radius:4px;color:var(--color-silver);border:1px solid var(--color-divider)}
 
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
+/* ═════ STAT CARDS ═════ */
+.stat-cards{max-width:1200px;margin:0 auto var(--space-12);padding:0 var(--space-4);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+@media(min-width:768px){.stat-cards{grid-template-columns:repeat(4,1fr);gap:var(--space-4)}}
+.stat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);position:relative;overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.stat-card:hover{border-color:color-mix(in oklch,var(--color-silver) 35%,var(--color-border));transform:translateY(-2px)}
+.stat-card__icon{width:32px;height:32px;color:var(--color-silver);margin-bottom:var(--space-3)}
+.stat-card--copper .stat-card__icon{color:var(--color-copper)}
+.stat-card__value{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);letter-spacing:-.02em;line-height:1;margin-bottom:var(--space-2);font-variant-numeric:tabular-nums}
+.stat-card__label{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.4}
 
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+/* ═════ SECTION COMMON ═════ */
+.section{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
+.section--narrow{max-width:920px}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:var(--space-5);flex-wrap:wrap;gap:var(--space-3)}
+.section-head__left{flex:1;min-width:200px}
+.section-eyebrow{display:inline-block;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-silver);margin-bottom:var(--space-2)}
+.section-eyebrow--copper{color:var(--color-copper)}
+.section-title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);line-height:1.2;margin-bottom:var(--space-2);letter-spacing:-.015em}
+.section-sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;max-width:60ch}
 
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+/* ═════ PRICE TABLE ═════ */
+.price-table-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.price-table-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden}
+.price-table-card__head{padding:var(--space-5) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3)}
+@media(min-width:768px){.price-table-card__head{padding:var(--space-6) var(--space-8) var(--space-5)}}
+.price-table-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1)}
+.price-table-card__sub{font-size:var(--text-xs);color:var(--color-text-muted)}
+.price-table-card__sub strong{color:var(--color-success);font-weight:700}
+.currency-switch{display:inline-flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px;gap:2px;flex-wrap:wrap}
+.currency-switch__btn{min-height:32px;padding:6px var(--space-3);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);border-radius:var(--radius-full);cursor:pointer;transition:all var(--transition);letter-spacing:.04em}
+.currency-switch__btn:hover{color:var(--color-text)}
+.currency-switch__btn.active{background:var(--gradient-silver-luxe);color:#0f172a}
+.price-table-card__body{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.price-table-pro{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums;min-width:520px}
+.price-table-pro th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-5);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);white-space:nowrap}
+.price-table-pro th:not(:first-child){text-align:right}
+.price-table-pro td{padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.price-table-pro td:first-child{color:var(--color-text);font-weight:600;font-family:var(--font-display)}
+.price-table-pro td:not(:first-child){text-align:right;color:var(--color-text);font-weight:500}
+.price-table-pro td.price-table-pro__primary{color:var(--color-silver);font-weight:700}
+.price-table-pro tr:last-child td{border-bottom:none}
+.price-table-pro tr:hover td{background:color-mix(in oklch,var(--color-silver) 4%,var(--color-surface))}
+.price-table-pro .weight-label-sub{color:var(--color-text-faint);font-size:11px;font-weight:400;display:block;margin-top:2px;font-family:var(--font-body)}
+.price-table-pro tr.row-coin td:first-child::before{content:'';display:inline-block;width:8px;height:8px;border-radius:50%;background:var(--gradient-copper);margin-right:8px;vertical-align:middle;box-shadow:0 0 0 1px color-mix(in oklch,var(--color-silver) 60%,transparent)}
 
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+/* ═════ PURITY GRID ═════ */
+.purity-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.purity-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.purity-cards{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:900px){.purity-cards{grid-template-columns:repeat(4,1fr);gap:var(--space-3)}}
+.purity-card{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4);text-decoration:none;transition:all var(--transition);overflow:hidden;display:flex;flex-direction:column;gap:var(--space-2);color:var(--color-text)}
+.purity-card:hover{border-color:color-mix(in oklch,var(--color-silver) 50%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-md);color:var(--color-text);text-decoration:none}
+.purity-card--featured{background:linear-gradient(135deg,color-mix(in oklch,var(--color-silver) 12%,var(--color-surface)) 0%,color-mix(in oklch,var(--color-copper) 8%,var(--color-surface)) 100%);border-color:var(--color-silver);box-shadow:0 0 0 1px var(--color-silver),var(--shadow-silver)}
+.purity-card--featured::before{content:'YOU ARE HERE';position:absolute;top:8px;right:8px;font-size:9px;font-weight:700;letter-spacing:.1em;color:var(--color-silver);background:color-mix(in oklch,var(--color-silver) 14%,transparent);padding:2px 6px;border-radius:4px;font-family:var(--font-mono)}
+.purity-card__purity{font-family:var(--font-editorial);font-size:clamp(2rem,1.4rem + 2vw,2.75rem);font-weight:600;color:var(--color-text);letter-spacing:-.025em;line-height:1}
+.purity-card--featured .purity-card__purity{color:var(--color-silver);font-style:italic}
+.purity-card__grade{font-size:var(--text-sm);color:var(--color-silver);font-weight:700;font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+.purity-card__pct{font-size:11px;font-weight:600;color:var(--color-text-faint);font-family:var(--font-mono);letter-spacing:.1em;text-transform:uppercase}
+.purity-card__price{font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;padding-top:var(--space-2);border-top:1px solid var(--color-divider);margin-top:auto}
+.purity-card__price-label{display:block;font-size:10px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-bottom:2px}
+.purity-card__use{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
 
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+/* ═════ FORMULA BLOCK ═════ */
+.formula-block{max-width:920px;margin:var(--space-10) auto var(--space-8);padding:0 var(--space-4)}
+.formula-card{background:linear-gradient(180deg,var(--color-surface-offset) 0%,var(--color-surface) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6) var(--space-5);position:relative;overflow:hidden}
+@media(min-width:768px){.formula-card{padding:var(--space-8)}}
+.formula-card__eyebrow{font-size:11px;font-weight:700;color:var(--color-silver);text-transform:uppercase;letter-spacing:.12em;margin-bottom:var(--space-3)}
+.formula-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-4)}
+.formula-card__equation{font-family:var(--font-mono);font-size:clamp(.875rem,.8rem + .5vw,1.125rem);color:var(--color-text);background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);overflow-x:auto;-webkit-overflow-scrolling:touch;white-space:nowrap;font-variant-numeric:tabular-nums;line-height:1.6}
+.formula-card__equation .op{color:var(--color-silver);font-weight:600}
+.formula-card__equation .var{color:var(--color-primary);font-weight:600}
+.formula-card__equation .pure{color:var(--color-copper);font-weight:600}
+.formula-card__steps{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:768px){.formula-card__steps{grid-template-columns:repeat(3,1fr)}}
+.formula-step{display:flex;gap:var(--space-3);padding:var(--space-3);background:var(--color-surface);border:1px solid var(--color-divider);border-radius:var(--radius-md)}
+.formula-step__num{flex-shrink:0;width:28px;height:28px;border-radius:50%;background:var(--gradient-silver-luxe);color:#0f172a;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
+.formula-step__text{font-size:var(--text-sm);color:var(--color-text);line-height:1.5}
+.formula-step__text strong{color:var(--color-silver);font-variant-numeric:tabular-nums}
 
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+/* ═════ HERITAGE / COIN USE CASE CARDS ═════ */
+.luxe-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.luxe-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.luxe-cards{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:1024px){.luxe-cards{grid-template-columns:repeat(3,1fr)}}
+.luxe-card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-5) var(--space-6);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.luxe-card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent 0%,var(--color-silver) 50%,transparent 100%);opacity:.7}
+.luxe-card::after{content:'';position:absolute;top:-30%;right:-30%;width:200px;height:200px;background:radial-gradient(circle,color-mix(in oklch,var(--color-silver) 12%,transparent) 0%,transparent 65%);pointer-events:none;transition:opacity var(--transition)}
+.luxe-card:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-luxe)}
+.luxe-card--copper::before{background:linear-gradient(90deg,transparent 0%,var(--color-copper) 50%,transparent 100%)}
+.luxe-card--copper::after{background:radial-gradient(circle,color-mix(in oklch,var(--color-copper) 14%,transparent) 0%,transparent 65%)}
+.luxe-card--copper:hover{border-color:color-mix(in oklch,var(--color-copper) 40%,var(--color-border));box-shadow:var(--shadow-copper)}
+.luxe-card__icon-wrap{width:64px;height:64px;border-radius:50%;background:var(--gradient-coin-soft);border:1px solid color-mix(in oklch,var(--color-silver) 25%,var(--color-border));display:flex;align-items:center;justify-content:center;margin-bottom:var(--space-4);position:relative}
+.luxe-card--copper .luxe-card__icon-wrap{background:linear-gradient(135deg,oklch(0.78 0.02 250/0.12) 0%,oklch(0.70 0.12 55/0.18) 100%);border-color:color-mix(in oklch,var(--color-copper) 25%,var(--color-border))}
+.luxe-card__icon{width:36px;height:36px;color:var(--color-silver)}
+.luxe-card--copper .luxe-card__icon{color:var(--color-copper)}
+.luxe-card__category{font-size:11px;font-weight:700;color:var(--color-silver);text-transform:uppercase;letter-spacing:.14em;margin-bottom:var(--space-2);font-family:var(--font-mono)}
+.luxe-card--copper .luxe-card__category{color:var(--color-copper)}
+.luxe-card__title{font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:600;color:var(--color-text);line-height:1.25;margin-bottom:var(--space-3);font-style:italic}
+.luxe-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin-bottom:var(--space-4)}
+.luxe-card__stat{display:flex;align-items:baseline;gap:var(--space-2);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.luxe-card__stat-val{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.luxe-card--copper .luxe-card__stat-val{color:var(--color-copper)}
+.luxe-card__stat-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+.luxe-card__meta{display:flex;flex-wrap:wrap;gap:var(--space-3);margin-bottom:var(--space-3);font-size:var(--text-xs);color:var(--color-text-muted);font-family:var(--font-mono);letter-spacing:.04em}
+.luxe-card__meta-item strong{color:var(--color-text);font-weight:600}
 
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+/* ═════ IDENTIFICATION / DATE CARDS ═════ */
+.id-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.id-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.id-grid{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:1024px){.id-grid{grid-template-columns:repeat(4,1fr)}}
+.id-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-3);transition:border-color var(--transition),transform var(--transition);position:relative;overflow:hidden}
+.id-card:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border));transform:translateY(-2px)}
+.id-card__year{font-family:var(--font-editorial);font-size:clamp(1.5rem,1.2rem + 1.5vw,2.25rem);font-weight:600;font-style:italic;color:var(--color-silver);line-height:1;letter-spacing:-.02em;font-variant-numeric:tabular-nums}
+.id-card--warning .id-card__year{color:var(--color-copper)}
+.id-card--neutral .id-card__year{color:var(--color-patina)}
+.id-card__label{font-size:11px;font-weight:700;color:var(--color-text);text-transform:uppercase;letter-spacing:.08em;font-family:var(--font-mono)}
+.id-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;flex:1}
+.id-card__badge{display:inline-flex;align-items:center;gap:6px;font-size:11px;font-weight:600;padding:4px 10px;border-radius:var(--radius-full);background:color-mix(in oklch,var(--color-silver) 10%,var(--color-surface-offset));color:var(--color-silver);align-self:flex-start;font-family:var(--font-mono);letter-spacing:.04em}
+.id-card--warning .id-card__badge{background:color-mix(in oklch,var(--color-copper) 10%,var(--color-surface-offset));color:var(--color-copper)}
+.id-card--neutral .id-card__badge{background:color-mix(in oklch,var(--color-patina) 10%,var(--color-surface-offset));color:var(--color-patina)}
+
+/* ═════ EDITORIAL PROSE ═════ */
+.content-section{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-12)}
+.prose-pro{max-width:760px;margin:0 auto}
+.prose-pro h2{font-family:var(--font-display);font-size:clamp(1.5rem,1.1rem + 1.5vw,2rem);font-weight:700;color:var(--color-text);margin:var(--space-12) 0 var(--space-4);line-height:1.2;letter-spacing:-.015em;position:relative;padding-top:var(--space-3)}
+.prose-pro h2::before{content:'';position:absolute;top:0;left:0;width:48px;height:3px;background:var(--gradient-coin);border-radius:2px}
+.prose-pro h2:first-child{margin-top:0}
+.prose-pro h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-8) 0 var(--space-3);letter-spacing:-.01em}
+.prose-pro p{font-size:var(--text-base);color:var(--color-text);line-height:1.75;margin-bottom:var(--space-4)}
+.prose-pro p.has-dropcap::first-letter{font-family:var(--font-editorial);font-size:3.6em;font-weight:700;float:left;line-height:.85;margin:.1em .12em 0 0;color:var(--color-silver);font-style:italic}
+.prose-pro ul,.prose-pro ol{padding-left:var(--space-5);margin-bottom:var(--space-5)}
+.prose-pro li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:var(--space-2)}
+.prose-pro li::marker{color:var(--color-silver)}
+.prose-pro strong{color:var(--color-text);font-weight:700}
+.prose-pro a{color:var(--color-primary);text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;transition:color var(--transition)}
+.prose-pro a:hover{color:var(--color-primary-hover);text-decoration-thickness:2px}
+.prose-pro blockquote{margin:var(--space-5) 0;padding:var(--space-4) var(--space-5);background:var(--color-surface);border-left:3px solid var(--color-silver);border-radius:var(--radius-md);font-family:var(--font-editorial);font-size:var(--text-lg);font-style:italic;color:var(--color-text);font-weight:500;line-height:1.5}
+.prose-pro blockquote strong{font-style:normal;font-family:var(--font-mono);color:var(--color-silver);font-size:var(--text-base);font-weight:600}
+.snippet-answer{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-silver);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);margin:var(--space-4) 0;font-size:var(--text-base);color:var(--color-text);line-height:1.7}
+.snippet-answer strong{color:var(--color-silver)}
+.snippet-answer .pure{color:var(--color-copper)}
+.callout{background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--color-silver) 30%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-5) 0;display:flex;gap:var(--space-3);align-items:flex-start}
+.callout--copper{background:linear-gradient(135deg,oklch(0.78 0.02 250/0.10) 0%,oklch(0.70 0.12 55/0.12) 100%);border-color:color-mix(in oklch,var(--color-copper) 30%,var(--color-border))}
+.callout__icon{flex-shrink:0;width:32px;height:32px;color:var(--color-silver);margin-top:2px}
+.callout--copper .callout__icon{color:var(--color-copper)}
+.callout__title{font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);font-family:var(--font-display)}
+.callout__body{font-size:var(--text-sm);color:var(--color-text);line-height:1.6}
+
+/* MARKET / TIMELINE TABLE */
+.market-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px solid var(--color-border);border-radius:var(--radius-lg);margin:var(--space-5) 0}
+.market-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:480px}
+.market-table th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-4);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
+.market-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text);vertical-align:top}
+.market-table td:first-child{font-weight:600;font-family:var(--font-display);white-space:nowrap}
+.market-table td:nth-child(2){color:var(--color-silver);font-family:var(--font-mono);font-size:11px;letter-spacing:.06em;white-space:nowrap}
+.market-table tr:last-child td{border-bottom:none}
+
+/* FAQ ACCORDION */
+.faq-pro{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+.faq-pro__item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.faq-pro__item:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
+.faq-pro__item[open]{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
+.faq-pro__summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;min-height:60px}
+.faq-pro__summary::-webkit-details-marker{display:none}
+.faq-pro__summary:hover{background:var(--color-surface-offset)}
+.faq-pro__summary:focus-visible{outline:2px solid var(--color-silver);outline-offset:-2px}
+.faq-pro__plus{flex-shrink:0;width:24px;height:24px;border:1px solid var(--color-border);border-radius:50%;display:flex;align-items:center;justify-content:center;position:relative;transition:transform var(--transition),border-color var(--transition),background var(--transition)}
+.faq-pro__plus::before,.faq-pro__plus::after{content:'';position:absolute;background:var(--color-text-muted);transition:transform var(--transition),background var(--transition)}
+.faq-pro__plus::before{width:10px;height:2px}
+.faq-pro__plus::after{width:2px;height:10px}
+.faq-pro__item[open] .faq-pro__plus{background:var(--color-silver);border-color:var(--color-silver);transform:rotate(45deg)}
+.faq-pro__item[open] .faq-pro__plus::before,.faq-pro__item[open] .faq-pro__plus::after{background:#0f172a}
+.faq-pro__body{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;border-top:1px solid var(--color-divider);padding-top:var(--space-4)}
+.faq-pro__body strong{color:var(--color-text)}
+
+/* STICKY MOBILE PRICE BAR */
+.sticky-price{position:fixed;bottom:0;left:0;right:0;background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-3) var(--space-4);z-index:80;display:none;align-items:center;gap:var(--space-3);box-shadow:0 -8px 24px rgba(0,0,0,.2);backdrop-filter:blur(12px);transform:translateY(100%);transition:transform .3s ease-out;padding-bottom:max(var(--space-3),env(safe-area-inset-bottom))}
+.sticky-price.visible{transform:translateY(0)}
+@media(max-width:768px){.sticky-price{display:flex}body{padding-bottom:80px}}
+.sticky-price__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.sticky-price__value{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;line-height:1.1}
+.sticky-price__info{flex:1;min-width:0}
+.sticky-price__cta{display:inline-flex;align-items:center;gap:6px;padding:10px var(--space-4);background:var(--gradient-silver-luxe);color:#0f172a;border-radius:var(--radius-md);font-size:var(--text-xs);font-weight:700;text-decoration:none;letter-spacing:.04em;text-transform:uppercase;min-height:44px;white-space:nowrap}
+.sticky-price__cta:hover{filter:brightness(1.08);color:#0f172a;text-decoration:none}
+
+/* DISCLAIMER */
+.disclaimer{margin-top:var(--space-8);padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--color-text-faint);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+.disclaimer strong{color:var(--color-text)}
 
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
-.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
 .mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
 .mega-nav__item{position:relative}
-.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s;min-height:36px}
 .mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
 .mega-nav__trigger--link{text-decoration:none}
 .mega-nav__chevron{transition:transform .2s;flex-shrink:0}
@@ -300,7 +453,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
 .theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
 .theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer;min-width:44px;min-height:44px;align-items:center;justify-content:center}
 .hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
 .hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
 .hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
@@ -309,40 +462,24 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu.open{display:block;transform:translateX(0)}
 .mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
 .mobile-section{border-radius:var(--radius-md);overflow:hidden}
-.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s;min-height:44px}
 .mobile-section__toggle:hover{background:var(--color-surface-offset)}
 .mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
 .mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
 .mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
 .mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
 .mobile-section__items.open{display:flex}
-.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-sm);transition:color .12s,background .12s;min-height:44px;display:flex;align-items:center}
 .mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
 .mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
 .mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
-.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-md);min-height:44px;display:flex;align-items:center}
 .mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
 .mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
-.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+.mobile-menu__search input{width:100%;padding:12px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm);min-height:44px}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
 .footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
@@ -352,133 +489,38 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
+footer{background:var(--color-surface);border-top:1px solid var(--color-border)}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
-
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
-
-
-/* ── Shared layout CSS ── */
+/* Breadcrumb */
 .breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted)}
+.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted);flex-wrap:wrap}
 .breadcrumb li+li::before{content:"/";margin-right:var(--space-2);color:var(--color-text-faint)}
 .breadcrumb a{color:var(--color-text-muted);text-decoration:none}
 .breadcrumb a:hover{color:var(--color-primary)}
 .breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.hero-tag{display:inline-block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-.hero-title{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero-title{font-size:var(--text-xl)}
-.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:72ch;line-height:1.7;margin-bottom:var(--space-6)}
-.price-card{display:inline-flex;flex-direction:column;gap:var(--space-1);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-2)}
-.price-card{width:100%}
-.price-label{font-size:var(--text-sm);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.price-value{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-gold-bright);font-weight:400;line-height:1}
-.price-usd{font-size:var(--text-base);color:var(--color-text-muted)}
-.price-purity{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-1)}
-.prose{max-width:72ch}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-1)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose{max-width:100%}
-.content{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
-.data-source{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.faq-answer-summary{font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4);cursor:pointer;list-style:none;background:var(--color-surface-offset);transition:background .15s}
-.faq-answer-summary:hover{background:var(--color-surface-dynamic)}
-.faq-answer-summary::marker,.faq-answer-summary::-webkit-details-marker{display:none}
-.faq-answer-summary::after{content:"＋";float:right;color:var(--color-text-faint)}
-.faq-answer-summary::after{content:"－"}
-.faq-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-4);border-top:1px solid var(--color-divider)}
-
-/* ═══════════════════════════════════════════════
-   .900 SILVER PAGE — LAYOUT & COMPONENT FIXES
-   ═══════════════════════════════════════════════ */
-
-/* Hero: single column, centred */
-.hero{grid-template-columns:1fr!important;max-width:860px;padding:var(--space-8) var(--space-4) var(--space-6);align-items:start}
-.hero-title{font-size:clamp(1.75rem,3.5vw,2.75rem)!important;line-height:1.15!important;margin-bottom:var(--space-3)!important}
-
-/* Trust bar */
-.trust-bar{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.trust-bar a{color:var(--color-primary);text-decoration:underline}
-
-/* Prose reading width */
-.prose{max-width:860px!important}
-
-/* Data tables */
-.data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-2) 0 var(--space-8);max-width:860px}
-.data-table thead tr{border-bottom:2px solid var(--color-border)}
-.data-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-4) var(--space-2) 0;white-space:nowrap}
-.data-table th:first-child{padding-left:0}
-.data-table td{padding:var(--space-3) var(--space-4) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle;white-space:nowrap}
-.data-table td:first-child{color:var(--color-text);font-weight:600;padding-left:0}
-.data-table tr:last-child td{border-bottom:none}
-.data-table td:nth-child(2),.data-table td:nth-child(3),.data-table td:nth-child(4),.data-table td:nth-child(5){font-variant-numeric:tabular-nums;color:var(--color-text)}
-
-/* Blockquote */
-blockquote{background:color-mix(in oklch,var(--color-silver) 6%,var(--color-surface-offset));border-left:3px solid var(--color-silver);border-radius:0 var(--radius-md) var(--radius-md) 0;padding:var(--space-4) var(--space-5);margin:var(--space-4) 0 var(--space-6);font-size:var(--text-base);color:var(--color-text-muted);max-width:860px}
-blockquote strong{color:var(--color-text)}
-
-/* Snippet answer */
-.snippet-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);margin-bottom:var(--space-6);max-width:860px;border-left:3px solid color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
-.snippet-answer span{font-weight:600;color:var(--color-text)}
-
-/* FAQ accordion */
-.faq-container{display:flex;flex-direction:column;gap:var(--space-2);margin:var(--space-2) 0 var(--space-6);max-width:860px}
-.prose details,.faq-container details{border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;margin-bottom:0}
-.faq-answer-summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5)!important;background:var(--color-surface)!important;user-select:none}
-.faq-answer-summary::after{content:"＋"!important;margin-left:var(--space-3);flex-shrink:0}
-details[open]>.faq-answer-summary{background:var(--color-surface-offset)!important}
-details[open]>.faq-answer-summary::after{content:"－"!important}
-.faq-answer,.prose details p{padding:var(--space-4) var(--space-5)!important;font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;border-top:1px solid var(--color-border);margin:0!important}
 
 /* Share buttons */
-.share-buttons{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2);margin:var(--space-6) 0}
-.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);margin-right:var(--space-1)}
-.share-buttons a{display:inline-flex;align-items:center;gap:var(--space-2);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:var(--space-2) var(--space-4);text-decoration:none;transition:border-color .15s,color .15s,background .15s}
-.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:color-mix(in oklch,var(--color-primary) 6%,var(--color-surface))}
-.share-buttons svg{flex-shrink:0}
+.share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) 0 var(--space-6);padding-top:var(--space-6);border-top:1px solid var(--color-border)}
+.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
+.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface);min-height:44px}
+.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset);text-decoration:none}
+.share-buttons a svg{flex-shrink:0}
 
-/* Related guides grid & cards */
-.related-guides-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-4);margin-top:var(--space-4)}
-@media(max-width:900px){.related-guides-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:540px){.related-guides-grid{grid-template-columns:1fr}}
-.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s}
-.related-card:hover{border-color:color-mix(in oklch,var(--color-primary) 40%,var(--color-border));box-shadow:var(--shadow-sm)}
-.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright)}
-.related-card__title{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.3}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin-top:auto}
-
-/* Related guides section */
-.related-guides{background:var(--color-surface-offset);padding:var(--space-10) var(--space-4)}
-.related-guides .container,.container{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
-.related-guides h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-
-@media(max-width:640px){.hero{padding:var(--space-6) var(--space-4) var(--space-4)}}
+/* Related guides */
+.related-guides{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.related-guides-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.related-guides-grid{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:900px){.related-guides-grid{grid-template-columns:repeat(4,1fr)}}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,transform .15s,box-shadow .15s;color:var(--color-text)}
+.related-card:hover{border-color:var(--color-silver);box-shadow:var(--shadow-md);transform:translateY(-2px);text-decoration:none;color:var(--color-text)}
+.related-card:hover .related-card__title{color:var(--color-silver)}
+.related-card__tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-silver);align-self:flex-start;padding:2px 8px;background:color-mix(in oklch,var(--color-silver) 10%,transparent);border-radius:99px}
+.related-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0;line-height:1.3;transition:color var(--transition)}
+.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
 </style>
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org/",
-  "@type": "WebPage",
-  "name": ".900 Coin Silver Price Per Gram",
-  "url": "https://goldpricetools.com/900-silver-price-per-gram",
-  "speakable": {
-    "@type": "SpeakableSpecification",
-    "cssSelector": [".snippet-answer", ".faq-answer"]
-  }
-}
-</script>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
@@ -551,223 +593,653 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
     </div>
   </div>
 </nav>
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">.900 Coin Silver Price Per Gram</li></ol></div>
-<div class="hero">
-  <div class="hero-tag">Live .900 Coin Silver Price</div>
-  <h1 class="hero-title">.900 Coin Silver Price Per Gram Today</h1>
-  <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Live silver spot price in multiple weights. Updated every 60 seconds.</p>
-  </div>
-<div class="content">
-  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about">About our data</a></div>
 
-      <div class="calc-panel" id="panel-silver" role="tabpanel" style="display:block; max-width: 600px; margin: 2rem auto; border: 1px solid var(--color-border); border-radius: 12px; padding: 1.5rem;">
-        <div class="calc-row" style="display:grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem;">
-          <div class="form-group">
-            <label class="form-label" for="silverPurity" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Silver Purity</label>
-            <div class="form-select-wrap">
-              <select class="form-select" id="silverPurity" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);" disabled>
-                <option value="0.900" selected>.900 Coin Silver</option>
-              </select>
-            </div>
-            <p style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: 0.25rem;">Locked to .900 Coin Silver</p>
-          </div>
-          <div class="form-group">
-            <label class="form-label" for="silverWeight" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Weight</label>
-            <input class="form-input" type="number" id="silverWeight" value="1" min="0" step="0.01" placeholder="Enter weight" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
-          </div>
-        </div>
-        <div class="calc-row" style="display:grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem;">
-          <div class="form-group">
-            <label class="form-label" for="silverUnit" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Weight Unit</label>
-            <div class="form-select-wrap">
-              <select class="form-select" id="silverUnit" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
-                <option value="1" selected>Grams (g)</option>
-                <option value="31.1035">Troy Ounces (oz t)</option>
-                <option value="1000">Kilograms (kg)</option>
-                <option value="1.55517">Pennyweight (dwt)</option>
-              </select>
-            </div>
-          </div>
-          <div class="form-group">
-            <label class="form-label" for="silverCurrency" style="display:block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; color: var(--color-text-faint);">Currency</label>
-            <div class="form-select-wrap">
-              <select class="form-select" id="silverCurrency" style="width: 100%; padding: 0.75rem; background: var(--color-surface-offset); border: 1px solid var(--color-border); border-radius: 6px; color: var(--color-text);">
-                <option value="USD" selected>USD ($)</option>
-                <option value="GBP">GBP (£)</option>
-                <option value="EUR">EUR (€)</option>
-                <option value="INR">INR (₹)</option>
-              </select>
-            </div>
-          </div>
-        </div>
-        <div class="calc-result" style="text-align:center; padding: 1.5rem; background: var(--color-surface); border-radius: 8px;">
-          <div class="calc-result-label" style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--color-text-muted); margin-bottom: 0.5rem;">Estimated Value</div>
-          <div class="calc-result-value" id="silverResult" style="font-family: var(--font-display); font-size: 2.5rem; font-weight: 700; color: var(--color-gold-bright);">—</div>
-          <div class="calc-result-meta" id="silverResultMeta" style="font-size: 0.875rem; color: var(--color-text-muted); margin-top: 0.5rem;"></div>
-        </div>
-      </div>
-
-  <div class="prose">
-    <h2>Silver Price by Weight</h2>
-    <!-- STATIC-FIRST: Table structure pre-rendered for SEO; prices are JS-updated -->
-    <table class="data-table" aria-label="Live silver price by weight">
-      <thead><tr><th>Weight</th><th>GBP (live)</th><th>USD (live)</th></tr></thead>
-      <tbody>
-        <tr><td>1 gram</td><td id="t-1g-gbp" data-nosnippet>&mdash;</td><td id="t-1g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>10 grams</td><td id="t-10g-gbp" data-nosnippet>&mdash;</td><td id="t-10g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>100 grams</td><td id="t-100g-gbp" data-nosnippet>&mdash;</td><td id="t-100g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>1 troy ounce (31.1g)</td><td id="t-oz-gbp" data-nosnippet>&mdash;</td><td id="t-oz-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>500 grams</td><td id="t-500g-gbp" data-nosnippet>&mdash;</td><td id="t-500g-usd" data-nosnippet>&mdash;</td></tr>
-        <tr><td>1 kilogram</td><td id="t-1k-gbp" data-nosnippet>&mdash;</td><td id="t-1k-usd" data-nosnippet>&mdash;</td></tr>
-      </tbody>
-    </table>
-    <h2>Silver Purity Grades</h2>
-<table class="data-table" aria-label="Silver purity grades and indicative prices">
-  <thead><tr><th>Purity</th><th>Grade</th><th>Price per Gram</th><th>Price per Kg</th><th>Price per Troy Oz</th></tr></thead>
-  <tbody>
-    <tr><td>.999</td><td>Fine</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
-    <tr><td>.925</td><td>Sterling</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
-    <tr><td>.900</td><td>Coin</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
-    <tr><td>.800</td><td>European</td><td>[live]</td><td>[live]</td><td>[live]</td></tr>
-  </tbody>
-</table>
-
-
-    <h2>What is .900 Coin Silver?</h2>
-    <p>.900 silver, commonly known as <strong>coin silver</strong>, is an alloy consisting of 90% pure silver and 10% other metals, typically copper. The copper is added to provide durability and strength, making the silver hard enough to withstand the wear and tear of daily circulation.</p>
-    <p>This purity was the standard for United States circulating silver coins minted before 1965, including Morgan Dollars, Peace Dollars, Washington Quarters, Roosevelt Dimes, and Franklin Half Dollars. Because of its historical use in currency, the melt value of these coins is heavily traded by investors and collectors today. You can calculate the exact value of specific US coins using our <a href="/silver-coins-calculator">US Silver Coins Calculator</a>.</p>
-
-    <h2>Identifying .900 Silver</h2>
-    <p>Unlike sterling silver which is usually marked "925" or "Sterling", coin silver may not have a numerical hallmark if it is an actual circulated coin. Instead, the coin's date and denomination indicate its composition. For non-coin items made of .900 silver (which is rare but exists in some antique flatware), look for a hallmark stamp of "900".</p>
-
-    <h2>.900 vs .925 Sterling Silver</h2>
-    <p>The primary difference is purity. .900 silver contains 90% pure silver, while sterling silver contains 92.5%. This means a sterling silver item has slightly more intrinsic melt value per gram than a coin silver item of the same weight. However, coin silver is often more durable due to the higher copper content.</p>
-
-    <h2>UK Context and Value</h2>
-    <p>In the UK, .900 silver is less common than sterling (.925), which has been the standard for centuries. Most .900 silver encountered in the UK is imported American coinage. When selling these coins, scrap dealers will pay a percentage of the live melt value calculated at 90% purity.</p>
-
-<h2>Frequently Asked Questions</h2>
-
-<div class="faq-container">
-<div class="faq-card">
-  <h3 class="faq-answer-summary">What is .900 coin silver worth today?</h3>
-  <p class="faq-answer">The value of .900 coin silver is calculated by multiplying the live silver spot price per troy ounce by 0.900 (90% purity). The live price in GBP and USD is shown above, updated every 60 seconds.</p>
+<div class="breadcrumb-wrap">
+  <ol class="breadcrumb" aria-label="Breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/guides/silver-guides/">Silver Guides</a></li>
+    <li aria-current="page">.900 Coin Silver Per Gram</li>
+  </ol>
 </div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">How do I calculate the melt value of .900 silver coins?</h3>
-  <p class="faq-answer">You can calculate the melt value by weighing your coins in grams, multiplying by 0.900 to find the pure silver weight, and then multiplying by the live silver spot price per gram.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">Is .900 silver the same as sterling silver?</h3>
-  <p class="faq-answer">No, .900 silver is 90% pure silver and 10% copper (often called coin silver). Sterling silver is .925, meaning it is slightly purer at 92.5% silver.</p>
-</div>
-<div class="faq-card">
-  <h3 class="faq-answer-summary">What US coins are made of .900 silver?</h3>
-  <p class="faq-answer">Most US silver coins minted before 1965, including Morgan and Peace Dollars, Washington Quarters, and Roosevelt Dimes, are made of .900 coin silver.</p>
-</div>
-</div>
-
-
-    <h2>What is 900 Silver?</h2>
-    <p>900 silver (also called <em>coin silver</em>) contains <strong>90.0% pure silver</strong>, with the remaining 10.0% made up of copper or other base metals. The hallmark <strong>900</strong> indicates 900 parts per thousand of silver. 900 silver is best known as the purity used in pre-1965 US circulated coins. It is also found in older Scandinavian silverware and antique pieces from the late 19th and early 20th centuries.</p>
-    <p>It is commonly found in coin silver (US pre-1965 dimes, quarters and half-dollars), Scandinavian silverware, and some antique jewellery pieces. Understanding its silver content is essential when calculating scrap or melt value.</p>
-
-    <h2>How to Calculate the 900 Silver Price Per Gram</h2>
-    <p>The melt value formula for 900 silver is:</p>
-    <blockquote><strong>900 silver price per gram = (Spot price per troy oz ÷ 31.1035) × 0.9</strong></blockquote>
-    <p>For example, if silver spot is $33.00 per troy ounce:</p>
-    <ul>
-      <li>Price per gram of pure silver = $33.00 ÷ 31.1035 = <strong>$1.061</strong></li>
-      <li>900 silver price per gram = $1.061 × 0.9 = <strong>$0.955</strong></li>
-    </ul>
-    <p>The melt value is the maximum intrinsic value. Dealers will pay a percentage of this — typically 70%–90% for scrap silver, depending on quantity and condition. Our live calculator above applies the current spot price automatically.</p>
-
-    <h2>The 900 Hallmark</h2>
-    <p>In the UK, the Hallmarking Act 1973 requires independent assay of precious metals above certain weight thresholds. A <strong>900 mark</strong> on silverware or jewellery confirms a silver purity of 90.0%. Unlike 925 sterling silver (the most common UK standard) or 999 fine silver (used in bullion), 900 silver has a slightly warmer, slightly duller appearance due to its higher copper content.</p>
-    <p>When valuing antique 900 silver items, always weigh them accurately (deducting any non-silver components such as resin-filled bases or glass inserts) before calculating melt value.</p>
-
-    <h2>900 vs 925 Sterling Silver</h2>
-    <table class="data-table" aria-label="Silver purity comparison">
-      <thead><tr><th>Standard</th><th>Purity</th><th>Hallmark</th><th>Common Use</th></tr></thead>
-      <tbody>
-        <tr><td>999 Fine</td><td>99.9%</td><td>999</td><td>Bullion bars and coins</td></tr>
-        <tr><td>958 Britannia</td><td>95.8%</td><td>958</td><td>UK commemorative silver</td></tr>
-        <tr><td>925 Sterling</td><td>92.5%</td><td>925</td><td>Most UK/US jewellery and silverware</td></tr>
-        <tr><td>900 Coin Silver</td><td>90.0%</td><td>900</td><td>Pre-1965 US coins, Scandinavian silverware</td></tr>
-        <tr><td><strong>900</strong></td><td><strong>90.0%</strong></td><td><strong>900</strong></td><td><strong>Coin silver, antique items</strong></td></tr>
-      </tbody>
-    </table>
-
-    <h2>Selling 900 Silver in the UK</h2>
-    <p>Scrap 900 silver is accepted by most UK precious metal dealers and some pawnbrokers. Because its purity is below 925 sterling, some dealers apply a slightly lower buy rate. The best prices are typically offered by weight-based online buyers who evaluate items purely on metal content rather than craftsmanship.</p>
-    <p>For antique 900 silver items in good condition (e.g. Continental tea sets, cutlery, or decorative pieces), specialist antique silver dealers or auction houses may offer significantly more than melt value — sometimes 2×–5× melt for sought-after makers or patterns.</p>
-
-    <h2>Frequently Asked Questions</h2>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Is 900 silver worth buying as an investment?</h3>
-      <p class="faq-answer">900 silver has real silver content and tracks the silver price, so it retains intrinsic value. However, for pure investment purposes, 999 fine silver bullion (bars or coins) has a lower premium over spot and is more liquid. 900 silver is best viewed as a store of value you may also use or display.</p>
+<!-- ═════════════ PREMIUM HERO ═════════════ -->
+<section class="hero-premium" aria-labelledby="hero-title">
+  <div class="hero-premium__inner">
+    <div class="hero-eyebrow">
+      <span class="hero-eyebrow__pulse" aria-hidden="true"></span>
+      <span>Live · LBMA Spot · XAG/USD · .900 Coin Silver</span>
     </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">How can I identify 900 silver at home?</h3>
-      <p class="faq-answer">Look for the stamped 900 mark, often accompanied by other hallmarks (maker's mark, assay office symbol, or date letter). A jeweller's loupe helps with small items. Acid testing kits available online can confirm silver purity. Genuine 900 silver will not be magnetic.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-answer-summary">Does 900 silver tarnish?</h3>
-      <p class="faq-answer">Yes — all silver alloys tarnish over time through oxidation of the copper content. 900 silver tarnishes slightly faster than 925 sterling due to its higher base metal content. Regular polishing with a silver cloth and proper storage in anti-tarnish pouches will maintain its appearance.</p>
+    <h1 class="hero-premium__title" id="hero-title">
+      .900 Coin Silver <span class="hero-premium__title-em">per gram</span> today
+    </h1>
+    <p class="hero-premium__sub">Real-time melt valuation for <strong>pre-1965 US silver coinage</strong> &mdash; Morgan &amp; Peace Dollars, Walking Liberty &amp; Franklin Halves, Washington Quarters, Mercury &amp; Roosevelt Dimes. <span class="em-copper">90.0% silver, 10.0% copper.</span> Quoted in <strong>USD</strong>, GBP and EUR, refreshed every 60 seconds from LBMA London spot data.</p>
+
+    <!-- 3-currency live price tiles — USD primary -->
+    <div class="price-tiles" role="region" aria-label="Live .900 coin silver prices per gram">
+      <article class="price-tile price-tile--primary">
+        <div class="price-tile__head">
+          <span class="price-tile__label">USD / gram</span>
+          <span class="price-tile__flag">US &middot; Primary</span>
+        </div>
+        <div class="price-tile__value" id="hero-usd" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>.900 fineness &middot; 90% pure Ag</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">GBP / gram</span>
+          <span class="price-tile__flag">UK</span>
+        </div>
+        <div class="price-tile__value" id="hero-gbp" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>.900 fineness &middot; ECB ref rate</div>
+      </article>
+      <article class="price-tile">
+        <div class="price-tile__head">
+          <span class="price-tile__label">EUR / gram</span>
+          <span class="price-tile__flag">EU</span>
+        </div>
+        <div class="price-tile__value" id="hero-eur" data-nosnippet>&mdash;</div>
+        <div class="price-tile__sub"><span class="price-tile__purity-dot"></span>.900 fineness &middot; ECB ref rate</div>
+      </article>
     </div>
 
-    <div class="disclaimer"><strong>Disclaimer:</strong> Prices are indicative spot values and do not include dealer premiums. Physical silver coins and bars typically sell at 5&ndash;20% above spot. Not financial advice.</div>
-  </div>
-</div>
-<div class="content" style="padding-bottom:1.5rem">
-<!-- Social share buttons (WP-34) -->
-<div class="share-buttons">
-  <span>Share:</span>
-  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/900-silver-price-per-gram&text=.900+Coin+Silver+Price+Per+Gram+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
-  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/900-silver-price-per-gram&title=Silver+Price+Per+Kilo+Today+%28Live%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
-  <a href="https://api.whatsapp.com/send?text=.900+Coin+Silver+Price+Per+Gram+Today+%28Live%29%20https%3A%2F%2Fgoldpricetools.com%2Fsilver-price-per-kilo" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
-</div>
-</div>
-
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
-    <h2>Related Gold &amp; Silver Guides</h2>
-    <div class="related-guides-grid">
-      <a href="/800-silver-price-per-gram" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">.800 Silver Price Per Gram</div>
-        <div class="related-card__desc">Today's .800 silver price per gram — common in European and Middle Eastern silverware.</div>
-      </a>
-      <a href="/silver-price-per-kilo" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">Silver Price Per Kilo</div>
-        <div class="related-card__desc">Live silver price per kilogram in GBP and USD.</div>
-      </a>
-      <a href="/guides/what-is-925-sterling-silver" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">What is 925 Sterling Silver?</div>
-        <div class="related-card__desc">Understand the difference between .900, .925 and .800 silver purity grades.</div>
-      </a>
-      <a href="/guides/silver-price-per-gram-explained" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Silver Price Per Gram Explained</div>
-        <div class="related-card__desc">How silver spot prices translate to per-gram rates for coins and jewellery.</div>
-      </a>
-      <a href="/scrap-gold-calculator" class="related-card">
-        <div class="related-card__tag">Tool</div>
-        <div class="related-card__title">Scrap Metal Calculator</div>
-        <div class="related-card__desc">Find the melt value of .900 silver coins or items at today's live silver price.</div>
-      </a>
-      <a href="/gold-silver-ratio" class="related-card">
-        <div class="related-card__tag">Live Tool</div>
-        <div class="related-card__title">Gold-Silver Ratio</div>
-        <div class="related-card__desc">The live gold-to-silver ratio — essential context for any silver price comparison.</div>
+    <!-- Live status bar -->
+    <div class="live-status" role="status" aria-live="polite">
+      <span class="live-status__dot" aria-hidden="true"></span>
+      <span class="live-status__label">Live</span>
+      <span class="live-status__divider" aria-hidden="true">&middot;</span>
+      <span class="live-status__meta">Spot: <strong id="spot-usd" data-nosnippet>&mdash;</strong></span>
+      <span class="live-status__divider" aria-hidden="true">&middot;</span>
+      <span class="live-status__meta">Updated <span id="updated-time">just now</span></span>
+      <span class="live-status__divider" aria-hidden="true">&middot;</span>
+      <span class="live-status__meta">Refresh in <span id="refresh-counter">60s</span></span>
+      <a href="#calculator" class="live-status__cta">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>
+        Calculate
       </a>
     </div>
   </div>
 </section>
 
+<!-- Trust strip -->
+<div class="trust-strip">
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    LBMA-sourced XAG spot
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+    60-second refresh
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/><circle cx="12" cy="12" r="10"/></svg>
+    USD &middot; GBP &middot; EUR
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="3"/></svg>
+    .900 fineness locked
+  </span>
+  <a href="/about" class="trust-strip__item trust-strip__item--link">About our data &rarr;</a>
+</div>
+<!-- ═════════════ LIVE CALCULATOR ═════════════ -->
+<section class="calc-pro" id="calculator" aria-labelledby="calc-title">
+  <div class="calc-pro__card">
+    <div class="calc-pro__head">
+      <div class="calc-pro__head-left">
+        <h2 class="calc-pro__title" id="calc-title">
+          <svg class="calc-pro__title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M12 14h.01M16 14h.01M8 18h2M12 18h.01M16 18h.01"/></svg>
+          .900 Coin Silver Calculator
+        </h2>
+        <p class="calc-pro__sub">Enter weight or tap a US coin preset &mdash; get live melt value, junk silver dealer payout estimate and numismatic premium guidance. <strong>USD primary</strong>, GBP and EUR conversions live.</p>
+      </div>
+      <span class="calc-pro__head-badge">
+        <span class="live-dot" aria-hidden="true"></span>
+        Live &middot; 60s refresh
+      </span>
+    </div>
+
+    <div class="calc-pro__body">
+      <div class="calc-pro__row">
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-weight">Weight</label>
+          <input class="calc-pro__input" type="number" id="calc-weight" inputmode="decimal" placeholder="e.g. 26.73" min="0" step="0.01" value="26.73" aria-label="Weight value">
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-unit">Unit</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-unit" aria-label="Weight unit">
+              <option value="1" selected>grams</option>
+              <option value="1000">kilograms</option>
+              <option value="31.1035">troy ounces</option>
+              <option value="1.55517">pennyweight (dwt)</option>
+            </select>
+          </div>
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-currency">Currency</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-currency" aria-label="Display currency">
+              <option value="USD" selected>USD ($)</option>
+              <option value="GBP">GBP (&pound;)</option>
+              <option value="EUR">EUR (&euro;)</option>
+              <option value="INR">INR (&#8377;)</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class="calc-pro__row" style="grid-template-columns:1fr;margin-top:calc(-1 * var(--space-2))">
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-purity">Purity</label>
+          <div class="calc-pro__purity-locked">
+            <span>
+              <strong>.900 Coin Silver</strong> &nbsp;&middot;&nbsp; 90.0% pure Ag, 10.0% copper &nbsp;&middot;&nbsp; locked
+            </span>
+            <svg class="lock-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 018 0v4"/></svg>
+          </div>
+          <input type="hidden" id="calc-purity" value="0.900">
+        </div>
+      </div>
+
+      <div class="calc-pro__chips" role="group" aria-label="Quick weight presets — US silver coins">
+        <span class="calc-pro__chips-label">US coin presets:</span>
+        <button class="calc-chip" type="button" data-weight="2.5" data-unit="1">Roosevelt/Mercury Dime &middot; 2.5g</button>
+        <button class="calc-chip" type="button" data-weight="6.25" data-unit="1">Washington Quarter &middot; 6.25g</button>
+        <button class="calc-chip" type="button" data-weight="12.5" data-unit="1">Walking Liberty Half &middot; 12.5g</button>
+        <button class="calc-chip active" type="button" data-weight="26.73" data-unit="1">Morgan / Peace Dollar &middot; 26.73g</button>
+        <button class="calc-chip" type="button" data-weight="25" data-unit="1">$1 face junk silver</button>
+        <button class="calc-chip" type="button" data-weight="250" data-unit="1">$10 face roll</button>
+        <button class="calc-chip" type="button" data-weight="2500" data-unit="1">$100 face bag</button>
+        <button class="calc-chip" type="button" data-weight="25000" data-unit="1">$1,000 face bag</button>
+      </div>
+
+      <div class="calc-pro__result">
+        <div class="calc-pro__result-primary">
+          <span class="calc-pro__result-label-main">Melt value (.900)</span>
+          <span class="calc-pro__result-main" id="calc-melt" data-nosnippet>&mdash;</span>
+        </div>
+        <div class="calc-pro__result-grid">
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Dealer pays (~85% of melt)</span>
+            <span class="calc-pro__result-item-value" id="calc-dealer" data-nosnippet>&mdash;</span>
+          </div>
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Numismatic premium (rare dates, BU)</span>
+            <span class="calc-pro__result-item-value" id="calc-numis" data-nosnippet>&mdash;</span>
+          </div>
+        </div>
+      </div>
+      <p class="calc-pro__hint">Formula: <code>weight (g) &times; (spot USD/oz &divide; 31.1035) &times; 0.900</code>. Junk silver buyers typically pay <strong>85&ndash;100% of melt</strong> (sometimes above spot for clean rolls); rare-date Morgans, key-date Walking Liberty Halves or BU graded coins can fetch <strong>5&times;&ndash;100&times; melt</strong> via auction. Use our <a href="/silver-coins-calculator">US silver coins calculator</a> for per-coin granular pricing.</p>
+    </div>
+  </div>
+</section>
+<!-- ═════════════ STAT CARDS ═════════════ -->
+<section class="stat-cards" aria-label=".900 coin silver key facts">
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+    <div class="stat-card__value">90.0%</div>
+    <div class="stat-card__label">Pure silver content &mdash; balance 10% copper for durability</div>
+  </article>
+  <article class="stat-card stat-card--copper">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="6" width="18" height="13" rx="2"/><path d="M3 10h18M7 15h3"/></svg>
+    <div class="stat-card__value">1792&ndash;1964</div>
+    <div class="stat-card__label">US Mint era of 90% silver dimes, quarters &amp; half dollars</div>
+  </article>
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 6v6M12 12h4"/></svg>
+    <div class="stat-card__value">0.7234 oz</div>
+    <div class="stat-card__label">Pure silver per $1 face value &mdash; uncirculated</div>
+  </article>
+  <article class="stat-card stat-card--copper">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    <div class="stat-card__value">0.715 oz</div>
+    <div class="stat-card__label">Trade-standard per $1 face (worn junk silver)</div>
+  </article>
+</section>
+<!-- ═════════════ LIVE PRICE TABLE ═════════════ -->
+<section class="price-table-section" aria-labelledby="price-table-title">
+  <div class="price-table-card">
+    <div class="price-table-card__head">
+      <div>
+        <h2 class="price-table-card__title" id="price-table-title">.900 Coin Silver Price by Weight</h2>
+        <p class="price-table-card__sub"><strong>Live</strong> &middot; 90% pure silver &middot; per-coin &amp; per-bag &middot; USD primary</p>
+      </div>
+      <div class="currency-switch" role="tablist" aria-label="Choose currency to highlight">
+        <button class="currency-switch__btn active" role="tab" data-currency="USD" aria-selected="true">USD</button>
+        <button class="currency-switch__btn" role="tab" data-currency="GBP" aria-selected="false">GBP</button>
+        <button class="currency-switch__btn" role="tab" data-currency="EUR" aria-selected="false">EUR</button>
+      </div>
+    </div>
+    <div class="price-table-card__body">
+      <figure itemscope itemtype="https://schema.org/Table" style="margin:0">
+        <figcaption class="sr-only">Live .900 US coin silver price by weight in USD, GBP and EUR &mdash; updated every 60 seconds</figcaption>
+        <table class="price-table-pro" aria-label=".900 coin silver price by weight">
+          <thead><tr><th>Weight</th><th data-col="USD">USD</th><th data-col="GBP">GBP</th><th data-col="EUR">EUR</th></tr></thead>
+          <tbody>
+            <tr><td>1g <span class="weight-label-sub">Per-gram benchmark</span></td><td id="t-1g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-1g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-1g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr class="row-coin"><td>2.5g <span class="weight-label-sub">Roosevelt / Mercury Dime</span></td><td id="t-dime-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-dime-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-dime-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr class="row-coin"><td>6.25g <span class="weight-label-sub">Washington Quarter</span></td><td id="t-qtr-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-qtr-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-qtr-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>10g <span class="weight-label-sub">Small lot reference</span></td><td id="t-10g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-10g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-10g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr class="row-coin"><td>12.5g <span class="weight-label-sub">Walking Liberty / Franklin Half</span></td><td id="t-half-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-half-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-half-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1 <a href="/how-many-grams-in-troy-ounce">troy oz</a> <span class="weight-label-sub">31.1035g &middot; Spot quote unit</span></td><td id="t-oz-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-oz-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-oz-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr class="row-coin"><td>26.73g <span class="weight-label-sub">Morgan / Peace Dollar</span></td><td id="t-dollar-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-dollar-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-dollar-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>100g <span class="weight-label-sub">Small accumulation</span></td><td id="t-100g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-100g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-100g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr class="row-coin"><td>250g <span class="weight-label-sub">$10 face junk silver roll</span></td><td id="t-10face-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-10face-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-10face-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>500g <span class="weight-label-sub">Larger accumulation</span></td><td id="t-500g-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-500g-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-500g-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+            <tr><td>1 kg <span class="weight-label-sub">Wholesale lot reference</span></td><td id="t-1k-usd" data-col="USD" data-nosnippet>&mdash;</td><td id="t-1k-gbp" data-col="GBP" data-nosnippet>&mdash;</td><td id="t-1k-eur" data-col="EUR" data-nosnippet>&mdash;</td></tr>
+          </tbody>
+        </table>
+      </figure>
+    </div>
+  </div>
+</section>
+<!-- ═════════════ PURITY GRID ═════════════ -->
+<section class="purity-section" aria-labelledby="purity-section-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Silver purity grades compared</span>
+      <h2 class="section-title" id="purity-section-title">Where .900 fits in the silver hierarchy</h2>
+      <p class="section-sub">All four grades use the same XAG/USD spot price as a base, multiplied by the purity ratio. .999 fine is the LBMA bullion standard; .900 was the US Mint's circulating coinage standard from 1792 through 1964. Live USD prices below.</p>
+    </div>
+  </div>
+  <div class="purity-cards">
+    <a href="/silver-price-per-kilo" class="purity-card">
+      <div class="purity-card__purity">.999</div>
+      <div class="purity-card__grade">Fine Silver</div>
+      <div class="purity-card__pct">99.9% pure</div>
+      <div class="purity-card__use">Investment bullion &middot; LBMA standard &middot; 1kg bars, American Eagles</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / gram</span><span id="purity-999-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <a href="/guides/what-is-925-sterling-silver" class="purity-card">
+      <div class="purity-card__purity">.925</div>
+      <div class="purity-card__grade">Sterling</div>
+      <div class="purity-card__pct">92.5% pure</div>
+      <div class="purity-card__use">Jewellery, flatware, UK/US hallmarked standard</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / gram</span><span id="purity-925-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+    <div class="purity-card purity-card--featured">
+      <div class="purity-card__purity">.900</div>
+      <div class="purity-card__grade">Coin Silver</div>
+      <div class="purity-card__pct">90.0% pure</div>
+      <div class="purity-card__use">US pre-1965 dimes, quarters, halves, Morgan &amp; Peace Dollars</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / gram</span><span id="purity-900-usd" data-nosnippet>&mdash;</span></div>
+    </div>
+    <a href="/800-silver-price-per-gram" class="purity-card">
+      <div class="purity-card__purity">.800</div>
+      <div class="purity-card__grade">European</div>
+      <div class="purity-card__pct">80.0% pure</div>
+      <div class="purity-card__use">Continental antique silverware &middot; German Halbmond &amp; Krone</div>
+      <div class="purity-card__price"><span class="purity-card__price-label">USD / gram</span><span id="purity-800-usd" data-nosnippet>&mdash;</span></div>
+    </a>
+  </div>
+</section>
+<!-- ═════════════ FORMULA BLOCK ═════════════ -->
+<section class="formula-block" aria-labelledby="formula-title">
+  <div class="formula-card">
+    <div class="formula-card__eyebrow">The Math</div>
+    <h2 class="formula-card__title" id="formula-title">How the .900 coin silver price per gram is calculated</h2>
+    <p style="color:var(--color-text-muted);font-size:var(--text-sm);margin-bottom:var(--space-4);line-height:1.7">Silver is quoted globally in <strong style="color:var(--color-silver)">USD per troy ounce</strong> on COMEX (New York) and via the LBMA Silver Price benchmark in London. To get the .900 coin silver gram value, divide spot by 31.1035 (grams in a troy ounce), then multiply by the <strong style="color:var(--color-silver)">0.900 purity ratio</strong>. The remaining 10% is <strong style="color:var(--color-copper)">copper</strong> &mdash; added by US Mint metallurgists for durability in circulation.</p>
+    <div class="formula-card__equation"><span class="var">.900 USD/g</span> <span class="op">=</span> ( <span class="var">spot USD/oz</span> <span class="op">&divide;</span> 31.1035 ) <span class="op">&times;</span> <span class="pure">0.900</span></div>
+    <div class="formula-card__steps">
+      <div class="formula-step">
+        <div class="formula-step__num">1</div>
+        <div class="formula-step__text">Take the live LBMA spot price (<strong>USD per troy oz</strong> of .999 fine silver)</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">2</div>
+        <div class="formula-step__text">Divide by <strong>31.1035</strong> &mdash; grams in one troy ounce &mdash; to get pure silver USD/g</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">3</div>
+        <div class="formula-step__text">Multiply by the <strong>0.900 purity ratio</strong> to get the .900 coin silver USD/g melt value</div>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- ═════════════ US COIN HERITAGE ═════════════ -->
+<section class="luxe-section" aria-labelledby="usecase-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow section-eyebrow--copper">American numismatic heritage</span>
+      <h2 class="section-title" id="usecase-title">Where you'll find .900 US coin silver</h2>
+      <p class="section-sub">From Morgan and Peace Dollars to Walking Liberty Half Dollars and Mercury Dimes &mdash; .900 was the United States Mint's working silver standard for circulating coinage from 1792 through 1964. Live USD melt values below.</p>
+    </div>
+  </div>
+  <div class="luxe-cards">
+    <article class="luxe-card luxe-card--copper">
+      <div class="luxe-card__icon-wrap">
+        <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+          <circle cx="24" cy="24" r="20"/>
+          <circle cx="24" cy="24" r="16"/>
+          <path d="M24 12c3 4 3 16 0 24c-3-8-3-20 0-24z"/>
+          <path d="M16 24h16M14 20l1 8M33 20l1 8"/>
+        </svg>
+      </div>
+      <div class="luxe-card__category">Silver Dollar &middot; 1878&ndash;1935</div>
+      <h3 class="luxe-card__title">Morgan &amp; Peace Dollars</h3>
+      <div class="luxe-card__meta">
+        <span class="luxe-card__meta-item">Total: <strong>26.73g</strong></span>
+        <span class="luxe-card__meta-item">Pure Ag: <strong>24.057g</strong></span>
+        <span class="luxe-card__meta-item">ASW: <strong>0.7734 oz</strong></span>
+      </div>
+      <p class="luxe-card__desc">The most-collected US silver coins. Morgan (1878&ndash;1904, 1921) by George T. Morgan; Peace (1921&ndash;1935) by Anthony de Francisci. Identical melt value; numismatic premium for key dates (1893-S Morgan, 1928 Peace) can reach <strong>100&times; melt</strong>.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-dollar-stat" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">Melt value, single dollar</span>
+      </div>
+    </article>
+    <article class="luxe-card">
+      <div class="luxe-card__icon-wrap">
+        <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+          <circle cx="24" cy="24" r="18"/>
+          <circle cx="24" cy="24" r="14"/>
+          <path d="M24 14v20M19 18c2 0 4 2 4 6s-2 6-4 6M29 18c-2 0-4 2-4 6s2 6 4 6"/>
+        </svg>
+      </div>
+      <div class="luxe-card__category">Half Dollar &middot; 1916&ndash;1964</div>
+      <h3 class="luxe-card__title">Walking Liberty, Franklin &amp; Kennedy</h3>
+      <div class="luxe-card__meta">
+        <span class="luxe-card__meta-item">Total: <strong>12.5g</strong></span>
+        <span class="luxe-card__meta-item">Pure Ag: <strong>11.25g</strong></span>
+        <span class="luxe-card__meta-item">ASW: <strong>0.3617 oz</strong></span>
+      </div>
+      <p class="luxe-card__desc">Walking Liberty (1916&ndash;1947) by Adolph Weinman is widely considered the most beautiful US coin ever struck. Franklin (1948&ndash;1963) and 1964 Kennedy halves complete the 90% silver half-dollar lineage. 1965&ndash;1970 Kennedys are <strong>40% silver</strong> &mdash; a distinct intermediate alloy.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-half-stat" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">Melt value, single half dollar</span>
+      </div>
+    </article>
+    <article class="luxe-card luxe-card--copper">
+      <div class="luxe-card__icon-wrap">
+        <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+          <circle cx="24" cy="24" r="14"/>
+          <circle cx="24" cy="24" r="10"/>
+          <path d="M24 16v6l3 2M19 14l3-2M26 14l3-2"/>
+        </svg>
+      </div>
+      <div class="luxe-card__category">Dime &middot; 1916&ndash;1964</div>
+      <h3 class="luxe-card__title">Mercury &amp; Roosevelt Dimes</h3>
+      <div class="luxe-card__meta">
+        <span class="luxe-card__meta-item">Total: <strong>2.5g</strong></span>
+        <span class="luxe-card__meta-item">Pure Ag: <strong>2.25g</strong></span>
+        <span class="luxe-card__meta-item">ASW: <strong>0.0723 oz</strong></span>
+      </div>
+      <p class="luxe-card__desc">Mercury Dimes (1916&ndash;1945) by Adolph Weinman are mistakenly named &mdash; the figure is Liberty wearing a winged cap, not Mercury. Roosevelt Dimes (1946&ndash;1964) replaced them. Both are <strong>90% silver, 2.5g total</strong>. Common date Mercurys trade close to melt; 1916-D commands <strong>10,000&times;</strong>.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="luxe-dime-stat" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">Melt value, single dime</span>
+      </div>
+    </article>
+  </div>
+</section>
+<!-- ═════════════ DATE-BASED IDENTIFICATION ═════════════ -->
+<section class="id-section" aria-labelledby="id-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Identification by date</span>
+      <h2 class="section-title" id="id-title">No hallmarks &mdash; identify .900 silver by year</h2>
+      <p class="section-sub">Unlike Continental European silverware, US circulating coins do not carry a fineness hallmark. The mint year determines composition. Use a coin loupe to verify the date clearly, then cross-reference with the four eras below.</p>
+    </div>
+  </div>
+  <div class="id-grid">
+    <div class="id-card">
+      <span class="id-card__badge">90% silver</span>
+      <div class="id-card__year">&le;1964</div>
+      <div class="id-card__label">Pre-1965 dimes, quarters, halves</div>
+      <p class="id-card__desc">Any Roosevelt or Mercury <strong>Dime</strong>, Washington <strong>Quarter</strong>, or Walking Liberty / Franklin / 1964 Kennedy <strong>Half Dollar</strong> dated 1964 or earlier is <strong>90% silver</strong>. The cleanest scrap-silver identification rule in US numismatics.</p>
+    </div>
+    <div class="id-card id-card--warning">
+      <span class="id-card__badge">Transition year</span>
+      <div class="id-card__year">1964 / 1965</div>
+      <div class="id-card__label">The Coinage Act cutoff</div>
+      <p class="id-card__desc">The <strong>Coinage Act of 1965</strong> ended 90% silver in dimes and quarters. From 1965 onward, dimes and quarters became <em>copper-nickel clad</em> with <strong>no silver content</strong>. Edge appearance is the giveaway &mdash; clad coins show a distinct copper stripe; silver coins show solid white edges.</p>
+    </div>
+    <div class="id-card id-card--neutral">
+      <span class="id-card__badge">40% silver</span>
+      <div class="id-card__year">1965&ndash;1970</div>
+      <div class="id-card__label">Kennedy Halves (intermediate)</div>
+      <p class="id-card__desc">Kennedy Half Dollars dated 1965 through 1970 are a unique <strong>40% silver</strong> alloy &mdash; not 90%, not zero. They contain <strong>4.6g pure silver</strong> per coin (0.1479 oz). The 1976 Bicentennial Half and Quarter (in Proof &amp; Mint sets) also carry 40% silver clad.</p>
+    </div>
+    <div class="id-card id-card--warning">
+      <span class="id-card__badge">90% silver</span>
+      <div class="id-card__year">1878&ndash;1935</div>
+      <div class="id-card__label">Morgan &amp; Peace Dollars</div>
+      <p class="id-card__desc">Morgan Dollars (1878&ndash;1904, 1921) and Peace Dollars (1921&ndash;1935) carry <strong>26.73g total weight, 0.7734 oz pure silver</strong>. The 1971&ndash;1978 Eisenhower Dollar is mostly copper-nickel clad &mdash; only the <em>Mint &amp; Proof set Eisenhowers</em> are <strong>40% silver</strong>.</p>
+    </div>
+  </div>
+</section>
+<!-- ═════════════ EDITORIAL CONTENT ═════════════ -->
+<div class="content-section">
+  <article class="prose-pro">
+    <h2 id="what-is-900-silver">What is .900 coin silver?</h2>
+    <div class="snippet-answer">.900 coin silver is an alloy of <strong>90.0% pure silver</strong> and <span class="pure">10.0% copper</span>, the United States Mint's standard for circulating silver coinage from <strong>1792 through 1964</strong>. The added copper produced a harder, more wear-resistant coin able to withstand daily handling. The "coin silver" name distinguishes it from sterling .925 (UK/US jewellery and flatware) and .999 fine bullion. It is also the standard for Morgan (1878&ndash;1904, 1921) and Peace Dollars (1921&ndash;1935), and was used historically for Scandinavian silverware.</div>
+
+    <h2 id="todays-900-silver-price">What is .900 coin silver worth per gram today?</h2>
+    <div class="snippet-answer">The live .900 coin silver price per gram is approximately <strong><span id="snippet-price" data-nosnippet>[live USD value]</span></strong> today. This is calculated by multiplying the live LBMA spot price (USD per troy ounce) by <strong>0.900</strong> (the purity ratio) and dividing by <strong>31.1035</strong> (grams in a troy ounce). <strong>USD is the primary currency</strong> on this page because silver is quoted globally in US dollars on COMEX and via the LBMA London benchmark. GBP and EUR conversions use live ECB reference rates and refresh every 60 seconds.</div>
+
+    <h2 id="lbma-spot">How the LBMA spot price drives .900 coin silver value</h2>
+    <p class="has-dropcap">Silver's global benchmark is the <strong>LBMA Silver Price</strong>, an electronic auction conducted at <strong>12:00 GMT daily</strong> by ICE Benchmark Administration. Throughout the trading day, the live spot price is set by COMEX (New York) silver futures, with significant activity in Shanghai (SHFE) and London OTC markets. GoldPriceTools sources live XAG/USD spot prices from <code style="font-family:var(--font-mono);background:var(--color-surface-offset);padding:2px 6px;border-radius:4px;font-size:90%">gold-api.com</code> (LBMA-derived), updated every 60 seconds. Currency conversion to GBP, EUR and INR uses the <strong>Frankfurter API</strong> (ECB reference rates). The same USD spot is applied uniformly across every page on this site to ensure cross-page consistency &mdash; your Morgan Dollar melt value here matches the per-gram figure on our <a href="/silver-price-per-kilo">silver price per kilo</a> page, scaled only by purity and weight.</p>
+
+    <h2 id="identifying-900">How to identify .900 US coin silver</h2>
+    <p>US circulating coins do not carry a fineness hallmark. Identification is by <strong>mint year and denomination</strong>. The five rules to remember:</p>
+    <ul>
+      <li><strong>Pre-1965 dimes</strong> &mdash; Roosevelt (1946&ndash;1964), Mercury (1916&ndash;1945) and earlier Barber dimes (1892&ndash;1916) are all 90% silver, 2.5g total weight.</li>
+      <li><strong>Pre-1965 quarters</strong> &mdash; Washington (1932&ndash;1964) and earlier Standing Liberty (1916&ndash;1930) quarters are 90% silver, 6.25g total.</li>
+      <li><strong>Pre-1965 half dollars</strong> &mdash; Walking Liberty (1916&ndash;1947), Franklin (1948&ndash;1963) and 1964 Kennedy are 90% silver, 12.5g total. 1965&ndash;1970 Kennedys are <em>40% silver</em>; post-1970 Kennedys are clad copper-nickel.</li>
+      <li><strong>Silver dollars</strong> &mdash; Morgan (1878&ndash;1904, 1921) and Peace (1921&ndash;1935) are 90% silver, 26.73g. Eisenhower business strikes (1971&ndash;1978) are clad; only Mint &amp; Proof Eisenhowers carry 40% silver.</li>
+      <li><strong>Edge test</strong> &mdash; Hold the coin edge-on. Solid silver coins show a uniform white edge; copper-nickel clad coins display a distinct copper-coloured stripe sandwiched between two nickel-white layers.</li>
+    </ul>
+
+    <h2 id="calculating-melt">How to calculate .900 coin silver melt value</h2>
+    <p>The formula is:</p>
+    <blockquote><strong>.900 silver USD/g = (Spot USD/oz &divide; 31.1035) &times; 0.900</strong></blockquote>
+    <p>For example, at a silver spot price of $33.00 per troy ounce:</p>
+    <ul>
+      <li>Pure silver USD/g = $33.00 &divide; 31.1035 = <strong>$1.061 / gram</strong></li>
+      <li>.900 coin silver USD/g = $1.061 &times; 0.900 = <strong>$0.955 / gram</strong></li>
+      <li>A single Morgan Dollar (26.73g) = $0.955 &times; 26.73 = <strong>$25.52 melt value</strong></li>
+      <li>$1,000 face value junk silver bag (~715 oz pure silver) = <strong>$23,595 melt value</strong></li>
+    </ul>
+    <p>Use the live calculator at the top of this page for real-time figures &mdash; the maths refreshes every 60 seconds with the current LBMA spot.</p>
+
+    <div class="callout callout--copper">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 8v4M12 16h.01"/></svg>
+      <div>
+        <div class="callout__title">Junk silver &mdash; the $1 face rule</div>
+        <div class="callout__body"><strong>$1 face value</strong> of any combination of 90% silver dimes, quarters or halves contains theoretically <strong>0.7234 troy oz</strong> of pure silver. In practice, the trade-standard figure is <strong>0.715 oz per $1 face</strong> &mdash; the difference accounts for typical circulation wear. A $1,000 face value bag holds about <strong>715 troy oz</strong> of silver. This is the most-quoted figure in the precious metals trade.</div>
+      </div>
+    </div>
+
+    <h2 id="selling-900">Selling .900 coin silver: junk vs numismatic value</h2>
+    <p>A key decision when valuing pre-1965 US silver coins is whether to sell at <strong>junk silver</strong> rate (bullion value only) or pursue <strong>numismatic premium</strong> (collector value above melt):</p>
+    <div class="market-table-wrap">
+      <table class="market-table" aria-label=".900 coin silver selling channels comparison">
+        <thead><tr><th>Channel</th><th>Typical payout</th><th>Best for</th></tr></thead>
+        <tbody>
+          <tr><td>Bullion / junk silver dealer</td><td>92&ndash;100% of melt</td><td>Common date pre-1965 dimes, quarters, halves in any condition</td></tr>
+          <tr><td>Local coin shop</td><td>90&ndash;98% of melt</td><td>Walk-in convenience, immediate cash, mixed lots</td></tr>
+          <tr><td>Online bullion broker</td><td>95&ndash;102% of melt</td><td>Larger bags ($100+ face), shipped to refiner</td></tr>
+          <tr><td>Pawnbroker</td><td>60&ndash;80% of melt</td><td>Quick liquidity, lower priority</td></tr>
+          <tr><td>Coin show / auction</td><td>Premium &times; 1.5&ndash;100&times; melt</td><td>Key dates, BU/MS-graded, certified coins</td></tr>
+          <tr><td>Direct collector (eBay)</td><td>Variable; 1.2&ndash;5&times; melt</td><td>Photographed Morgans, slabbed coins, sets</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p>For most common-date pre-1965 dimes, quarters and halves, junk silver buyers offer the best balance of price and convenience. For Morgan Dollars, Walking Liberty Halves or coins in BU (Brilliant Uncirculated) condition, an auction or a graded sale (PCGS / NGC) is worth the wait. See our <a href="/where-to-sell-gold-silver">where to sell gold &amp; silver guide</a> for vetted US dealers.</p>
+
+    <h2 id="900-vs-925">.900 coin silver vs sterling .925 &mdash; the math</h2>
+    <p>Sterling silver (.925) contains 92.5% pure silver, making it only 2.8% richer in silver content per gram than .900. The melt-value ratio: <strong>0.900 &divide; 0.925 = 97.3%</strong>. So a gram of .900 coin silver is worth about 97.3% of sterling. Other differences:</p>
+    <ul>
+      <li><strong>Hardness &amp; durability</strong> &mdash; .900 was specifically selected by US Mint metallurgists for circulating coinage. Higher copper content makes it harder and more wear-resistant than sterling.</li>
+      <li><strong>Tarnish rate</strong> &mdash; .900 tarnishes slightly faster than .925 due to higher copper content. Vintage coins develop characteristic patina (toning) that can <em>increase</em> collector value.</li>
+      <li><strong>Colour</strong> &mdash; .900 has a subtle warmer, slightly duller hue than sterling. Old toned Morgans display rainbow / album toning prized by numismatists.</li>
+      <li><strong>Use case</strong> &mdash; .925 is the jewellery/flatware standard; .900 is the US circulating coinage standard. Different markets, different premiums.</li>
+      <li><strong>Numismatic value</strong> &mdash; .900 coins carry significant collector premiums for key dates. .925 sterling is mostly valued at scrap/melt with few collector items.</li>
+    </ul>
+
+    <div class="callout">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/><path d="M9 12l2 2 4-4"/></svg>
+      <div>
+        <div class="callout__title">Verifying authenticity</div>
+        <div class="callout__body">Genuine .900 US coin silver is <strong>non-magnetic</strong>. If your coin sticks to a magnet, it is plated or counterfeit. Authentic pre-1965 dimes, quarters and halves have a <strong>distinct ring</strong> when dropped on a hard surface &mdash; called the "silver ping" by collectors. The visual edge test is most reliable: solid white edge = silver; copper stripe = clad. For high-value coins (especially Morgan Dollars), use <strong>PCGS or NGC grading</strong> for guaranteed authenticity.</div>
+      </div>
+    </div>
+
+    <h2 id="common-weights">.900 silver content of every US silver coin</h2>
+    <p>Knowing the exact silver content of each denomination helps you instantly estimate melt value when buying or selling junk silver:</p>
+    <div class="market-table-wrap">
+      <table class="market-table" aria-label="US 90% silver coin weights and silver content">
+        <thead><tr><th>Coin</th><th>Year range</th><th>Total weight</th><th>Pure silver (ASW)</th></tr></thead>
+        <tbody>
+          <tr><td>Roosevelt Dime</td><td>1946&ndash;1964</td><td>2.5g</td><td>2.25g (0.07234 oz)</td></tr>
+          <tr><td>Mercury Dime</td><td>1916&ndash;1945</td><td>2.5g</td><td>2.25g (0.07234 oz)</td></tr>
+          <tr><td>Barber Dime</td><td>1892&ndash;1916</td><td>2.5g</td><td>2.25g (0.07234 oz)</td></tr>
+          <tr><td>Washington Quarter</td><td>1932&ndash;1964</td><td>6.25g</td><td>5.625g (0.18084 oz)</td></tr>
+          <tr><td>Standing Liberty Quarter</td><td>1916&ndash;1930</td><td>6.25g</td><td>5.625g (0.18084 oz)</td></tr>
+          <tr><td>Walking Liberty Half</td><td>1916&ndash;1947</td><td>12.5g</td><td>11.25g (0.36169 oz)</td></tr>
+          <tr><td>Franklin Half</td><td>1948&ndash;1963</td><td>12.5g</td><td>11.25g (0.36169 oz)</td></tr>
+          <tr><td>Kennedy Half (90%)</td><td>1964 only</td><td>12.5g</td><td>11.25g (0.36169 oz)</td></tr>
+          <tr><td>Kennedy Half (40%)</td><td>1965&ndash;1970</td><td>11.5g</td><td>4.6g (0.14792 oz)</td></tr>
+          <tr><td>Morgan Dollar</td><td>1878&ndash;1904, 1921</td><td>26.73g</td><td>24.057g (0.77344 oz)</td></tr>
+          <tr><td>Peace Dollar</td><td>1921&ndash;1935</td><td>26.73g</td><td>24.057g (0.77344 oz)</td></tr>
+          <tr><td>Eisenhower Dollar (40%)</td><td>1971&ndash;1976 S</td><td>24.59g</td><td>9.84g (0.31625 oz)</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p>For per-coin live pricing, use our dedicated <a href="/silver-coins-calculator">US silver coins calculator</a> &mdash; it handles mixed-denomination junk silver bags as well as single coins.</p>
+
+    <h2 id="faq">Frequently asked questions</h2>
+    <div class="faq-pro">
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What is .900 coin silver worth per gram today in USD?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">The live .900 US coin silver price per gram in USD is shown in the hero tile at the top of this page and refreshes every 60 seconds. It is calculated as <strong>(LBMA spot USD/oz &divide; 31.1035) &times; 0.900</strong>. USD is the primary currency on this page because silver is quoted globally in US dollars; GBP and EUR conversions use live ECB reference rates.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How much silver is in a pre-1965 US quarter, dime or half dollar?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Pre-1965 US 90% silver coins contain: Roosevelt/Mercury <strong>Dime</strong> &mdash; 2.25g pure silver (0.07234 troy oz); Washington <strong>Quarter</strong> &mdash; 5.625g (0.18084 troy oz); Walking Liberty/Franklin/1964 Kennedy <strong>Half Dollar</strong> &mdash; 11.25g (0.36169 troy oz); Morgan/Peace <strong>Dollar</strong> &mdash; 24.057g (0.77344 troy oz). The trade convention for $1 face value of junk silver is <strong>0.715 troy oz</strong> of pure silver content accounting for typical circulation wear.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How do I identify .900 US silver coins?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">US coins do not carry a hallmark stamp. Identify .900 coin silver by <strong>date</strong>: any Roosevelt or Mercury Dime, Washington Quarter, or Walking Liberty / Franklin / Kennedy Half Dollar minted <strong>1964 or earlier</strong> is 90% silver. Morgan (1878&ndash;1904, 1921) and Peace Dollars (1921&ndash;1935) are also 90% silver. 1965&ndash;1970 Kennedy Halves are <em>40% silver</em> &mdash; a distinct intermediate alloy. Post-1971 dimes and quarters are copper-nickel clad with no silver content. The <strong>edge test</strong> (solid white edge vs copper stripe) is the fastest visual check.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What is junk silver and how do I calculate $1 face value?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Junk silver refers to circulated pre-1965 US 90% silver coins with <strong>no numismatic premium</strong> &mdash; valued purely for silver content. $1 face value of any 90% combination (10 dimes, 4 quarters, 2 halves) contains approximately <strong>0.715 troy oz</strong> of pure silver (the trade-standard figure accounting for normal coin wear; uncirculated coins technically hold 0.7234 oz). At today's spot, a <strong>$1,000 face value bag</strong> holds about 715 troy oz of silver.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Is .900 coin silver the same as sterling silver (.925)?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">No. .900 coin silver is <strong>90.0% pure silver</strong> with 10.0% copper, historically used for US circulating coinage. Sterling silver (.925) is <strong>92.5% pure</strong> and is the UK/US jewellery and flatware standard. By melt value, .900 coin silver is worth approximately <strong>97.3% of sterling per gram</strong> (0.900 &divide; 0.925). The added copper in .900 produced harder, more wear-resistant coinage.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>What is the difference between Morgan and Peace silver dollars?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Both Morgan (1878&ndash;1904, 1921) and Peace (1921&ndash;1935) Dollars are <strong>.900 silver with identical 26.73g total weight and 24.057g (0.77344 troy oz) pure silver content</strong>. Morgan Dollars feature Lady Liberty's portrait by George T. Morgan; Peace Dollars feature Anthony de Francisci's Liberty commemorating the end of WWI. Both share <strong>identical melt value</strong> &mdash; but numismatic premium for rare dates (1893-S Morgan, 1928 Peace, 1934-S Peace) can multiply melt 5&times;&ndash;100&times; at auction.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>Why is silver priced in USD globally?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Silver is quoted in US dollars per troy ounce on the <strong>COMEX</strong> futures exchange and via the <strong>LBMA Silver Price</strong> daily auction in London. USD is the world's reserve currency and the most liquid quote unit for precious metals globally. All conversions to GBP, EUR or INR are mathematically derived from the live USD spot using ECB reference rates from the Frankfurter API.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary">
+          <span>How accurate are these live .900 coin silver prices?</span>
+          <span class="faq-pro__plus" aria-hidden="true"></span>
+        </summary>
+        <div class="faq-pro__body">Spot prices come direct from the LBMA via gold-api.com and refresh every 60 seconds. Currency conversion from USD to GBP, EUR and INR uses the Frankfurter API's live ECB reference rates. The figures shown are <em>melt values</em> &mdash; the raw silver content. <strong>Junk silver dealer buy prices typically sit at 85&ndash;100% of spot</strong> (sometimes above spot for clean bag-quality rolls); rare-date or BU-graded Morgan Dollars can command <strong>5&times;&ndash;100&times; melt</strong> at auction.</div>
+      </details>
+    </div>
+
+    <div class="disclaimer"><strong>Disclaimer:</strong> Prices shown are indicative melt values only and do not constitute financial advice. Junk silver dealer buy prices for .900 US coin silver are typically 85&ndash;100% of melt (sometimes above spot for clean rolls). Numismatic premium for key-date or BU-graded coins can exceed 5&times;&ndash;100&times; melt at auction. Always verify with your dealer or auction house before transacting.</div>
+  </article>
+</div>
+<!-- Social share buttons -->
+<div class="content-section" style="padding-top:0;padding-bottom:1.5rem">
+<div class="share-buttons" style="max-width:760px;margin:0 auto">
+  <span>Share:</span>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/900-silver-price-per-gram&text=.900+Coin+Silver+Price+Per+Gram+Today+%28Live+USD%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="twitter" aria-label="Share on X / Twitter"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.258 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z"/></svg> X</a>
+  <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/900-silver-price-per-gram&title=.900+Coin+Silver+Price+Per+Gram+Today+%28Live+USD%29" rel="nofollow noreferrer noopener" target="_blank" data-platform="reddit" aria-label="Share on Reddit"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=.900+Coin+Silver+Price+Per+Gram+Today+%28Live+USD%29%20https%3A%2F%2Fgoldpricetools.com%2F900-silver-price-per-gram" rel="nofollow noreferrer noopener" target="_blank" data-platform="whatsapp" aria-label="Share on WhatsApp"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+</div>
+</div>
+<!-- Related Guides -->
+<section class="related-guides" aria-labelledby="related-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Keep reading</span>
+      <h2 class="section-title" id="related-title">Related Silver &amp; Gold Guides</h2>
+    </div>
+  </div>
+  <div class="related-guides-grid">
+    <a href="/800-silver-price-per-gram" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">.800 European Silver Per Gram</div>
+      <div class="related-card__desc">Today's .800 Continental silver per gram &mdash; German Halbmond, Italian and French antique flatware.</div>
+    </a>
+    <a href="/silver-price-per-kilo" class="related-card">
+      <span class="related-card__tag">Live Price</span>
+      <div class="related-card__title">Silver Price Per Kilo</div>
+      <div class="related-card__desc">Live .999 fine silver per kilogram &mdash; bullion bars and wholesale silver trading.</div>
+    </a>
+    <a href="/silver-coins-calculator" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">US Silver Coins Calculator</div>
+      <div class="related-card__desc">Live USD melt value for US silver coins, Eagles and pre-1965 dimes, quarters, halves.</div>
+    </a>
+    <a href="/us-silver-dollar-values" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">US Silver Dollar Values</div>
+      <div class="related-card__desc">Morgan, Peace and Eisenhower Dollar values, key dates and numismatic premiums.</div>
+    </a>
+    <a href="/guides/what-is-925-sterling-silver" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">What is 925 Sterling Silver?</div>
+      <div class="related-card__desc">How .925 sterling compares to .900 coin and .800 European silver in purity and value.</div>
+    </a>
+    <a href="/silver-purity-grades" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Silver Purity Grades</div>
+      <div class="related-card__desc">Complete guide to .999, .958, .925, .900, .835 and .800 &mdash; fineness, hallmarks and uses.</div>
+    </a>
+    <a href="/gold-silver-ratio" class="related-card">
+      <span class="related-card__tag">Live Tool</span>
+      <div class="related-card__title">Gold-Silver Ratio</div>
+      <div class="related-card__desc">Track the live gold-to-silver ratio &mdash; a key precious metals timing indicator.</div>
+    </a>
+    <a href="/where-to-sell-gold-silver" class="related-card">
+      <span class="related-card__tag">Guide</span>
+      <div class="related-card__title">Where to Sell Gold &amp; Silver</div>
+      <div class="related-card__desc">Vetted US and UK dealers, coin shops and online buyers for junk silver and Morgans.</div>
+    </a>
+  </div>
+</section>
+<!-- Sticky mobile price bar -->
+<div class="sticky-price" id="stickyPrice" role="complementary" aria-label="Live price quick access">
+  <div class="sticky-price__info">
+    <div class="sticky-price__label">.900 Coin Silver &middot; USD/g</div>
+    <div class="sticky-price__value" id="sticky-usd" data-nosnippet>&mdash;</div>
+  </div>
+  <a href="#calculator" class="sticky-price__cta">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M8 18h2"/></svg>
+    Calculate
+  </a>
+</div>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">
@@ -775,7 +1247,7 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz, kilo and per gram by purity. Prices sourced from LBMA via gold-api.com, updated every 60 seconds. USD primary currency.</p>
       <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
@@ -788,7 +1260,6 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -818,17 +1289,6 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Blog</h4>
-      <ul>
-        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
-        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
-        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
-        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
-        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
-        <li><a href="/blog/">All Articles</a></li>
-      </ul>
-    </div>
-    <div class="footer-col">
       <h4>Info</h4>
       <ul>
         <li><a href="/about">About</a></li>
@@ -841,57 +1301,284 @@ details[open]>.faq-answer-summary::after{content:"－"!important}
   </div>
   <div class="footer-bottom">
     <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
-    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com. USD primary.</span>
   </div>
 </footer>
 <script>
-async function fetchFx(){try{const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch{window._gbpusd=0.79;}}
+/* ───────── Live .900 coin silver price engine — USD primary, multi-currency ─────────
+   Sources:
+     • Silver spot: https://api.gold-api.com/price/XAG  (LBMA-derived USD/oz)
+     • FX rates:    https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR
+   Refresh: 60s — DO NOT change interval (keeps cross-page consistency)
+   Purity: 0.900 (locked — this is the .900 US coin silver page)
+*/
+(function(){
+  const G_PER_OZ = 31.1035;
+  const PURITY = 0.900;
+  const REFRESH_MS = 60000;
+  const PURITIES = {'999':0.999, '925':0.925, '900':0.900, '800':0.800};
+  let lastFetchTs = 0;
+  let countdownTimer = null;
 
+  // Currency formatters — USD is primary
+  const fmtUSD = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:4,minimumFractionDigits:2});
+  const fmtGBP = new Intl.NumberFormat('en-GB',{style:'currency',currency:'GBP',maximumFractionDigits:4,minimumFractionDigits:2});
+  const fmtEUR = new Intl.NumberFormat('en-IE',{style:'currency',currency:'EUR',maximumFractionDigits:4,minimumFractionDigits:2});
+  const fmtINR = new Intl.NumberFormat('en-IN',{style:'currency',currency:'INR',maximumFractionDigits:2});
+  const fmtSpot = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
 
-function fmtCurr(val, cur) {
-  if (cur==='USD') return '$'+val.toFixed(2);
-  if (cur==='GBP') return '£'+(val*window._gbpusd).toFixed(2);
-  if (cur==='EUR') return '€'+(val*1.16).toFixed(2);
-  if (cur==='INR') return '₹'+(val*83.0).toFixed(2);
-  return val.toFixed(2);
-}
-function calcSilver(spotOz) {
-  if (!spotOz) return;
-  const purity=0.900, weight=parseFloat(document.getElementById('silverWeight').value)||0, unit=parseFloat(document.getElementById('silverUnit').value), currency=document.getElementById('silverCurrency').value;
-  const grams = weight * unit;
-  const usdVal = (spotOz / 31.1035) * purity * grams;
-  document.getElementById('silverResult').textContent = fmtCurr(usdVal, currency);
-  document.getElementById('silverResultMeta').textContent = `${grams.toFixed(4)}g × $90.0% purity × $${(spotOz/31.1035).toFixed(2)}/g spot`;
-}
+  function $(id){return document.getElementById(id);}
 
-async function fetchSpot(){try{const r=await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});if(!r.ok)throw new Error();const d=await r.json();const ozUSD=d.price;const gbpusd=window._gbpusd||0.79;const perG_USD=(ozUSD/31.1035)*0.900;const perG_GBP=perG_USD*gbpusd;
-    [[1,'1g'],[10,'10g'],[100,'100g'],[31.1035,'oz'],[500,'500g'],[1000,'1k']].forEach(([w,id])=>{const g=document.getElementById('t-'+id+'-gbp');const u=document.getElementById('t-'+id+'-usd');if(g)g.textContent='£'+(perG_GBP*w).toFixed(2);if(u)u.textContent='$'+(perG_USD*w).toFixed(2);});
+  async function fetchFx(){
+    try{
+      const r = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR',{cache:'no-store'});
+      if(!r.ok) throw new Error('FX fetch failed');
+      const d = await r.json();
+      window._gbpusd = d.rates.GBP || 0.79;
+      window._eurusd = d.rates.EUR || 0.92;
+      window._inrusd = d.rates.INR || 83.0;
+    }catch(e){
+      console.warn('FX fallback used',e);
+      window._gbpusd = window._gbpusd || 0.79;
+      window._eurusd = window._eurusd || 0.92;
+      window._inrusd = window._inrusd || 83.0;
+    }
+  }
 
-    // Purity Table logic
-    const purities = [0.999, 0.925, 0.900, 0.800];
-    const pure_oz = ozUSD;
-    const pure_g = pure_oz / 31.1035;
-    const tbody = document.querySelector('.data-table:nth-of-type(2) tbody');
-    if (tbody) {
-      const rows = tbody.querySelectorAll('tr');
-      purities.forEach((p, i) => {
-        if (rows[i]) {
-          const p_g = pure_g * p;
-          rows[i].cells[2].textContent = '£' + (p_g * gbpusd).toFixed(2);
-          rows[i].cells[3].textContent = '£' + (p_g * 1000 * gbpusd).toFixed(2);
-          rows[i].cells[4].textContent = '£' + (pure_oz * p * gbpusd).toFixed(2);
-        }
-      });
+  async function fetchSpot(){
+    try{
+      const r = await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});
+      if(!r.ok) throw new Error('Spot fetch failed');
+      const d = await r.json();
+      const spotUSD = d.price;
+      window._spotUSD = spotUSD;
+      lastFetchTs = Date.now();
+      render(spotUSD);
+      gtag('event','price_view',{metal:'silver',unit:'0.900'});
+    }catch(e){
+      console.warn('Silver spot fetch failed',e);
+    }
+  }
+
+  function render(spotUSD){
+    const gbp = window._gbpusd || 0.79;
+    const eur = window._eurusd || 0.92;
+
+    // Pure silver USD baselines
+    const pureG_USD = spotUSD / G_PER_OZ;             // .999 fine USD/g
+    const nineG_USD = pureG_USD * PURITY;             // .900 USD/g
+    const nineG_GBP = nineG_USD * gbp;
+    const nineG_EUR = nineG_USD * eur;
+
+    // Hero tiles — USD primary, .900 per gram
+    if($('hero-usd')) $('hero-usd').textContent = fmtUSD.format(nineG_USD);
+    if($('hero-gbp')) $('hero-gbp').textContent = fmtGBP.format(nineG_GBP);
+    if($('hero-eur')) $('hero-eur').textContent = fmtEUR.format(nineG_EUR);
+
+    // Sticky mobile bar (USD)
+    if($('sticky-usd')) $('sticky-usd').textContent = fmtUSD.format(nineG_USD);
+
+    // Spot reference (per troy oz, pure silver)
+    if($('spot-usd')) $('spot-usd').textContent = fmtSpot.format(spotUSD) + ' /oz';
+
+    // Snippet inline price (USD primary, .900 per gram)
+    if($('snippet-price')) $('snippet-price').textContent = fmtUSD.format(nineG_USD) + ' / g (' + fmtGBP.format(nineG_GBP) + ' / g)';
+
+    // Weight table — 1g, dime 2.5g, qtr 6.25g, 10g, half 12.5g, troy oz, dollar 26.73g, 100g, $10face 250g, 500g, 1kg — .900 silver
+    const rows = [
+      {id:'1g', mult:1},
+      {id:'dime', mult:2.5},
+      {id:'qtr', mult:6.25},
+      {id:'10g', mult:10},
+      {id:'half', mult:12.5},
+      {id:'oz', mult:G_PER_OZ},
+      {id:'dollar', mult:26.73},
+      {id:'100g', mult:100},
+      {id:'10face', mult:250},
+      {id:'500g', mult:500},
+      {id:'1k', mult:1000},
+    ];
+    rows.forEach(r => {
+      const u = $('t-'+r.id+'-usd');
+      const g = $('t-'+r.id+'-gbp');
+      const e = $('t-'+r.id+'-eur');
+      const v = nineG_USD * r.mult;
+      if(u) u.textContent = fmtUSD.format(v);
+      if(g) g.textContent = fmtGBP.format(v * gbp);
+      if(e) e.textContent = fmtEUR.format(v * eur);
+    });
+
+    // Purity grid — USD per gram for each purity grade (pure_g × purity)
+    Object.keys(PURITIES).forEach(k => {
+      const el = $('purity-'+k+'-usd');
+      if(el) el.textContent = fmtUSD.format(pureG_USD * PURITIES[k]);
+    });
+
+    // Heritage coin card stats (USD)
+    const dollarEl = $('luxe-dollar-stat');           // single Morgan/Peace Dollar (26.73g)
+    const halfEl   = $('luxe-half-stat');             // single Walking Liberty/Franklin/64 Kennedy Half (12.5g)
+    const dimeEl   = $('luxe-dime-stat');             // single Mercury/Roosevelt Dime (2.5g)
+    if(dollarEl) dollarEl.textContent = fmtUSD.format(nineG_USD * 26.73);
+    if(halfEl)   halfEl.textContent   = fmtUSD.format(nineG_USD * 12.5);
+    if(dimeEl)   dimeEl.textContent   = fmtUSD.format(nineG_USD * 2.5);
+
+    // Calculator — update live
+    updateCalculator();
+
+    // Update timestamp
+    updateTimestamp();
+    startCountdown();
+  }
+
+  function updateTimestamp(){
+    const el = $('updated-time');
+    if(!el) return;
+    el.textContent = 'just now';
+  }
+
+  function startCountdown(){
+    if(countdownTimer) clearInterval(countdownTimer);
+    const counterEl = $('refresh-counter');
+    const updatedEl = $('updated-time');
+    countdownTimer = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - lastFetchTs) / 1000);
+      const remaining = Math.max(0, 60 - elapsed);
+      if(counterEl) counterEl.textContent = remaining + 's';
+      if(updatedEl){
+        if(elapsed < 10) updatedEl.textContent = 'just now';
+        else if(elapsed < 60) updatedEl.textContent = elapsed + 's ago';
+        else updatedEl.textContent = Math.floor(elapsed/60) + 'm ago';
+      }
+    }, 1000);
+  }
+
+  // ───────── Calculator interaction ─────────
+  function updateCalculator(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD) return;
+    const weightEl = $('calc-weight');
+    const unitEl = $('calc-unit');
+    const currencyEl = $('calc-currency');
+    const purityEl = $('calc-purity');
+    if(!weightEl || !unitEl || !currencyEl) return;
+    const rawWeight = parseFloat(weightEl.value) || 0;
+    const unitMult = parseFloat(unitEl.value) || 1;       // multiplier to grams
+    const grams = rawWeight * unitMult;
+    const purity = parseFloat(purityEl ? purityEl.value : PURITY) || PURITY;
+    const currency = currencyEl.value;
+
+    const pureG_USD = spotUSD / G_PER_OZ;
+    const meltUSD = pureG_USD * grams * purity;
+    let melt, fmt;
+    if(currency === 'GBP'){
+      melt = meltUSD * (window._gbpusd || 0.79);
+      fmt = fmtGBP;
+    }else if(currency === 'EUR'){
+      melt = meltUSD * (window._eurusd || 0.92);
+      fmt = fmtEUR;
+    }else if(currency === 'INR'){
+      melt = meltUSD * (window._inrusd || 83.0);
+      fmt = fmtINR;
+    }else{
+      melt = meltUSD;
+      fmt = fmtUSD;
     }
 
-    calcSilver(ozUSD);
+    const dealer = melt * 0.85;     // junk silver dealer payout midpoint (85% — center of 85–100%)
+    const numis  = melt * 5;        // numismatic premium starting point (5× — common key-date entry)
 
-    ['silverWeight','silverUnit','silverCurrency'].forEach(id=>document.getElementById(id)?.addEventListener('input',() => calcSilver(ozUSD)));
+    if($('calc-melt')) $('calc-melt').textContent = fmt.format(melt);
+    if($('calc-dealer')) $('calc-dealer').textContent = fmt.format(dealer);
+    if($('calc-numis')) $('calc-numis').textContent = fmt.format(numis);
+  }
 
-    gtag('event','price_view',{metal:'silver',unit:'0.900'});}catch(e){console.warn('Silver price fetch failed',e);}}
+  function bindCalculator(){
+    ['calc-weight','calc-unit','calc-currency'].forEach(id=>{
+      const el = $(id);
+      if(el) el.addEventListener('input', updateCalculator);
+      if(el) el.addEventListener('change', updateCalculator);
+    });
+    document.querySelectorAll('.calc-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const w = chip.getAttribute('data-weight');
+        const u = chip.getAttribute('data-unit');
+        const weightEl = $('calc-weight');
+        const unitEl = $('calc-unit');
+        if(weightEl){
+          weightEl.value = w;
+          if(u && unitEl) unitEl.value = u;
+          updateCalculator();
+        }
+        document.querySelectorAll('.calc-chip').forEach(c => c.classList.remove('active'));
+        chip.classList.add('active');
+        gtag('event','calc_chip_click',{metal:'silver-900',weight:w});
+      });
+    });
+  }
 
-Promise.all([fetchFx(),fetchSpot()]);setInterval(fetchSpot,60000);
+  // Currency switch (highlights column in price table + drives calculator)
+  function bindCurrencySwitch(){
+    const btns = document.querySelectorAll('.currency-switch__btn');
+    btns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const cur = btn.getAttribute('data-currency');
+        btns.forEach(b => {
+          b.classList.toggle('active', b === btn);
+          b.setAttribute('aria-selected', b === btn ? 'true' : 'false');
+        });
+        document.querySelectorAll('.price-table-pro td, .price-table-pro th').forEach(c => {
+          c.classList.toggle('price-table-pro__primary', c.getAttribute('data-col') === cur);
+        });
+        const calcCur = $('calc-currency');
+        if(calcCur && calcCur.value !== cur){
+          calcCur.value = cur;
+          updateCalculator();
+        }
+      });
+    });
+    // Set initial highlight — USD default
+    document.querySelectorAll('.price-table-pro td[data-col="USD"], .price-table-pro th[data-col="USD"]').forEach(c => c.classList.add('price-table-pro__primary'));
+  }
+
+  // Sticky mobile bar — show after scroll past hero
+  function bindStickyBar(){
+    const bar = $('stickyPrice');
+    if(!bar) return;
+    let visible = false;
+    window.addEventListener('scroll', () => {
+      const show = window.scrollY > 400;
+      if(show !== visible){
+        bar.classList.toggle('visible', show);
+        visible = show;
+      }
+    }, {passive: true});
+  }
+
+  // Init
+  document.addEventListener('DOMContentLoaded', () => {
+    bindCalculator();
+    bindCurrencySwitch();
+    bindStickyBar();
+  });
+
+  // Boot
+  Promise.all([fetchFx(), fetchSpot()]).catch(e => console.warn('init',e));
+  setInterval(fetchSpot, REFRESH_MS);
+})();
 </script>
+
+<script>(function(){
+  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
+  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+  root.setAttribute('data-theme',theme);
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);try{localStorage.setItem('gpt-theme',theme);}catch(e){}themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
+  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
+  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
+  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
+  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
+})();</script>
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>
 let _deepReadFired = false;


### PR DESCRIPTION
## Summary

Premium mobile-first redesign of `/900-silver-price-per-gram`, matching the design language of the recently shipped `.800` sister page but personalised with **US numismatic / coin heritage character** (Morgan & Peace Dollars, Walking Liberty & Franklin Halves, Mercury & Roosevelt Dimes, Washington Quarters).

Bumps the page from 909 lines to 1,596 lines of complete, structured editorial content.

## What changed (UI/UX)

- **Premium hero** with eyebrow pulse badge, Playfair Display italic emphasis, 3 live currency tiles (USD primary, GBP, EUR), and a live-status bar with spot price + 60s refresh countdown.
- **Heritage palette** — silver gradients carried over from the .800 design, plus a new warm-copper/patina accent palette reflecting the 10% copper alloy in `.900` coin silver. Both light and dark themes supported.
- **Live calculator** with `.900` purity locked, 8 US coin chip presets (Roosevelt Dime 2.5g, Washington Quarter 6.25g, Walking Liberty Half 12.5g, Morgan/Peace Dollar 26.73g, plus `$1` / `$10` / `$100` / `$1,000` face junk silver bag presets), 3 result tiles (melt, dealer-pays @ ~85%, numismatic premium @ ~5× starting point).
- **4 stat cards**, **11-row price-by-weight table** with currency switch (USD/GBP/EUR), and per-coin rows (dime, quarter, half, dollar, $10-face roll) visually distinguished with copper dots.
- **Silver purity comparison grid** — `.999` / `.925` / `.900` (YOU ARE HERE, featured) / `.800`, each linking to its sister page with live USD/g price.
- **"How the math works" formula block** with monospace equation and 3-step explainer.
- **3 US coin heritage cards** — Morgan & Peace Dollars, Walking Liberty/Franklin/Kennedy Halves, Mercury & Roosevelt Dimes — each with weight metadata and live melt-value stat.
- **4 date-based identification cards** — pre-1965 / 1964–65 transition / 1965–70 40% Kennedys / Morgan-Peace era — since US coins lack hallmarks and must be identified by year.
- **Editorial prose** with drop caps, pull-quote blockquote, copper-accented callouts (junk silver `$1` face rule, authenticity verification), selling channels comparison table, and complete US silver coin weight table.
- **FAQ accordion** (8 items, all reflected in `FAQPage` JSON-LD).
- **Sticky mobile price bar** showing live USD/g + Calculate CTA (visible on `< 768px`).
- **Related guides grid** (8 cards).

## Live data integrity

All live values pull from the same site-wide APIs on the same 60-second cadence, so cross-page prices reconcile exactly:

| Endpoint | Purpose |
|---|---|
| `https://api.gold-api.com/price/XAG` | LBMA-derived silver spot in **USD/oz** |
| `https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR` | ECB reference rates for currency conversion |

JS constants identical to `.800` sister page (`G_PER_OZ = 31.1035`, `REFRESH_MS = 60000`), with only `PURITY = 0.900`. **USD is the primary currency** throughout — every hero tile, calculator output, table column and sticky bar leads with `$`. GBP, EUR and INR are derived conversions.

## Accessibility & responsive

- Mobile-first breakpoints: `560px`, `768px`, `900px`, `1024px`.
- All touch targets ≥ 44px (hamburger, mobile-section toggles, chips, share buttons).
- `prefers-reduced-motion` respected (transitions/animations disabled).
- Live regions: `role="status" aria-live="polite"` on the live-status bar.
- `<details>` native FAQ accordion with `:focus-visible` rings.
- `data-nosnippet` on all live-data values so Google doesn't index stale prices.

## SEO

- `BreadcrumbList`, `FAQPage`, `Dataset` and `WebPage` JSON-LD blocks all parse clean (validated).
- Breadcrumb adds `Silver Guides` → page (matches the `.800` page hierarchy).
- Meta description rewritten to lead with USD and Morgan / junk silver keywords.
- 8 deep-linked FAQ entries; 11 in-page price-table IDs for rich snippets.

## Test plan

- [ ] Load `/900-silver-price-per-gram` and confirm hero shows live USD/g (with GBP and EUR tiles populated).
- [ ] Verify spot price in live-status bar matches what `/800-silver-price-per-gram` and `/silver-price-per-kilo` show within the same minute.
- [ ] Tap each US coin chip preset and confirm the calculator updates the melt result; verify the Morgan ($26.73g × 0.900 × spot/oz/31.1035) matches the heritage card stat.
- [ ] Switch the price-table currency between USD / GBP / EUR; confirm the calculator currency follows.
- [ ] Compare `.900` USD/g in the purity grid against `.800` and `.999` figures — ratios should equal `0.900 / 0.800 = 1.125` and `0.900 / 0.999 ≈ 0.901`.
- [ ] Resize to 375px and check: hero stacks single column, currency tiles stack, calculator chips wrap, sticky USD/g bar appears after scrolling 400px.
- [ ] Toggle theme (dark ↔ light) via header button — verify silver and copper gradients render correctly in both.
- [ ] Keyboard-tab through hero → calculator → currency switch → FAQ; confirm visible focus rings throughout.

https://claude.ai/code/session_01TXaFirig1pQZQkezpF94HH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXaFirig1pQZQkezpF94HH)_