### PR TITLE
Redesign US Silver Dollar Values: live engine, dollar-focused UI, mobile-first

### DIFF
--- a/us-silver-dollar-values.html
+++ b/us-silver-dollar-values.html
@@ -7,9 +7,9 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>US Silver Dollar Values & Coin Calculator | GoldPriceTools</title>
+<title>US Silver Dollar Values — Live Melt Value Calculator | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Calculate the live melt value of US silver dollars. Free calculator for Morgan, Peace, Eisenhower, and half dollars using real-time silver spot prices.">
+<meta name="description" content="Find the live melt value of US silver dollars — Morgan, Peace, Trade, Eisenhower & American Silver Eagle — in USD. Free calculator with real-time silver spot prices, updated every 60 seconds.">
 <meta name="robots" content="index, follow">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/us-silver-dollar-values">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/us-silver-dollar-values">
@@ -20,14 +20,14 @@
 
 <!-- SoftwareApplication JSON-LD -->
 <script type="application/ld+json">
-{"@context": "https://schema.org", "@type": "SoftwareApplication", "name": "GoldPriceTools US Silver Dollar Calculator", "url": "https://goldpricetools.com/us-silver-dollar-values", "description": "Free calculator to determine the melt value of US silver dollars and half dollars using real-time silver spot prices.", "applicationCategory": "FinanceApplication", "operatingSystem": "Web Browser", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}
+{"@context": "https://schema.org", "@type": "SoftwareApplication", "name": "GoldPriceTools US Silver Dollar Value Calculator", "url": "https://goldpricetools.com/us-silver-dollar-values", "description": "Free calculator to determine the live melt value of US silver dollars (Morgan, Peace, Trade, Eisenhower) and half dollars using real-time silver spot prices in USD.", "applicationCategory": "FinanceApplication", "operatingSystem": "Web Browser", "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"}}
 </script>
 
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": "US Silver Dollar Values & Prices Calculator",
+  "name": "US Silver Dollar Values & Melt Value Calculator",
   "url": "https://goldpricetools.com/us-silver-dollar-values",
   "speakable": {
     "@type": "SpeakableSpecification",
@@ -36,10 +36,12 @@
 }
 </script>
 
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What are US silver coins worth?","acceptedAnswer":{"@type":"Answer","text":"The worth of US silver coins depends on their silver content and the current spot price. For example, a pre-1965 90% silver quarter contains 0.18084 troy ounces of silver. You can use our calculator to find the exact live melt value based on today's silver price."}},{"@type":"Question","name":"How much silver is in a silver dollar?","acceptedAnswer":{"@type":"Answer","text":"Morgan and Peace silver dollars minted before 1936 are 90% silver and contain 0.77344 troy ounces of pure silver. Eisenhower silver dollars (1971-1973) are 40% silver and contain 0.3161 troy ounces."}},{"@type":"Question","name":"Which quarters are silver?","acceptedAnswer":{"@type":"Answer","text":"US Washington and Standing Liberty quarters minted in 1964 or earlier are 90% silver. They contain 0.18084 troy ounces of silver and their melt value fluctuates with the live spot price."}},{"@type":"Question","name":"What is junk silver?","acceptedAnswer":{"@type":"Answer","text":"Junk silver refers to old US silver coins that hold no numismatic (collector) value above their bullion content. People invest in them purely for their silver melt value. Common examples are pre-1965 dimes, quarters, and half dollars."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Dataset","name":"Live US Silver Dollar Melt Values & Silver Spot Price","description":"Live melt values for US silver dollars (Morgan, Peace, Trade, Seated Liberty and 40% Eisenhower), 90% and 40% silver half dollars and the American Silver Eagle, derived from the silver spot price in USD (primary), with GBP and EUR conversions. Spot sourced from the LBMA market via gold-api.com and refreshed every 60 seconds.","url":"https://goldpricetools.com/us-silver-dollar-values","keywords":["us silver dollar values","morgan dollar value","peace dollar value","silver dollar melt value","XAG/USD","silver spot price","american silver eagle"],"license":"https://goldpricetools.com/terms","isAccessibleForFree":true,"creator":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com"},"distribution":[{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-1Y.json"},{"@type":"DataDownload","encodingFormat":"JSON","contentUrl":"https://goldpricetools.com/chart-data/XAG-10Y.json"}],"variableMeasured":"Silver spot price per troy ounce (XAG/USD) and derived US silver dollar melt values"}</script>
 
-<meta property="og:title" content="US Silver Dollar Values & Coin Calculator | GoldPriceTools">>
-<meta property="og:description" content="Calculate the live melt value of US silver dollars including Morgan, Peace, and Eisenhower dollars. Updated with real-time silver prices.">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How much is a US silver dollar worth today?","acceptedAnswer":{"@type":"Answer","text":"A Morgan or Peace silver dollar contains 0.77344 troy ounces of pure silver, so its melt value tracks the live silver spot price in USD. Use the calculator above for the exact figure. Collector (numismatic) value can run far higher for key dates, mint marks and high grades."}},{"@type":"Question","name":"How much silver is in a silver dollar?","acceptedAnswer":{"@type":"Answer","text":"Morgan, Peace and Seated Liberty silver dollars contain 0.77344 troy ounces of pure silver (90% silver). The 1873-1885 Trade Dollar contains slightly more at 0.78750 troy ounces, and 40% silver Eisenhower dollars (1971-1976 collector issues) contain 0.31610 troy ounces."}},{"@type":"Question","name":"Which US silver dollars are 90% silver?","acceptedAnswer":{"@type":"Answer","text":"US silver dollars minted from 1794 through 1935 — Flowing Hair, Draped Bust, Seated Liberty, Trade, Morgan and Peace dollars — are roughly 89-90% silver. Eisenhower dollars struck for circulation are copper-nickel; only the 1971-1976 collector issues are 40% silver."}},{"@type":"Question","name":"Are US silver dollars a good investment?","acceptedAnswer":{"@type":"Answer","text":"Common-date Morgan and Peace dollars are a popular, recognisable way to own physical silver and trade close to their melt value. Rare dates, mint marks and high grades carry numismatic premiums. Always weigh dealer premiums against the live melt value before buying or selling."}},{"@type":"Question","name":"Should I clean my silver dollars?","acceptedAnswer":{"@type":"Answer","text":"No. Cleaning strips a coin's natural patina and leaves microscopic scratches that can sharply reduce its numismatic value. Leave any conservation to a professional coin grading service."}}]}</script>
+
+<meta property="og:title" content="US Silver Dollar Values — Live Melt Value Calculator">
+<meta property="og:description" content="Find the live melt value of US silver dollars — Morgan, Peace, Trade, Eisenhower & American Silver Eagle — in USD with real-time silver spot prices.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://goldpricetools.com/us-silver-dollar-values">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
@@ -136,7 +138,7 @@ nav{position:sticky;top:0;z-index:100;background:var(--color-surface);border-bot
 .ad-slot-sidebar ins{display:block;width:100%}
 
 /* HERO */
-.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:center}
+.hero{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr 1fr;gap:var(--space-8);align-items:start}
 @media(max-width:768px){.hero{grid-template-columns:1fr;padding:var(--space-8) var(--space-4) var(--space-4)}}
 .hero-badge{display:inline-flex;align-items:center;gap:var(--space-2);background:color-mix(in oklch,var(--color-gold) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-gold-bright);margin-bottom:var(--space-4);letter-spacing:.05em;text-transform:uppercase}
 .hero h1{font-family:var(--font-display);font-size:var(--text-2xl);color:var(--color-text);margin-bottom:var(--space-4);line-height:1.15}
@@ -400,64 +402,186 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .faq-answer-summary::after{content:"－"}
 .faq-answer{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-4);border-top:1px solid var(--color-divider)}
 
-/* ═══════════════════════════════════════════════════
-   US SILVER DOLLAR VALUES — full layout & component fix
-   ═══════════════════════════════════════════════════ */
+/* ── Hero left column ── */
+.hero-left{display:flex;flex-direction:column;justify-content:flex-start;gap:var(--space-3)}
+.hero-left .hero-title{margin-bottom:0}
+.hero-left .hero-tag{margin-bottom:var(--space-2)}
+@media(max-width:768px){.hero-left{margin-bottom:var(--space-4)}}
 
-/* 1 — Hero: single column */
-.hero{grid-template-columns:1fr!important;max-width:860px!important;padding:var(--space-8) var(--space-4) var(--space-6)}
-.hero-title{font-size:clamp(1.75rem,3.5vw,2.75rem)!important;line-height:1.15!important}
+/* ── Data Table ── */
+.data-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
+.data-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-4) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
+.data-table td{padding:var(--space-3) var(--space-4) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
+.data-table td:first-child{color:var(--color-text);font-weight:500}
+.data-table td:not(:first-child){text-align:right;padding-right:0}
+.data-table th:not(:first-child){text-align:right;padding-right:0}
+.data-table tr:last-child td{border-bottom:none}
+.data-table tr:hover td{background:var(--color-surface)}
+.data-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border-radius:var(--radius-md)}
 
-/* 2 — Prose width fix (override 100% override) */
+/* ── Trust bar ── */
+.trust-bar{font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset,var(--color-surface));border-radius:var(--radius-md);border-left:3px solid var(--color-gold)}
+.trust-bar a{color:var(--color-primary);text-decoration:none}
+.trust-bar a:hover{text-decoration:underline}
+
+/* Prose width */
 .prose{max-width:860px!important}
 
-/* 3 — Trust bar */
-.trust-bar{font-size:var(--text-sm);color:var(--color-text-faint);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-gold);margin-bottom:var(--space-5)}
-.trust-bar a{color:var(--color-primary);text-decoration:underline}
+/* ── Share buttons ── */
+.share-buttons{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin:var(--space-8) 0 var(--space-6);padding-top:var(--space-6);border-top:1px solid var(--color-border)}
+.share-buttons span{font-size:var(--text-sm);font-weight:600;color:var(--color-text-faint);margin-right:var(--space-1)}
+.share-buttons a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-full,9999px);font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;transition:border-color .15s,color .15s,background .15s;background:var(--color-surface)}
+.share-buttons a:hover{border-color:var(--color-primary);color:var(--color-primary);background:var(--color-surface-offset)}
+.share-buttons a svg{flex-shrink:0}
 
