### PR TITLE
Redesign Silver Purity Grades hub with premium editorial UI (USD primary)

### DIFF
--- a/silver-purity-grades.html
+++ b/silver-purity-grades.html
@@ -3,35 +3,53 @@
 <head>
 <meta charset="UTF-8">
 <script>
-(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
+(function(){var root=document.documentElement;var stored=localStorage.getItem('gpt-theme');var theme=stored||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');root.setAttribute('data-theme',theme);})();
 </script>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Silver Purity Grades &amp; Live Prices | GoldPriceTools</title>
-  <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Live silver prices by purity: .999 Fine, .925 Sterling, .900 Coin and .800 European silver. Per gram, per troy ounce and per kilo. Updated live.">
+<meta name="cf-no-email-obfuscation">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Silver Purity Grades: .999, .925, .900, .800 Live Prices in USD | GoldPriceTools</title>
+<meta name="google-adsense-account" content="ca-pub-8849494330640880">
+<meta name="description" content="Live silver purity prices in USD per gram, troy ounce and kilo for .999 Fine, .925 Sterling, .900 Coin and .800 European silver. Free universal purity calculator, hallmark identification and heritage guide. Updated every 60 seconds from LBMA spot — USD primary.">
+<meta name="robots" content="index, follow">
+<link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/silver-purity-grades">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/silver-purity-grades">
+<link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/silver-purity-grades">
 <link rel="canonical" href="https://goldpricetools.com/silver-purity-grades">
-<meta property="og:title" content="Silver Purity Grades &amp; Live Prices | GoldPriceTools">
-<meta property="og:description" content="Live prices for all silver purities: .999, .925, .900 and .800. Per gram, per oz, per kilo. Updated every 60 seconds.">
-<meta property="og:url" content="https://goldpricetools.com/silver-purity-grades">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Silver Guides","item":"https://goldpricetools.com/guides/silver-guides/"},{"@type":"ListItem","position":3,"name":"Silver Purity Grades","item":"https://goldpricetools.com/silver-purity-grades"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What are the four main silver purity grades?","acceptedAnswer":{"@type":"Answer","text":"The four most widely traded silver purity grades are .999 Fine Silver (99.9% pure — investment bullion standard), .925 Sterling Silver (92.5% pure — jewellery and flatware standard), .900 Coin Silver (90.0% pure — US pre-1965 circulating coinage) and .800 European Silver (80.0% pure — Continental antique flatware). Each is a millesimal fineness — parts per thousand of pure silver — with the balance alloyed with copper for hardness."}},{"@type":"Question","name":"How is the price of each silver purity calculated?","acceptedAnswer":{"@type":"Answer","text":"The price per gram for any silver purity is calculated as (LBMA spot USD per troy ounce ÷ 31.1035) × purity ratio. USD is the primary currency because silver is quoted globally in US dollars on COMEX and via the LBMA Silver Price benchmark. For example at $33.00/oz spot: .999 = $1.061/g, .925 = $0.981/g, .900 = $0.955/g, .800 = $0.849/g. GBP, EUR and INR conversions use live ECB reference rates from the Frankfurter API."}},{"@type":"Question","name":"How do I identify silver purity from a hallmark?","acceptedAnswer":{"@type":"Answer","text":"Look for a three-digit millesimal fineness number stamped on the piece: 999 or FINE for bullion-grade fine silver; 925 or STERLING for sterling, often alongside a lion passant (UK assay); 900 has no hallmark on US coins — identify by year ≤1964; 800 is the Continental European mark, frequently paired with a German Halbmond (crescent moon) and Krone (crown), or the Italian fasces stamp. Older Britannia silver carries 958 and a seated Britannia figure."}},{"@type":"Question","name":"Which silver purity is the best investment?","acceptedAnswer":{"@type":"Answer","text":".999 fine silver is the global investment grade — used by every major mint for bullion bars and coins including the American Silver Eagle, Britannia, Canadian Maple Leaf and Vienna Philharmonic. Its price tracks the LBMA spot one-for-one (minus a small minting premium). .925, .900 and .800 are valued at proportional melt — useful for scrap and antique resale, but not bullion-grade. For pure exposure to silver as an asset, choose .999 in 1-oz coins or 1-kg bars."}},{"@type":"Question","name":"How do I calculate scrap silver value by purity?","acceptedAnswer":{"@type":"Answer","text":"Weigh the item in grams, multiply by the purity ratio (0.999, 0.925, 0.900 or 0.800), then multiply by the live USD-per-gram .999 price. Example: 100g of .925 sterling at a $1.061/g .999 price = 100 × 0.925 × $1.061 = $98.14 melt. Use the universal purity calculator at the top of this page — it handles any weight, any purity, any currency live."}},{"@type":"Question","name":"Why is silver priced in USD globally?","acceptedAnswer":{"@type":"Answer","text":"Silver is quoted globally in US dollars per troy ounce on COMEX (New York) silver futures and via the LBMA Silver Price daily auction in London. USD is the world's reserve currency and the most liquid quote unit for precious metals. Every conversion on this page to GBP, EUR or INR is mathematically derived from the live USD spot using ECB reference rates."}},{"@type":"Question","name":"How accurate are these live silver purity prices?","acceptedAnswer":{"@type":"Answer","text":"Spot prices come direct from the LBMA via gold-api.com and refresh every 60 seconds. Currency conversion from USD to GBP, EUR and INR uses the Frankfurter API's live ECB reference rates. Figures shown are melt values — the raw silver content. Dealer buy prices typically sit 5–20% below melt; antique or rare-date pieces can fetch 2×–10× melt for collector premiums."}},{"@type":"Question","name":"Is sterling silver (.925) magnetic?","acceptedAnswer":{"@type":"Answer","text":"No — genuine sterling silver, like all silver purities (.999, .925, .900, .800), is non-magnetic. Silver and copper (its main alloying metal) are both non-ferromagnetic. If your item is attracted to a magnet, it is silver-plated over a steel or iron base rather than solid sterling. This is one of the simplest authenticity tests for any silver purity grade."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Dataset","name":"Live Silver Purity Grades Price Data — .999, .925, .900, .800","description":"Live silver spot prices per gram and troy ounce in USD (primary), GBP and EUR for the four major silver fineness standards: .999 Fine (bullion), .925 Sterling (jewellery), .900 Coin (US pre-1965), .800 European (Continental antique). Updated every 60 seconds from LBMA spot market via gold-api.com.","url":"https://goldpricetools.com/silver-purity-grades","keywords":["silver purity","silver grades","999 fine silver","925 sterling silver","900 coin silver","800 european silver","silver hallmark","silver fineness","LBMA spot","XAG/USD","silver price per gram","silver melt value"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"temporalCoverage":"2016-06-01/..","variableMeasured":"Silver spot price per troy ounce in USD (XAG/USD) multiplied by purity factor (0.999, 0.925, 0.900, 0.800)"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"WebPage","name":"Silver Purity Grades — Live Prices in USD","url":"https://goldpricetools.com/silver-purity-grades","speakable":{"@type":"SpeakableSpecification","cssSelector":[".snippet-answer",".faq-pro__body"]}}</script>
+<meta property="og:title" content="Silver Purity Grades: .999, .925, .900, .800 Live USD Prices">
+<meta property="og:description" content="Live silver purity prices in USD per gram, troy ounce and kilo for all four grades. Universal purity calculator, hallmark identification and heritage guide. Updated every 60 seconds.">
 <meta property="og:type" content="website">
+<meta property="og:url" content="https://goldpricetools.com/silver-purity-grades">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<meta property="og:image:width" content="1200">
-<meta property="og:image:height" content="630">
-<meta property="og:image:alt" content="GoldPriceTools — Silver Purity Grades &amp; Live Prices">
-<meta property="og:site_name" content="GoldPriceTools">
-<meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="Silver Purity Grades &amp; Live Prices">
-<meta name="twitter:description" content="Live silver prices for .999 Fine, .925 Sterling, .900 Coin and .800 European silver. Updated every 60 seconds.">
-<link rel="icon" href="https://assets.goldpricetools.com/favicon.ico" sizes="any">
-<link rel="icon" href="https://assets.goldpricetools.com/favicon.svg" type="image/svg+xml">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
+<script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
+<script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
+<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <script>
-(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();
+(adsbygoogle = window.adsbygoogle || []).push({
+  google_ad_client: "ca-pub-8849494330640880",
+  enable_page_level_ads: true,
+  overlays: {bottom: false},
+  vignette: { new_triggers: false }
+});
 </script>
+<link rel="manifest" href="/manifest.json">
+<link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
+<meta name="theme-color" content="#0f0e0c">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://api.gold-api.com">
+<link rel="preconnect" href="https://api.frankfurter.dev">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:wght@500;600;700;800&display=swap" rel="stylesheet">
 <style>
-
-
-/* ── Guides mega panel — category links ── */
+/* ── Guides mega panel ── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
 .mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
@@ -40,28 +58,79 @@
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 
-
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+/* ═════ DESIGN TOKENS — Silver Purity Grades Hub edition ═════ */
+:root,[data-theme="light"]{
+  --color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;
+  --color-text:#28251d;--color-text-muted:#5a5953;--color-text-faint:#8a8983;--color-text-inverse:#f9f8f4;
+  --color-primary:#01696f;--color-primary-hover:#0c4e54;
+  --color-gold:#b07a00;--color-gold-bright:#c08a00;
+  --color-silver:#6b7280;--color-silver-bright:#4b5563;--color-silver-deep:#374151;--color-silver-luxe:#9ca3af;--color-platinum:#d1d5db;
+  /* Per-grade accents */
+  --color-fine:#7c8da3;          /* .999 — cool platinum */
+  --color-sterling:#5a6a82;      /* .925 — sterling steel */
+  --color-copper:#a05a2c;--color-copper-bright:#c47339;--color-copper-deep:#7a4220;  /* .900 */
+  --color-patina:#5e7d6e;--color-patina-bright:#7ea38e;                              /* .800 European patina */
+  --color-heritage:#8c6a2f;--color-heritage-bright:#a98443;
+  --color-success:#0f7a3d;--color-danger:#b91c1c;
+  --shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);
+  --shadow-silver:0 8px 32px -8px oklch(0.6 0.02 250/0.3);--shadow-luxe:0 20px 50px -20px oklch(0.55 0.02 250/0.35);
+  --shadow-copper:0 8px 32px -8px oklch(0.55 0.12 50/0.25);
+  --shadow-patina:0 8px 32px -8px oklch(0.55 0.07 160/0.25);
+  --radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;
+  --space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--space-20:5rem;
+  --text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--text-3xl:clamp(2.5rem,1.5rem + 4vw,5rem);
+  --font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-editorial:'Playfair Display',Georgia,serif;--font-mono:'IBM Plex Mono',ui-monospace,monospace;
+  --transition:180ms cubic-bezier(0.16,1,0.3,1);--transition-slow:400ms cubic-bezier(0.16,1,0.3,1);
+  --gradient-silver:linear-gradient(135deg,#e5e7eb 0%,#cbd5e1 35%,#94a3b8 70%,#475569 100%);
+  --gradient-silver-luxe:linear-gradient(135deg,#f1f5f9 0%,#e2e8f0 25%,#cbd5e1 55%,#94a3b8 100%);
+  --gradient-silver-deep:linear-gradient(135deg,#cbd5e1 0%,#94a3b8 30%,#64748b 65%,#334155 100%);
+  --gradient-silver-soft:linear-gradient(135deg,oklch(0.78 0.01 250/0.18) 0%,oklch(0.65 0.01 250/0.06) 100%);
+  --gradient-copper:linear-gradient(135deg,#d4915c 0%,#c47339 45%,#a05a2c 100%);
+  --gradient-patina:linear-gradient(135deg,#a0c4b1 0%,#7ea38e 50%,#5e7d6e 100%);
+  --gradient-heritage:linear-gradient(135deg,#dab170 0%,#c69a4f 50%,#9b7833 100%);
+  --gradient-spectrum:linear-gradient(90deg,#e2e8f0 0%,#94a3b8 25%,#c47339 50%,#7ea38e 75%,#9b7833 100%);
+  --silver-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.78 0.02 250/0.16),transparent 60%);
+  --silver-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.78 0.02 250/0.22),transparent 65%);
+  --copper-glow:radial-gradient(ellipse 70% 55% at 25% 100%,oklch(0.65 0.10 55/0.16),transparent 65%);
+  --patina-glow:radial-gradient(ellipse 70% 55% at 80% 100%,oklch(0.65 0.07 160/0.14),transparent 65%)
+}
+[data-theme="dark"]{
+  --color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;
+  --color-text:#e8e6e0;--color-text-muted:#a09e98;--color-text-faint:#6a6864;--color-text-inverse:#1a1917;
+  --color-primary:#4f98a3;--color-primary-hover:#6ab3be;
+  --color-gold:#b07a00;--color-gold-bright:#e8af34;
+  --color-silver:#cbd5e1;--color-silver-bright:#e2e8f0;--color-silver-deep:#94a3b8;--color-silver-luxe:#f1f5f9;--color-platinum:#f8fafc;
+  --color-fine:#e2e8f0;
+  --color-sterling:#b6c3d4;
+  --color-copper:#d4915c;--color-copper-bright:#e8a87c;--color-copper-deep:#a05a2c;
+  --color-patina:#82a292;--color-patina-bright:#a8c5b6;
+  --color-heritage:#c69a4f;--color-heritage-bright:#dab170;
+  --color-success:#4ade80;--color-danger:#f87171;
+  --shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5);
+  --shadow-silver:0 8px 32px -4px oklch(0.75 0.02 250/0.32);--shadow-luxe:0 30px 60px -20px oklch(0.7 0.03 250/0.42);
+  --shadow-copper:0 8px 32px -4px oklch(0.7 0.10 55/0.30);
+  --shadow-patina:0 8px 32px -4px oklch(0.7 0.07 160/0.30);
+  --gradient-silver:linear-gradient(135deg,#f1f5f9 0%,#cbd5e1 35%,#94a3b8 70%,#475569 100%);
+  --gradient-silver-luxe:linear-gradient(135deg,#f8fafc 0%,#e2e8f0 30%,#cbd5e1 55%,#64748b 100%);
+  --gradient-silver-deep:linear-gradient(135deg,#f1f5f9 0%,#cbd5e1 25%,#94a3b8 55%,#475569 100%);
+  --gradient-silver-soft:linear-gradient(135deg,oklch(0.78 0.02 250/0.16) 0%,oklch(0.55 0.02 250/0.04) 100%);
+  --gradient-copper:linear-gradient(135deg,#e8a87c 0%,#d4915c 45%,#a05a2c 100%);
+  --gradient-patina:linear-gradient(135deg,#b8d4c4 0%,#82a292 50%,#5e7d6e 100%);
+  --gradient-heritage:linear-gradient(135deg,#dab170 0%,#c69a4f 50%,#9b7833 100%);
+  --gradient-spectrum:linear-gradient(90deg,#f1f5f9 0%,#94a3b8 25%,#d4915c 50%,#82a292 75%,#c69a4f 100%);
+  --silver-glow:radial-gradient(ellipse 80% 60% at 70% 0%,oklch(0.78 0.03 250/0.18),transparent 60%);
+  --silver-glow-deep:radial-gradient(ellipse 100% 70% at 50% 0%,oklch(0.82 0.03 250/0.22),transparent 70%);
+  --copper-glow:radial-gradient(ellipse 70% 55% at 25% 100%,oklch(0.70 0.12 55/0.18),transparent 65%);
+  --patina-glow:radial-gradient(ellipse 70% 55% at 80% 100%,oklch(0.70 0.10 160/0.18),transparent 65%)
+}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-/* ── Global link reset — enforce brand colours site-wide ── */
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-/* ── Card colour reset — cards are content blocks, not bare links ── */
 .article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
 .article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-/* Article card inner elements */
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-/* Hover: title becomes primary teal */
-.article-card:hover .article-title,.article-card:hover .article-card-title{color:var(--color-primary)}
-.blog-preview-card:hover h3{color:var(--color-primary)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
 
-
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:calc(var(--space-16) + var(--space-2))}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
@@ -69,199 +138,341 @@ input,select{font:inherit;color:inherit}
 h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
+:focus-visible{outline:2px solid var(--color-silver);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
-@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-
-/* TICKER */
-.ticker-wrap{background:var(--color-surface);border-bottom:1px solid var(--color-border);overflow:hidden;height:36px;position:relative}
-.ticker-wrap::before,.ticker-wrap::after{content:'';position:absolute;top:0;width:60px;height:100%;z-index:2}
-.ticker-wrap::before{left:0;background:linear-gradient(90deg,var(--color-surface),transparent)}
-.ticker-wrap::after{right:0;background:linear-gradient(-90deg,var(--color-surface),transparent)}
-.ticker{display:flex;align-items:center;height:100%;animation:ticker-scroll 40s linear infinite;white-space:nowrap;width:max-content}
-.ticker:hover{animation-play-state:paused}
-@keyframes ticker-scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
-.ticker-item{display:inline-flex;align-items:center;gap:var(--space-2);padding:0 var(--space-6);font-size:var(--text-xs);font-weight:500}
-.ticker-label{color:var(--color-text-muted)}
-.ticker-value{color:var(--color-text);font-variant-numeric:tabular-nums}
-.ticker-change.up{color:#4ade80}
-.ticker-change.down{color:#f87171}
-.live-dot{width:6px;height:6px;border-radius:50%;background:#4ade80;animation:pulse 2s ease-in-out infinite}
-@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
-
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px}
-.nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none}
-.nav-links{display:flex;align-items:center;gap:var(--space-1)}
-.nav-links a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md)}
-.nav-links a:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.nav-actions{display:flex;align-items:center;gap:var(--space-2)}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border)}
-.theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md)}
-.hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .2s,opacity .2s}
-@media(max-width:768px){.nav-links{display:none}.hamburger{display:flex}}
-
-/* MOBILE MENU */
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;background:var(--color-surface);border-bottom:1px solid var(--color-border);padding:var(--space-4);z-index:99}
-.mobile-menu.open{display:flex;flex-direction:column;gap:var(--space-2)}
-.mobile-menu a{font-size:var(--text-base);color:var(--color-text-muted);text-decoration:none;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md)}
-.mobile-menu a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-.mobile-menu .menu-section{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;padding:var(--space-3) var(--space-4) var(--space-1)}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important;scroll-behavior:auto!important}}
 
 /* AD SLOTS */
 .ad-slot{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;margin:var(--space-6) auto;max-width:1200px;padding:0 var(--space-4);min-height:100px}
 .ad-slot ins{display:block;width:100%}
-.ad-slot-sidebar{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-md);display:block;width:100%;overflow:hidden;min-height:250px}
-.ad-slot-sidebar ins{display:block;width:100%}
 
-/* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
-@media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
-.hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
-.hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero h1 .gold{color:var(--color-gold-bright)}
-.hero h1 .silver{color:var(--color-silver)}
-.hero-desc{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:52ch;margin-bottom:var(--space-6)}
-.spot-cards{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.spot-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.spot-card-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-1)}
-.spot-card-value{font-size:var(--text-xl);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.spot-card-value.gold-val{color:var(--color-gold-bright)}
-.spot-card-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.spot-card-change{font-size:var(--text-xs);font-weight:600;margin-top:var(--space-1)}
-.spot-card-change.up{color:#4ade80}
-.spot-card-change.down{color:#f87171}
+/* ═════ PREMIUM HERO ═════ */
+.hero-premium{position:relative;overflow:hidden;border-bottom:1px solid var(--color-border)}
+.hero-premium::before{content:'';position:absolute;inset:0;background:var(--silver-glow-deep);pointer-events:none;z-index:0}
+.hero-premium::after{content:'';position:absolute;inset:0;background:var(--copper-glow),var(--patina-glow);pointer-events:none;z-index:0}
+.hero-premium__inner{position:relative;z-index:1;max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-10)}
+@media(min-width:768px){.hero-premium__inner{padding:var(--space-12) var(--space-6) var(--space-12)}}
+@media(min-width:1024px){.hero-premium__inner{padding:var(--space-16) var(--space-8) var(--space-12)}}
+.hero-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);padding:6px var(--space-3);background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--color-silver) 35%,transparent);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--color-silver);margin-bottom:var(--space-5);min-height:32px}
+.hero-eyebrow__pulse{width:6px;height:6px;border-radius:50%;background:var(--color-silver);box-shadow:0 0 8px var(--color-silver);animation:heroPulse 2.4s ease-in-out infinite;flex-shrink:0}
+@keyframes heroPulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.5;transform:scale(.8)}}
+.hero-premium__title{font-family:var(--font-editorial);font-weight:600;color:var(--color-text);line-height:.98;letter-spacing:-.025em;margin-bottom:var(--space-5);font-size:clamp(2.25rem,1.35rem + 5vw,5rem)}
+.hero-premium__title-em{display:inline-block;background:var(--gradient-silver-luxe);-webkit-background-clip:text;background-clip:text;color:transparent;font-style:italic;font-weight:500}
+.hero-premium__sub{font-size:clamp(1rem,.95rem + .35vw,1.25rem);color:var(--color-text-muted);line-height:1.6;max-width:62ch;margin-bottom:var(--space-8)}
+.hero-premium__sub strong{color:var(--color-silver);font-weight:600}
+.hero-premium__sub .em-copper{color:var(--color-copper)}
+.hero-premium__sub .em-patina{color:var(--color-patina)}
+.hero-premium__sub .em-heritage{color:var(--color-heritage-bright)}
 