-/* 4 — Calc card (hero right → now below H1) */
-.calc-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);display:flex;flex-direction:column;gap:var(--space-4);margin-top:var(--space-4)}
-.calc-spot-info{font-size:var(--text-sm);color:var(--color-text-muted);background:var(--color-surface-offset);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4)}
-.calc-spot-info strong{color:var(--color-gold-bright);font-size:var(--text-base);font-weight:700}
+/* ── Related guides grid ── */
+.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin-top:var(--space-6)}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface-offset,var(--color-surface));border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);text-decoration:none;transition:border-color .15s,box-shadow .15s;min-height:140px;color:var(--color-text)}
+.related-card:hover{border-color:var(--color-primary);box-shadow:var(--shadow-sm)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin:var(--space-1) 0}
+.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
 
-/* 5 — Coin rows */
-#coin-list{display:flex;flex-direction:column;gap:0}
-.coin-row{display:grid;grid-template-columns:1fr auto;align-items:center;gap:var(--space-4);padding:var(--space-3) 0;border-bottom:1px solid var(--color-border)}
-.coin-row:last-child{border-bottom:none}
-.coin-info{display:flex;flex-direction:column;gap:2px}
-.coin-name{font-size:var(--text-sm);font-weight:600;color:var(--color-text)}
-.coin-details{font-size:var(--text-xs);color:var(--color-text-faint)}
-.coin-input-group{display:flex;align-items:center;gap:var(--space-3)}
-.coin-input{width:72px;padding:var(--space-2) var(--space-3);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);color:var(--color-text);font-size:var(--text-sm);text-align:center;-moz-appearance:textfield}
-.coin-input::-webkit-inner-spin-button,.coin-input::-webkit-outer-spin-button{-webkit-appearance:none}
-.coin-input:focus{outline:2px solid var(--color-primary);outline-offset:1px;border-color:var(--color-primary)}
-.coin-value{font-size:var(--text-sm);font-variant-numeric:tabular-nums;color:var(--color-text-muted);min-width:56px;text-align:right;font-weight:500}
+/* ── Prose spacing ── */
+.prose p{margin-bottom:var(--space-4);line-height:1.7}
+.prose li{margin-bottom:var(--space-2);line-height:1.65}
+.prose h2{margin-top:var(--space-10);margin-bottom:var(--space-3)}
+.prose h3{margin-top:var(--space-6);margin-bottom:var(--space-2)}
 
-/* 6 — Total melt value */
-.result-box{background:color-mix(in oklch,var(--color-gold) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold) 25%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);margin-top:var(--space-2);text-align:center}
-.result-label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:var(--space-2)}
-.result-usd{font-size:var(--text-2xl);font-weight:700;font-variant-numeric:tabular-nums;color:var(--color-gold-bright);line-height:1}
+/* ── Related guides section ── */
+.related-guides{background:var(--color-surface-offset);padding:var(--space-10) var(--space-4)}
+.related-guides .container{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
+.related-guides h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-2)}
+.container{max-width:1200px;margin:0 auto;padding:0 var(--space-4)}
 
-/* 7 — FAQ <div class="faq-card"> cards */
-.faq-container{display:flex;flex-direction:column;gap:var(--space-3);margin-top:var(--space-4)}
-.faq-container details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden}
-.faq-container summary{font-size:var(--text-sm);font-weight:600;color:var(--color-text);padding:var(--space-4) var(--space-5);cursor:pointer;list-style:none;display:flex;align-items:center;justify-content:space-between}
-.faq-container summary::-webkit-details-marker{display:none}
-.faq-container summary::after{content:'+';font-size:var(--text-lg);font-weight:400;color:var(--color-text-faint);flex-shrink:0;margin-left:var(--space-3)}
-.faq-container details[open] summary::after{content:'−'}
-.faq-container details[open]{border-color:var(--color-primary)}
-.faq-answer{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;padding:0 var(--space-5) var(--space-4);margin:0}
+/* ═══════════════════════════════════════════════════
+   US SILVER DOLLAR VALUES — 2026 redesign
+   Silver-accented identity layered on the site tokens.
+   Mobile-first; scales fluidly to any viewport.
+   ═══════════════════════════════════════════════════ */
 
-/* 8 — Snippet answer */
-.snippet-answer{background:color-mix(in oklch,var(--color-primary) 5%,var(--color-surface-offset));border-left:3px solid var(--color-primary);border-radius:0 var(--radius-md) var(--radius-md) 0;padding:var(--space-4) var(--space-5);margin:var(--space-4) 0 var(--space-6);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7}
+/* ── Hero shell ── */
+.sc-hero{max-width:1200px;margin:0 auto;padding:var(--space-8) var(--space-4) var(--space-6);display:grid;grid-template-columns:minmax(0,0.92fr) minmax(0,1.08fr);gap:var(--space-8);align-items:start}
+@media(max-width:880px){.sc-hero{grid-template-columns:1fr;padding:var(--space-6) var(--space-4) var(--space-2);gap:var(--space-5)}}
+.sc-hero__intro{display:flex;flex-direction:column}
+.sc-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);align-self:flex-start;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-silver);background:color-mix(in oklch,var(--color-silver) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-silver) 28%,var(--color-border));padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);margin-bottom:var(--space-4)}
+.sc-eyebrow .live-dot{width:7px;height:7px}
+.sc-hero h1{font-family:var(--font-display);font-size:var(--text-2xl);line-height:1.1;letter-spacing:-.02em;color:var(--color-text);margin-bottom:var(--space-3)}
+.sc-hero h1 .accent{background:linear-gradient(92deg,#c9ced6,#9097a0 55%,#71777f);-webkit-background-clip:text;background-clip:text;color:transparent}
+[data-theme="light"] .sc-hero h1 .accent{background:none;color:var(--color-silver);-webkit-text-fill-color:var(--color-silver)}
+.sc-lead{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;max-width:50ch;margin-bottom:var(--space-5)}
 
-/* 9 — Blockquote */
-blockquote{background:color-mix(in oklch,var(--color-silver) 6%,var(--color-surface-offset));border-left:3px solid var(--color-silver);border-radius:0 var(--radius-md) var(--radius-md) 0;padding:var(--space-4) var(--space-5);margin:var(--space-4) 0 var(--space-6);font-size:var(--text-base);color:var(--color-text-muted)}
-blockquote strong{color:var(--color-text)}
+/* ── Live spot panel ── */
+.spot-panel{background:linear-gradient(158deg,var(--color-surface),var(--color-surface-offset));border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);box-shadow:var(--shadow-sm);position:relative;overflow:hidden}
+.spot-panel::before{content:"";position:absolute;inset:0;background:radial-gradient(120% 80% at 100% 0,color-mix(in oklch,var(--color-silver) 16%,transparent),transparent 58%);pointer-events:none}
+.spot-panel>*{position:relative}
+.spot-panel__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);margin-bottom:var(--space-3)}
+.spot-panel__label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.spot-panel__live{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);font-weight:700;color:var(--color-up);text-transform:uppercase;letter-spacing:.06em}
+.spot-panel__main{display:flex;align-items:baseline;gap:var(--space-2);flex-wrap:wrap}
+.spot-panel__price{font-family:var(--font-display);font-size:clamp(2rem,1.4rem+3vw,2.875rem);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em;line-height:1}
+.spot-panel__unit{font-size:var(--text-sm);color:var(--color-text-muted)}
+.spot-panel__chg{font-size:var(--text-sm);font-weight:700;font-variant-numeric:tabular-nums;margin-left:var(--space-1)}
+.spot-panel__chg.up{color:var(--color-up)}.spot-panel__chg.down{color:var(--color-down)}
+.spot-panel__grid{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-2);margin-top:var(--space-4)}
+.spot-chip{background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-2) var(--space-3)}
+.spot-chip__k{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:var(--color-text-faint);margin-bottom:3px}
+.spot-chip__v{font-size:var(--text-sm);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.spot-panel__foot{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2) var(--space-4);margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-muted);flex-wrap:wrap}
+.spot-panel__fx{font-variant-numeric:tabular-nums;font-weight:600;color:var(--color-text-muted)}
+.spot-panel__refresh{display:inline-flex;align-items:center;gap:6px}
+.spot-panel__refresh .live-dot{width:6px;height:6px}
 