-/* MAIN LAYOUT */
-.main-wrap{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr 300px;gap:var(--space-8);align-items:start}
-@media(max-width:1024px){.main-wrap{grid-template-columns:1fr}}
+/* HERO SPOT — XAG/USD primary */
+.hero-spot{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-4) var(--space-5);background:linear-gradient(135deg,var(--color-surface) 0%,var(--color-surface-offset) 100%);border:1px solid color-mix(in oklch,var(--color-silver) 28%,var(--color-border));border-radius:var(--radius-xl);margin-bottom:var(--space-5);position:relative;overflow:hidden}
+.hero-spot::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:var(--gradient-spectrum);opacity:.8}
+.hero-spot__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);flex-wrap:wrap}
+.hero-spot__label{font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--color-silver)}
+.hero-spot__flag{display:inline-flex;align-items:center;gap:6px;font-size:11px;color:var(--color-text-faint);font-weight:600;font-family:var(--font-mono);letter-spacing:.04em}
+.hero-spot__value{font-family:var(--font-display);font-size:clamp(2rem,1.4rem + 2.5vw,3rem);font-weight:600;color:var(--color-text);letter-spacing:-.02em;line-height:1;font-variant-numeric:tabular-nums}
+.hero-spot__sub{font-size:var(--text-xs);color:var(--color-text-muted);display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap}
+.hero-spot__sub strong{color:var(--color-text);font-weight:600;font-variant-numeric:tabular-nums}
 
-/* CALCULATORS */
-.calc-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-sm)}
-.calc-tabs{display:flex;border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);overflow-x:auto;scrollbar-width:none}
-.calc-tabs::-webkit-scrollbar{display:none}
-.calc-tab{flex:1;min-width:max-content;padding:var(--space-3) var(--space-4);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border-bottom:2px solid transparent;white-space:nowrap;cursor:pointer}
-.calc-tab:hover{color:var(--color-text)}
-.calc-tab.active{color:var(--color-gold-bright);border-bottom-color:var(--color-gold-bright)}
-.calc-panel{display:none;padding:var(--space-6)}
-.calc-panel.active{display:block}
-.calc-row{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin-bottom:var(--space-4)}
-@media(max-width:600px){.calc-row{grid-template-columns:1fr}}
-.form-group{display:flex;flex-direction:column;gap:var(--space-2)}
-.form-label{font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted)}
-.form-input,.form-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none}
-.form-input:focus,.form-select:focus{border-color:var(--color-primary);background:var(--color-surface)}
-.form-select-wrap{position:relative}
-.form-select-wrap::after{content:'▾';position:absolute;right:var(--space-3);top:50%;transform:translateY(-50%);color:var(--color-text-muted);pointer-events:none;font-size:var(--text-xs)}
-.calc-result{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-4)}
-.calc-result-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.calc-result-value{font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
-.calc-result-meta{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-1)}
-.calc-hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.6;max-width:60ch}
+/* PRICE TILES — 4 grades per gram */
+.price-tiles{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin-bottom:var(--space-6)}
+@media(min-width:768px){.price-tiles{grid-template-columns:repeat(4,1fr);gap:var(--space-3)}}
+@media(min-width:1024px){.price-tiles{gap:var(--space-4)}}
+.price-tile{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-4);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition);text-decoration:none;color:var(--color-text);display:flex;flex-direction:column;gap:var(--space-2);min-height:140px}
+.price-tile::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:var(--tile-accent,var(--gradient-silver-luxe));opacity:.85}
+.price-tile:hover{border-color:color-mix(in oklch,var(--tile-color,var(--color-silver)) 45%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-silver);text-decoration:none;color:var(--color-text)}
+.price-tile--fine{--tile-color:var(--color-fine);--tile-accent:var(--gradient-silver-luxe)}
+.price-tile--sterling{--tile-color:var(--color-sterling);--tile-accent:linear-gradient(135deg,#b6c3d4 0%,#7c8da3 50%,#5a6a82 100%)}
+.price-tile--coin{--tile-color:var(--color-copper);--tile-accent:var(--gradient-copper)}
+.price-tile--european{--tile-color:var(--color-patina);--tile-accent:var(--gradient-patina)}
+.price-tile__head{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-2)}
+.price-tile__purity{font-family:var(--font-editorial);font-size:clamp(1.5rem,1.1rem + 1.4vw,2.25rem);font-weight:600;font-style:italic;color:var(--tile-color);letter-spacing:-.025em;line-height:1}
+.price-tile__pct{font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--color-text-faint);font-family:var(--font-mono);align-self:flex-start;padding:2px 6px;border:1px solid var(--color-border);border-radius:4px}
+.price-tile__grade{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.price-tile__value{font-family:var(--font-display);font-size:clamp(1.125rem,.95rem + 1vw,1.5rem);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1;margin-top:auto}
+.price-tile__unit{font-size:10px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-top:2px}
 
-/* SCRAP TABLE */
-.scrap-table{width:100%;border-collapse:collapse;margin-bottom:var(--space-4)}
-.scrap-table th{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-2) var(--space-3);text-align:left;border-bottom:1px solid var(--color-border)}
-.scrap-table td{padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-divider)}
-.scrap-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.scrap-table input{width:100%;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text)}
-.scrap-total{background:var(--color-surface-offset);border-radius:var(--radius-lg);padding:var(--space-4);display:grid;grid-template-columns:1fr 1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:600px){.scrap-total{grid-template-columns:1fr}}
-.scrap-total-item{text-align:center}
-.scrap-total-label{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-1)}
-.scrap-total-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+/* LIVE STATUS */
+.live-status{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-2) var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted)}
+.live-status__dot{width:8px;height:8px;border-radius:50%;background:var(--color-success);box-shadow:0 0 8px color-mix(in oklch,var(--color-success) 80%,transparent);animation:heroPulse 2s ease-in-out infinite;flex-shrink:0}
+.live-status__label{font-weight:600;color:var(--color-text)}
+.live-status__divider{color:var(--color-text-faint);user-select:none}
+.live-status__meta{font-variant-numeric:tabular-nums}
+.live-status__meta strong{color:var(--color-silver);font-weight:600}
+.live-status__cta{margin-left:auto;display:inline-flex;align-items:center;gap:6px;padding:8px var(--space-3);background:var(--gradient-silver-luxe);color:#0f172a;border-radius:var(--radius-md);font-weight:700;font-size:11px;letter-spacing:.06em;text-transform:uppercase;text-decoration:none;min-height:36px;transition:filter var(--transition),box-shadow var(--transition)}
+.live-status__cta:hover{filter:brightness(1.08);text-decoration:none;color:#0f172a;box-shadow:var(--shadow-silver)}
 
-/* KARAT TABLES */
-.karat-section{margin-top:var(--space-8)}
-.karat-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.karat-section p{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4);max-width:60ch}
-.karat-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4);margin-bottom:var(--space-8)}
-.karat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-sm)}
-.karat-card-header{padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);display:flex;align-items:center;justify-content:space-between}
-.karat-card-title{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
-.karat-card-purity{font-size:var(--text-xs);color:var(--color-text-muted)}
-.karat-table{width:100%;border-collapse:collapse}
-.karat-table td{padding:var(--space-2) var(--space-4);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.karat-table td:first-child{color:var(--color-text-muted)}
-.karat-table td:last-child{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums;text-align:right}
-.karat-table tr:last-child td{border-bottom:none}
+/* TRUST STRIP */
+.trust-strip{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4);display:flex;flex-wrap:wrap;gap:var(--space-3);align-items:center;border-bottom:1px solid var(--color-divider)}
+.trust-strip__item{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+.trust-strip__item svg{width:14px;height:14px;color:var(--color-silver);flex-shrink:0}
+.trust-strip__item--link{margin-left:auto;color:var(--color-primary);font-weight:600;text-decoration:none}
+.trust-strip__item--link:hover{color:var(--color-primary-hover);text-decoration:underline}
+@media(max-width:540px){.trust-strip__item--link{margin-left:0}}
 
-/* SIDEBAR */
-.sidebar{display:flex;flex-direction:column;gap:var(--space-4);position:sticky;top:72px;align-self:start}
-.sidebar-widget{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-sm)}
-.sidebar-widget h3{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.quick-ref-row{display:flex;justify-content:space-between;align-items:center;padding:var(--space-2) 0;border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
-.quick-ref-row:last-child{border-bottom:none}
-.quick-ref-label{color:var(--color-text-muted)}
-.quick-ref-value{color:var(--color-gold-bright);font-weight:600;font-variant-numeric:tabular-nums}
-.quick-ref-value.silver-val{color:var(--color-silver)}
+/* ═════ UNIVERSAL CALCULATOR ═════ */
+.calc-pro{max-width:1200px;margin:var(--space-10) auto;padding:0 var(--space-4)}
+@media(min-width:768px){.calc-pro{margin:var(--space-12) auto}}
+.calc-pro__card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden;box-shadow:var(--shadow-md)}
+.calc-pro__card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:var(--gradient-spectrum);opacity:.6}
+.calc-pro__head{padding:var(--space-6) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-4);flex-wrap:wrap}
+@media(min-width:768px){.calc-pro__head{padding:var(--space-8) var(--space-8) var(--space-5)}}
+.calc-pro__head-left{flex:1;min-width:200px}
+.calc-pro__title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);display:flex;align-items:center;gap:var(--space-2)}
+.calc-pro__title-icon{width:24px;height:24px;color:var(--color-silver);flex-shrink:0}
+.calc-pro__sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;max-width:56ch}
+.calc-pro__head-badge{display:inline-flex;align-items:center;gap:6px;padding:6px var(--space-3);background:color-mix(in oklch,var(--color-success) 12%,transparent);border:1px solid color-mix(in oklch,var(--color-success) 30%,transparent);color:var(--color-success);border-radius:var(--radius-full);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase}
+.calc-pro__head-badge .live-dot{width:6px;height:6px;border-radius:50%;background:var(--color-success);animation:heroPulse 2s ease-in-out infinite}
+.calc-pro__body{padding:var(--space-5)}
+@media(min-width:768px){.calc-pro__body{padding:var(--space-6) var(--space-8) var(--space-8)}}
+.calc-pro__row{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-4)}
+@media(min-width:560px){.calc-pro__row{grid-template-columns:1.4fr .8fr .8fr;gap:var(--space-4)}}
+.calc-pro__row--purity{grid-template-columns:1fr;gap:var(--space-3);margin-bottom:var(--space-4)}
+@media(min-width:560px){.calc-pro__row--purity{grid-template-columns:1fr 1fr;gap:var(--space-4)}}
+.calc-pro__field{display:flex;flex-direction:column;gap:var(--space-2)}
+.calc-pro__field-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__input,.calc-pro__select{width:100%;min-height:48px;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-base);color:var(--color-text);-webkit-appearance:none;appearance:none;transition:border-color var(--transition),background var(--transition),box-shadow var(--transition)}
+.calc-pro__input:focus,.calc-pro__select:focus{border-color:var(--color-silver);background:var(--color-surface);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-silver) 18%,transparent);outline:none}
+.calc-pro__input{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;font-variant-numeric:tabular-nums}
+.calc-pro__select-wrap{position:relative}
+.calc-pro__select-wrap::after{content:'';position:absolute;right:var(--space-4);top:50%;width:8px;height:8px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:translateY(-70%) rotate(45deg);pointer-events:none}
 
-/* SIDEBAR NAV LINKS */
-.sidebar-nav{display:flex;flex-direction:column;gap:var(--space-2)}
-.sidebar-nav a{display:flex;align-items:center;justify-content:space-between;padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.sidebar-nav a:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset))}
-.sidebar-nav a span{color:var(--color-text-faint);font-size:var(--text-xs)}
+/* Purity segmented control */
+.purity-seg{display:grid;grid-template-columns:repeat(4,1fr);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:3px;gap:2px;min-height:48px}
+.purity-seg__btn{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1px;padding:6px 4px;border-radius:calc(var(--radius-md) - 3px);font-size:var(--text-xs);font-weight:700;color:var(--color-text-muted);cursor:pointer;transition:all var(--transition);font-family:var(--font-mono);letter-spacing:.04em;border:none;background:none;min-height:42px}
+.purity-seg__btn:hover{color:var(--color-text)}
+.purity-seg__btn.active{background:var(--seg-accent,var(--gradient-silver-luxe));color:#0f172a;font-weight:700;box-shadow:var(--shadow-sm)}
+.purity-seg__btn[data-purity="0.999"].active{--seg-accent:var(--gradient-silver-luxe)}
+.purity-seg__btn[data-purity="0.925"].active{--seg-accent:linear-gradient(135deg,#cbd5e1 0%,#94a3b8 50%,#5a6a82 100%);color:#fff}
+.purity-seg__btn[data-purity="0.900"].active{--seg-accent:var(--gradient-copper);color:#fff}
+.purity-seg__btn[data-purity="0.800"].active{--seg-accent:var(--gradient-patina);color:#fff}
+.purity-seg__num{font-size:var(--text-sm);font-weight:700;font-family:var(--font-editorial);font-style:italic;letter-spacing:0}
+.purity-seg__lbl{font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;opacity:.85}
 
-/* CHART */
-.chart-section{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin-bottom:var(--space-6);box-shadow:var(--shadow-sm)}
-.chart-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);flex-wrap:wrap;gap:var(--space-3)}
-.chart-title{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text)}
-.chart-controls{display:flex;gap:var(--space-2);flex-wrap:wrap}
-.chart-btn{padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;border-radius:var(--radius-full);border:1px solid var(--color-border);color:var(--color-text-muted)}
-.chart-btn:hover,.chart-btn.active{background:var(--color-gold-bright);color:#0f0e0c;border-color:var(--color-gold-bright)}
-.chart-wrap{position:relative;height:280px}
-.chart-loading{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:var(--text-sm)}
+.calc-pro__chips{display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-5);align-items:center}
+.calc-pro__chips-label{font-size:var(--text-xs);font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;margin-right:var(--space-2);width:100%}
+@media(min-width:560px){.calc-pro__chips-label{width:auto;margin-right:var(--space-1)}}
+.calc-chip{min-height:36px;padding:6px var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);cursor:pointer;transition:all var(--transition);white-space:nowrap;font-family:var(--font-body)}
+.calc-chip:hover{border-color:var(--color-silver);color:var(--color-silver);background:color-mix(in oklch,var(--color-silver) 8%,var(--color-surface-offset))}
+.calc-chip:focus-visible{outline:2px solid var(--color-silver);outline-offset:2px}
+.calc-chip.active{background:var(--gradient-silver-luxe);color:#0f172a;border-color:transparent;font-weight:700}
+.calc-pro__result{background:linear-gradient(135deg,color-mix(in oklch,var(--color-silver) 10%,var(--color-surface)) 0%,var(--color-surface) 100%);border:1px solid color-mix(in oklch,var(--color-silver) 25%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-5);position:relative;overflow:hidden}
+.calc-pro__result::before{content:'';position:absolute;top:-50%;right:-20%;width:280px;height:280px;background:radial-gradient(circle,color-mix(in oklch,var(--color-silver) 18%,transparent) 0%,transparent 60%);pointer-events:none}
+.calc-pro__result::after{content:'';position:absolute;bottom:-40%;left:-20%;width:240px;height:240px;background:radial-gradient(circle,color-mix(in oklch,var(--color-copper) 14%,transparent) 0%,transparent 60%);pointer-events:none}
+.calc-pro__result-primary{position:relative;display:flex;align-items:baseline;justify-content:space-between;padding-bottom:var(--space-4);margin-bottom:var(--space-4);border-bottom:1px solid color-mix(in oklch,var(--color-silver) 18%,var(--color-border));flex-wrap:wrap;gap:var(--space-2)}
+.calc-pro__result-label-main{font-size:var(--text-sm);font-weight:700;color:var(--color-text);text-transform:uppercase;letter-spacing:.08em}
+.calc-pro__result-label-main strong{font-family:var(--font-editorial);font-style:italic;color:var(--color-silver);font-weight:600;font-size:1.1em;text-transform:none;letter-spacing:0}
+.calc-pro__result-main{font-family:var(--font-display);font-size:clamp(2rem,1.5rem + 2vw,3rem);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;letter-spacing:-.025em;line-height:1}
+.calc-pro__result-grid{position:relative;display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3) var(--space-4)}
+.calc-pro__result-item{display:flex;flex-direction:column;gap:var(--space-1)}
+.calc-pro__result-item-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.calc-pro__result-item-value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+.calc-pro__hint{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-4);line-height:1.6;max-width:62ch}
+.calc-pro__hint code{font-family:var(--font-mono);font-size:11px;background:var(--color-surface-offset-2);padding:2px 6px;border-radius:4px;color:var(--color-silver);border:1px solid var(--color-divider)}
 
-/* FAQ / SEO CARDS */
-.faq-section{margin-top:var(--space-8)}
-.faq-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-6)}
-.faq-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:var(--space-4)}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.faq-q{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
-.faq-a{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-.faq-a .highlight{color:var(--color-gold-bright);font-weight:600}
+/* ═════ STAT CARDS ═════ */
+.stat-cards{max-width:1200px;margin:0 auto var(--space-12);padding:0 var(--space-4);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
+@media(min-width:768px){.stat-cards{grid-template-columns:repeat(4,1fr);gap:var(--space-4)}}
+.stat-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);position:relative;overflow:hidden;transition:border-color var(--transition),transform var(--transition)}
+.stat-card:hover{border-color:color-mix(in oklch,var(--color-silver) 35%,var(--color-border));transform:translateY(-2px)}
+.stat-card__icon{width:32px;height:32px;color:var(--color-silver);margin-bottom:var(--space-3)}
+.stat-card--copper .stat-card__icon{color:var(--color-copper)}
+.stat-card--patina .stat-card__icon{color:var(--color-patina)}
+.stat-card--heritage .stat-card__icon{color:var(--color-heritage-bright)}
+.stat-card__value{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);letter-spacing:-.02em;line-height:1;margin-bottom:var(--space-2);font-variant-numeric:tabular-nums}
+.stat-card__label{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.4}
 