-@media(max-width:768px){
-  .calc-card{padding:var(--space-4)}
-  .coin-input{width:60px}
+/* ── Calculator card ── */
+.calc-pro{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);box-shadow:var(--shadow-md);overflow:hidden;scroll-margin-top:var(--space-16)}
+.calc-pro__head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-border);background:var(--color-surface-offset)}
+.calc-pro__title{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.calc-pro__title svg{color:var(--color-silver)}
+.calc-pro__clear{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:7px 14px;background:var(--color-surface);min-height:34px}
+.calc-pro__clear:hover{color:var(--color-text);border-color:var(--color-silver);background:var(--color-surface-dynamic)}
+.calc-pro__body{padding:var(--space-3) var(--space-4) var(--space-4)}
+
+/* Roll quick-add chips */
+.roll-presets{display:flex;flex-wrap:wrap;gap:var(--space-2);padding-bottom:var(--space-3);margin-bottom:var(--space-1);border-bottom:1px dashed var(--color-border)}
+.roll-chip{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:7px 13px;min-height:34px;white-space:nowrap}
+.roll-chip:hover{color:var(--color-silver);border-color:color-mix(in oklch,var(--color-silver) 45%,var(--color-border));background:color-mix(in oklch,var(--color-silver) 8%,var(--color-surface-offset))}
+
+/* Coin rows */
+#coin-list{display:flex;flex-direction:column}
+.coin{display:grid;grid-template-columns:auto minmax(0,1fr) auto;align-items:center;gap:var(--space-3);padding:var(--space-3) var(--space-1);border-bottom:1px solid var(--color-divider)}
+.coin:last-child{border-bottom:none}
+.coin__medal{width:44px;height:44px;border-radius:50%;background:radial-gradient(circle at 34% 28%,#f6f7f9,#d2d6dc 42%,#9aa0a9 72%,#6b7280);box-shadow:inset 0 1px 2px rgba(255,255,255,.65),inset 0 -2px 4px rgba(0,0,0,.28),0 1px 2px rgba(0,0,0,.3);display:flex;align-items:center;justify-content:center;border:1px solid rgba(0,0,0,.18);position:relative;flex-shrink:0}
+.coin__medal::after{content:"";position:absolute;inset:4px;border-radius:50%;border:1px dashed rgba(45,50,60,.4)}
+.coin__denom{position:relative;z-index:1;font-size:11px;font-weight:800;color:#363b43;letter-spacing:-.03em}
+.coin__info{min-width:0}
+.coin__name{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.25}
+.coin__purity{font-size:10px;font-weight:700;letter-spacing:.03em;color:var(--color-silver);border:1px solid color-mix(in oklch,var(--color-silver) 38%,var(--color-border));border-radius:var(--radius-full);padding:1px 7px}
+.coin__meta{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:3px}
+.coin__line{font-size:var(--text-sm);font-weight:700;color:var(--color-silver);font-variant-numeric:tabular-nums;margin-top:4px}
+.coin__line.zero{color:var(--color-text-faint);font-weight:600}
+
+/* Stepper */
+.stepper{display:inline-flex;align-items:center;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface-offset);overflow:hidden}
+.stepper button{width:40px;height:44px;display:flex;align-items:center;justify-content:center;color:var(--color-text-muted);font-size:1.25rem;line-height:1;font-weight:600}
+.stepper button:hover{background:var(--color-surface-dynamic);color:var(--color-text)}
+.stepper button:active{background:color-mix(in oklch,var(--color-silver) 18%,var(--color-surface-dynamic))}
+.stepper input{width:52px;height:44px;border:none;border-left:1px solid var(--color-border);border-right:1px solid var(--color-border);background:transparent;color:var(--color-text);text-align:center;font-size:var(--text-sm);font-weight:700;font-variant-numeric:tabular-nums;-moz-appearance:textfield}
+.stepper input::-webkit-inner-spin-button,.stepper input::-webkit-outer-spin-button{-webkit-appearance:none;margin:0}
+.stepper input:focus{outline:2px solid var(--color-primary);outline-offset:-2px}
+
+/* Total melt value */
+.melt{background:linear-gradient(155deg,color-mix(in oklch,var(--color-silver) 15%,var(--color-surface-offset)),var(--color-surface-offset) 62%);border-top:1px solid var(--color-border);padding:var(--space-5)}
+.melt__top{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-3)}
+.melt__label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.melt__value{font-family:var(--font-display);font-size:clamp(2rem,1.3rem+3.4vw,2.75rem);font-weight:700;line-height:1;color:var(--color-text);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.melt__value.is-bump{animation:meltBump .3s cubic-bezier(.16,1,.3,1)}
+@keyframes meltBump{0%{transform:scale(1)}45%{transform:scale(1.035)}100%{transform:scale(1)}}
+.melt__conv{font-size:var(--text-sm);color:var(--color-text-muted);margin-top:var(--space-2);font-variant-numeric:tabular-nums}
+.melt__badge{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);font-weight:700;color:var(--color-silver);border:1px solid color-mix(in oklch,var(--color-silver) 35%,var(--color-border));border-radius:var(--radius-full);padding:5px 11px;white-space:nowrap;flex-shrink:0}
+.melt__badge .live-dot{width:6px;height:6px}
+.melt__stats{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-2);margin-top:var(--space-4)}
+.melt__stat{background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-2);text-align:center}
+.melt__stat b{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.melt__stat small{display:block;font-size:10px;text-transform:uppercase;letter-spacing:.04em;color:var(--color-text-faint);margin-top:3px}
+
+/* Dealer payout note */
+.calc-note{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6;margin-top:var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-radius:var(--radius-md);border-left:3px solid var(--color-silver)}
+.calc-note a{color:var(--color-primary)}
+
+/* ── Silver price chart ── */
+.chart-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:2px}
+.ag-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-2);margin-top:var(--space-5)}
+@media(max-width:520px){.ag-stats{grid-template-columns:repeat(2,1fr)}}
+.ag-stat{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3);text-align:center}
+.ag-stat__k{display:block;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:var(--color-text-faint);margin-bottom:4px}
+.ag-stat__v{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.ag-stat__v.live{color:var(--color-silver)}
+
+/* Live melt cell in reference table */
+.data-table td.melt-cell{color:var(--color-silver);font-weight:700;font-variant-numeric:tabular-nums}
+.data-table th.melt-col,.data-table td.melt-cell{text-align:right;padding-right:0}
+.live-inline{color:var(--color-silver);font-weight:700;font-variant-numeric:tabular-nums}
+
+/* ── FAQ accordion ── */
+.faq-list{display:flex;flex-direction:column;gap:var(--space-3);margin-top:var(--space-2)}
+.faq-item{border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;background:var(--color-surface)}
+.faq-item[open]{border-color:color-mix(in oklch,var(--color-silver) 35%,var(--color-border))}
+.faq-item summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);font-size:var(--text-base);font-weight:600;color:var(--color-text);padding:var(--space-4) var(--space-5);cursor:pointer;list-style:none}
+.faq-item summary::-webkit-details-marker{display:none}
+.faq-item summary:hover{background:var(--color-surface-offset)}
+.faq-item summary::after{content:"";width:11px;height:11px;border-right:2px solid var(--color-text-muted);border-bottom:2px solid var(--color-text-muted);transform:rotate(45deg);transition:transform var(--transition);flex-shrink:0;margin-top:-4px}
+.faq-item[open] summary::after{transform:rotate(-135deg);margin-top:2px}
+.faq-item .faq-body{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:0 var(--space-5) var(--space-4)}
+
+/* ── Responsive ── */
+@media(max-width:520px){
+  .calc-pro__body{padding:var(--space-2) var(--space-3) var(--space-3)}
+  .coin{gap:var(--space-2);padding:var(--space-3) 0}
+  .coin__medal{width:38px;height:38px}
+  .stepper input{width:46px}
+  .stepper button{width:38px}
+  .melt__stat b{font-size:var(--text-sm)}
 }
 </style>
 <link rel="stylesheet" href="/assets/site.css">
@@ -508,6 +632,7 @@ blockquote strong{color:var(--color-text)}
       <li class="mega-nav__item" role="none">
         <button class="mega-nav__trigger" role="menuitem" aria-haspopup="true" aria-expanded="false">Calculators <svg class="mega-nav__chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 4l4 4 4-4"/></svg></button>
         <div class="mega-panel" role="menu" aria-label="Calculators">
+          <div class="mega-panel__col"><span class="mega-panel__heading">Silver Tools</span><a href="/silver-coins-calculator">Silver Coins Calculator</a><a href="/silver-price-per-kilo">Silver Per Kilo</a><a href="/900-silver-price-per-gram">.900 Coin Silver</a><a href="/800-silver-price-per-gram">.800 European Silver</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Gold Tools</span><a href="/scrap-gold-calculator">Scrap Gold Calculator</a><a href="/gold-bar-value">Gold Bar Value</a><a href="/gold-coins-vs-bars">Gold Coins vs Bars</a><a href="/guides/how-much-is-a-gold-ring-worth">Gold Ring Worth</a><a href="/gold-silver-test-kit-reviews">Testing Kit Reviews</a></div>
           <div class="mega-panel__col"><span class="mega-panel__heading">Special Tools</span><a href="/zakat-gold-silver-calculator">Zakat Calculator</a><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a><a href="/best-gold-ira-companies">Best Gold IRA Companies</a><a href="/where-to-sell-gold-silver">Where to Sell Gold</a></div>
         </div>
@@ -557,82 +682,221 @@ blockquote strong{color:var(--color-text)}
     </div>
   </div>
 </nav>
-</div>
 
 
 <div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb"><li><a href="/">Home</a></li><li aria-current="page">US Silver Dollar Values</li></ol></div>
 
-<div class="hero">
-  <div class="hero-tag">Live Prices</div>
-  <h1 class="hero-title">US Silver Dollar Values & Calculator</h1>
-  <p style="font-size:.9375rem;color:var(--color-text-muted);margin-bottom:1.5rem">Calculate the live melt value of US silver dollars and half dollars. Enter quantities below.</p>
+<main id="top">
+<section class="sc-hero">
+  <div class="sc-hero__intro">
+    <span class="sc-eyebrow"><span class="live-dot"></span> Live Silver &middot; USD Spot</span>
+    <h1>US <span class="accent">Silver Dollar</span> Values &amp; Melt Calculator</h1>
+    <p class="sc-lead">See what your Morgan, Peace, Trade, Eisenhower and American Silver Eagle dollars are really worth. Live melt values are priced in USD against the silver spot price, with GBP &amp; EUR conversions &mdash; updated every 60 seconds.</p>
 