-/* CONVERTER */
-.converter-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-3);margin-top:var(--space-4)}
-.converter-item{background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
-.converter-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.converter-value{font-size:var(--text-base);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums}
+/* ═════ SECTION COMMON ═════ */
+.section{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
+.section--narrow{max-width:920px}
+.section-head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:var(--space-5);flex-wrap:wrap;gap:var(--space-3)}
+.section-head__left{flex:1;min-width:200px}
+.section-eyebrow{display:inline-block;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-silver);margin-bottom:var(--space-2)}
+.section-eyebrow--copper{color:var(--color-copper)}
+.section-eyebrow--patina{color:var(--color-patina)}
+.section-eyebrow--heritage{color:var(--color-heritage-bright)}
+.section-title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--color-text);line-height:1.2;margin-bottom:var(--space-2);letter-spacing:-.015em}
+.section-sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;max-width:62ch}
 
-/* ARTICLES SECTION */
-.articles-section{margin-top:var(--space-10)}
-.articles-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
-.articles-section .section-desc{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6);max-width:60ch}
-.articles-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:var(--space-4)}
-.article-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;display:block;transition:border-color var(--transition),box-shadow var(--transition)}
-.article-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.article-tag{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-2)}
-.article-title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.article-excerpt{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+/* ═════ MATRIX PRICE TABLE ═════ */
+.price-table-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.price-table-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);overflow:hidden}
+.price-table-card__head{padding:var(--space-5) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3)}
+@media(min-width:768px){.price-table-card__head{padding:var(--space-6) var(--space-8) var(--space-5)}}
+.price-table-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1)}
+.price-table-card__sub{font-size:var(--text-xs);color:var(--color-text-muted)}
+.price-table-card__sub strong{color:var(--color-success);font-weight:700}
+.currency-switch{display:inline-flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px;gap:2px;flex-wrap:wrap}
+.currency-switch__btn{min-height:32px;padding:6px var(--space-3);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);border-radius:var(--radius-full);cursor:pointer;transition:all var(--transition);letter-spacing:.04em}
+.currency-switch__btn:hover{color:var(--color-text)}
+.currency-switch__btn.active{background:var(--gradient-silver-luxe);color:#0f172a}
+.price-table-card__body{overflow-x:auto;-webkit-overflow-scrolling:touch}
+.price-table-pro{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums;min-width:560px}
+.price-table-pro th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-5);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);white-space:nowrap}
+.price-table-pro th:not(:first-child){text-align:right}
+.price-table-pro td{padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-divider);font-size:var(--text-sm)}
+.price-table-pro td:first-child{color:var(--color-text);font-weight:600;font-family:var(--font-display);white-space:nowrap}
+.price-table-pro td:not(:first-child){text-align:right;color:var(--color-text);font-weight:500}
+.price-table-pro tr:last-child td{border-bottom:none}
+.price-table-pro tr:hover td{background:color-mix(in oklch,var(--color-silver) 4%,var(--color-surface))}
+.price-table-pro .weight-label-sub{color:var(--color-text-faint);font-size:11px;font-weight:400;display:block;margin-top:2px;font-family:var(--font-body)}
+.price-table-pro .purity-dot{display:inline-block;width:8px;height:8px;border-radius:50%;margin-right:8px;vertical-align:middle;box-shadow:0 0 0 1px color-mix(in oklch,var(--color-border) 60%,transparent)}
+.price-table-pro .purity-dot--999{background:var(--gradient-silver-luxe)}
+.price-table-pro .purity-dot--925{background:linear-gradient(135deg,#cbd5e1 0%,#5a6a82 100%)}
+.price-table-pro .purity-dot--900{background:var(--gradient-copper)}
+.price-table-pro .purity-dot--800{background:var(--gradient-patina)}
 
-/* FOOTER */
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
-@media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
-.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-brand-col{min-width:0;overflow:hidden}.footer-col{min-width:0}.footer-col ul{list-style:none}
-.footer-col li{margin-bottom:var(--space-2)}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{margin:var(--space-6) 0 0;padding:var(--space-4) var(--space-6) 0;border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-faint);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+/* ═════ HALLMARK GRID ═════ */
+.hallmark-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.hallmark-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.hallmark-grid{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:1024px){.hallmark-grid{grid-template-columns:repeat(4,1fr)}}
+.hallmark-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);text-align:center;display:flex;flex-direction:column;align-items:center;gap:var(--space-3);transition:border-color var(--transition),transform var(--transition);position:relative;overflow:hidden}
+.hallmark-card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:var(--mark-accent,var(--gradient-silver-luxe));opacity:.7}
+.hallmark-card:hover{border-color:color-mix(in oklch,var(--mark-color,var(--color-silver)) 40%,var(--color-border));transform:translateY(-2px)}
+.hallmark-card--fine{--mark-color:var(--color-fine);--mark-accent:var(--gradient-silver-luxe)}
+.hallmark-card--sterling{--mark-color:var(--color-sterling);--mark-accent:linear-gradient(135deg,#cbd5e1 0%,#5a6a82 100%)}
+.hallmark-card--coin{--mark-color:var(--color-copper);--mark-accent:var(--gradient-copper)}
+.hallmark-card--european{--mark-color:var(--color-patina);--mark-accent:var(--gradient-patina)}
+.hallmark-card__mark{font-family:var(--font-editorial);font-size:clamp(1.75rem,1.3rem + 1.6vw,2.5rem);line-height:1;color:var(--mark-color,var(--color-silver));letter-spacing:.05em;padding:var(--space-3) var(--space-5);background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--mark-color,var(--color-silver)) 30%,var(--color-border));border-radius:var(--radius-md);font-variant-numeric:tabular-nums;font-weight:600;display:flex;align-items:center;gap:8px;min-height:64px;font-style:italic}
+.hallmark-card__mark svg{width:24px;height:24px;color:var(--mark-color,var(--color-silver))}
+.hallmark-card__country{font-size:var(--text-sm);font-weight:700;color:var(--color-text);font-family:var(--font-display)}
+.hallmark-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.5}
+.hallmark-card__price{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--mark-color,var(--color-silver));font-variant-numeric:tabular-nums;padding-top:var(--space-3);border-top:1px solid var(--color-divider);margin-top:auto;width:100%}
+.hallmark-card__price-label{display:block;font-size:10px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-bottom:2px}
+
+/* ═════ HERITAGE LUXE CARDS — 4 grades ═════ */
+.luxe-section{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.luxe-cards{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.luxe-cards{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:1024px){.luxe-cards{grid-template-columns:repeat(4,1fr)}}
+.luxe-card{position:relative;background:linear-gradient(180deg,var(--color-surface) 0%,var(--color-surface-2) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5) var(--space-5) var(--space-6);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition);text-decoration:none;color:var(--color-text);display:flex;flex-direction:column}
+.luxe-card::before{content:'';position:absolute;top:0;left:0;right:0;height:1px;background:var(--lx-accent,var(--gradient-silver-luxe));opacity:.7}
+.luxe-card::after{content:'';position:absolute;top:-30%;right:-30%;width:200px;height:200px;background:radial-gradient(circle,color-mix(in oklch,var(--lx-color,var(--color-silver)) 14%,transparent) 0%,transparent 65%);pointer-events:none;transition:opacity var(--transition)}
+.luxe-card:hover{border-color:color-mix(in oklch,var(--lx-color,var(--color-silver)) 40%,var(--color-border));transform:translateY(-3px);box-shadow:var(--lx-shadow,var(--shadow-luxe));text-decoration:none;color:var(--color-text)}
+.luxe-card--fine{--lx-color:var(--color-fine);--lx-accent:var(--gradient-silver-luxe);--lx-shadow:var(--shadow-silver)}
+.luxe-card--sterling{--lx-color:var(--color-sterling);--lx-accent:linear-gradient(135deg,#cbd5e1 0%,#5a6a82 100%);--lx-shadow:var(--shadow-silver)}
+.luxe-card--coin{--lx-color:var(--color-copper);--lx-accent:var(--gradient-copper);--lx-shadow:var(--shadow-copper)}
+.luxe-card--european{--lx-color:var(--color-patina);--lx-accent:var(--gradient-patina);--lx-shadow:var(--shadow-patina)}
+.luxe-card__icon-wrap{width:64px;height:64px;border-radius:50%;background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--lx-color,var(--color-silver)) 25%,var(--color-border));display:flex;align-items:center;justify-content:center;margin-bottom:var(--space-4);position:relative;color:var(--lx-color,var(--color-silver))}
+.luxe-card__icon{width:36px;height:36px}
+.luxe-card__category{font-size:11px;font-weight:700;color:var(--lx-color,var(--color-silver));text-transform:uppercase;letter-spacing:.14em;margin-bottom:var(--space-2);font-family:var(--font-mono)}
+.luxe-card__title{font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:600;color:var(--color-text);line-height:1.25;margin-bottom:var(--space-3);font-style:italic}
+.luxe-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin-bottom:var(--space-4);flex:1}
+.luxe-card__meta{display:flex;flex-wrap:wrap;gap:var(--space-3) var(--space-3);margin-bottom:var(--space-3);font-size:var(--text-xs);color:var(--color-text-muted);font-family:var(--font-mono);letter-spacing:.04em}
+.luxe-card__meta-item strong{color:var(--color-text);font-weight:600}
+.luxe-card__stat{display:flex;align-items:baseline;gap:var(--space-2);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.luxe-card__stat-val{font-family:var(--font-display);font-size:var(--text-xl);font-weight:700;color:var(--lx-color,var(--color-silver));font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.luxe-card__stat-label{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:500}
+
+/* ═════ FORMULA BLOCK ═════ */
+.formula-block{max-width:920px;margin:var(--space-10) auto var(--space-8);padding:0 var(--space-4)}
+.formula-card{background:linear-gradient(180deg,var(--color-surface-offset) 0%,var(--color-surface) 100%);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6) var(--space-5);position:relative;overflow:hidden}
+@media(min-width:768px){.formula-card{padding:var(--space-8)}}
+.formula-card__eyebrow{font-size:11px;font-weight:700;color:var(--color-silver);text-transform:uppercase;letter-spacing:.12em;margin-bottom:var(--space-3)}
+.formula-card__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-4)}
+.formula-card__equation{font-family:var(--font-mono);font-size:clamp(.875rem,.8rem + .5vw,1.125rem);color:var(--color-text);background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);overflow-x:auto;-webkit-overflow-scrolling:touch;white-space:nowrap;font-variant-numeric:tabular-nums;line-height:1.6}
+.formula-card__equation .op{color:var(--color-silver);font-weight:600}
+.formula-card__equation .var{color:var(--color-primary);font-weight:600}
+.formula-card__equation .pure{color:var(--color-copper);font-weight:600}
+.formula-card__steps{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:768px){.formula-card__steps{grid-template-columns:repeat(3,1fr)}}
+.formula-step{display:flex;gap:var(--space-3);padding:var(--space-3);background:var(--color-surface);border:1px solid var(--color-divider);border-radius:var(--radius-md)}
+.formula-step__num{flex-shrink:0;width:28px;height:28px;border-radius:50%;background:var(--gradient-silver-luxe);color:#0f172a;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
+.formula-step__text{font-size:var(--text-sm);color:var(--color-text);line-height:1.5}
+.formula-step__text strong{color:var(--color-silver);font-variant-numeric:tabular-nums}
+
+/* ═════ EDITORIAL PROSE ═════ */
+.content-section{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-12)}
+.prose-pro{max-width:760px;margin:0 auto}
+.prose-pro h2{font-family:var(--font-display);font-size:clamp(1.5rem,1.1rem + 1.5vw,2rem);font-weight:700;color:var(--color-text);margin:var(--space-12) 0 var(--space-4);line-height:1.2;letter-spacing:-.015em;position:relative;padding-top:var(--space-3)}
+.prose-pro h2::before{content:'';position:absolute;top:0;left:0;width:48px;height:3px;background:var(--gradient-spectrum);border-radius:2px}
+.prose-pro h2:first-child{margin-top:0}
+.prose-pro h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-8) 0 var(--space-3);letter-spacing:-.01em}
+.prose-pro p{font-size:var(--text-base);color:var(--color-text);line-height:1.75;margin-bottom:var(--space-4)}
+.prose-pro p.has-dropcap::first-letter{font-family:var(--font-editorial);font-size:3.6em;font-weight:700;float:left;line-height:.85;margin:.1em .12em 0 0;color:var(--color-silver);font-style:italic}
+.prose-pro ul,.prose-pro ol{padding-left:var(--space-5);margin-bottom:var(--space-5)}
+.prose-pro li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:var(--space-2)}
+.prose-pro li::marker{color:var(--color-silver)}
+.prose-pro strong{color:var(--color-text);font-weight:700}
+.prose-pro a{color:var(--color-primary);text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;transition:color var(--transition)}
+.prose-pro a:hover{color:var(--color-primary-hover);text-decoration-thickness:2px}
+.prose-pro blockquote{margin:var(--space-5) 0;padding:var(--space-4) var(--space-5);background:var(--color-surface);border-left:3px solid var(--color-silver);border-radius:var(--radius-md);font-family:var(--font-editorial);font-size:var(--text-lg);font-style:italic;color:var(--color-text);font-weight:500;line-height:1.5}
+.prose-pro blockquote strong{font-style:normal;font-family:var(--font-mono);color:var(--color-silver);font-size:var(--text-base);font-weight:600}
+.snippet-answer{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-silver);border-radius:var(--radius-md);padding:var(--space-4) var(--space-5);margin:var(--space-4) 0;font-size:var(--text-base);color:var(--color-text);line-height:1.7}
+.snippet-answer strong{color:var(--color-silver)}
+.snippet-answer .pure{color:var(--color-copper)}
+.callout{background:var(--gradient-silver-soft);border:1px solid color-mix(in oklch,var(--color-silver) 30%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);margin:var(--space-5) 0;display:flex;gap:var(--space-3);align-items:flex-start}
+.callout--copper{background:linear-gradient(135deg,oklch(0.78 0.02 250/0.10) 0%,oklch(0.70 0.12 55/0.12) 100%);border-color:color-mix(in oklch,var(--color-copper) 30%,var(--color-border))}
+.callout--patina{background:linear-gradient(135deg,oklch(0.78 0.02 250/0.10) 0%,oklch(0.70 0.07 160/0.12) 100%);border-color:color-mix(in oklch,var(--color-patina) 30%,var(--color-border))}
+.callout__icon{flex-shrink:0;width:32px;height:32px;color:var(--color-silver);margin-top:2px}
+.callout--copper .callout__icon{color:var(--color-copper)}
+.callout--patina .callout__icon{color:var(--color-patina)}
+.callout__title{font-weight:700;color:var(--color-text);margin-bottom:var(--space-1);font-family:var(--font-display)}
+.callout__body{font-size:var(--text-sm);color:var(--color-text);line-height:1.6}
+
+/* MARKET / TIMELINE TABLE */
+.market-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px solid var(--color-border);border-radius:var(--radius-lg);margin:var(--space-5) 0}
+.market-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);min-width:480px}
+.market-table th{font-size:var(--text-xs);font-weight:700;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;padding:var(--space-3) var(--space-4);text-align:left;background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
+.market-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text);vertical-align:top}
+.market-table td:first-child{font-weight:600;font-family:var(--font-display);white-space:nowrap}
+.market-table td:nth-child(2){color:var(--color-silver);font-family:var(--font-mono);font-size:11px;letter-spacing:.06em;white-space:nowrap}
+.market-table tr:last-child td{border-bottom:none}
+
+/* FAQ ACCORDION */
+.faq-pro{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+.faq-pro__item{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.faq-pro__item:hover{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
+.faq-pro__item[open]{border-color:color-mix(in oklch,var(--color-silver) 40%,var(--color-border))}
+.faq-pro__summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;min-height:60px}
+.faq-pro__summary::-webkit-details-marker{display:none}
+.faq-pro__summary:hover{background:var(--color-surface-offset)}
+.faq-pro__summary:focus-visible{outline:2px solid var(--color-silver);outline-offset:-2px}
+.faq-pro__plus{flex-shrink:0;width:24px;height:24px;border:1px solid var(--color-border);border-radius:50%;display:flex;align-items:center;justify-content:center;position:relative;transition:transform var(--transition),border-color var(--transition),background var(--transition)}
+.faq-pro__plus::before,.faq-pro__plus::after{content:'';position:absolute;background:var(--color-text-muted);transition:transform var(--transition),background var(--transition)}
+.faq-pro__plus::before{width:10px;height:2px}
+.faq-pro__plus::after{width:2px;height:10px}
+.faq-pro__item[open] .faq-pro__plus{background:var(--color-silver);border-color:var(--color-silver);transform:rotate(45deg)}
+.faq-pro__item[open] .faq-pro__plus::before,.faq-pro__item[open] .faq-pro__plus::after{background:#0f172a}
+.faq-pro__body{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;border-top:1px solid var(--color-divider);padding-top:var(--space-4)}
+.faq-pro__body strong{color:var(--color-text)}
+
+/* RELATED CARDS */
+.related-guides{max-width:1200px;margin:var(--space-12) auto;padding:0 var(--space-4)}
+.related-guides-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:560px){.related-guides-grid{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
+@media(min-width:900px){.related-guides-grid{grid-template-columns:repeat(4,1fr)}}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color .15s,transform .15s,box-shadow .15s;color:var(--color-text)}
+.related-card:hover{border-color:var(--color-silver);box-shadow:var(--shadow-md);transform:translateY(-2px);text-decoration:none;color:var(--color-text)}
+.related-card:hover .related-card__title{color:var(--color-silver)}
+.related-card__tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-silver);align-self:flex-start;padding:2px 8px;background:color-mix(in oklch,var(--color-silver) 10%,transparent);border-radius:99px}
+.related-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0;line-height:1.3;transition:color var(--transition)}
+.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
+
+/* STICKY MOBILE PRICE BAR */
+.sticky-price{position:fixed;bottom:0;left:0;right:0;background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-3) var(--space-4);z-index:80;display:none;align-items:center;gap:var(--space-3);box-shadow:0 -8px 24px rgba(0,0,0,.2);backdrop-filter:blur(12px);transform:translateY(100%);transition:transform .3s ease-out;padding-bottom:max(var(--space-3),env(safe-area-inset-bottom))}
+.sticky-price.visible{transform:translateY(0)}
+@media(max-width:768px){.sticky-price{display:flex}body{padding-bottom:80px}}
+.sticky-price__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.sticky-price__value{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;line-height:1.1}
+.sticky-price__info{flex:1;min-width:0}
+.sticky-price__cta{display:inline-flex;align-items:center;gap:6px;padding:10px var(--space-4);background:var(--gradient-silver-luxe);color:#0f172a;border-radius:var(--radius-md);font-size:var(--text-xs);font-weight:700;text-decoration:none;letter-spacing:.04em;text-transform:uppercase;min-height:44px;white-space:nowrap}
+.sticky-price__cta:hover{filter:brightness(1.08);color:#0f172a;text-decoration:none}
+
+/* DISCLAIMER */
+.disclaimer{margin-top:var(--space-8);padding:var(--space-4) var(--space-5);background:var(--color-surface-offset);border:1px solid var(--color-border);border-left:3px solid var(--color-text-faint);border-radius:var(--radius-md);font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+.disclaimer strong{color:var(--color-text)}
 
 #googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
 
 /* MEGA MENU */
-.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
+.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border);backdrop-filter:blur(12px)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
 .mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
 .mega-nav__item{position:relative}
-.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s}
+.mega-nav__trigger{display:flex;align-items:center;gap:4px;padding:6px 11px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-md);cursor:pointer;white-space:nowrap;transition:color .15s,background .15s;min-height:36px}
 .mega-nav__trigger:hover,.mega-nav__item:hover .mega-nav__trigger,.mega-nav__trigger[aria-expanded="true"]{color:var(--color-text);background:var(--color-surface-offset)}
 .mega-nav__trigger--link{text-decoration:none}
 .mega-nav__chevron{transition:transform .2s;flex-shrink:0}
@@ -282,7 +493,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
 .theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
 .theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer;min-width:44px;min-height:44px;align-items:center;justify-content:center}
 .hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
 .hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
 .hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
@@ -291,40 +502,24 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .mobile-menu.open{display:block;transform:translateX(0)}
 .mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
 .mobile-section{border-radius:var(--radius-md);overflow:hidden}
-.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s;min-height:44px}
 .mobile-section__toggle:hover{background:var(--color-surface-offset)}
 .mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
 .mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
 .mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
 .mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
 .mobile-section__items.open{display:flex}
-.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-sm);transition:color .12s,background .12s;min-height:44px;display:flex;align-items:center}
 .mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
 .mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
 .mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
-.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-md);min-height:44px;display:flex;align-items:center}
 .mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
 .mobile-menu__search{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
-.mobile-menu__search input{width:100%;padding:10px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm)}
+.mobile-menu__search input{width:100%;padding:12px 14px;border-radius:var(--radius-md);border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text);font-size:var(--text-sm);min-height:44px}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 
-
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
 /* FOOTER */
 .footer-brand-col{max-width:260px}
 .footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
@@ -334,122 +529,18 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
+footer{background:var(--color-surface);border-top:1px solid var(--color-border)}
+.footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
 
-
-/* ── Article card — unified markup styles ── */
-.article-card-title{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-1) 0 var(--space-2);line-height:1.3}
-.article-card .article-tag{display:inline-block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.article-card p,.article-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0}
-.article-card:hover .article-card-title{color:var(--color-primary)}
-
-
-/* ---- Silver Purity Grades page styles ---- */
-.purity-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:var(--space-3);margin:var(--space-5) 0}
-.purity-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm)}
-.purity-card-grade{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:2px}
-.purity-card-name{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-2)}
-.purity-card-gram{font-size:var(--text-2xl);font-weight:700;color:var(--color-text);margin-bottom:4px}
-.purity-card-unit{font-size:var(--text-xs);color:var(--color-text-muted)}
-.purity-card-sub{display:flex;gap:var(--space-3);margin-top:var(--space-2);padding-top:var(--space-2);border-top:1px solid var(--color-border)}
-.purity-card-sub-item{flex:1}
-.purity-card-sub-val{font-size:var(--text-sm);font-weight:600;color:var(--color-text)}
-.purity-card-sub-label{font-size:10px;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.05em}
-.live-badge{display:inline-flex;align-items:center;gap:6px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:999px;padding:4px 12px;font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);margin-bottom:var(--space-4)}
-.live-dot{width:8px;height:8px;border-radius:50%;background:#4ade80;animation:pulseDot 2s infinite}
-@keyframes pulseDot{0%,100%{opacity:1}50%{opacity:.4}}
-.spot-meta{font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-5)}
-.spot-meta strong{color:var(--color-text)}
-.currency-row{display:flex;gap:var(--space-2);align-items:center;margin-bottom:var(--space-4);flex-wrap:wrap}
-.currency-row label{font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted)}
-.content-section{margin:var(--space-8) 0}
-.content-section h2{font-size:var(--text-xl);font-weight:700;margin-bottom:var(--space-3)}
-.content-section p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-3)}
-.purity-detail-grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-4);margin:var(--space-4) 0}
-@media(max-width:640px){.purity-detail-grid{grid-template-columns:1fr}.purity-cards{grid-template-columns:1fr 1fr}}
-.purity-detail-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4)}
-.purity-detail-card h3{font-size:var(--text-base);font-weight:700;margin-bottom:var(--space-2)}
-.purity-detail-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
-.faq-grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);margin-top:var(--space-4)}
-@media(max-width:640px){.faq-grid{grid-template-columns:1fr}}
-.faq-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4)}
-.faq-q{font-size:var(--text-sm);font-weight:600;cursor:pointer;list-style:none;color:var(--color-text)}
-.faq-q::-webkit-details-marker{display:none}
-.faq-q::before{content:"\25BA ";color:var(--color-gold)}
-details[open] .faq-q::before{content:"\25BC ";color:var(--color-gold)}
-.faq-a{margin-top:var(--space-2);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
-
-/* ── Shared layout CSS ── */
+/* Breadcrumb */
 .breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted)}
+.breadcrumb{display:flex;align-items:center;gap:var(--space-2);list-style:none;font-size:var(--text-sm);color:var(--color-text-muted);flex-wrap:wrap}
 .breadcrumb li+li::before{content:"/";margin-right:var(--space-2);color:var(--color-text-faint)}
 .breadcrumb a{color:var(--color-text-muted);text-decoration:none}
 .breadcrumb a:hover{color:var(--color-primary)}
 .breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.hero-tag{display:inline-block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-.hero-title{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
-.hero-title{font-size:var(--text-xl)}
-.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);max-width:72ch;line-height:1.7;margin-bottom:var(--space-6)}
-.price-card{display:inline-flex;flex-direction:column;gap:var(--space-1);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-top:var(--space-2)}
-.price-card{width:100%}
-.price-label{font-size:var(--text-sm);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.price-value{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-gold-bright);font-weight:400;line-height:1}
-.price-usd{font-size:var(--text-base);color:var(--color-text-muted)}
-.price-purity{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-1)}
-.prose{max-width:72ch}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-1)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose{max-width:100%}
-.content{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
-.data-source{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.faq-answer-summary{font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4);cursor:pointer;list-style:none;background:var(--color-surface-offset);transition:background .15s}
-.faq-answer-summary:hover{background:var(--color-surface-dynamic)}
-.faq-answer-summary::marker,.faq-answer-summary::-webkit-details-marker{display:none}
-.faq-answer-summary::after{content:"＋";float:right;color:var(--color-text-faint)}
-.faq-answer-summary::after{content:"－"}
-.faq-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-4);border-top:1px solid var(--color-divider)}
-
-/* ═══════════════════════════════════════════════════
-   SILVER PURITY GRADES — layout & component fixes
-   ═══════════════════════════════════════════════════ */
-
-/* Hero: single column, centred */
-.hero{grid-template-columns:1fr!important;max-width:1200px;padding:var(--space-8) var(--space-4) var(--space-6);align-items:start}
-.hero-title{font-size:clamp(1.75rem,3.5vw,2.75rem)!important;line-height:1.15!important;margin-bottom:var(--space-3)!important}
-
-/* Trust bar */
-.trust-bar{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-4);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
-.trust-bar a{color:var(--color-primary);text-decoration:underline}
-
-/* Data table */
-.data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-2) 0 var(--space-6)}
-.data-table thead tr{border-bottom:2px solid var(--color-border)}
-.data-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-3) var(--space-2) 0;white-space:nowrap}
-.data-table th:first-child{padding-left:0}
-.data-table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle;white-space:nowrap}
-.data-table td:first-child{padding-left:0;font-weight:700;color:var(--color-text)}
-.data-table tr:last-child td{border-bottom:none}
-.data-table td:nth-child(4),.data-table td:nth-child(5),.data-table td:nth-child(6),.data-table td:nth-child(7){font-variant-numeric:tabular-nums;color:var(--color-text)}
-
-/* Sidebar links */
-.sidebar-link{display:block;font-size:var(--text-sm);color:var(--color-primary);text-decoration:none;padding:var(--space-2) 0;border-bottom:1px solid var(--color-border)}
-.sidebar-link:last-child{border-bottom:none}
-.sidebar-link:hover{color:var(--color-text);text-decoration:underline}
-
-/* Currency display selector */
-.display-currency{display:inline-flex;align-items:center;gap:var(--space-2);font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-4)}
-.display-currency select{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-1) var(--space-3);font-size:var(--text-sm);color:var(--color-text);cursor:pointer}
-
-/* Blockquote */
-blockquote{background:color-mix(in oklch,var(--color-silver) 6%,var(--color-surface-offset));border-left:3px solid var(--color-silver);border-radius:0 var(--radius-md) var(--radius-md) 0;padding:var(--space-4) var(--space-5);margin:var(--space-4) 0 var(--space-6);font-size:var(--text-base);color:var(--color-text-muted)}
-blockquote strong{color:var(--color-text)}
 </style>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
@@ -515,7 +606,7 @@ blockquote strong{color:var(--color-text)}
     <div class="mobile-menu__inner">
       <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Gold Prices</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/gold-silver-ratio">Gold / Silver Ratio</a><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a><a href="/10k-gold-price-per-gram">10K Gold Per Gram</a><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></div></div>
       <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Calculators</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/scrap-gold-calculator">Scrap Gold Calculator</a><a href="/gold-bar-value">Gold Bar Value</a><a href="/gold-coins-vs-bars">Gold Coins vs Bars</a><a href="/zakat-gold-silver-calculator">Zakat Calculator</a><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a><a href="/where-to-sell-gold-silver">Where to Sell Gold</a><a href="/best-gold-ira-companies">Best Gold IRA Companies</a></div></div>
-      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Silver</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/silver-price-guide">Silver Price Guide</a></div></div>
+      <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Silver</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/800-silver-price-per-gram">.800 Silver Per Gram</a><a href="/900-silver-price-per-gram">.900 Silver Per Gram</a><a href="/silver-purity-grades">Silver Purity Grades</a><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/us-silver-dollar-values">US Silver Dollar Values</a><a href="/guides/silver-price-guide">Silver Price Guide</a></div></div>
       <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Guides</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/guides/buying-investing/">Buying &amp; Investing</a><a href="/guides/selling-testing/">Selling &amp; Testing</a><a href="/guides/market-prices/">Market &amp; Prices</a><a href="/guides/silver-guides/">Silver Guides</a><a href="/guides/deep-dives/">Deep Dives</a><a href="/guides/">Browse All Guides</a></div></div>
       <div class="mobile-section"><button class="mobile-section__toggle" aria-expanded="false"><span>Blog</span><svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button><div class="mobile-section__items"><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers 2026</a><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced in 2026?</a><a href="/blog/gold-etf-vs-physical-gold-uk">Gold ETFs vs Physical Gold</a><a href="/blog/" class="mobile-view-all">All Articles &rarr;</a></div></div>
       <div class="mobile-section mobile-section--flat"><a href="/about">About</a><a href="/contact">Contact</a><a href="/editorial-standards/">Editorial Standards</a></div>
@@ -523,230 +614,680 @@ blockquote strong{color:var(--color-text)}
     </div>
   </div>
 </nav>
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li><a href="/silver-price-per-kilo">Silver</a></li><li aria-current="page">Silver Purity Grades</li></ol></div>
 
-<div class="hero">
-  <div class="hero-tag">Live Silver Prices by Purity</div>
-  <h1 class="hero-title">Silver Purity Grades &amp; Live Prices</h1>
-  <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Live silver spot prices for .999 Fine, .925 Sterling, .900 Coin and .800 European silver &#8212; per gram, per troy oz and per kilo. Updated every 60 seconds.</p>
+<div class="breadcrumb-wrap">
+  <ol class="breadcrumb" aria-label="Breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/guides/silver-guides/">Silver Guides</a></li>
+    <li aria-current="page">Silver Purity Grades</li>
+  </ol>
 </div>
 
-<section class="main-wrap">
-<div class="content">
-  <div class="trust-bar">Live prices sourced from LBMA spot market via gold-api.com &middot; Updated every 60 seconds &middot; <a href="/about">About our data</a></div>
+<!-- ═════════════ PREMIUM HERO ═════════════ -->
+<section class="hero-premium" aria-labelledby="hero-title">
+  <div class="hero-premium__inner">
+    <div class="hero-eyebrow">
+      <span class="hero-eyebrow__pulse" aria-hidden="true"></span>
+      <span>Live &middot; LBMA Spot &middot; XAG/USD &middot; Four Silver Grades</span>
+    </div>
+    <h1 class="hero-premium__title" id="hero-title">
+      Silver purity <span class="hero-premium__title-em">grades</span>, decoded
+    </h1>
+    <p class="hero-premium__sub">A live, USD-primary hub for the four silver fineness standards: <strong>.999 Fine</strong> bullion, <strong>.925 Sterling</strong> jewellery, <span class="em-copper">.900 Coin</span> US pre-1965 silver and <span class="em-patina">.800 European</span> Continental antique. Quoted in <strong>USD</strong>, GBP, EUR and INR &mdash; refreshed every 60 seconds from LBMA London spot data.</p>
 