-  <div class="calc-card">
-    <div class="calc-spot-info">
-      Live Silver Spot Price: <strong id="spot-price-display">$---.--</strong> / troy oz
-    </div>
-
-    <div id="coin-list">
-      <!-- Generated by JS -->
-    </div>
-
-    <div class="result-box">
-      <div class="result-label">Total Melt Value</div>
-      <div class="result-usd" id="total-val-usd" data-nosnippet>$0.00</div>
+    <div class="spot-panel" aria-label="Live silver spot price">
+      <div class="spot-panel__head">
+        <span class="spot-panel__label">Silver Spot &middot; XAG/USD</span>
+        <span class="spot-panel__live"><span class="live-dot"></span> Live</span>
+      </div>
+      <div class="spot-panel__main">
+        <span class="spot-panel__price" id="spot-oz" data-nosnippet>$--.--</span>
+        <span class="spot-panel__unit">per troy oz</span>
+        <span class="spot-panel__chg" id="spot-chg" data-nosnippet></span>
+      </div>
+      <div class="spot-panel__grid">
+        <div class="spot-chip"><div class="spot-chip__k">Per Gram</div><div class="spot-chip__v" id="spot-gram" data-nosnippet>$--</div></div>
+        <div class="spot-chip"><div class="spot-chip__k">Per Kilo</div><div class="spot-chip__v" id="spot-kilo" data-nosnippet>$--</div></div>
+        <div class="spot-chip"><div class="spot-chip__k">Gold : Silver</div><div class="spot-chip__v" id="spot-ratio" data-nosnippet>--</div></div>
+      </div>
+      <div class="spot-panel__foot">
+        <span class="spot-panel__fx" id="spot-fx">&asymp; &pound;-- &middot; &euro;-- /oz</span>
+        <span class="spot-panel__refresh"><span class="live-dot"></span> Updated <span id="spot-updated">just now</span> &middot; next in <span id="spot-countdown">60s</span></span>
+      </div>
     </div>
   </div>
+
+  <div class="calc-pro" id="calc">
+    <div class="calc-pro__head">
+      <span class="calc-pro__title">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="8" cy="8" r="6"/><path d="M18.09 10.37A6 6 0 1 1 10.34 18"/><path d="M7 6h1v4"/><path d="m16.71 13.88.7.71-2.82 2.82"/></svg>
+        Your Silver Dollars
+      </span>
+      <button type="button" class="calc-pro__clear" id="clear-all">Clear all</button>
+    </div>
+    <div class="calc-pro__body">
+      <div class="roll-presets" role="group" aria-label="Quick-add a standard coin roll">
+        <button type="button" class="roll-chip" data-roll="morgan" data-add="20">+ Roll of Morgans (20)</button>
+        <button type="button" class="roll-chip" data-roll="peace" data-add="20">+ Roll of Peace $ (20)</button>
+        <button type="button" class="roll-chip" data-roll="ase" data-add="20">+ Tube of Eagles (20)</button>
+      </div>
+      <div id="coin-list"><!-- coin rows injected by JS --></div>
+    </div>
+    <div class="melt">
+      <div class="melt__top">
+        <div>
+          <div class="melt__label">Total Melt Value</div>
+          <div class="melt__value" id="melt-usd" data-nosnippet>$0.00</div>
+          <div class="melt__conv" id="melt-conv" data-nosnippet>&asymp; &pound;0.00 &middot; &euro;0.00</div>
+        </div>
+        <span class="melt__badge"><span class="live-dot"></span> Live spot</span>
+      </div>
+      <div class="melt__stats">
+        <div class="melt__stat"><b id="melt-oz">0.000</b><small>troy oz silver</small></div>
+        <div class="melt__stat"><b id="melt-coins">0</b><small>coins</small></div>
+        <div class="melt__stat"><b id="melt-face">$0.00</b><small>face value</small></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="content" style="padding-bottom:0">
+  <div class="trust-bar">Live silver spot from the LBMA market via gold&#8209;api.com &middot; <strong>USD primary</strong>, GBP &amp; EUR conversions &middot; Refreshes every 60 seconds &middot; <a href="/about">About our data</a></div>
 </div>
+
+<section class="content" style="padding-bottom:0">
+  <div class="chart-section ag-chart">
+    <div class="chart-header">
+      <div>
+        <div class="chart-title">Silver Price History</div>
+        <div class="chart-sub" id="ag-range-label">Last 30 days &middot; USD per troy ounce</div>
+      </div>
+      <div class="chart-controls" id="ag-toggle" role="group" aria-label="Chart time range">
+        <button type="button" class="chart-btn active" data-range="1M">1M</button>
+        <button type="button" class="chart-btn" data-range="3M">3M</button>
+        <button type="button" class="chart-btn" data-range="1Y">1Y</button>
+        <button type="button" class="chart-btn" data-range="5Y">5Y</button>
+        <button type="button" class="chart-btn" data-range="10Y">10Y</button>
+      </div>
+    </div>
+    <div class="chart-wrap"><canvas id="ag-chart" aria-label="Silver spot price history line chart"></canvas><div class="chart-loading" id="ag-loader">Loading historical data&hellip;</div></div>
+    <div class="ag-stats">
+      <div class="ag-stat"><span class="ag-stat__k">Period Low</span><span class="ag-stat__v" id="ag-low">&mdash;</span></div>
+      <div class="ag-stat"><span class="ag-stat__k">Period High</span><span class="ag-stat__v" id="ag-high">&mdash;</span></div>
+      <div class="ag-stat"><span class="ag-stat__k">Average</span><span class="ag-stat__v" id="ag-avg">&mdash;</span></div>
+      <div class="ag-stat"><span class="ag-stat__k">Live Spot</span><span class="ag-stat__v live" id="ag-now" data-nosnippet>&mdash;</span></div>
+    </div>
+  </div>
+</section>
 
 <div class="content">
-  <div class="trust-bar">Live silver price sourced from spot market &middot; Updated every 60 seconds &middot; <a href="/about">About our data</a></div>
-
-
   <div class="prose">
-    <h2 id="1-troy-oz-silver">How much is 1 troy ounce of silver worth today?</h2>
-    <p class="snippet-answer">One troy ounce of silver (.999 fine) is worth <span class="live-spot-replace-usd data-nosnippet">[live price]</span> today. The troy ounce is the standard unit for precious metals pricing. At today's spot price, a standard American Silver Eagle coin (1 troy oz .999 silver) has a melt value of <span class="live-spot-replace-usd data-nosnippet">[live price]</span>.</p>
+    <h2>US Silver Dollar Values: Melt &amp; Collector Reference</h2>
+    <p>Every US silver dollar carries two very different numbers. Its <strong>melt value</strong> is the worth of the pure silver inside, and it moves every minute with the spot price in the panel above. Its <strong>collector (numismatic) value</strong> depends on the date, mint mark and grade, and can be many times higher. The <strong>Live Melt</strong> column below updates automatically in USD; the collector ranges are typical retail guides for circulated-to-average coins.</p>
+
+    <div class="data-table-wrap"><table class="data-table" aria-label="US Silver Dollar Types, Silver Content, Live Melt Values and Typical Collector Value">
+      <thead><tr><th>Silver Dollar Type</th><th>Years</th><th>Silver %</th><th>Silver (Troy Oz)</th><th class="melt-col">Live Melt (USD)</th><th>Typical Collector Value</th></tr></thead>
+      <tbody>
+        <tr><td>Flowing Hair Dollar</td><td>1794–1795</td><td>~89%</td><td>0.77344 oz</td><td class="melt-cell" id="ref-flowing" data-nosnippet>&mdash;</td><td>$2,000 – $10M+</td></tr>
+        <tr><td>Draped Bust Dollar</td><td>1795–1804</td><td>~89%</td><td>0.77344 oz</td><td class="melt-cell" id="ref-draped" data-nosnippet>&mdash;</td><td>$1,500 – $500,000</td></tr>
+        <tr><td>Seated Liberty Dollar</td><td>1840–1873</td><td>90%</td><td>0.77344 oz</td><td class="melt-cell" id="ref-seated" data-nosnippet>&mdash;</td><td>$300 – $5,000+</td></tr>
+        <tr><td>Trade Dollar</td><td>1873–1885</td><td>90%</td><td>0.78750 oz</td><td class="melt-cell" id="ref-trade" data-nosnippet>&mdash;</td><td>$90 – $3,000+</td></tr>
+        <tr><td>Morgan Dollar</td><td>1878–1921</td><td>90%</td><td>0.77344 oz</td><td class="melt-cell" id="ref-morgan" data-nosnippet>&mdash;</td><td>$25 – $500+</td></tr>
+        <tr><td>Peace Dollar</td><td>1921–1935</td><td>90%</td><td>0.77344 oz</td><td class="melt-cell" id="ref-peace" data-nosnippet>&mdash;</td><td>$22 – $300+</td></tr>
+        <tr><td>Eisenhower Dollar (40%)</td><td>1971–1976</td><td>40%</td><td>0.31610 oz</td><td class="melt-cell" id="ref-ike" data-nosnippet>&mdash;</td><td>$7 – $30</td></tr>
+        <tr><td>American Silver Eagle</td><td>1986–present</td><td>99.9%</td><td>1.00000 oz</td><td class="melt-cell" id="ref-ase" data-nosnippet>&mdash;</td><td>Spot + 10–35%</td></tr>
+      </tbody>
+    </table></div>
+
+    <p class="calc-note" style="margin-top:var(--space-2)"><strong>Dealer payouts vs. melt:</strong> Dealers typically pay <strong>85&ndash;95% of melt</strong> for common-date &ldquo;junk&rdquo; silver dollars, while certified key dates sell for a large numismatic premium. The melt figures above are the pure-silver value only &mdash; your actual sale price depends on the coin's grade and the buyer's spread. <a href="/where-to-sell-gold-silver">Compare where to sell &rarr;</a></p>
+
+    <h2 id="how-much-is-a-silver-dollar-worth">How Much Is a US Silver Dollar Worth Today?</h2>
+    <p class="snippet-answer">A classic 90% silver US dollar &mdash; the Morgan or Peace dollar &mdash; contains <strong>0.77344 troy ounces</strong> of pure silver. At the live silver spot price of <span class="live-inline js-spot" data-nosnippet>$--</span> per troy ounce, its melt value works out to about <span class="live-inline js-morgan-usd" data-nosnippet>$--</span>. Key dates, mint marks and high grades are worth far more to collectors.</p>
+    <p>To value any silver dollar for its metal, multiply its pure-silver weight by the live spot price. A Morgan or Peace dollar holds 0.77344 oz, so at a spot price of $30/oz the melt value is roughly $23.20 (0.77344 × $30). An <strong>American Silver Eagle</strong> contains a full troy ounce, so its melt value equals the spot price itself &mdash; currently <span class="live-inline js-spot" data-nosnippet>$--</span> &mdash; plus a dealer premium. You can cross-check the broader market on our <a href="/silver-price-per-kilo">silver price per kilo</a> and <a href="/silver-coins-calculator">silver coins calculator</a> pages.</p>
 
     <h2>The History of US Silver Dollars</h2>