-  <div class="live-badge"><span class="live-dot"></span> Prices update every 60 seconds</div>
-
-  <p class="spot-meta">Silver spot: <strong id="spot-oz-display">loading&#8230;</strong>&nbsp;&nbsp;Last updated: <span id="last-updated">&#8212;</span></p>
-
-  <div class="currency-row">
-    <label for="pgCurrency">Display currency:</label>
-    <select class="form-select" id="pgCurrency" style="width:auto;padding:.4rem .8rem">
-      <option value="GBP">GBP (&#163;)</option>
-      <option value="USD">USD ($)</option>
-      <option value="EUR">EUR (&#8364;)</option>
-    </select>
-  </div>
-
-  <!-- LIVE PURITY CARDS -->
-  <div class="purity-cards">
-    <div class="purity-card">
-      <div class="purity-card-grade">.999</div>
-      <div class="purity-card-name">Fine Silver</div>
-      <div class="purity-card-gram" id="c999-gram">&#8212;</div>
-      <div class="purity-card-unit">per gram</div>
-      <div class="purity-card-sub">
-        <div class="purity-card-sub-item"><div class="purity-card-sub-val" id="c999-oz">&#8212;</div><div class="purity-card-sub-label">per troy oz</div></div>
-        <div class="purity-card-sub-item"><div class="purity-card-sub-val" id="c999-kg">&#8212;</div><div class="purity-card-sub-label">per kilo</div></div>
+    <!-- XAG/USD spot ribbon -->
+    <div class="hero-spot" role="region" aria-label="Live silver spot price">
+      <div class="hero-spot__head">
+        <span class="hero-spot__label">Silver spot &middot; XAG/USD &middot; .999 fine</span>
+        <span class="hero-spot__flag">LBMA &middot; per troy oz</span>
+      </div>
+      <div class="hero-spot__value" id="hero-spot-oz" data-nosnippet>&mdash;</div>
+      <div class="hero-spot__sub">
+        <span>Per gram (.999): <strong id="hero-spot-g" data-nosnippet>&mdash;</strong></span>
+        <span aria-hidden="true">&middot;</span>
+        <span>Per kilo (.999): <strong id="hero-spot-kg" data-nosnippet>&mdash;</strong></span>
       </div>
     </div>
-    <div class="purity-card">
-      <div class="purity-card-grade">.925</div>
-      <div class="purity-card-name">Sterling Silver</div>
-      <div class="purity-card-gram" id="c925-gram">&#8212;</div>
-      <div class="purity-card-unit">per gram</div>
-      <div class="purity-card-sub">
-        <div class="purity-card-sub-item"><div class="purity-card-sub-val" id="c925-oz">&#8212;</div><div class="purity-card-sub-label">per troy oz</div></div>
-        <div class="purity-card-sub-item"><div class="purity-card-sub-val" id="c925-kg">&#8212;</div><div class="purity-card-sub-label">per kilo</div></div>
-      </div>
-    </div>
-    <div class="purity-card">
-      <div class="purity-card-grade">.900</div>
-      <div class="purity-card-name">Coin Silver</div>
-      <div class="purity-card-gram" id="c900-gram">&#8212;</div>
-      <div class="purity-card-unit">per gram</div>
-      <div class="purity-card-sub">
-        <div class="purity-card-sub-item"><div class="purity-card-sub-val" id="c900-oz">&#8212;</div><div class="purity-card-sub-label">per troy oz</div></div>
-        <div class="purity-card-sub-item"><div class="purity-card-sub-val" id="c900-kg">&#8212;</div><div class="purity-card-sub-label">per kilo</div></div>
-      </div>
-    </div>
-    <div class="purity-card">
-      <div class="purity-card-grade">.800</div>
-      <div class="purity-card-name">European Silver</div>
-      <div class="purity-card-gram" id="c800-gram">&#8212;</div>
-      <div class="purity-card-unit">per gram</div>
-      <div class="purity-card-sub">
-        <div class="purity-card-sub-item"><div class="purity-card-sub-val" id="c800-oz">&#8212;</div><div class="purity-card-sub-label">per troy oz</div></div>
-        <div class="purity-card-sub-item"><div class="purity-card-sub-val" id="c800-kg">&#8212;</div><div class="purity-card-sub-label">per kilo</div></div>
-      </div>
-    </div>
-  </div>
 
-  <!-- FULL PRICE TABLE -->
-  <h2 style="margin-bottom:var(--space-3)">Silver Purity Price Comparison Table</h2>
-  <div style="overflow-x:auto;margin-bottom:var(--space-6)">
-    <table class="data-table" aria-label="Silver purity price comparison">
-      <thead>
-        <tr>
-          <th>Purity</th>
-          <th>Grade</th>
-          <th>Common Use</th>
-          <th>Per Gram</th>
-          <th>Per Troy Oz</th>
-          <th>Per Kilo</th>
-          <th>Per 100g</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><strong>.999</strong></td><td>Fine Silver</td><td>Bullion bars &amp; coins</td>
-          <td id="tbl-999g">&#8212;</td><td id="tbl-999oz">&#8212;</td><td id="tbl-999kg">&#8212;</td><td id="tbl-999-100g">&#8212;</td>
-        </tr>
-        <tr>
-          <td><strong>.925</strong></td><td>Sterling Silver</td><td>Jewellery &amp; silverware</td>
-          <td id="tbl-925g">&#8212;</td><td id="tbl-925oz">&#8212;</td><td id="tbl-925kg">&#8212;</td><td id="tbl-925-100g">&#8212;</td>
-        </tr>
-        <tr>
-          <td><strong>.900</strong></td><td>Coin Silver</td><td>Pre-1965 US coins</td>
-          <td id="tbl-900g">&#8212;</td><td id="tbl-900oz">&#8212;</td><td id="tbl-900kg">&#8212;</td><td id="tbl-900-100g">&#8212;</td>
-        </tr>
-        <tr>
-          <td><strong>.800</strong></td><td>European Silver</td><td>Continental jewellery &amp; flatware</td>
-          <td id="tbl-800g">&#8212;</td><td id="tbl-800oz">&#8212;</td><td id="tbl-800kg">&#8212;</td><td id="tbl-800-100g">&#8212;</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-
-  <!-- EDITORIAL CONTENT -->
-  <div class="content-section">
-    <h2>What Do Silver Purity Grades Mean?</h2>
-    <p>Silver purity is expressed as a millesimal fineness &#8212; the number of parts per thousand that are pure silver. A hallmark of .999, for example, means the item contains 999 parts silver and just 1 part other metals, usually copper or germanium added for hardness. Understanding purity grades is essential when buying scrap silver, jewellery or bullion, because the price you pay or receive should directly reflect the actual silver content.</p>
-    <p>The four grades you encounter most frequently in the UK and international markets are .999 Fine, .925 Sterling, .900 Coin and .800 European. Each has a distinct history, a set of common applications, and a price per gram that scales proportionally with the silver spot price.</p>
-    <div class="purity-detail-grid">
-      <div class="purity-detail-card">
-        <h3>.999 Fine Silver &#8212; Investment Grade</h3>
-        <p>The purest commercially traded form of silver, .999 fine is the international standard for silver bullion bars and coins, including Britannia, American Silver Eagle and Canadian Maple Leaf. Because it is 99.9% pure, the price per gram is essentially the spot price divided by 31.1035 troy oz per gram. Fine silver is too soft for everyday jewellery but is the benchmark against which all other purities are priced.</p>
-      </div>
-      <div class="purity-detail-card">
-        <h3>.925 Sterling Silver &#8212; Jewellery Standard</h3>
-        <p>Sterling silver contains 92.5% pure silver alloyed with 7.5% copper, which dramatically improves hardness and durability without compromising its bright white appearance. It is the global standard for silver jewellery, cutlery and silverware. When valuing sterling scrap, multiply the weight by 0.925 to find the fine silver content, then multiply by the current .999 gram price above.</p>
-      </div>
-      <div class="purity-detail-card">
-        <h3>.900 Coin Silver &#8212; Historic US Standard</h3>
-        <p>Coin silver at 90.0% purity was the standard used in US silver coinage from 1837 until 1964, covering dimes, quarters, half dollars and dollar coins. These are widely traded as &#8220;junk silver&#8221; in the US and carry well-established melt values. For precise gram pricing, use the live .900 coin silver rate in the price card and table above.</p>
-      </div>
-      <div class="purity-detail-card">
-        <h3>.800 European Silver &#8212; Continental Standard</h3>
-        <p>An 80.0% silver alloy was the standard across continental Europe &#8212; particularly Germany, Scandinavia and Eastern Europe &#8212; for flatware, jewellery and decorative objects from the 19th century through to the mid-20th century. Pieces typically carry an 800 hallmark and are frequently found in antique shops and estate sales with meaningful scrap value.</p>
-      </div>
-    </div>
-  </div>
-
-  <div class="content-section">
-    <h2>How Are Silver Purity Prices Calculated?</h2>
-    <p>Every price on this page is derived in real time from the XAG silver spot price &#8212; the global benchmark price for one troy ounce of .999 fine silver traded on the LBMA (London Bullion Market Association). The spot price is fetched every 60 seconds via our live data feed at gold-api.com.</p>
-    <p>The calculation for each purity is: <strong>Price per gram = (Silver spot oz &#247; 31.1035) &#215; purity</strong>. So at a spot price of $75.00/oz, .999 fine is $2.41/g, .925 sterling is $2.23/g, .900 coin is $2.17/g and .800 European is $1.93/g. The kilo price is simply the gram price multiplied by 1,000. Currency conversion uses live GBP/USD/EUR exchange rates, also refreshed every 60 seconds.</p>
-  </div>
-
-  <div class="content-section">
-    <h2>Silver Hallmarks &amp; How to Identify Purity</h2>
-    <p>In the UK, silver items are required by law to be hallmarked by one of the four Assay Offices (London, Birmingham, Sheffield and Edinburgh) before they can be described or sold as silver. The millesimal fineness mark &#8212; 999, 925, 800 &#8212; is stamped alongside the Assay Office mark, the date letter and the maker&#8217;s mark. Recognising these marks lets you calculate melt value using the live prices above.</p>
-    <p>Older items may carry traditional Britannia marks (958 fine) or a lion passant for sterling .925. Continental European pieces often carry just the three-digit fineness number without additional assay marks. If you are unsure, a silver testing kit or professional assay is the most reliable way to confirm purity before buying or selling scrap silver.</p>
-  </div>
-
-  <!-- RELATED PAGES -->
-  <div class="content-section">
-    <h2>Related Silver Price Pages</h2>
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:var(--space-3)">
-      <a class="article-card" href="/silver-price-per-kilo">
-        <div class="article-tag">Silver</div>
-        <div class="article-card-title">Silver Price Per Kilo</div>
-        <div class="article-card-desc">Live .999 silver price per kilogram with daily chart.</div>
+    <!-- 4 grade tiles — USD primary, per gram -->
+    <div class="price-tiles" role="region" aria-label="Live silver purity prices per gram in USD">
+      <a class="price-tile price-tile--fine" href="/silver-price-per-kilo" aria-label=".999 fine silver — view price per kilo">
+        <div class="price-tile__head">
+          <span class="price-tile__purity">.999</span>
+          <span class="price-tile__pct">99.9%</span>
+        </div>
+        <span class="price-tile__grade">Fine &middot; Bullion</span>
+        <div class="price-tile__value" id="tile-999" data-nosnippet>&mdash;</div>
+        <div class="price-tile__unit">USD / gram</div>
       </a>
-      <a class="article-card" href="/800-silver-price-per-gram">
-        <div class="article-tag">Silver</div>
-        <div class="article-card-title">.800 Silver Per Gram</div>
-        <div class="article-card-desc">Live European .800 silver price per gram today.</div>
+      <a class="price-tile price-tile--sterling" href="/guides/what-is-925-sterling-silver" aria-label=".925 sterling silver — view sterling guide">
+        <div class="price-tile__head">
+          <span class="price-tile__purity">.925</span>
+          <span class="price-tile__pct">92.5%</span>
+        </div>
+        <span class="price-tile__grade">Sterling &middot; Jewellery</span>
+        <div class="price-tile__value" id="tile-925" data-nosnippet>&mdash;</div>
+        <div class="price-tile__unit">USD / gram</div>
       </a>
-      <a class="article-card" href="/900-silver-price-per-gram">
-        <div class="article-tag">Silver</div>
-        <div class="article-card-title">.900 Coin Silver Per Gram</div>
-        <div class="article-card-desc">Live .900 coin silver price per gram today.</div>
+      <a class="price-tile price-tile--coin" href="/900-silver-price-per-gram" aria-label=".900 coin silver — view coin silver per gram">
+        <div class="price-tile__head">
+          <span class="price-tile__purity">.900</span>
+          <span class="price-tile__pct">90.0%</span>
+        </div>
+        <span class="price-tile__grade">Coin &middot; US Pre-1965</span>
+        <div class="price-tile__value" id="tile-900" data-nosnippet>&mdash;</div>
+        <div class="price-tile__unit">USD / gram</div>
       </a>
-      <a class="article-card" href="/guides/what-is-925-sterling-silver">
-        <div class="article-tag">Guide</div>
-        <div class="article-card-title">What Is 925 Sterling Silver?</div>
-        <div class="article-card-desc">Everything you need to know about sterling silver hallmarks.</div>
+      <a class="price-tile price-tile--european" href="/800-silver-price-per-gram" aria-label=".800 European silver — view European per gram">
+        <div class="price-tile__head">
+          <span class="price-tile__purity">.800</span>
+          <span class="price-tile__pct">80.0%</span>
+        </div>
+        <span class="price-tile__grade">European &middot; Antique</span>
+        <div class="price-tile__value" id="tile-800" data-nosnippet>&mdash;</div>
+        <div class="price-tile__unit">USD / gram</div>
+      </a>
+    </div>
+
+    <!-- Live status bar -->
+    <div class="live-status" role="status" aria-live="polite">
+      <span class="live-status__dot" aria-hidden="true"></span>
+      <span class="live-status__label">Live</span>
+      <span class="live-status__divider" aria-hidden="true">&middot;</span>
+      <span class="live-status__meta">Spot: <strong id="spot-usd" data-nosnippet>&mdash;</strong></span>
+      <span class="live-status__divider" aria-hidden="true">&middot;</span>
+      <span class="live-status__meta">Updated <span id="updated-time">just now</span></span>
+      <span class="live-status__divider" aria-hidden="true">&middot;</span>
+      <span class="live-status__meta">Refresh in <span id="refresh-counter">60s</span></span>
+      <a href="#calculator" class="live-status__cta">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>
+        Calculate
       </a>
     </div>
   </div>
-
-  <!-- FAQ -->
-  <section class="content-section" id="faq" aria-label="Frequently asked questions">
-    <h2>Frequently Asked Questions</h2>
-    <div class="faq-grid">
-      <div class="faq-card">
-        <h3 class="faq-q">What is the difference between .999 and .925 silver?</h3>
-        <p class="faq-a">.999 fine silver is 99.9% pure &#8212; the investment grade standard for bullion bars and coins. .925 sterling silver is 92.5% pure silver alloyed with copper for durability, making it the standard for jewellery. Fine silver is softer and more valuable gram-for-gram.</p>
-      </div>
-      <div class="faq-card">
-        <h3 class="faq-q">How do I calculate scrap silver value by purity?</h3>
-        <p class="faq-a">Weigh your item in grams, multiply by the purity (e.g. 0.925 for sterling), then multiply by the current .999 fine gram price. For example: 50g of sterling &#215; 0.925 = 46.25g fine content &#215; current gram price = scrap melt value.</p>
-      </div>
-      <div class="faq-card">
-        <h3 class="faq-q">Why does the silver price change every 60 seconds?</h3>
-        <p class="faq-a">Silver is traded 24 hours a day on global markets. The XAG spot price fluctuates continuously based on supply, demand, dollar strength and macro factors. This page refreshes every 60 seconds so prices always reflect the current melt value of your silver.</p>
-      </div>
-      <div class="faq-card">
-        <h3 class="faq-q">Is .800 silver worth buying as an investment?</h3>
-        <p class="faq-a">.800 silver is not typically used for bullion investment. Its lower purity means less silver content per gram. However, antique .800 items may carry numismatic or collectible value above their melt price, particularly pieces from notable European silversmiths.</p>
-      </div>
-      <div class="faq-card">
-        <h3 class="faq-q">What is coin silver (.900) used for?</h3>
-        <p class="faq-a">.900 coin silver was the standard for US silver coins until 1964. Pre-1965 dimes, quarters, half dollars and dollars are 90% silver and are traded as &#8220;junk silver.&#8221; They remain a cost-effective way to hold physical silver and are widely recognised by dealers.</p>
-      </div>
-      <div class="faq-card">
-        <h3 class="faq-q">How accurate are these silver purity prices?</h3>
-        <p class="faq-a">Prices are calculated from the live XAG spot price via gold-api.com, updated every 60 seconds. Currency rates use live FX data. Prices reflect melt value only &#8212; actual buy/sell prices from dealers will include a premium or discount above spot.</p>
-      </div>
-    </div>
-  </section>
-
-</div><!-- /content -->
-
-<!-- SIDEBAR -->
-<aside class="sidebar" aria-label="Silver quick reference">
-  <div class="sidebar-widget">
-    <h3>Silver Quick Reference</h3>
-    <div class="quick-ref-row"><span class="quick-ref-label">.999 / gram</span><span class="quick-ref-value" id="sb-999g">&#8212;</span></div>
-    <div class="quick-ref-row"><span class="quick-ref-label">.925 / gram</span><span class="quick-ref-value" id="sb-925g">&#8212;</span></div>
-    <div class="quick-ref-row"><span class="quick-ref-label">.900 / gram</span><span class="quick-ref-value" id="sb-900g">&#8212;</span></div>
-    <div class="quick-ref-row"><span class="quick-ref-label">.800 / gram</span><span class="quick-ref-value" id="sb-800g">&#8212;</span></div>
-    <div class="quick-ref-row"><span class="quick-ref-label">.999 / oz</span><span class="quick-ref-value" id="sb-999oz">&#8212;</span></div>
-    <div class="quick-ref-row"><span class="quick-ref-label">.925 / oz</span><span class="quick-ref-value" id="sb-925oz">&#8212;</span></div>
-    <div class="quick-ref-row"><span class="quick-ref-label">.999 / kilo</span><span class="quick-ref-value" id="sb-999kg">&#8212;</span></div>
-  </div>
-  <div class="sidebar-widget" style="margin-top:var(--space-4)">
-    <h3>Price Pages</h3>
-    <a class="sidebar-link" href="/silver-price-per-kilo">Silver Price Per Kilo &#8594;</a>
-    <a class="sidebar-link" href="/800-silver-price-per-gram">.800 Silver Per Gram &#8594;</a>
-    <a class="sidebar-link" href="/900-silver-price-per-gram">.900 Silver Per Gram &#8594;</a>
-    <a class="sidebar-link" href="/scrap-gold-calculator">Scrap Gold Calculator &#8594;</a>
-    <a class="sidebar-link" href="/guides/what-is-925-sterling-silver">925 Sterling Silver Guide &#8594;</a>
-  </div>
-</aside>
 </section>
+
+<!-- Trust strip -->
+<div class="trust-strip">
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    LBMA-sourced XAG spot
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+    60-second refresh
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/><circle cx="12" cy="12" r="10"/></svg>
+    USD &middot; GBP &middot; EUR &middot; INR
+  </span>
+  <span class="trust-strip__item">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="3"/></svg>
+    Four grades, one engine
+  </span>
+  <a href="/about" class="trust-strip__item trust-strip__item--link">About our data &rarr;</a>
+</div>
+
+<!-- ═════════════ UNIVERSAL MULTI-PURITY CALCULATOR ═════════════ -->
+<section class="calc-pro" id="calculator" aria-labelledby="calc-title">
+  <div class="calc-pro__card">
+    <div class="calc-pro__head">
+      <div class="calc-pro__head-left">
+        <h2 class="calc-pro__title" id="calc-title">
+          <svg class="calc-pro__title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M8 6h8M8 10h8M8 14h2M12 14h.01M16 14h.01M8 18h2M12 18h.01M16 18h.01"/></svg>
+          Universal Silver Purity Calculator
+        </h2>
+        <p class="calc-pro__sub">Enter any weight, choose a purity (.999, .925, .900 or .800) and a currency. Live melt value updates every 60 seconds from <strong>LBMA spot</strong>. USD primary, with GBP, EUR and INR conversions on tap.</p>
+      </div>
+      <span class="calc-pro__head-badge">
+        <span class="live-dot" aria-hidden="true"></span>
+        Live &middot; 60s refresh
+      </span>
+    </div>
+
+    <div class="calc-pro__body">
+      <!-- Purity selector — segmented control -->
+      <div class="calc-pro__row calc-pro__row--purity">
+        <div class="calc-pro__field" style="grid-column:1/-1">
+          <label class="calc-pro__field-label" for="calc-purity-seg">Purity grade</label>
+          <div class="purity-seg" id="calc-purity-seg" role="tablist" aria-label="Choose silver purity">
+            <button type="button" class="purity-seg__btn" role="tab" data-purity="0.999" aria-selected="false"><span class="purity-seg__num">.999</span><span class="purity-seg__lbl">Fine</span></button>
+            <button type="button" class="purity-seg__btn active" role="tab" data-purity="0.925" aria-selected="true"><span class="purity-seg__num">.925</span><span class="purity-seg__lbl">Sterling</span></button>
+            <button type="button" class="purity-seg__btn" role="tab" data-purity="0.900" aria-selected="false"><span class="purity-seg__num">.900</span><span class="purity-seg__lbl">Coin</span></button>
+            <button type="button" class="purity-seg__btn" role="tab" data-purity="0.800" aria-selected="false"><span class="purity-seg__num">.800</span><span class="purity-seg__lbl">European</span></button>
+          </div>
+          <input type="hidden" id="calc-purity" value="0.925">
+        </div>
+      </div>
+
+      <div class="calc-pro__row">
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-weight">Weight</label>
+          <input class="calc-pro__input" type="number" id="calc-weight" inputmode="decimal" placeholder="e.g. 50" min="0" step="0.01" value="50" aria-label="Weight value">
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-unit">Unit</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-unit" aria-label="Weight unit">
+              <option value="1" selected>grams</option>
+              <option value="1000">kilograms</option>
+              <option value="31.1035">troy ounces</option>
+              <option value="1.55517">pennyweight (dwt)</option>
+              <option value="28.3495">avoirdupois ounces</option>
+            </select>
+          </div>
+        </div>
+        <div class="calc-pro__field">
+          <label class="calc-pro__field-label" for="calc-currency">Currency</label>
+          <div class="calc-pro__select-wrap">
+            <select class="calc-pro__select" id="calc-currency" aria-label="Display currency">
+              <option value="USD" selected>USD ($)</option>
+              <option value="GBP">GBP (&pound;)</option>
+              <option value="EUR">EUR (&euro;)</option>
+              <option value="INR">INR (&#8377;)</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class="calc-pro__chips" role="group" aria-label="Quick weight presets">
+        <span class="calc-pro__chips-label">Quick presets:</span>
+        <button class="calc-chip" type="button" data-weight="1" data-unit="1">1g benchmark</button>
+        <button class="calc-chip" type="button" data-weight="31.1035" data-unit="1">1 troy oz</button>
+        <button class="calc-chip" type="button" data-weight="50" data-unit="1">50g (sterling chain)</button>
+        <button class="calc-chip" type="button" data-weight="100" data-unit="1">100g</button>
+        <button class="calc-chip" type="button" data-weight="250" data-unit="1">250g (tea service)</button>
+        <button class="calc-chip" type="button" data-weight="1000" data-unit="1">1 kg</button>
+        <button class="calc-chip" type="button" data-weight="26.73" data-unit="1">Morgan Dollar 26.73g</button>
+        <button class="calc-chip" type="button" data-weight="800" data-unit="1">German .800 flatware set 800g</button>
+      </div>
+
+      <div class="calc-pro__result">
+        <div class="calc-pro__result-primary">
+          <span class="calc-pro__result-label-main">Melt value &middot; <strong id="calc-purity-label">.925 Sterling</strong></span>
+          <span class="calc-pro__result-main" id="calc-melt" data-nosnippet>&mdash;</span>
+        </div>
+        <div class="calc-pro__result-grid">
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Pure silver content</span>
+            <span class="calc-pro__result-item-value" id="calc-pure" data-nosnippet>&mdash;</span>
+          </div>
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Dealer payout (~85% of melt)</span>
+            <span class="calc-pro__result-item-value" id="calc-dealer" data-nosnippet>&mdash;</span>
+          </div>
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Per troy oz equivalent</span>
+            <span class="calc-pro__result-item-value" id="calc-per-oz" data-nosnippet>&mdash;</span>
+          </div>
+          <div class="calc-pro__result-item">
+            <span class="calc-pro__result-item-label">Per kilo equivalent</span>
+            <span class="calc-pro__result-item-value" id="calc-per-kg" data-nosnippet>&mdash;</span>
+          </div>
+        </div>
+      </div>
+      <p class="calc-pro__hint">Formula: <code>weight (g) &times; (spot USD/oz &divide; 31.1035) &times; purity</code>. Dealers typically pay <strong>75&ndash;95% of melt</strong> for scrap; antique or collector pieces from notable makers (WMF, Christofle, Tiffany, Mappin &amp; Webb) can fetch <strong>2&times;&ndash;10&times; melt</strong>. For US pre-1965 coins use our <a href="/silver-coins-calculator">silver coins calculator</a>; for kilo lots see <a href="/silver-price-per-kilo">silver per kilo</a>.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ STAT CARDS ═════════════ -->
+<section class="stat-cards" aria-label="Silver purity key facts">
+  <article class="stat-card">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+    <div class="stat-card__value">31.1035 g</div>
+    <div class="stat-card__label">Grams in one troy ounce &mdash; the silver spot quote unit</div>
+  </article>
+  <article class="stat-card stat-card--copper">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 21V8l9-5 9 5v13M3 21h18M9 21V12h6v9"/></svg>
+    <div class="stat-card__value">12:00 GMT</div>
+    <div class="stat-card__label">LBMA Silver Price daily auction by ICE Benchmark</div>
+  </article>
+  <article class="stat-card stat-card--patina">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2v20M2 12h20M5 5l14 14M19 5L5 19"/></svg>
+    <div class="stat-card__value">‰ fineness</div>
+    <div class="stat-card__label">Millesimal parts per thousand &mdash; the universal silver standard</div>
+  </article>
+  <article class="stat-card stat-card--heritage">
+    <svg class="stat-card__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/></svg>
+    <div class="stat-card__value">24/5</div>
+    <div class="stat-card__label">Global XAG trading hours &mdash; London &middot; New York &middot; Shanghai</div>
+  </article>
+</section>
+
+<!-- ═════════════ LIVE PRICE MATRIX TABLE ═════════════ -->
+<section class="price-table-section" aria-labelledby="price-table-title">
+  <div class="price-table-card">
+    <div class="price-table-card__head">
+      <div>
+        <h2 class="price-table-card__title" id="price-table-title">Live Silver Price by Purity &amp; Weight</h2>
+        <p class="price-table-card__sub"><strong>Live</strong> &middot; all four grades &middot; per gram, troy oz, 100g and kilo &middot; USD primary</p>
+      </div>
+      <div class="currency-switch" role="tablist" aria-label="Choose currency">
+        <button class="currency-switch__btn active" role="tab" data-currency="USD" aria-selected="true">USD</button>
+        <button class="currency-switch__btn" role="tab" data-currency="GBP" aria-selected="false">GBP</button>
+        <button class="currency-switch__btn" role="tab" data-currency="EUR" aria-selected="false">EUR</button>
+        <button class="currency-switch__btn" role="tab" data-currency="INR" aria-selected="false">INR</button>
+      </div>
+    </div>
+    <div class="price-table-card__body">
+      <figure itemscope itemtype="https://schema.org/Table" style="margin:0">
+        <figcaption class="sr-only">Live silver price by purity grade and weight in USD, GBP, EUR and INR &mdash; updated every 60 seconds</figcaption>
+        <table class="price-table-pro" aria-label="Silver purity prices by weight">
+          <thead>
+            <tr>
+              <th>Purity</th>
+              <th>Per gram</th>
+              <th>Per troy oz</th>
+              <th>Per 100g</th>
+              <th>Per kilo</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="purity-dot purity-dot--999"></span>.999 Fine<span class="weight-label-sub">Bullion standard</span></td>
+              <td id="m-999-g" data-nosnippet>&mdash;</td>
+              <td id="m-999-oz" data-nosnippet>&mdash;</td>
+              <td id="m-999-100g" data-nosnippet>&mdash;</td>
+              <td id="m-999-kg" data-nosnippet>&mdash;</td>
+            </tr>
+            <tr>
+              <td><span class="purity-dot purity-dot--925"></span>.925 Sterling<span class="weight-label-sub">UK/US jewellery &amp; flatware</span></td>
+              <td id="m-925-g" data-nosnippet>&mdash;</td>
+              <td id="m-925-oz" data-nosnippet>&mdash;</td>
+              <td id="m-925-100g" data-nosnippet>&mdash;</td>
+              <td id="m-925-kg" data-nosnippet>&mdash;</td>
+            </tr>
+            <tr>
+              <td><span class="purity-dot purity-dot--900"></span>.900 Coin<span class="weight-label-sub">US pre-1965 coinage</span></td>
+              <td id="m-900-g" data-nosnippet>&mdash;</td>
+              <td id="m-900-oz" data-nosnippet>&mdash;</td>
+              <td id="m-900-100g" data-nosnippet>&mdash;</td>
+              <td id="m-900-kg" data-nosnippet>&mdash;</td>
+            </tr>
+            <tr>
+              <td><span class="purity-dot purity-dot--800"></span>.800 European<span class="weight-label-sub">Continental antique silverware</span></td>
+              <td id="m-800-g" data-nosnippet>&mdash;</td>
+              <td id="m-800-oz" data-nosnippet>&mdash;</td>
+              <td id="m-800-100g" data-nosnippet>&mdash;</td>
+              <td id="m-800-kg" data-nosnippet>&mdash;</td>
+            </tr>
+          </tbody>
+        </table>
+      </figure>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ HALLMARK IDENTIFICATION GRID ═════════════ -->
+<section class="hallmark-section" aria-labelledby="hallmark-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Identification &middot; hallmarks &amp; dates</span>
+      <h2 class="section-title" id="hallmark-title">How to identify each silver purity at a glance</h2>
+      <p class="section-sub">The millesimal fineness mark &mdash; a three-digit number stamped on the piece &mdash; is the universal silver identifier. Below: the most common hallmark for each grade, the country of origin, and a live USD-per-gram melt anchor.</p>
+    </div>
+  </div>
+  <div class="hallmark-grid">
+    <div class="hallmark-card hallmark-card--fine">
+      <div class="hallmark-card__mark">999</div>
+      <div class="hallmark-card__country">UK &middot; Global Bullion</div>
+      <div class="hallmark-card__desc"><strong>FINE</strong>, 999 or BRITANNIA hallmark with refiner stamp (Heimerle &amp; Meule, PAMP, LBMA Good Delivery). Found on 1 oz / 1 kg bullion bars and coins.</div>
+      <div class="hallmark-card__price"><span class="hallmark-card__price-label">Live USD / gram</span><span id="hm-999" data-nosnippet>&mdash;</span></div>
+    </div>
+    <div class="hallmark-card hallmark-card--sterling">
+      <div class="hallmark-card__mark">925</div>
+      <div class="hallmark-card__country">UK / US &middot; Jewellery</div>
+      <div class="hallmark-card__desc"><strong>STERLING</strong>, 925 or a UK <strong>lion passant</strong> alongside the Assay Office mark (London leopard, Birmingham anchor, Sheffield rose, Edinburgh castle).</div>
+      <div class="hallmark-card__price"><span class="hallmark-card__price-label">Live USD / gram</span><span id="hm-925" data-nosnippet>&mdash;</span></div>
+    </div>
+    <div class="hallmark-card hallmark-card--coin">
+      <div class="hallmark-card__mark">90%</div>
+      <div class="hallmark-card__country">US &middot; Pre-1965 Coinage</div>
+      <div class="hallmark-card__desc">No hallmark &mdash; identify by date. Any Roosevelt/Mercury Dime, Washington Quarter, Walking Liberty/Franklin Half or Morgan/Peace Dollar dated <strong>&le; 1964</strong> is 90% silver.</div>
+      <div class="hallmark-card__price"><span class="hallmark-card__price-label">Live USD / gram</span><span id="hm-900" data-nosnippet>&mdash;</span></div>
+    </div>
+    <div class="hallmark-card hallmark-card--european">
+      <div class="hallmark-card__mark">800</div>
+      <div class="hallmark-card__country">DE / IT / AT &middot; Antique</div>
+      <div class="hallmark-card__desc"><strong>800</strong> stamp with German <strong>Halbmond &amp; Krone</strong> (crescent moon and crown) from 1888 onwards. Italian fasces or French Minerva head also appear on Continental pieces.</div>
+      <div class="hallmark-card__price"><span class="hallmark-card__price-label">Live USD / gram</span><span id="hm-800" data-nosnippet>&mdash;</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ FORMULA BLOCK ═════════════ -->
+<section class="formula-block" aria-labelledby="formula-title">
+  <div class="formula-card">
+    <div class="formula-card__eyebrow">The Math</div>
+    <h2 class="formula-card__title" id="formula-title">One formula, four purities</h2>
+    <p style="color:var(--color-text-muted);font-size:var(--text-sm);margin-bottom:var(--space-4);line-height:1.7">Silver is quoted globally in <strong style="color:var(--color-silver)">USD per troy ounce</strong> on COMEX (New York) and via the LBMA Silver Price benchmark in London. To get any purity per gram, divide the spot by 31.1035 (grams in a troy ounce), then multiply by the <strong style="color:var(--color-silver)">purity ratio</strong> (0.999, 0.925, 0.900 or 0.800). The balance is <strong style="color:var(--color-copper)">copper</strong>, added for hardness in jewellery and coinage.</p>
+    <div class="formula-card__equation"><span class="var">purity USD/g</span> <span class="op">=</span> ( <span class="var">spot USD/oz</span> <span class="op">&divide;</span> 31.1035 ) <span class="op">&times;</span> <span class="pure">purity ratio</span></div>
+    <div class="formula-card__steps">
+      <div class="formula-step">
+        <div class="formula-step__num">1</div>
+        <div class="formula-step__text">Take the live LBMA spot price (<strong>USD per troy oz</strong> of .999 fine silver)</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">2</div>
+        <div class="formula-step__text">Divide by <strong>31.1035</strong> &mdash; the grams in one troy ounce &mdash; for the pure silver USD/g baseline</div>
+      </div>
+      <div class="formula-step">
+        <div class="formula-step__num">3</div>
+        <div class="formula-step__text">Multiply by the purity ratio: <strong>0.999</strong>, <strong>0.925</strong>, <strong>0.900</strong> or <strong>0.800</strong></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ HERITAGE / USE CASE LUXE CARDS ═════════════ -->
+<section class="luxe-section" aria-labelledby="heritage-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow section-eyebrow--heritage">Heritage &middot; where each grade lives</span>
+      <h2 class="section-title" id="heritage-title">The four silver standards in context</h2>
+      <p class="section-sub">From investment-grade bullion to Victorian flatware &mdash; each fineness has a defined market, a recognised hallmark and a distinct premium structure. Live USD melt values anchor each card.</p>
+    </div>
+  </div>
+  <div class="luxe-cards">
+    <a href="/silver-price-per-kilo" class="luxe-card luxe-card--fine">
+      <div class="luxe-card__icon-wrap">
+        <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+          <rect x="8" y="14" width="32" height="20" rx="2"/>
+          <path d="M14 14V8h20v6M14 34v6h20v-6M16 22h16M16 26h12"/>
+        </svg>
+      </div>
+      <div class="luxe-card__category">Investment &middot; 1 oz / 1 kg</div>
+      <h3 class="luxe-card__title">.999 Fine bullion</h3>
+      <div class="luxe-card__meta">
+        <span class="luxe-card__meta-item">Purity: <strong>99.9%</strong></span>
+        <span class="luxe-card__meta-item">Alloy: <strong>Pure</strong></span>
+      </div>
+      <p class="luxe-card__desc">The investment standard. <strong>American Silver Eagle</strong>, <strong>British Britannia</strong>, <strong>Canadian Maple Leaf</strong> and <strong>Vienna Philharmonic</strong> coins are all .999. LBMA Good Delivery bars are the wholesale benchmark.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="lx-999" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">USD / gram melt</span>
+      </div>
+    </a>
+    <a href="/guides/what-is-925-sterling-silver" class="luxe-card luxe-card--sterling">
+      <div class="luxe-card__icon-wrap">
+        <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+          <path d="M24 8l4 8h8l-6 6 2 10-8-4-8 4 2-10-6-6h8z"/>
+          <circle cx="24" cy="34" r="2"/>
+        </svg>
+      </div>
+      <div class="luxe-card__category">Jewellery &middot; Flatware</div>
+      <h3 class="luxe-card__title">.925 Sterling Silver</h3>
+      <div class="luxe-card__meta">
+        <span class="luxe-card__meta-item">Purity: <strong>92.5%</strong></span>
+        <span class="luxe-card__meta-item">Alloy: <strong>7.5% Cu</strong></span>
+      </div>
+      <p class="luxe-card__desc">The global jewellery and flatware standard. UK pieces carry a <strong>lion passant</strong> and Assay Office mark. <strong>Tiffany</strong>, <strong>Mappin &amp; Webb</strong>, <strong>Christofle</strong> and <strong>Georg Jensen</strong> are all sterling .925.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="lx-925" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">USD / gram melt</span>
+      </div>
+    </a>
+    <a href="/900-silver-price-per-gram" class="luxe-card luxe-card--coin">
+      <div class="luxe-card__icon-wrap">
+        <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+          <circle cx="24" cy="24" r="18"/>
+          <circle cx="24" cy="24" r="14"/>
+          <path d="M24 12c3 4 3 16 0 24c-3-8-3-20 0-24z"/>
+          <path d="M16 24h16"/>
+        </svg>
+      </div>
+      <div class="luxe-card__category">US Coinage &middot; 1792&ndash;1964</div>
+      <h3 class="luxe-card__title">.900 Coin Silver</h3>
+      <div class="luxe-card__meta">
+        <span class="luxe-card__meta-item">Purity: <strong>90.0%</strong></span>
+        <span class="luxe-card__meta-item">Alloy: <strong>10% Cu</strong></span>
+      </div>
+      <p class="luxe-card__desc">The United States Mint's circulating silver standard. <strong>Morgan</strong> and <strong>Peace Dollars</strong>, <strong>Walking Liberty Halves</strong>, <strong>Mercury Dimes</strong> &mdash; all 90% silver. Traded as "junk silver" by bullion brokers.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="lx-900" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">USD / gram melt</span>
+      </div>
+    </a>
+    <a href="/800-silver-price-per-gram" class="luxe-card luxe-card--european">
+      <div class="luxe-card__icon-wrap">
+        <svg class="luxe-card__icon" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+          <path d="M14 8c0 6 2 10 5 14H29c3-4 5-8 5-14M14 8h20M16 22h16v6c0 6-3 12-8 12s-8-6-8-12v-6z"/>
+          <path d="M19 36v4M29 36v4"/>
+        </svg>
+      </div>
+      <div class="luxe-card__category">Continental &middot; 1888&ndash;1940s</div>
+      <h3 class="luxe-card__title">.800 European Silver</h3>
+      <div class="luxe-card__meta">
+        <span class="luxe-card__meta-item">Purity: <strong>80.0%</strong></span>
+        <span class="luxe-card__meta-item">Alloy: <strong>20% Cu</strong></span>
+      </div>
+      <p class="luxe-card__desc">Continental Europe's working standard for cutlery, tea services and decorative ware. <strong>German Halbmond &amp; Krone</strong> hallmark mandated from 1888. <strong>WMF</strong>, <strong>Wilkens</strong>, <strong>Bruckmann</strong> and Austrian pieces commonly carry the 800 mark.</p>
+      <div class="luxe-card__stat">
+        <span class="luxe-card__stat-val" id="lx-800" data-nosnippet>&mdash;</span>
+        <span class="luxe-card__stat-label">USD / gram melt</span>
+      </div>
+    </a>
+  </div>
+</section>
+
+<!-- ═════════════ EDITORIAL CONTENT ═════════════ -->
+<div class="content-section">
+  <article class="prose-pro">
+    <h2 id="what-is-silver-purity">What is silver purity?</h2>
+    <div class="snippet-answer">Silver purity is a <strong>millesimal fineness</strong> &mdash; the number of parts per thousand that are pure silver. A <strong>.999</strong> hallmark means 999 parts pure silver, with just 1 part copper or germanium added; <strong>.925 sterling</strong> means 925 parts silver and 75 parts copper. The four most widely traded grades are .999, .925, .900 and .800. Each scales proportionally with the live LBMA spot price &mdash; the same XAG/USD figure that anchors the bullion market.</div>
+
+    <h2 id="live-purity-prices">Live silver purity prices today</h2>
+    <p class="has-dropcap">Every figure on this page is derived in real time from the <strong>LBMA Silver Price</strong>, the global benchmark set by ICE Benchmark Administration at <strong>12:00 GMT daily</strong>. Between auctions, the live spot is driven by COMEX (New York) silver futures and significant volume on the Shanghai Futures Exchange. GoldPriceTools pulls live XAG/USD from <code style="font-family:var(--font-mono);background:var(--color-surface-offset);padding:2px 6px;border-radius:4px;font-size:90%">gold-api.com</code> every 60 seconds, and currency conversion to GBP, EUR and INR runs through the <strong>Frankfurter API</strong> (ECB reference rates). Identical math powers our <a href="/900-silver-price-per-gram">.900 coin silver</a>, <a href="/800-silver-price-per-gram">.800 European silver</a> and <a href="/silver-price-per-kilo">silver per kilo</a> pages &mdash; numbers stay consistent across the site.</p>
+
+    <h2 id="why-usd">Why USD is the primary currency</h2>
+    <p>Silver is quoted globally in <strong>US dollars per troy ounce</strong> on COMEX and via the LBMA London benchmark. USD is the world's reserve currency and the most liquid quote unit for precious metals. Every conversion on this page to GBP, EUR or INR is mathematically derived from the live USD spot &mdash; never the other way around. This matters for cross-page consistency: the .925 sterling figure here in GBP equals the same .925 figure on any of our purity calculators, down to the cent.</p>
+
+    <h2 id="hallmark-guide">Reading silver hallmarks &mdash; the four key marks</h2>
+    <p>In the UK, silver items must be hallmarked by one of the four Assay Offices (London, Birmingham, Sheffield, Edinburgh) before they can be sold as silver. Elsewhere, hallmarks are conventional but not always legally required. The fineness mark itself &mdash; the three-digit millesimal &mdash; is the universal element:</p>
+    <ul>
+      <li><strong>.999 / FINE / BRITANNIA 958</strong> &mdash; investment bullion. .999 is global; .958 Britannia is the higher-purity UK variant introduced in 1697 to reduce coin clipping. Both trade at near-spot.</li>
+      <li><strong>.925 / STERLING / lion passant</strong> &mdash; the jewellery and silverware standard. UK pieces carry a lion passant alongside the date letter and Assay Office mark; US sterling carries the word STERLING or 925.</li>
+      <li><strong>.900 (no hallmark on US coins)</strong> &mdash; identification is by year and denomination. Any pre-1965 US dime, quarter or half dollar is 90% silver. <a href="/900-silver-price-per-gram">See the .900 coin silver page</a> for date-by-date identification.</li>
+      <li><strong>.800 / Halbmond &amp; Krone</strong> &mdash; the Continental antique standard. German pieces from 1888 carry the crescent moon and crown alongside the 800 stamp. Italian, French, Austrian and Dutch antiques use the same fineness with country-specific assay marks.</li>
+    </ul>
+
+    <h2 id="purity-comparison">.999 vs .925 vs .900 vs .800 &mdash; the math</h2>
+    <p>The four grades sit on a continuous scale of silver content per gram. At a silver spot of <span id="example-spot" style="font-family:var(--font-mono);color:var(--color-silver);font-weight:600">$33.00/oz</span>, the per-gram melt values are:</p>
+    <blockquote><strong>.999 fine</strong>: $1.061 / g &middot; <strong>.925 sterling</strong>: $0.981 / g &middot; <strong>.900 coin</strong>: $0.955 / g &middot; <strong>.800 European</strong>: $0.849 / g</blockquote>
+    <p>Relative to .999 as the benchmark: sterling .925 = <strong>92.5%</strong>, coin .900 = <strong>90.0%</strong>, European .800 = <strong>80.1%</strong>. These ratios hold at every spot price &mdash; if .999 doubles, so does every other purity. The universal calculator at the top of this page applies these factors live.</p>
+
+    <div class="callout">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2L4 6v6c0 5 3.5 9.5 8 10 4.5-.5 8-5 8-10V6l-8-4z"/><path d="M9 12l2 2 4-4"/></svg>
+      <div>
+        <div class="callout__title">The 31.1035 rule</div>
+        <div class="callout__body">There are <strong>31.1035 grams</strong> in one troy ounce of silver &mdash; not the 28.3495 grams of an avoirdupois ounce. Silver, gold and platinum are all quoted per <strong>troy oz</strong>, which is heavier. To convert spot to per gram for any purity, divide the USD/oz figure by 31.1035 first, then multiply by purity. See our <a href="/how-many-grams-in-troy-ounce">troy ounce converter</a> for a deeper dive.</div>
+      </div>
+    </div>
+
+    <h2 id="999-fine">.999 Fine Silver &mdash; the investment standard</h2>
+    <p>At <strong>99.9% pure</strong>, .999 fine silver is the bullion-grade standard used by every major mint. The remaining 0.1% is typically copper or germanium added for hardness during minting. .999 trades at spot &mdash; a 1 oz American Silver Eagle from the US Mint is priced at <span id="ex-eagle" style="font-family:var(--font-mono);color:var(--color-silver);font-weight:600">[live spot]</span> plus a premium of 8&ndash;20% for minting, fabrication and dealer margin. LBMA Good Delivery wholesale bars (typically 1,000 troy oz) trade essentially at spot. Recognised .999 products include:</p>
+    <ul>
+      <li><strong>American Silver Eagle</strong> &mdash; 1 oz, .999 fine, minted since 1986. The bestselling silver bullion coin worldwide.</li>
+      <li><strong>British Britannia</strong> &mdash; 1 oz, .999 fine since 2013 (was .958 from 1997). UK Capital Gains Tax exempt for British residents.</li>
+      <li><strong>Canadian Silver Maple Leaf</strong> &mdash; 1 oz, .9999 fine (four nines). Often considered the purest minted silver coin available.</li>
+      <li><strong>PAMP / Heraeus / Argor-Heraeus 1 kg bars</strong> &mdash; LBMA Good Delivery refiner bars for wholesale and serious accumulation.</li>
+    </ul>
+
+    <h2 id="925-sterling">.925 Sterling Silver &mdash; jewellery &amp; flatware</h2>
+    <p>Sterling silver at <strong>92.5% pure</strong> is alloyed with 7.5% copper to dramatically improve hardness without compromising its bright white appearance. It is the global standard for silver jewellery, dinner flatware and decorative ware. The word "sterling" originates from "Easterling" silver coins traded in 12th-century England &mdash; the term was formalised in UK law in 1300. For valuation:</p>
+    <ul>
+      <li>Weigh the piece in grams, then multiply weight &times; 0.925 to find pure silver content.</li>
+      <li>Multiply pure silver grams by the live <strong>.999 USD/gram</strong> figure shown in the hero above.</li>
+      <li>Or: skip the intermediate step &mdash; use the universal calculator with .925 selected.</li>
+    </ul>
+    <p>Notable sterling makers include <strong>Tiffany &amp; Co.</strong>, <strong>Gorham</strong>, <strong>Mappin &amp; Webb</strong>, <strong>Garrard</strong>, <strong>Georg Jensen</strong>, <strong>Christofle</strong> and <strong>Buccellati</strong>. Pieces from these houses can carry a <strong>2&times;&ndash;10&times; premium</strong> over melt at auction.</p>
+
+    <h2 id="900-coin">.900 Coin Silver &mdash; US pre-1965 heritage</h2>
+    <p>The United States Mint used <strong>90% silver</strong> for all circulating coinage from 1792 through 1964. The remaining 10% is copper, giving coin silver the durability needed for daily handling. Identification is by year and denomination &mdash; US coins do not carry a fineness hallmark:</p>
+    <ul>
+      <li><strong>Dimes (1916&ndash;1964)</strong> &mdash; Mercury and Roosevelt designs, 2.5g total weight, 2.25g pure silver.</li>
+      <li><strong>Quarters (1932&ndash;1964)</strong> &mdash; Washington design, 6.25g total, 5.625g pure silver.</li>
+      <li><strong>Half Dollars (1916&ndash;1964)</strong> &mdash; Walking Liberty, Franklin and 1964 Kennedy, 12.5g total, 11.25g pure.</li>
+      <li><strong>Silver Dollars (1878&ndash;1935)</strong> &mdash; Morgan and Peace Dollars, 26.73g total, 24.057g (0.7734 oz) pure silver.</li>
+    </ul>
+    <p>Junk silver lots are traded at <strong>$1 face value = 0.715 troy oz</strong> of pure silver (accounting for circulation wear &mdash; the uncirculated figure is 0.7234 oz). For per-coin live valuation, see our <a href="/900-silver-price-per-gram">.900 coin silver per gram</a> page and the <a href="/silver-coins-calculator">silver coins calculator</a>.</p>
+
+    <h2 id="800-european">.800 European Silver &mdash; Continental antique</h2>
+    <p>From 1888 onwards, the German Empire mandated the <strong>Halbmond and Krone</strong> hallmark &mdash; a crescent moon and crown &mdash; alongside the 800 fineness number for silver items meeting the 80% purity standard. This became the de-facto Continental standard, adopted across Austria-Hungary, Italy, France (for second-quality), the Netherlands and Scandinavia.</p>
+    <p>Common .800 finds include German <strong>WMF</strong>, <strong>Wilkens</strong>, <strong>Bruckmann</strong> and <strong>Koch &amp; Bergfeld</strong> flatware sets; Italian Buccellati-school cutlery; Austrian tea services from the Wiener Werkstätte era; and Hungarian Pest-Buda hallmarked decorative ware. Per gram at <strong>80% silver</strong>, .800 sits at the bottom of the major trading grades but remains valuable both for melt and for antique premium when by sought-after makers.</p>
+
+    <div class="callout callout--patina">
+      <svg class="callout__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/><circle cx="12" cy="12" r="10"/></svg>
+      <div>
+        <div class="callout__title">Continental hallmark variations</div>
+        <div class="callout__body">Outside Germany, .800 silver carries country-specific marks: <strong>Italy</strong> &mdash; province number in a hexagonal cartouche (e.g. 1 AL for Alessandria); <strong>France</strong> &mdash; Minerva head (post-1838) for second-quality silver including some .800; <strong>Austria-Hungary</strong> &mdash; Diana head (Vienna) or Saint Stephen Crown (Hungary); <strong>Netherlands</strong> &mdash; sword (Lion's Head also used). Always weigh and verify against the 800 stamp.</div>
+      </div>
+    </div>
+
+    <h2 id="scrap-value">Calculating scrap silver value across purities</h2>
+    <p>For any silver lot, the universal scrap formula is:</p>
+    <blockquote><strong>Melt USD = weight (g) &times; (spot USD/oz &divide; 31.1035) &times; purity ratio</strong></blockquote>
+    <p>Worked examples at a $33.00/oz silver spot:</p>
+    <div class="market-table-wrap">
+      <table class="market-table" aria-label="Worked silver scrap examples">
+        <thead><tr><th>Lot</th><th>Math</th><th>Melt value</th></tr></thead>
+        <tbody>
+          <tr><td>50g sterling chain</td><td>50 &times; $1.061 &times; 0.925</td><td>$49.07</td></tr>
+          <tr><td>100g .800 German flatware</td><td>100 &times; $1.061 &times; 0.800</td><td>$84.88</td></tr>
+          <tr><td>1 troy oz Britannia (.999)</td><td>31.1035 &times; $1.061 &times; 0.999</td><td>$32.97</td></tr>
+          <tr><td>Morgan Dollar (.900, 26.73g)</td><td>26.73 &times; $1.061 &times; 0.900</td><td>$25.52</td></tr>
+          <tr><td>1 kg .925 sterling bar</td><td>1000 &times; $1.061 &times; 0.925</td><td>$981.43</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p>Dealer payouts typically sit at <strong>75&ndash;95% of melt</strong>, varying by lot size, market liquidity and dealer overheads. Antique or maker-marked pieces can fetch <strong>2&times;&ndash;10&times; melt</strong> at auction. See our <a href="/where-to-sell-gold-silver">where to sell gold &amp; silver</a> guide for vetted dealers.</p>
+
+    <h2 id="authenticity">Verifying silver authenticity</h2>
+    <p>Before selling at scrap value, confirm the piece is solid silver &mdash; not plated, not filled, not counterfeit. The three free tests every silver owner should know:</p>
+    <ol>
+      <li><strong>Magnet test</strong> &mdash; genuine silver is non-magnetic. If the piece sticks to a magnet, it is silver-plated over a steel or iron base.</li>
+      <li><strong>Hallmark inspection</strong> &mdash; use a 10&times; loupe to read the fineness stamp. Genuine hallmarks are crisply struck; counterfeits often appear soft or shallow.</li>
+      <li><strong>Edge test (coins)</strong> &mdash; for US coins, view the edge: solid silver shows a uniform white edge, while clad shows a distinct copper-coloured stripe sandwiched between two layers.</li>
+    </ol>
+    <p>For higher-value pieces, the gold standard is a <strong>silver acid test kit</strong> or professional XRF analysis at a refiner or assay office. Our <a href="/gold-silver-test-kit-reviews">silver test kit reviews</a> cover home-use kits compatible with all four purities on this page.</p>
+
+    <div class="disclaimer">
+      <strong>Disclaimer:</strong> Live silver prices on this page reflect <strong>spot melt values only</strong> &mdash; the raw silver content based on the LBMA XAG/USD spot. Actual buying or selling prices include dealer premiums, fabrication costs, refiner spreads and (for collectibles) numismatic or antique premium. Figures are indicative for reference and educational use, not financial advice. Currency conversions use ECB reference rates from the Frankfurter API and may differ slightly from your local retail FX.
+    </div>
+  </article>
+</div>
+
+<!-- ═════════════ FAQ ACCORDION ═════════════ -->
+<section class="content-section" id="faq" aria-labelledby="faq-title">
+  <div style="max-width:760px;margin:0 auto">
+    <div style="position:relative;padding-top:var(--space-3);margin-bottom:var(--space-5)">
+      <span style="position:absolute;top:0;left:0;width:48px;height:3px;background:var(--gradient-spectrum);border-radius:2px;display:block"></span>
+      <h2 id="faq-title" style="font-family:var(--font-display);font-size:clamp(1.5rem,1.1rem + 1.5vw,2rem);font-weight:700;color:var(--color-text);line-height:1.2;letter-spacing:-.015em">Frequently asked questions</h2>
+    </div>
+    <div class="faq-pro">
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary"><span>What are the four main silver purity grades?</span><span class="faq-pro__plus" aria-hidden="true"></span></summary>
+        <div class="faq-pro__body">The four most widely traded silver purity grades are <strong>.999 Fine Silver</strong> (99.9% pure &mdash; investment bullion standard), <strong>.925 Sterling Silver</strong> (92.5% pure &mdash; jewellery and flatware standard), <strong>.900 Coin Silver</strong> (90.0% pure &mdash; US pre-1965 circulating coinage) and <strong>.800 European Silver</strong> (80.0% pure &mdash; Continental antique flatware). Each is a millesimal fineness, with the balance alloyed with copper for hardness.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary"><span>How is the price of each silver purity calculated?</span><span class="faq-pro__plus" aria-hidden="true"></span></summary>
+        <div class="faq-pro__body">The price per gram for any silver purity is <strong>(LBMA spot USD per troy ounce &divide; 31.1035) &times; purity ratio</strong>. USD is the primary currency because silver is quoted globally in US dollars. At a $33.00/oz spot: .999 = $1.061/g, .925 = $0.981/g, .900 = $0.955/g, .800 = $0.849/g. GBP, EUR and INR conversions use live ECB reference rates from the Frankfurter API.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary"><span>How do I identify silver purity from a hallmark?</span><span class="faq-pro__plus" aria-hidden="true"></span></summary>
+        <div class="faq-pro__body">Look for a three-digit millesimal number stamped on the piece: <strong>999 or FINE</strong> for bullion; <strong>925 or STERLING</strong> for sterling, often with a UK lion passant; <strong>900</strong> has no hallmark on US coins &mdash; identify by year &le;1964; <strong>800</strong> is Continental European, frequently paired with the German Halbmond (crescent moon) and Krone (crown). Use a 10&times; loupe to verify the mark is crisply struck.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary"><span>Which silver purity is the best investment?</span><span class="faq-pro__plus" aria-hidden="true"></span></summary>
+        <div class="faq-pro__body"><strong>.999 fine silver</strong> is the global investment grade &mdash; used by every major mint for bullion bars and coins including the American Silver Eagle, Britannia, Canadian Maple Leaf and Vienna Philharmonic. Its price tracks the LBMA spot one-for-one, minus an 8&ndash;20% minting premium. .925, .900 and .800 are valued at proportional melt &mdash; useful for scrap and antique resale, but not bullion-grade. For pure exposure to silver as an asset, choose .999 in 1 oz coins or 1 kg bars.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary"><span>How do I calculate scrap silver value by purity?</span><span class="faq-pro__plus" aria-hidden="true"></span></summary>
+        <div class="faq-pro__body">Weigh the item in grams, multiply by the purity ratio (0.999, 0.925, 0.900 or 0.800), then multiply by the live USD-per-gram .999 price. Example: 100g of .925 sterling at a $1.061/g .999 price = 100 &times; 0.925 &times; $1.061 = <strong>$98.14 melt</strong>. Use the universal purity calculator at the top of this page &mdash; it handles any weight, any purity, any currency, live.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary"><span>Why is silver priced in USD globally?</span><span class="faq-pro__plus" aria-hidden="true"></span></summary>
+        <div class="faq-pro__body">Silver is quoted globally in <strong>US dollars per troy ounce</strong> on COMEX (New York) silver futures and via the LBMA Silver Price daily auction in London. USD is the world's reserve currency and the most liquid quote unit for precious metals. Every conversion on this page to GBP, EUR or INR is mathematically derived from the live USD spot using ECB reference rates from the Frankfurter API.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary"><span>What is the difference between .999 and .999 Britannia (.958) silver?</span><span class="faq-pro__plus" aria-hidden="true"></span></summary>
+        <div class="faq-pro__body"><strong>.958 Britannia silver</strong> is a UK historical standard introduced in 1697 to reduce coin clipping &mdash; 958 parts silver per thousand, slightly higher than sterling .925 but lower than modern .999. Britannia coins minted by The Royal Mint since 2013 are now .999 fine; older Britannia hallmarked silverware will be .958. For melt value, .958 is worth 95.8% of pure silver per gram, sitting between sterling and fine.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary"><span>How accurate are these live silver purity prices?</span><span class="faq-pro__plus" aria-hidden="true"></span></summary>
+        <div class="faq-pro__body">Spot prices come direct from the LBMA via <code style="font-family:var(--font-mono);background:var(--color-surface-offset);padding:2px 6px;border-radius:4px;font-size:90%">gold-api.com</code> and refresh every 60 seconds. Currency conversion from USD to GBP, EUR and INR uses the Frankfurter API's live ECB reference rates. Figures shown are <strong>melt values</strong> &mdash; the raw silver content. Dealer buy prices typically sit 5&ndash;20% below melt; antique or rare-date pieces can fetch 2&times;&ndash;10&times; melt for collector premiums.</div>
+      </details>
+      <details class="faq-pro__item">
+        <summary class="faq-pro__summary"><span>Is sterling silver (.925) magnetic?</span><span class="faq-pro__plus" aria-hidden="true"></span></summary>
+        <div class="faq-pro__body">No &mdash; genuine sterling silver, like all silver purities (.999, .925, .900, .800), is <strong>non-magnetic</strong>. Silver and copper (its main alloying metal) are both non-ferromagnetic. If your item is attracted to a magnet, it is silver-plated over a steel or iron base rather than solid sterling. This is the simplest authenticity test for any silver purity grade.</div>
+      </details>
+    </div>
+  </div>
+</section>
+
+<!-- ═════════════ RELATED PAGES ═════════════ -->
+<section class="related-guides" aria-labelledby="related-title">
+  <div class="section-head">
+    <div class="section-head__left">
+      <span class="section-eyebrow">Keep exploring</span>
+      <h2 class="section-title" id="related-title">Related silver tools &amp; guides</h2>
+      <p class="section-sub">Dive deeper into any of the four purities with live per-gram pricing, dedicated calculators and full editorial guides.</p>
+    </div>
+  </div>
+  <div class="related-guides-grid">
+    <a class="related-card" href="/silver-price-per-kilo">
+      <span class="related-card__tag">Bullion</span>
+      <h3 class="related-card__title">Silver Per Kilo</h3>
+      <p class="related-card__desc">Live .999 silver per kilo with currency switch and wholesale lot reference. The bullion benchmark page.</p>
+    </a>
+    <a class="related-card" href="/900-silver-price-per-gram">
+      <span class="related-card__tag">US Coin Silver</span>
+      <h3 class="related-card__title">.900 Coin Silver Per Gram</h3>
+      <p class="related-card__desc">Live .900 melt for Morgan Dollars, Walking Liberty Halves, Mercury Dimes and the full pre-1965 lineup.</p>
+    </a>
+    <a class="related-card" href="/800-silver-price-per-gram">
+      <span class="related-card__tag">European Antique</span>
+      <h3 class="related-card__title">.800 European Silver Per Gram</h3>
+      <p class="related-card__desc">Live .800 melt with German Halbmond hallmark guide, WMF and Wilkens maker references.</p>
+    </a>
+    <a class="related-card" href="/silver-coins-calculator">
+      <span class="related-card__tag">Calculator</span>
+      <h3 class="related-card__title">US Silver Coins Calculator</h3>
+      <p class="related-card__desc">Per-coin and per-bag melt values for every US 90% silver denomination including 40% Kennedy halves.</p>
+    </a>
+    <a class="related-card" href="/guides/what-is-925-sterling-silver">
+      <span class="related-card__tag">Guide</span>
+      <h3 class="related-card__title">What Is .925 Sterling Silver?</h3>
+      <p class="related-card__desc">Deep dive into sterling silver: history, hallmark identification, jewellery, flatware and care.</p>
+    </a>
+    <a class="related-card" href="/how-many-grams-in-troy-ounce">
+      <span class="related-card__tag">Conversion</span>
+      <h3 class="related-card__title">Grams in a Troy Ounce</h3>
+      <p class="related-card__desc">Why 31.1035g &mdash; the precious metals industry weight standard. Live USD spot converter.</p>
+    </a>
+    <a class="related-card" href="/us-silver-dollar-values">
+      <span class="related-card__tag">Numismatics</span>
+      <h3 class="related-card__title">US Silver Dollar Values</h3>
+      <p class="related-card__desc">Morgan and Peace Dollar melt values plus key-date premium guidance.</p>
+    </a>
+    <a class="related-card" href="/where-to-sell-gold-silver">
+      <span class="related-card__tag">Marketplace</span>
+      <h3 class="related-card__title">Where to Sell Silver</h3>
+      <p class="related-card__desc">Vetted UK and US dealers for sterling, coin silver and bullion. Payout ratios and trust signals.</p>
+    </a>
+  </div>
+</section>
+
+<!-- Sticky mobile price bar -->
+<div class="sticky-price" id="stickyPrice" aria-label="Quick silver price">
+  <div class="sticky-price__info">
+    <div class="sticky-price__label" id="sticky-label">.925 sterling &middot; USD / g</div>
+    <div class="sticky-price__value" id="sticky-usd" data-nosnippet>&mdash;</div>
+  </div>
+  <a href="#calculator" class="sticky-price__cta">Calculate &rarr;</a>
+</div>
+
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">
@@ -754,7 +1295,7 @@ blockquote strong{color:var(--color-text)}
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700">GoldPriceTools</span>
       </div>
-      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Prices sourced from global markets via LBMA, updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver price calculator. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver purity grades and per troy oz and kilo prices. Sourced from LBMA, updated every 60 seconds. USD primary.</p>
       <p style="font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3)">Prices are indicative and for reference only. Not financial advice.</p>
     </div>
     <div class="footer-col">
@@ -767,20 +1308,18 @@ blockquote strong{color:var(--color-text)}
         <li><a href="/22k-gold-price-per-gram">22K Gold Per Gram</a></li>
         <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        <li></li>
       </ul>
     </div>
     <div class="footer-col">
-      <h4>Calculators</h4>
+      <h4>Silver</h4>
       <ul>
-        <li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li>
-        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
-        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/silver-purity-grades">Silver Purity Grades</a></li>
         <li><a href="/silver-price-per-kilo">Silver Per Kilo</a></li>
         <li><a href="/900-silver-price-per-gram">.900 Coin Silver</a></li>
         <li><a href="/800-silver-price-per-gram">.800 European Silver</a></li>
-        <li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li>
-        <li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li>
+        <li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li>
+        <li><a href="/us-silver-dollar-values">US Silver Dollar Values</a></li>
+        <li><a href="/guides/what-is-925-sterling-silver">925 Sterling Guide</a></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -792,19 +1331,7 @@ blockquote strong{color:var(--color-text)}
         <li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li>
         <li><a href="/guides/how-to-test-if-gold-is-real">Test if Gold Is Real</a></li>
         <li><a href="/guides/gold-hallmarks-explained">Gold Hallmarks Explained</a></li>
-        <li><a href="/guides/gold-price-history">Gold Price History</a></li>
         <li><a href="/guides/">All Guides</a></li>
-      </ul>
-    </div>
-    <div class="footer-col">
-      <h4>Blog</h4>
-      <ul>
-        <li><a href="/blog/gold-vs-bitcoin-2026">Gold vs Bitcoin 2026</a></li>
-        <li><a href="/blog/best-uk-gold-dealers-2026">Best UK Gold Dealers</a></li>
-        <li><a href="/blog/uk-gold-cgt-guide">Gold CGT UK Guide</a></li>
-        <li><a href="/blog/is-gold-overpriced-2026">Is Gold Overpriced?</a></li>
-        <li><a href="/blog/gold-etf-vs-physical-gold-uk">ETFs vs Physical Gold</a></li>
-        <li><a href="/blog/">All Articles</a></li>
       </ul>
     </div>
     <div class="footer-col">
@@ -820,86 +1347,302 @@ blockquote strong{color:var(--color-text)}
   </div>
   <div class="footer-bottom">
     <span>&copy; 2026 GoldPriceTools &mdash; goldpricetools.com</span>
-    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com.</span>
+    <span>Spot data refreshes every 60 seconds. Prices sourced from LBMA via gold-api.com. USD primary.</span>
   </div>
 </footer>
+
 <script>
-async function fetchFx(){
-  try{
-    const r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});
-    if(!r.ok)throw new Error();
-    const d=await r.json();
-    window._fx={GBP:d.GBPUSD||0.79,EUR:d.EURUSD||0.92};
-  }catch{window._fx={GBP:0.79,EUR:0.92};}
-}
+/* ───────── Live silver purity grades engine — USD primary, four purities, multi-currency ─────────
+   Sources:
+     • Silver spot: https://api.gold-api.com/price/XAG  (LBMA-derived USD/oz)
+     • FX rates:    https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR
+   Refresh: 60s — DO NOT change interval (keeps cross-page consistency)
+   Purities: .999, .925, .900, .800 — universal hub
+*/
+(function(){
+  const G_PER_OZ = 31.1035;
+  const REFRESH_MS = 60000;
+  const PURITIES = {'999':0.999, '925':0.925, '900':0.900, '800':0.800};
+  const PURITY_NAMES = {'0.999':'.999 Fine','0.925':'.925 Sterling','0.900':'.900 Coin','0.800':'.800 European'};
+  let lastFetchTs = 0;
+  let countdownTimer = null;
+  let currentMatrixCurrency = 'USD';
 
-function fmtVal(usdVal,cur){
-  const fx=window._fx||{GBP:0.79,EUR:0.92};
-  if(cur==='GBP') return '£'+(usdVal*fx.GBP).toFixed(2);
-  if(cur==='EUR') return '€'+(usdVal*fx.EUR).toFixed(2);
-  return '$'+usdVal.toFixed(2);
-}
+  // Currency formatters — USD is primary
+  const fmtUSD = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:4,minimumFractionDigits:2});
+  const fmtGBP = new Intl.NumberFormat('en-GB',{style:'currency',currency:'GBP',maximumFractionDigits:4,minimumFractionDigits:2});
+  const fmtEUR = new Intl.NumberFormat('en-IE',{style:'currency',currency:'EUR',maximumFractionDigits:4,minimumFractionDigits:2});
+  const fmtINR = new Intl.NumberFormat('en-IN',{style:'currency',currency:'INR',maximumFractionDigits:2});
+  const fmtSpot = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',maximumFractionDigits:2});
 
-function updateAll(ozUSD){
-  const cur=document.getElementById('pgCurrency')?.value||'GBP';
-  const TROY=31.1035;
-  const purities=[{p:0.999,id:'999'},{p:0.925,id:'925'},{p:0.900,id:'900'},{p:0.800,id:'800'}];
+  function $(id){return document.getElementById(id);}
 
-  const spotEl=document.getElementById('spot-oz-display');
-  if(spotEl) spotEl.textContent=fmtVal(ozUSD,'USD')+' · '+fmtVal(ozUSD,'GBP');
-  const lu=document.getElementById('last-updated');
-  if(lu) lu.textContent=new Date().toLocaleTimeString('en-GB',{hour:'2-digit',minute:'2-digit',second:'2-digit'})+' BST';
+  function fmt(cur){
+    if(cur==='GBP') return fmtGBP;
+    if(cur==='EUR') return fmtEUR;
+    if(cur==='INR') return fmtINR;
+    return fmtUSD;
+  }
 
-  purities.forEach(function(item){
-    var p=item.p,id=item.id;
-    var gUSD=(ozUSD/TROY)*p;
-    var ozVal=ozUSD*p;
-    var kgUSD=gUSD*1000;
-    var h100=gUSD*100;
+  function fxRate(cur){
+    if(cur==='GBP') return window._gbpusd || 0.79;
+    if(cur==='EUR') return window._eurusd || 0.92;
+    if(cur==='INR') return window._inrusd || 83.0;
+    return 1;
+  }
 
-    var cg=document.getElementById('c'+id+'-gram');
-    var co=document.getElementById('c'+id+'-oz');
-    var ck=document.getElementById('c'+id+'-kg');
-    if(cg) cg.textContent=fmtVal(gUSD,cur);
-    if(co) co.textContent=fmtVal(ozVal,cur);
-    if(ck) ck.textContent=fmtVal(kgUSD,cur);
+  async function fetchFx(){
+    try{
+      const r = await fetch('https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR',{cache:'no-store'});
+      if(!r.ok) throw new Error('FX fetch failed');
+      const d = await r.json();
+      window._gbpusd = d.rates.GBP || 0.79;
+      window._eurusd = d.rates.EUR || 0.92;
+      window._inrusd = d.rates.INR || 83.0;
+    }catch(e){
+      console.warn('FX fallback used',e);
+      window._gbpusd = window._gbpusd || 0.79;
+      window._eurusd = window._eurusd || 0.92;
+      window._inrusd = window._inrusd || 83.0;
+    }
+  }
 
-    var tg=document.getElementById('tbl-'+id+'g');
-    var to_el=document.getElementById('tbl-'+id+'oz');
-    var tk=document.getElementById('tbl-'+id+'kg');
-    var t100=document.getElementById('tbl-'+id+'-100g');
-    if(tg)   tg.textContent  =fmtVal(gUSD,cur);
-    if(to_el) to_el.textContent=fmtVal(ozVal,cur);
-    if(tk)   tk.textContent  =fmtVal(kgUSD,cur);
-    if(t100) t100.textContent=fmtVal(h100,cur);
+  async function fetchSpot(){
+    try{
+      const r = await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});
+      if(!r.ok) throw new Error('Spot fetch failed');
+      const d = await r.json();
+      const spotUSD = d.price;
+      window._spotUSD = spotUSD;
+      lastFetchTs = Date.now();
+      render(spotUSD);
+      try{gtag('event','price_view',{metal:'silver',unit:'purity-grades'});}catch(_){}
+    }catch(e){
+      console.warn('Silver spot fetch failed',e);
+    }
+  }
 
-    var sg=document.getElementById('sb-'+id+'g');
-    var so=document.getElementById('sb-'+id+'oz');
-    var sk=document.getElementById('sb-'+id+'kg');
-    if(sg) sg.textContent=fmtVal(gUSD,cur);
-    if(so) so.textContent=fmtVal(ozVal,cur);
-    if(sk) sk.textContent=fmtVal(kgUSD,cur);
+  function render(spotUSD){
+    const pureG_USD = spotUSD / G_PER_OZ;       // .999 fine USD/g baseline
+
+    // Hero spot ribbon (USD primary)
+    if($('hero-spot-oz')) $('hero-spot-oz').textContent = fmtSpot.format(spotUSD) + ' / oz';
+    if($('hero-spot-g'))  $('hero-spot-g').textContent  = fmtUSD.format(pureG_USD);
+    if($('hero-spot-kg')) $('hero-spot-kg').textContent = fmtUSD.format(pureG_USD * 1000);
+    if($('spot-usd'))     $('spot-usd').textContent     = fmtSpot.format(spotUSD) + ' /oz';
+
+    // Four grade tiles + hallmark anchors + luxe stats — USD per gram
+    Object.keys(PURITIES).forEach(k => {
+      const v = pureG_USD * PURITIES[k];
+      const t = $('tile-'+k);   if(t) t.textContent = fmtUSD.format(v);
+      const h = $('hm-'+k);     if(h) h.textContent = fmtUSD.format(v);
+      const lx = $('lx-'+k);    if(lx) lx.textContent = fmtUSD.format(v);
+    });
+
+    // Live matrix table — purity × weight, currency-aware
+    renderMatrix(spotUSD);
+
+    // Universal calculator
+    updateCalculator();
+
+    // Sticky mobile bar — track selected purity in calc
+    updateStickyBar(spotUSD);
+
+    // Timestamp / countdown
+    updateTimestamp();
+    startCountdown();
+  }
+
+  function renderMatrix(spotUSD){
+    const pureG_USD = spotUSD / G_PER_OZ;
+    const cur = currentMatrixCurrency;
+    const rate = fxRate(cur);
+    const F = fmt(cur);
+    Object.keys(PURITIES).forEach(k => {
+      const pUSDg = pureG_USD * PURITIES[k];
+      const g = pUSDg * rate;
+      const oz = g * G_PER_OZ;
+      const h100 = g * 100;
+      const kg = g * 1000;
+      const eg  = $('m-'+k+'-g');    if(eg)  eg.textContent  = F.format(g);
+      const eoz = $('m-'+k+'-oz');   if(eoz) eoz.textContent = F.format(oz);
+      const e100= $('m-'+k+'-100g'); if(e100) e100.textContent = F.format(h100);
+      const ekg = $('m-'+k+'-kg');   if(ekg) ekg.textContent = F.format(kg);
+    });
+  }
+
+  function updateStickyBar(spotUSD){
+    const purity = parseFloat($('calc-purity')?.value || 0.925);
+    const purityKey = String(purity).replace('0.','').padEnd(3,'0');
+    const pureG_USD = spotUSD / G_PER_OZ;
+    const v = pureG_USD * purity;
+    if($('sticky-usd')) $('sticky-usd').textContent = fmtUSD.format(v);
+    if($('sticky-label')){
+      const name = PURITY_NAMES[purity.toFixed(3)] || (purityKey + ' silver');
+      $('sticky-label').textContent = name + ' · USD / g';
+    }
+  }
+
+  function updateTimestamp(){
+    const el = $('updated-time');
+    if(!el) return;
+    el.textContent = 'just now';
+  }
+
+  function startCountdown(){
+    if(countdownTimer) clearInterval(countdownTimer);
+    const counterEl = $('refresh-counter');
+    const updatedEl = $('updated-time');
+    countdownTimer = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - lastFetchTs) / 1000);
+      const remaining = Math.max(0, 60 - elapsed);
+      if(counterEl) counterEl.textContent = remaining + 's';
+      if(updatedEl){
+        if(elapsed < 10) updatedEl.textContent = 'just now';
+        else if(elapsed < 60) updatedEl.textContent = elapsed + 's ago';
+        else updatedEl.textContent = Math.floor(elapsed/60) + 'm ago';
+      }
+    }, 1000);
+  }
+
+  // ───────── Universal calculator ─────────
+  function updateCalculator(){
+    const spotUSD = window._spotUSD;
+    if(!spotUSD) return;
+    const weightEl = $('calc-weight');
+    const unitEl = $('calc-unit');
+    const currencyEl = $('calc-currency');
+    const purityEl = $('calc-purity');
+    if(!weightEl || !unitEl || !currencyEl || !purityEl) return;
+    const rawWeight = parseFloat(weightEl.value) || 0;
+    const unitMult = parseFloat(unitEl.value) || 1;
+    const grams = rawWeight * unitMult;
+    const purity = parseFloat(purityEl.value) || 0.925;
+    const currency = currencyEl.value;
+    const F = fmt(currency);
+    const rate = fxRate(currency);
+
+    const pureG_USD = spotUSD / G_PER_OZ;
+    const meltUSD = pureG_USD * grams * purity;
+    const melt = meltUSD * rate;
+    const dealer = melt * 0.85;
+    const pureSilverG = grams * purity;
+    const perOz = (pureG_USD * G_PER_OZ * purity) * rate;
+    const perKg = (pureG_USD * 1000 * purity) * rate;
+
+    if($('calc-melt')) $('calc-melt').textContent = F.format(melt);
+    if($('calc-dealer')) $('calc-dealer').textContent = F.format(dealer);
+    if($('calc-pure')) $('calc-pure').textContent = pureSilverG.toFixed(2) + ' g pure Ag';
+    if($('calc-per-oz')) $('calc-per-oz').textContent = F.format(perOz);
+    if($('calc-per-kg')) $('calc-per-kg').textContent = F.format(perKg);
+
+    // Update label
+    const purityKey = purity.toFixed(3);
+    if($('calc-purity-label')){
+      $('calc-purity-label').textContent = PURITY_NAMES[purityKey] || purityKey;
+    }
+
+    // Update sticky bar to mirror calculator purity
+    updateStickyBar(spotUSD);
+  }
+
+  function bindCalculator(){
+    ['calc-weight','calc-unit','calc-currency'].forEach(id=>{
+      const el = $(id);
+      if(el){
+        el.addEventListener('input', updateCalculator);
+        el.addEventListener('change', updateCalculator);
+      }
+    });
+    // Weight preset chips
+    document.querySelectorAll('.calc-pro__chips .calc-chip').forEach(chip => {
+      chip.addEventListener('click', () => {
+        const w = chip.getAttribute('data-weight');
+        const u = chip.getAttribute('data-unit');
+        const weightEl = $('calc-weight');
+        const unitEl = $('calc-unit');
+        if(weightEl){
+          weightEl.value = w;
+          if(u && unitEl) unitEl.value = u;
+          updateCalculator();
+        }
+        document.querySelectorAll('.calc-pro__chips .calc-chip').forEach(c => c.classList.remove('active'));
+        chip.classList.add('active');
+        try{gtag('event','calc_chip_click',{metal:'silver',weight:w});}catch(_){}
+      });
+    });
+    // Purity segmented control
+    document.querySelectorAll('.purity-seg__btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const p = btn.getAttribute('data-purity');
+        document.querySelectorAll('.purity-seg__btn').forEach(b => {
+          b.classList.toggle('active', b === btn);
+          b.setAttribute('aria-selected', b === btn ? 'true' : 'false');
+        });
+        const purityEl = $('calc-purity');
+        if(purityEl){
+          purityEl.value = p;
+          updateCalculator();
+        }
+        try{gtag('event','purity_seg_click',{purity:p});}catch(_){}
+      });
+    });
+  }
+
+  // Currency switch for matrix table
+  function bindCurrencySwitch(){
+    const btns = document.querySelectorAll('.currency-switch__btn');
+    btns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const cur = btn.getAttribute('data-currency');
+        btns.forEach(b => {
+          b.classList.toggle('active', b === btn);
+          b.setAttribute('aria-selected', b === btn ? 'true' : 'false');
+        });
+        currentMatrixCurrency = cur;
+        if(window._spotUSD) renderMatrix(window._spotUSD);
+      });
+    });
+  }
+
+  // Sticky mobile bar — show after scroll past hero
+  function bindStickyBar(){
+    const bar = $('stickyPrice');
+    if(!bar) return;
+    let visible = false;
+    window.addEventListener('scroll', () => {
+      const show = window.scrollY > 400;
+      if(show !== visible){
+        bar.classList.toggle('visible', show);
+        visible = show;
+      }
+    }, {passive: true});
+  }
+
+  // Init
+  document.addEventListener('DOMContentLoaded', () => {
+    bindCalculator();
+    bindCurrencySwitch();
+    bindStickyBar();
   });