-    <p>United States silver dollars have a rich and fascinating history, deeply intertwined with the economic growth of the nation. The first silver dollar was minted in 1794, known as the Flowing Hair dollar. However, the most iconic and widely recognized silver dollars are the Morgan Dollar and the Peace Dollar.</p>
+    <p>United States silver dollars trace the economic story of the nation. The first, the <strong>Flowing Hair dollar</strong>, was struck in 1794 and is among the most valuable coins in the world &mdash; a single specimen sold for over $10 million in 2013. It was followed by the Draped Bust and Seated Liberty dollars, all containing roughly three-quarters of an ounce of silver.</p>
+    <p>The <strong>Morgan Dollar</strong> (1878–1904, and again in 1921) is the most collected of all. Designed by US Mint Assistant Engraver George T. Morgan and authorised by the Bland–Allison Act, hundreds of millions were struck and many sat in Treasury vaults for decades, fuelling today's vibrant collector market. The <strong>Peace Dollar</strong> followed from 1921 to 1935, designed by Anthony de Francisci to commemorate the peace after World War I. Both are 90% silver and contain exactly 0.77344 troy ounces of pure silver.</p>
+    <p>The <strong>Trade Dollar</strong> (1873–1885) was a heavier 0.78750 oz coin made for commerce in Asia. The last circulating &ldquo;silver&rdquo; dollar, the <strong>Eisenhower Dollar</strong> (1971–1978), was mostly copper-nickel; only the 1971–1976 collector issues were struck in 40% silver. Since 1986 the US Mint has produced the one-ounce <strong>American Silver Eagle</strong>, the most popular silver bullion coin in the world.</p>
 
-    <p>The <strong>Morgan Dollar</strong>, minted from 1878 to 1904, and again in 1921, is named after its designer, United States Mint Assistant Engraver George T. Morgan. It was authorized by the Bland-Allison Act, which required the Treasury to purchase between two and four million dollars' worth of silver per month to be coined into dollars. These coins are incredibly popular among collectors and investors alike due to their substantial size, historical significance, and beautiful design. Many were stored in Treasury vaults for decades, only to be discovered and released in the mid-20th century, adding to their allure.</p>
+    <h2 id="how-much-silver-is-in-a-silver-dollar">How Much Silver Is in a Silver Dollar?</h2>
+    <p class="snippet-answer">The amount of silver in a US silver dollar depends on the type. Morgan, Peace and Seated Liberty dollars are 90% silver and contain <strong>0.77344 troy ounces</strong> of pure silver. The 1873–1885 Trade Dollar is slightly heavier at <strong>0.78750 oz</strong>, and 40% silver Eisenhower dollars contain <strong>0.31610 oz</strong>.</p>
+    <p>At the current spot price, a single Morgan or Peace dollar holds about <span class="live-inline js-morgan-usd" data-nosnippet>$--</span> in silver, a Trade Dollar about <span class="live-inline" id="live-trade" data-nosnippet>$--</span>, and a one-ounce American Silver Eagle about <span class="live-inline" id="live-ase" data-nosnippet>$--</span>. Always verify the date and mint mark before buying or selling, because a copper-nickel Eisenhower or clad dollar has no silver melt value at all.</p>
 
-    <p>Following the Morgan Dollar, the <strong>Peace Dollar</strong> was minted from 1921 to 1928, and again in 1934 and 1935. Designed by Anthony de Francisci, it was created to commemorate the peace that followed World War I. Both the Morgan and Peace dollars are composed of 90% silver and 10% copper, giving them exactly 0.7734 troy ounces of pure silver.</p>
+    <h2>Coin Value vs. Melt Value: The Numismatic Premium</h2>
+    <p>For a common, heavily circulated Morgan dollar, the <strong>melt value</strong> and the selling price are close &mdash; it trades as bullion. But condition and rarity create a <strong>numismatic premium</strong> on top of melt. A pristine, uncirculated coin, a low-mintage key date (such as an 1893-S Morgan), or a coin with a desirable mint mark can be worth hundreds or thousands of dollars above its silver content.</p>
+    <p>Grade is decisive: the difference between a worn coin and a Mint State example can be enormous. Have older or potentially rare coins evaluated by a professional grading service (PCGS or NGC) before selling them purely for melt &mdash; and never clean a coin, as that destroys the patina collectors pay for. For key dates, mint marks and grading detail by series, see our full <a href="/guides/us-silver-dollar-values">US silver dollar values guide</a>.</p>
 
-    <h2>Coin Value vs. Melt Value</h2>
-    <p>When determining the value of a US silver dollar, it's crucial to understand the difference between its <strong>numismatic (coin) value</strong> and its <strong>melt value</strong>.</p>
-    <p>The <strong>melt value</strong> is simply the value of the precious metal contained within the coin, based on the current live spot price of silver. For example, a common-date Morgan Dollar in heavily circulated condition might only be worth slightly more than its silver melt value. This is often referred to as "junk silver" when bought and sold strictly for bullion purposes.</p>
-    <p>The <strong>numismatic value</strong>, on the other hand, factors in the coin's rarity, condition (grade), mint mark, and historical demand among collectors. A rare date or a coin in pristine, uncirculated condition can be worth hundreds or even thousands of dollars above its inherent silver melt value. Always have older or potentially rare coins evaluated by a professional before selling them purely for their silver content. If you are looking to understand the broader market rates, you can check the <a href="/silver-price-per-kilo">silver price per kilo</a> or use our <a href="/">homepage calculator</a>.</p>
+    <h2 id="silver-dollar-value-other-currencies">Silver Dollar Melt Value in Other Currencies</h2>
+    <p>The global silver market is priced in <strong>US dollars per troy ounce</strong>, so USD is the primary reference for every figure on this page. For international buyers and sellers we convert the melt value using live ECB exchange rates. At today's spot price, the silver melt value of a single 90% Morgan or Peace dollar is:</p>
+    <ul>
+      <li><strong>USD:</strong> <span class="live-inline js-morgan-usd" data-nosnippet>$--</span> &middot; the world reserve currency and the basis for the silver spot price</li>
+      <li><strong>GBP:</strong> <span class="live-inline" id="live-dollar-gbp" data-nosnippet>&pound;--</span> &middot; converted from USD at the live rate</li>
+      <li><strong>EUR:</strong> <span class="live-inline" id="live-dollar-eur" data-nosnippet>&euro;--</span> &middot; converted from USD at the live rate</li>
+    </ul>
+    <p>Remember that investment silver attracts VAT in many countries (for example 20% in the UK), unlike investment gold &mdash; so an imported silver dollar can cost more than its raw melt value suggests. The spot panel and calculator at the top of this page always lead with USD and show GBP and EUR alongside.</p>
 
-    <h2>UK Context: Importing US Silver Coins</h2>
-    <p>For collectors and investors in the UK, purchasing US silver dollars often involves considerations regarding import duties and Value Added Tax (VAT). Unlike investment gold, which is generally VAT-free in the UK, investment silver is subject to the standard VAT rate of 20%.</p>
-    <p>When importing silver coins from the United States to the UK, you will typically be required to pay this 20% VAT on the total value of the shipment (including shipping and insurance costs). However, there is a notable exception: if the coins are considered "antique" or hold significant numismatic value, they might qualify for a reduced VAT rate of 5% under the Margin Scheme for antiques and collectors' items. Always consult with HM Revenue & Customs (HMRC) or a qualified tax advisor to understand the specific implications for your imports.</p>
-    <p>To understand more about silver purity, you might want to read our guide on <a href="/guides/what-is-925-sterling-silver">What is 925 Sterling Silver?</a>.</p>
+    <h2>How to Sell US Silver Dollars</h2>
+    <p>Decide first whether you are selling for <strong>melt</strong> or for <strong>collector value</strong>. Common-date coins sell fastest to bullion dealers at 85–95% of melt; rare dates and certified coins do better with numismatic dealers or at auction. Weigh and identify your coins, calculate the live melt value above, then compare offers. Our guide on <a href="/where-to-sell-gold-silver">where to sell gold &amp; silver</a> breaks down dealers, pawn shops and online buyers, and the <a href="/scrap-gold-calculator">scrap calculator</a> covers any gold you sell alongside.</p>
 
     <h2>Frequently Asked Questions</h2>
-    <div class="faq-container">
-      <div class="faq-card">
-        <h3>Are US silver dollars legal tender?</h3>
-        <p class="faq-answer">Yes, all US silver dollars minted by the United States Mint remain legal tender for their face value of one dollar. However, because their silver melt value and numismatic value far exceed their face value, they do not circulate in everyday commerce.</p>
-      </div>
-      <div class="faq-card">
-        <h3>What is the most valuable US silver coin?</h3>
-        <p class="faq-answer">The most valuable US silver coin is generally considered to be the 1794 Flowing Hair Silver Dollar. A pristine example of this coin, believed to be the very first silver dollar struck by the US Mint, sold at auction for over $10 million in 2013.</p>
-      </div>
-      <div class="faq-card">
-        <h3>When did US coins stop being made of silver?</h3>
-        <p class="faq-answer">The United States significantly reduced the silver content in its circulating coinage with the Coinage Act of 1965. Dimes and quarters stopped containing silver entirely after 1964. The Kennedy Half Dollar was reduced from 90% silver to 40% silver from 1965 to 1970, before silver was entirely removed from the half dollar in 1971.</p>
-      </div>
-      <div class="faq-card">
-        <h3>Should I clean my silver dollars?</h3>
-        <p class="faq-answer">No, you should never clean your silver dollars or any other potentially valuable coins. Cleaning a coin removes its natural patina and causes microscopic scratches, drastically reducing its numismatic value. If a coin needs conservation, it should only be done by a professional coin grading service.</p>
-      </div>
+    <div class="faq-list">
+      <details class="faq-item">
+        <summary>How much is a US silver dollar worth today?</summary>
+        <div class="faq-body faq-answer">A Morgan or Peace silver dollar contains 0.77344 troy ounces of pure silver, so its melt value tracks the live silver spot price in USD. Use the calculator above for the exact figure. Collector (numismatic) value can run far higher for key dates, mint marks and high grades.</div>
+      </details>
+      <details class="faq-item">
+        <summary>How much silver is in a silver dollar?</summary>
+        <div class="faq-body faq-answer">Morgan, Peace and Seated Liberty silver dollars contain 0.77344 troy ounces of pure silver (90% silver). The 1873–1885 Trade Dollar contains slightly more at 0.78750 troy ounces, and 40% silver Eisenhower dollars (1971–1976 collector issues) contain 0.31610 troy ounces.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Which US silver dollars are 90% silver?</summary>
+        <div class="faq-body faq-answer">US silver dollars minted from 1794 through 1935 — Flowing Hair, Draped Bust, Seated Liberty, Trade, Morgan and Peace dollars — are roughly 89–90% silver. Eisenhower dollars struck for circulation are copper-nickel; only the 1971–1976 collector issues are 40% silver.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Are US silver dollars a good investment?</summary>
+        <div class="faq-body faq-answer">Common-date Morgan and Peace dollars are a popular, recognisable way to own physical silver and trade close to their melt value. Rare dates, mint marks and high grades carry numismatic premiums. Always weigh dealer premiums against the live melt value before buying or selling.</div>
+      </details>
+      <details class="faq-item">
+        <summary>Should I clean my silver dollars?</summary>
+        <div class="faq-body faq-answer">No. Cleaning strips a coin's natural patina and leaves microscopic scratches that can sharply reduce its numismatic value. Leave any conservation to a professional coin grading service.</div>
+      </details>
     </div>
   </div>
-
 </div>
+</main>
 
+<div class="content" style="padding-bottom:0">
+  <div class="share-buttons">
+  <span>Share:</span>
+  <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/us-silver-dollar-values&text=US%20Silver%20Dollar%20Values" target="_blank" rel="noopener" data-platform="twitter"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.259 5.63zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg> X</a>
+  <a href="https://reddit.com/submit?url=https://goldpricetools.com/us-silver-dollar-values&title=US%20Silver%20Dollar%20Values" target="_blank" rel="noopener" data-platform="reddit"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg> Reddit</a>
+  <a href="https://api.whatsapp.com/send?text=US%20Silver%20Dollar%20Values%20https://goldpricetools.com/us-silver-dollar-values" target="_blank" rel="noopener" data-platform="whatsapp"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+</div>
+</div><!-- /.content end -->
 
-<div class="related-guides" style="margin:2rem 0;padding:1rem;background:var(--color-surface-offset);border-radius:var(--radius-md)"><p><strong>Related Guide:</strong> <a href="/guides/us-silver-dollar-values">US Silver Dollar Values: Coin Prices &amp; Melt Values Guide</a></p></div>
+<section class="related-guides">
+  <div class="container">
+    <h2>Related Gold &amp; Silver Guides</h2>
+    <div class="related-guides-grid">
+  <a href="/silver-price-per-kilo" class="related-card">
+    <span class="related-card__tag">LIVE PRICE</span>
+    <span class="related-card__title">Silver Price Per Kilo</span>
+    <span class="related-card__desc">Live silver price per kilogram — updated every 60 seconds from LBMA data.</span>
+  </a>
+  <a href="/gold-silver-ratio" class="related-card">
+    <span class="related-card__tag">LIVE TOOL</span>
+    <span class="related-card__title">Gold–Silver Ratio</span>
+    <span class="related-card__desc">Track the live gold-to-silver ratio and what it means for precious metals investors.</span>
+  </a>
+  <a href="/scrap-gold-calculator" class="related-card">
+    <span class="related-card__tag">TOOL</span>
+    <span class="related-card__title">Scrap Gold Calculator</span>
+    <span class="related-card__desc">Calculate the melt value of your gold jewellery using today's live spot price.</span>
+  </a>
+  <a href="/silver-coins-calculator" class="related-card">
+    <span class="related-card__tag">LIVE TOOL</span>
+    <span class="related-card__title">Silver Coins Calculator</span>
+    <span class="related-card__desc">Value pre-1965 junk silver — dimes, quarters, halves &amp; war nickels — at the live spot price.</span>
+  </a>
+  <a href="/guides/us-silver-dollar-values" class="related-card">
+    <span class="related-card__tag">GUIDE</span>
+    <span class="related-card__title">Silver Dollar Values Guide</span>
+    <span class="related-card__desc">Key dates, mint marks and grading — a deeper dive into what makes each silver dollar valuable.</span>
+  </a>
+    </div>
+  </div>
+</section>
+
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">
@@ -711,99 +975,250 @@ blockquote strong{color:var(--color-text)}
 </footer>
 
 <script>