-}
 
-async function fetchSpot(){
-  try{
-    const r=await fetch('https://api.gold-api.com/price/XAG',{cache:'no-store'});
-    if(!r.ok) throw new Error();
-    const d=await r.json();
-    window._silverOz=d.price;
-    updateAll(d.price);
-    gtag('event','price_view',{metal:'silver',unit:'purity-grades'});
-  }catch(e){console.warn('Silver price fetch failed',e);}
-}
-
-document.getElementById('pgCurrency')?.addEventListener('change',function(){
-  if(window._silverOz) updateAll(window._silverOz);
-});
-
-Promise.all([fetchFx(),fetchSpot()]);
-setInterval(fetchSpot,60000);
+  // Boot
+  Promise.all([fetchFx(), fetchSpot()]).catch(e => console.warn('init',e));
+  setInterval(fetchSpot, REFRESH_MS);
+})();
 </script>
+
+<script>(function(){
+  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
+  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+  root.setAttribute('data-theme',theme);
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);try{localStorage.setItem('gpt-theme',theme);}catch(e){}themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
+  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
+  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
+  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
+  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
+})();</script>
 
 <script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>
@@ -908,7 +1651,7 @@ window.addEventListener('scroll',function(){
   if(_deepReadFired)return;
   var st=window.scrollY||document.documentElement.scrollTop;
   var sh=document.documentElement.scrollHeight-document.documentElement.clientHeight;
-  if(sh>0&&(st/sh)>0.75){gtag('event','guide_deep_read');_deepReadFired=true;}
+  if(sh>0&&(st/sh)>0.75){try{gtag('event','guide_deep_read');}catch(_){}_deepReadFired=true;}
 },{passive:true});
 </script>
 </body>


### PR DESCRIPTION
## Summary

Rebuilds `silver-purity-grades.html` as a **mobile-first, museum-grade hub** for the four silver fineness standards — `.999 Fine`, `.925 Sterling`, `.900 Coin`, `.800 European` — using the same premium editorial design language as the `900-silver`, `800-silver` and `silver-price-per-kilo` pages.

USD is now the **primary currency** site-wide. GBP, EUR and INR are derived from live ECB reference rates (Frankfurter API). The same `gold-api.com` XAG/USD spot powers every silver page on a strict **60-second refresh**, so per-gram numbers stay consistent cross-page.

## Highlights

- **Premium hero** with XAG/USD live spot ribbon and 4 grade tiles, each linking to its dedicated page
- **Universal multi-purity calculator** — segmented `.999 / .925 / .900 / .800` control + weight/unit/currency selectors + 8 smart presets + 4-metric result panel (melt, dealer payout, pure Ag content, per-oz/per-kg equivalents)
- **Live matrix price table** with purity × weight grid and USD/GBP/EUR/INR currency switch
- **Hallmark identification grid** — 4 stylised mark cards (999, 925, 90%, 800) with country-specific guidance (UK lion passant, German Halbmond & Krone, etc.) and live USD/g anchor
- **Heritage luxe cards** — one per grade, with maker references (Tiffany, WMF, Wilkens, Christofle, Mappin & Webb, Britannia, Eagle, Maple Leaf, Morgan/Peace Dollars)
- **Universal formula block** explaining the single `(spot/31.1035) × purity` engine
- **Editorial prose** with .958 Britannia explanation, scrap math worked examples, Continental hallmark variations, 3 authenticity tests
- **9-item FAQ pro accordion**
- **Full structured data**: BreadcrumbList + FAQPage + Dataset + WebPage JSON-LD (validated ✓)
- **Sticky mobile price bar** that mirrors the calculator's selected purity