-const coins = [
-  { id: 'morgan', name: 'Morgan Dollar', desc: '90% Silver (1878–1921)', troyOz: 0.7734 },
-  { id: 'peace', name: 'Peace Dollar', desc: '90% Silver (1921–1935)', troyOz: 0.7734 },
-  { id: 'eisenhower', name: 'Eisenhower Dollar', desc: '40% Silver (1971–1976)', troyOz: 0.3161 },
-  { id: 'walking', name: 'Walking Liberty Half', desc: '90% Silver (1916–1947)', troyOz: 0.3617 },
-  { id: 'franklin', name: 'Franklin Half', desc: '90% Silver (1948–1963)', troyOz: 0.3617 },
-  { id: 'kennedy64', name: 'Kennedy Half (1964)', desc: '90% Silver', troyOz: 0.3617 },
-  { id: 'kennedy40', name: 'Kennedy Half (1965–1970)', desc: '40% Silver', troyOz: 0.1479 },
-  { id: 'ase', name: 'American Silver Eagle', desc: '99.9% Silver (1986–Present)', troyOz: 1.0 }
-];
-
-window._spotUSD = 0;
-
-function initCalc() {
-  const container = document.getElementById('coin-list');
-  container.innerHTML = coins.map(coin => `
-    <div class="coin-row">
-      <div class="coin-info">
-        <div class="coin-name">${coin.name}</div>
-        <div class="coin-details">${coin.desc} &middot; ${coin.troyOz} oz</div>
-      </div>
-      <div class="coin-input-group">
-        <input type="number" min="0" step="1" class="coin-input" id="qty-${coin.id}" placeholder="Qty" oninput="calcValues()">
-        <div class="coin-value" id="val-${coin.id}">$0.00</div>
-      </div>
-    </div>
-  `).join('');
-}
-
-function calcValues() {
-  let totalUSD = 0;
-  if (!window._spotUSD) return;
-
-  coins.forEach(coin => {
-    const qtyInput = document.getElementById(`qty-${coin.id}`);
-    const qty = parseInt(qtyInput.value) || 0;
-    const valueUSD = qty * coin.troyOz * window._spotUSD;
-    totalUSD += valueUSD;
-
-    document.getElementById(`val-${coin.id}`).textContent = '$' + valueUSD.toFixed(2);
-  });
-
-  document.getElementById('total-val-usd').textContent = '$' + totalUSD.toFixed(2);
-}
-
-async function fetchSpot() {
-  try {
-    const r = await fetch('https://api.gold-api.com/price/XAG', {cache: 'no-store'});
-    if (!r.ok) throw new Error();
-    const d = await r.json();
-    window._spotUSD = d.price;
-    document.getElementById('spot-price-display').textContent = '$' + window._spotUSD.toFixed(2);
-    calcValues();
-  } catch (e) {
-    console.warn('Silver API failed', e);
-  }
-}
-
-document.addEventListener("DOMContentLoaded", () => {
-  initCalc();
-  fetchSpot();
-  setInterval(fetchSpot, 60000);
-});
-
+/* ─────────────────────────────────────────────────────────────
+   US Silver Dollar Values — live price engine (USD primary)
+   Shared data sources across goldpricetools.com:
+     • Silver spot: https://api.gold-api.com/price/XAG  (LBMA, USD/oz)
+     • Gold spot:   https://api.gold-api.com/price/XAU  (ticker + ratio)
+     • FX rates:    https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR
+   Refresh: 60s — DO NOT change (keeps cross-page consistency).
+   Constants: 31.1035 g/troy-oz · 32.1507 troy-oz/kg (matches index.html).
+   ───────────────────────────────────────────────────────────── */
 (function(){
-  const t = document.querySelector('[data-theme-toggle]'), r = document.documentElement;
-  let d = matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light';
-  r.setAttribute('data-theme', d);
-  if(t) t.addEventListener('click', () => {
-    d = d === 'dark' ? 'light' : 'dark';
-    r.setAttribute('data-theme', d);
-    t.setAttribute('aria-label', 'Switch to ' + (d==='dark'?'light':'dark') + ' mode');
-    t.innerHTML = d === 'dark'
-      ? '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>'
-      : '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+  'use strict';
+  const API='https://api.gold-api.com/price';
+  const FX='https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR';
+  const G_PER_OZ=31.1035, OZ_PER_KG=32.1507, REFRESH_MS=60000;
+
+  /* troyOz = PURE silver content (coin purity already applied).
+     Constants are shared site-wide for cross-page consistency:
+     90% dollar 0.77344 · Trade 0.78750 · 40% Ike 0.31610 · ASE 1.0 · 90% half 0.36169 · 40% half 0.14792 */
+  const COINS=[
+    {id:'morgan', name:'Morgan Dollar',          sub:'90% silver dollar',                          era:'1878–1921',    purity:'90%',   denom:'$1',  face:1.00, troyOz:0.77344},
+    {id:'peace',  name:'Peace Dollar',           sub:'90% silver dollar',                          era:'1921–1935',    purity:'90%',   denom:'$1',  face:1.00, troyOz:0.77344},
+    {id:'trade',  name:'Trade Dollar',           sub:'90% silver · 420 grains',                    era:'1873–1885',    purity:'90%',   denom:'$1',  face:1.00, troyOz:0.78750},
+    {id:'ike40',  name:'Eisenhower Dollar',      sub:'40% silver (collector issue)',               era:'1971–1976',    purity:'40%',   denom:'$1',  face:1.00, troyOz:0.31610},
+    {id:'ase',    name:'American Silver Eagle',   sub:'.999 fine · 1 troy oz',                      era:'1986–present', purity:'99.9%', denom:'1oz', face:1.00, troyOz:1.00000},
+    {id:'half90', name:'90% Silver Half Dollar',  sub:'Walking Liberty · Franklin · Kennedy ’64',   era:'Pre-1965',     purity:'90%',   denom:'50¢', face:0.50, troyOz:0.36169},
+    {id:'half40', name:'40% Kennedy Half',        sub:'Kennedy clad',                               era:'1965–1970',    purity:'40%',   denom:'50¢', face:0.50, troyOz:0.14792}
+  ];
+
+  window._spotUSD=0;                  // silver USD/oz (shared global)
+  let goldUSD=0, agPrev=null;
+  let gbp=0.79, eur=0.92;
+  let lastFetchTs=0, countdownTimer=null;
+
+  const $=id=>document.getElementById(id);
+  const fmtUSD=v=>'$'+v.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2});
+  const fmtGBP=v=>'£'+v.toLocaleString('en-GB',{minimumFractionDigits:2,maximumFractionDigits:2});
+  const fmtEUR=v=>'€'+v.toLocaleString('en-IE',{minimumFractionDigits:2,maximumFractionDigits:2});
+  const fmtInt=v=>v.toLocaleString('en-US');
+
+  /* ── Build coin rows ── */
+  function initCalc(){
+    const c=$('coin-list'); if(!c) return;
+    c.innerHTML=COINS.map(coin=>`
+      <div class="coin" data-coin="${coin.id}">
+        <div class="coin__medal" aria-hidden="true"><span class="coin__denom">${coin.denom}</span></div>
+        <div class="coin__info">
+          <div class="coin__name">${coin.name} <span class="coin__purity">${coin.purity}</span></div>
+          <div class="coin__meta">${coin.sub} · ${coin.era} · ${coin.troyOz} oz</div>
+          <div class="coin__line zero" id="line-${coin.id}">$0.00</div>
+        </div>
+        <div class="stepper" role="group" aria-label="${coin.name} quantity">
+          <button type="button" data-step="-1" data-coin="${coin.id}" aria-label="Decrease ${coin.name} quantity">&minus;</button>
+          <input type="number" inputmode="numeric" min="0" step="1" value="0" id="qty-${coin.id}" aria-label="${coin.name} quantity">
+          <button type="button" data-step="1" data-coin="${coin.id}" aria-label="Increase ${coin.name} quantity">+</button>
+        </div>
+      </div>`).join('');
+  }
+
+  const getQty=id=>{const el=$('qty-'+id);const v=el?parseInt(el.value,10):0;return (isNaN(v)||v<0)?0:v;};
+  const setQty=(id,v)=>{const el=$('qty-'+id);if(el)el.value=Math.max(0,v|0);};
+
+  /* ── Core calculation (USD primary) ── */
+  function calc(){
+    const spot=window._spotUSD;
+    let totalOz=0, coins=0, face=0;
+    COINS.forEach(coin=>{
+      const qty=getQty(coin.id);
+      coins+=qty; face+=qty*coin.face;
+      const oz=qty*coin.troyOz; totalOz+=oz;
+      const lineEl=$('line-'+coin.id);
+      if(lineEl){ lineEl.textContent=spot?fmtUSD(oz*spot):'$0.00'; lineEl.classList.toggle('zero',qty===0||!spot); }
+    });
+    const totalUSD=totalOz*spot;
+    const meltEl=$('melt-usd');
+    if(meltEl){
+      meltEl.textContent=fmtUSD(totalUSD);
+      if(totalUSD>0){ meltEl.classList.remove('is-bump'); void meltEl.offsetWidth; meltEl.classList.add('is-bump'); }
+    }
+    if($('melt-conv')) $('melt-conv').textContent='≈ '+fmtGBP(totalUSD*gbp)+' · '+fmtEUR(totalUSD*eur);
+    if($('melt-oz'))   $('melt-oz').textContent=totalOz.toLocaleString('en-US',{minimumFractionDigits:3,maximumFractionDigits:3});
+    if($('melt-coins'))$('melt-coins').textContent=fmtInt(coins);
+    if($('melt-face')) $('melt-face').textContent=fmtUSD(face);
+    if(spot){
+      /* Reference-table live melt cells (troy-oz constants shared site-wide) */
+      const ROWS=[['ref-flowing',0.77344],['ref-draped',0.77344],['ref-seated',0.77344],['ref-trade',0.78750],['ref-morgan',0.77344],['ref-peace',0.77344],['ref-ike',0.31610],['ref-ase',1.00000]];
+      ROWS.forEach(function(r){const el=$(r[0]);if(el)el.textContent=fmtUSD(r[1]*spot);});
+      /* Inline live values in the prose — USD primary, with GBP & EUR conversions */
+      const morganUSD=0.77344*spot;
+      document.querySelectorAll('.js-spot').forEach(function(el){el.textContent=fmtUSD(spot);});
+      document.querySelectorAll('.js-morgan-usd').forEach(function(el){el.textContent=fmtUSD(morganUSD);});
+      if($('live-trade'))      $('live-trade').textContent=fmtUSD(0.78750*spot);
+      if($('live-ase'))        $('live-ase').textContent=fmtUSD(1.00000*spot);
+      if($('live-dollar-gbp')) $('live-dollar-gbp').textContent=fmtGBP(morganUSD*gbp);
+      if($('live-dollar-eur')) $('live-dollar-eur').textContent=fmtEUR(morganUSD*eur);
+    }
+  }
+
+  /* ── Spot panel render ── */
+  function renderSpot(){
+    const spot=window._spotUSD; if(!spot) return;
+    if($('spot-oz'))   $('spot-oz').textContent=fmtUSD(spot);
+    if($('spot-gram')) $('spot-gram').textContent=fmtUSD(spot/G_PER_OZ);
+    if($('spot-kilo')) $('spot-kilo').textContent=fmtUSD(spot*OZ_PER_KG);
+    if($('ag-now'))    $('ag-now').textContent=fmtUSD(spot)+' /oz';
+    if($('spot-fx'))   $('spot-fx').textContent='≈ '+fmtGBP(spot*gbp)+' · '+fmtEUR(spot*eur)+' /oz';
+    if(goldUSD && $('spot-ratio')) $('spot-ratio').textContent=(goldUSD/spot).toFixed(1)+':1';
+    const chgEl=$('spot-chg');
+    if(chgEl && agPrev){
+      const pct=(spot-agPrev)/agPrev*100;
+      chgEl.textContent=(pct>=0?'▲ ':'▼ ')+Math.abs(pct).toFixed(2)+'%';
+      chgEl.className='spot-panel__chg '+(pct>=0?'up':'down');
+    }
+  }
+
+  /* ── Top ticker (ids shared with index.html) ── */
+  function renderTicker(){
+    const sOz=window._spotUSD, gOz=goldUSD, gGram=gOz/G_PER_OZ, map=[];
+    if(gOz) map.push(
+      ['t-xau',fmtUSD(gOz)],['t-xau2',fmtUSD(gOz)],
+      ['t-24k',fmtUSD(gGram*0.9999)],['t-24k2',fmtUSD(gGram*0.9999)],
+      ['t-18k',fmtUSD(gGram*0.75)],['t-18k2',fmtUSD(gGram*0.75)],
+      ['t-14k',fmtUSD(gGram*0.5833)],['t-14k2',fmtUSD(gGram*0.5833)],
+      ['t-10k',fmtUSD(gGram*0.4167)],['t-10k2',fmtUSD(gGram*0.4167)]);
+    if(sOz) map.push(
+      ['t-xag',fmtUSD(sOz)],['t-xag2',fmtUSD(sOz)],
+      ['t-agoz',fmtUSD(sOz)],['t-agoz2',fmtUSD(sOz)],
+      ['t-agkg',fmtUSD(sOz*OZ_PER_KG)],['t-agkg2',fmtUSD(sOz*OZ_PER_KG)]);
+    map.forEach(([id,v])=>{const el=$(id);if(el)el.textContent=v;});
+  }
+
+  /* ── Refresh countdown ── */
+  function startCountdown(){
+    if(countdownTimer) clearInterval(countdownTimer);
+    const cEl=$('spot-countdown'), uEl=$('spot-updated');
+    countdownTimer=setInterval(()=>{
+      const el=Math.floor((Date.now()-lastFetchTs)/1000), rem=Math.max(0,60-el);
+      if(cEl) cEl.textContent=rem+'s';
+      if(uEl) uEl.textContent= el<10?'just now': el<60?el+'s ago': Math.floor(el/60)+'m ago';
+    },1000);
+  }
+
+  /* ── Data fetchers ── */
+  async function fetchFx(){
+    try{
+      const r=await fetch(FX,{cache:'no-store'}); if(!r.ok) throw new Error('FX '+r.status);
+      const d=await r.json(); gbp=d.rates.GBP||gbp; eur=d.rates.EUR||eur;
+    }catch(e){ console.warn('FX fallback used',e); }
+  }
+  async function fetchPrices(){
+    const [agR,auR]=await Promise.allSettled([
+      fetch(API+'/XAG',{cache:'no-store'}).then(r=>r.json()),
+      fetch(API+'/XAU',{cache:'no-store'}).then(r=>r.json())
+    ]);
+    if(agR.status==='fulfilled'&&agR.value&&agR.value.price){ window._spotUSD=agR.value.price; agPrev=agR.value.prev_close_price||agPrev; }
+    if(auR.status==='fulfilled'&&auR.value&&auR.value.price){ goldUSD=auR.value.price; }
+    if(!window._spotUSD){ console.warn('Silver spot unavailable'); return; }
+    lastFetchTs=Date.now();
+    renderTicker(); renderSpot(); calc(); startCountdown();
+    if(typeof gtag==='function') gtag('event','price_view',{metal:'silver',page:'us-silver-dollar-values'});
+  }
+
+  /* ── Interactions ── */
+  function bind(){
+    const list=$('coin-list');
+    if(list){
+      list.addEventListener('click',e=>{
+        const b=e.target.closest('button[data-step]'); if(!b) return;
+        const id=b.dataset.coin; setQty(id,getQty(id)+parseInt(b.dataset.step,10)); calc();
+      });
+      list.addEventListener('input',e=>{ if(e.target.matches('input[id^="qty-"]')) calc(); });
+    }
+    document.querySelectorAll('.roll-chip').forEach(chip=>{
+      chip.addEventListener('click',()=>{ const id=chip.dataset.roll; setQty(id,getQty(id)+parseInt(chip.dataset.add,10)); calc(); const el=$('qty-'+id); if(el) el.focus(); });
+    });
+    const clr=$('clear-all');
+    if(clr) clr.addEventListener('click',()=>{ COINS.forEach(c=>setQty(c.id,0)); calc(); });
+  }
+
+  /* ── Silver price chart (lazy Chart.js, local /chart-data) ── */
+  let chartPromise=null, agChart=null, chartLoaded=false;
+  function loadChartJS(){
+    if(chartPromise) return chartPromise;
+    chartPromise=new Promise((res,rej)=>{ const s=document.createElement('script'); s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js'; s.onload=res; s.onerror=rej; document.head.appendChild(s); });
+    return chartPromise;
+  }
+  const RANGE_LABEL={'1M':'Last 30 days','3M':'Last 3 months','1Y':'Last 12 months','5Y':'Last 5 years','10Y':'Last 10 years'};
+  async function loadHistory(range){
+    const loader=$('ag-loader'); if(loader){ loader.style.display='flex'; loader.textContent='Loading historical data…'; }
+    try{
+      const data=await fetch('/chart-data/XAG-'+range+'.json').then(r=>r.json());
+      await loadChartJS();
+      drawChart(data.labels,data.data); stats(data.data);
+      if($('ag-range-label')) $('ag-range-label').textContent=(RANGE_LABEL[range]||'')+' · USD per troy ounce';
+      if(loader) loader.style.display='none';
+    }catch(e){ console.warn('Silver history load failed',e); if(loader) loader.textContent='Historical data unavailable'; }
+  }
+  function drawChart(labels,data){
+    const cv=$('ag-chart'); if(!cv||typeof Chart==='undefined') return;
+    const dark=document.documentElement.getAttribute('data-theme')==='dark';
+    const line='#9ca3af', txt='#7a7974', grid=dark?'rgba(255,255,255,.05)':'rgba(0,0,0,.06)';
+    if(agChart) agChart.destroy();
+    agChart=new Chart(cv,{type:'line',data:{labels,datasets:[{data,borderColor:line,borderWidth:2,fill:true,
+      backgroundColor:c=>{const g=c.chart.ctx.createLinearGradient(0,0,0,300);g.addColorStop(0,line+'55');g.addColorStop(1,line+'00');return g;},
+      pointRadius:0,pointHitRadius:14,tension:0.3}]},
+      options:{responsive:true,maintainAspectRatio:false,
+        plugins:{legend:{display:false},tooltip:{backgroundColor:'rgba(15,14,12,.92)',titleColor:'#fff',bodyColor:'#fff',padding:10,displayColors:false,callbacks:{label:c=>' '+fmtUSD(c.parsed.y)+' /oz'}}},
+        scales:{x:{ticks:{color:txt,font:{size:11},maxTicksLimit:6},grid:{color:grid,drawTicks:false}},
+          y:{position:'right',ticks:{color:txt,font:{size:11},callback:v=>'$'+v},grid:{color:grid}}},
+        interaction:{mode:'index',intersect:false}}});
+    chartLoaded=true;
+  }
+  function stats(arr){
+    if(!arr||!arr.length) return;
+    const min=Math.min.apply(null,arr), max=Math.max.apply(null,arr), avg=arr.reduce((a,b)=>a+b,0)/arr.length;
+    if($('ag-low'))  $('ag-low').textContent=fmtUSD(min);
+    if($('ag-high')) $('ag-high').textContent=fmtUSD(max);
+    if($('ag-avg'))  $('ag-avg').textContent=fmtUSD(avg);
+  }
+  function bindChart(){
+    const tg=$('ag-toggle'); if(!tg) return;
+    tg.addEventListener('click',e=>{ const b=e.target.closest('button[data-range]'); if(!b) return;
+      tg.querySelectorAll('button').forEach(x=>x.classList.remove('active')); b.classList.add('active'); loadHistory(b.dataset.range); });
+    const sec=document.querySelector('.ag-chart');
+    if('IntersectionObserver' in window && sec){
+      const io=new IntersectionObserver((ents,obs)=>{ ents.forEach(en=>{ if(en.isIntersecting){ loadHistory('1M'); obs.disconnect(); } }); },{rootMargin:'200px'});
+      io.observe(sec);
+    } else { loadHistory('1M'); }
+  }
+  /* Redraw chart grid to match theme (deferred so theme attr is updated first) */
+  const themeBtn=document.querySelector('[data-theme-toggle]');
+  if(themeBtn) themeBtn.addEventListener('click',()=>{ if(chartLoaded&&agChart){ const l=agChart.data.labels, d=agChart.data.datasets[0].data; setTimeout(()=>drawChart(l,d),0); } });
+
+  /* ── Init ── */
+  document.addEventListener('DOMContentLoaded',()=>{
+    initCalc(); bind(); bindChart();
+    Promise.all([fetchFx(),fetchPrices()]).catch(e=>console.warn('init',e));
+    setInterval(fetchPrices,REFRESH_MS);
   });
 })();
-
 </script>
 
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPLL52C3K8"></script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-ZPLL52C3K8');</script>
-<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}
-  // Wait for prices to fetch and then update specific live spots
-  document.addEventListener('pricesUpdated', (e) => {
-    if (e.detail && e.detail.XAG) {
-      const livePrice = e.detail.XAG.toLocaleString('en-US', {style: 'currency', currency: 'USD'});
-      document.querySelectorAll('.live-spot-replace-usd').forEach(el => {
-        el.innerText = livePrice;
-      });
-    }
-  });
-</script>
+<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
 <script>(function(){
   const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
   let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');


### PR DESCRIPTION
## Summary

Full redesign of **`/us-silver-dollar-values`** onto the site's 2026 premium design system, tailored specifically to silver **dollars** so it complements — rather than duplicates — the junk‑silver `silver-coins-calculator`. Built mobile‑first and verified to scale cleanly from 360px to 1440px. Design direction was generated with the `ui-ux-pro-max` skill (Dark‑Mode OLED, trust + premium gold/silver accents, finance‑readable type, Chart.js line history).

## What changed

**Live data & accuracy (matches the rest of the site)**
- Unified live‑price engine: silver `XAG` + gold `XAU` via `gold-api.com`, FX via Frankfurter (ECB), **60s refresh**, constants `31.1035 g/oz` · `32.1507 oz/kg` — identical sources/constants to `index.html` and `silver-coins-calculator` for cross‑page consistency.
- **USD is the primary currency** everywhere, with live **GBP & EUR** conversions alongside.
- Canonical pure‑silver troy‑oz constants reused: 90% dollar `0.77344`, Trade `0.78750`, 40% Eisenhower `0.31610`, ASE `1.0`, 90% half `0.36169`, 40% half `0.14792`.

**UI / UX**
- Live **silver spot panel**: $/oz, per‑gram/kilo, gold:silver ratio, % change, FX line, and a refresh countdown.
- Interactive **calculator** with +/− steppers: Morgan, Peace, Trade, Eisenhower 40%, American Silver Eagle, 90% & 40% half dollars → live melt box (USD + GBP/EUR, troy‑oz / coin‑count / face‑value stats, value‑bump micro‑interaction) + quick‑add roll presets.
- Live **silver price‑history chart** (Chart.js, lazy‑loaded, local `/chart-data`).
- Live **reference table**: silver‑dollar types with live USD melt **and** a collector‑value column (the page's distinct angle).
- Rich dollar‑focused editorial (Flowing Hair → Trade → Morgan/Peace → Eisenhower → ASE), melt‑vs‑numismatic, a USD‑first currency section, "how to sell", and a 5‑item FAQ accordion.

**Bug fixes carried over from the old page**
- The top **live ticker was dead** (no JS populated it) — now populated by the shared engine.
- The snippet/prose showed the literal text **`[live price]`** (an event that was never dispatched) — replaced with properly wired live spans.

**SEO / structured data**
- `Breadcrumb`, `SoftwareApplication`, `WebPage` (speakable), **`Dataset`** (live melt values) and **`FAQPage`** JSON‑LD — all validated; FAQ schema matches the visible FAQ exactly. Canonical/OG/hreflang kept on `us-silver-dollar-values`.

## Verification (local, mocked feeds via `page.route`)
- Calculator math exact: 3 Morgan + 2 ASE = **$149.14**; roll of 20 Morgans = **$533.98**; FX ≈ £27.27 · €31.76/oz; ratio 97.1:1; table cells (e.g. Trade $27.18, Eisenhower $10.91) correct.
- Ticker now populates (XAG $34.52, XAU $3,352.40, 24K/g $107.77, Ag/kg $1,109.84); countdown live.
- **No horizontal overflow at 360 / 390 / 1440px.** All inline JS passes `node --check`; all 5 JSON‑LD blocks parse.

> Note: live price APIs and the Playwright browser CDN are blocked by this environment's network allowlist, so verification used the repo's documented mocked‑feed approach; a live Playwright audit against the deployed URL should be run post‑deploy per `DEVELOPMENT_RULES.md`.

https://claude.ai/code/session_01Cu7rL1FHMF8uPEKVrqeqwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cu7rL1FHMF8uPEKVrqeqwQ)_