## Design system

- Tokens: silver / sterling-steel / copper (`.900`) / patina (`.800`) accent palette with OKLCH gradients
- Typography: IBM Plex Sans (display) + Playfair Display (editorial) + IBM Plex Mono (data)
- Mobile-first: clean 360px → 1440px+ scaling, 44px touch targets, WCAG-AA contrast in both themes
- Honors `prefers-reduced-motion`, ships proper aria-live regions on the live status bar

## Data integrity

- Same `G_PER_OZ = 31.1035` constant and same purity ratios used on `900-silver-price-per-gram.html` and `800-silver-price-per-gram.html` — verified cross-page consistency in Python against the published math
- 60s refresh + 60s countdown timer + graceful FX fallback if Frankfurter is unreachable
- JSON-LD validator: ✅ 4 blocks valid

## Test plan

- [ ] Verify hero tiles populate live USD values for all four purities on first paint
- [ ] Click each purity segmented button in calculator — confirm result label + math updates
- [ ] Click each currency switch (USD/GBP/EUR/INR) — confirm matrix table re-renders
- [ ] Compare `.900` USD/g on this page vs `/900-silver-price-per-gram` — values must match
- [ ] Compare `.800` USD/g on this page vs `/800-silver-price-per-gram` — values must match
- [ ] Compare `.999` USD/kg on this page vs `/silver-price-per-kilo` — must match
- [ ] iPhone 14 Pro: confirm sticky price bar appears below 400px scroll and reflects current calculator purity
- [ ] Desktop 1440px: full strip review of hero, calc, matrix, hallmarks, heritage, prose, FAQ
- [ ] `prefers-color-scheme: light` rendering check
- [ ] Run project's `tools/playwright_audit.py https://goldpricetools.com/silver-purity-grades` after deploy

https://claude.ai/code/session_018CKCRUqyerxNhz1eoFFdwK

---
_Generated by [Claude Code](https://claude.ai/code/session_018CKCRUqyerxNhz1eoFFdwK)_