### PR TITLE
Redesign Gold Hallmarks guide: premium template + live USD value decoder

### DIFF
--- a/guides/gold-hallmarks-explained.html
+++ b/guides/gold-hallmarks-explained.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold Hallmarks Explained: Symbols, Meanings &amp; Identification Guide 2026 | GoldPriceTools</title>
 <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Everything about gold hallmarks — UK, European, antique, foreign and rare marks explained. Identify symbols on rings, necklaces and pocket watches.">
+<meta name="description" content="Everything about gold hallmarks — UK, European, antique, foreign and rare marks explained. Identify symbols on rings, necklaces and pocket watches, and see each fineness mark's live melt value in USD.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/guides/gold-hallmarks-explained">
 <link rel="alternate" hreflang="en" href="https://goldpricetools.com/guides/gold-hallmarks-explained">
@@ -39,8 +39,27 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,700&display=swap" rel="stylesheet">
 <style>
+/* ───────────────────────── DESIGN TOKENS ───────────────────────── */
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-alt:#f4f3ef;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-serif:'Playfair Display','Georgia',serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-alt:#161513;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+a{color:var(--color-primary);text-decoration:none}
+a:hover{color:var(--color-primary-hover);text-decoration:underline}
+a:visited{color:var(--color-primary)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:72px}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+img,svg{display:block;max-width:100%;height:auto}
+button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+p,li{text-wrap:pretty}
+a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
+:focus-visible{outline:2px solid var(--color-gold-bright);outline-offset:3px;border-radius:var(--radius-sm)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important;animation-iteration-count:1!important}html{scroll-behavior:auto}}
+
+/* ───────────────────────── NAV (shared chrome) ───────────────────────── */
 .mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
 .mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
 .mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
@@ -48,28 +67,6 @@
 .mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
 .mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
 .mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-alt:#f4f3ef;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
-*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-a{color:var(--color-primary);text-decoration:none}
-a:hover{color:var(--color-primary-hover);text-decoration:underline}
-a:visited{color:var(--color-primary)}
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
-body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
-img,svg{display:block;max-width:100%;height:auto}
-button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
-h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
-p,li{text-wrap:pretty;max-width:72ch}
-a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
-:focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
-@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
 .site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
 .nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
@@ -101,7 +98,7 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
 .hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
 .hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1);overscroll-behavior:contain}
 .mobile-menu.open{display:block;transform:translateX(0)}
 .mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
 .mobile-section{border-radius:var(--radius-md);overflow:hidden}
@@ -118,10 +115,253 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
 .mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
 .mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
+.mobile-menu__search{margin-top:var(--space-3)}
+.mobile-menu__search input{width:100%;padding:12px 14px;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface-offset);color:var(--color-text);font-size:var(--text-sm)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 .ad-slot{min-height:0!important;margin:var(--space-2) 0}
 .ad-slot:not(:has(ins[data-ad-status])){border:none!important;background:none!important;padding:0!important;min-height:0!important;margin:0!important}
+
+/* ───────────────────────── READING PROGRESS ───────────────────────── */
+#gp-progress{position:fixed;top:0;left:0;height:3px;background:linear-gradient(90deg,#b07a00,#f0c040,#b07a00);width:0%;z-index:300;transition:width .1s linear;border-radius:0 2px 2px 0}
+[data-theme="dark"] #gp-progress{background:linear-gradient(90deg,#c8960a,#f5d060,#c8960a)}
+
+/* ───────────────────────── HERO ───────────────────────── */
+.gp-hero{position:relative;overflow:hidden;background:var(--color-bg);border-bottom:1px solid var(--color-border)}
+[data-theme="dark"] .gp-hero{background:radial-gradient(ellipse at top right,#1a1408 0%,#161208 30%,#0f0e0c 70%)}
+[data-theme="light"] .gp-hero{background:radial-gradient(ellipse at top right,#faf3e0 0%,#f7f1e1 30%,#f7f6f2 70%)}
+.gp-hero__bg{position:absolute;inset:0;pointer-events:none;overflow:hidden}
+.gp-hero__orb{position:absolute;border-radius:50%;filter:blur(90px);opacity:.2}
+.gp-hero__orb--1{width:560px;height:560px;top:-160px;right:-100px;background:radial-gradient(circle,#d19900,transparent 65%)}
+.gp-hero__orb--2{width:340px;height:340px;bottom:-100px;left:5%;background:radial-gradient(circle,#b07a00,transparent 70%);opacity:.14}
+.gp-hero__grid{position:absolute;inset:0;background-image:linear-gradient(rgba(208,153,0,.04) 1px,transparent 1px),linear-gradient(90deg,rgba(208,153,0,.04) 1px,transparent 1px);background-size:40px 40px;mask-image:radial-gradient(ellipse at center,black 30%,transparent 70%)}
+.gp-hero__content{position:relative;z-index:1;max-width:1200px;margin:0 auto;padding:var(--space-6) var(--space-4) var(--space-10)}
+.gp-breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:6px;font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-6)}
+.gp-breadcrumb a{color:var(--color-text-muted);text-decoration:none}
+.gp-breadcrumb a:hover{color:var(--color-gold-bright)}
+.gp-breadcrumb-sep{color:var(--color-text-faint)}
+.gp-breadcrumb-current{color:var(--color-text)}
+.gp-hero__tag{display:inline-flex;align-items:center;gap:8px;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright);margin-bottom:var(--space-4)}
+.gp-hero__tag::before{content:'';width:22px;height:2px;background:linear-gradient(90deg,transparent,var(--color-gold-bright));border-radius:1px}
+.gp-hero__tag-year{color:var(--color-text-muted);font-weight:600}
+.gp-hero__title{font-family:var(--font-serif);font-size:clamp(2rem,1.1rem + 4vw,4.25rem);font-weight:700;line-height:1.05;color:var(--color-text);margin-bottom:var(--space-5);max-width:18ch;letter-spacing:-.02em}
+.gp-hero__title em{font-style:italic;color:var(--color-gold-bright);font-weight:700}
+.gp-hero__lead{font-size:clamp(1rem,.95rem + .4vw,1.2rem);color:var(--color-text-muted);line-height:1.7;max-width:62ch;margin-bottom:var(--space-6)}
+.gp-hero__lead strong{color:var(--color-text);font-weight:600}
+.gp-hero__meta{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);font-size:var(--text-sm);color:var(--color-text-muted);margin-bottom:var(--space-8)}
+.gp-hero__meta a{color:var(--color-gold-bright);text-decoration:none}
+.gp-hero__meta a:hover{text-decoration:underline}
+.gp-hero__meta .meta-sep{color:var(--color-border)}
+.gp-hero__cards{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);max-width:760px}
+@media(min-width:680px){.gp-hero__cards{grid-template-columns:repeat(4,1fr)}}
+.gp-hero__card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);box-shadow:var(--shadow-sm);position:relative;overflow:hidden;transition:transform var(--transition),border-color var(--transition)}
+.gp-hero__card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 50%,var(--color-border));transform:translateY(-2px)}
+.gp-hero__card::after{content:'';position:absolute;bottom:0;left:0;right:0;height:2px;background:linear-gradient(90deg,transparent,var(--color-gold-bright),transparent);opacity:.6}
+.gp-hero__card-label{font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.gp-hero__card-value{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.1;letter-spacing:-.01em}
+.gp-hero__card-sub{font-size:.7rem;color:var(--color-text-muted);margin-top:3px}
+
+/* ───────────────────────── LAYOUT + SIDEBAR TOC ───────────────────────── */
+.gp-layout{max-width:1200px;margin:0 auto;padding:0 var(--space-4) var(--space-16);display:grid;grid-template-columns:1fr;gap:var(--space-8);align-items:start}
+@media(min-width:1024px){.gp-layout{grid-template-columns:260px 1fr;padding-top:var(--space-8);gap:var(--space-10)}}
+.gp-toc-mobile{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4) 0}
+@media(min-width:1024px){.gp-toc-mobile{display:none}}
+.gp-toc-toggle{display:flex;align-items:center;gap:var(--space-2);width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);font-size:var(--text-sm);font-weight:600;color:var(--color-text);cursor:pointer;min-height:48px;transition:border-color var(--transition),background var(--transition)}
+.gp-toc-toggle:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset)}
+.gp-toc-toggle__icon{color:var(--color-gold-bright);flex-shrink:0}
+.gp-toc-chevron{margin-left:auto;transition:transform var(--transition);color:var(--color-text-muted)}
+.gp-toc-toggle[aria-expanded="true"] .gp-toc-chevron{transform:rotate(180deg);color:var(--color-gold-bright)}
+.gp-toc-nav--mobile{margin-top:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-3);box-shadow:var(--shadow-sm)}
+.gp-toc-nav--mobile ol{list-style:none;display:flex;flex-direction:column;gap:1px;counter-reset:toc}
+.gp-toc-nav--mobile a{display:block;padding:10px 12px;font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);min-height:40px;transition:color var(--transition),background var(--transition)}
+.gp-toc-nav--mobile a:hover{color:var(--color-gold-bright);background:var(--color-surface-offset)}
+.gp-sidebar{display:none}
+@media(min-width:1024px){.gp-sidebar{display:block}}
+.gp-toc{position:sticky;top:80px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);box-shadow:var(--shadow-sm);max-height:calc(100vh - 100px);overflow-y:auto;overscroll-behavior:contain}
+.gp-toc__header{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-text-muted);margin-bottom:var(--space-4);padding-bottom:var(--space-3);border-bottom:1px solid var(--color-divider)}
+.gp-toc__header svg{color:var(--color-gold-bright)}
+.gp-toc__list{list-style:none;display:flex;flex-direction:column;gap:1px}
+.gp-toc__link{display:block;padding:7px 12px;font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);border-left:2px solid transparent;transition:color var(--transition),background var(--transition),border-color var(--transition);line-height:1.35}
+.gp-toc__link:hover{color:var(--color-gold-bright);background:var(--color-surface-offset);border-left-color:var(--color-gold-bright)}
+.gp-toc__link.active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 8%,transparent);font-weight:600}
+.gp-toc__spot{margin-top:var(--space-5);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.gp-toc__spot-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-2)}
+.gp-toc__spot-title{font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted)}
+.gp-toc__spot-rows{display:grid;grid-template-columns:1fr;gap:var(--space-2)}
+.gp-toc__spot-row{display:flex;justify-content:space-between;align-items:baseline;font-size:var(--text-xs);padding:6px 10px;background:var(--color-surface-offset);border-radius:var(--radius-md)}
+.gp-toc__spot-label{color:var(--color-text-muted);font-weight:600;text-transform:uppercase;letter-spacing:.06em;font-size:.65rem}
+.gp-toc__spot-value{font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;font-size:var(--text-sm)}
+
+/* live dot (shared) */
+.live-dot{display:inline-block;width:7px;height:7px;border-radius:50%;background:#22c55e;box-shadow:0 0 0 0 rgba(34,197,94,.5);animation:livePulse 2s ease-in-out infinite}
+@keyframes livePulse{0%{box-shadow:0 0 0 0 rgba(34,197,94,.5)}70%{box-shadow:0 0 0 6px rgba(34,197,94,0)}100%{box-shadow:0 0 0 0 rgba(34,197,94,0)}}
+.gp-live-chip{display:inline-flex;align-items:center;gap:6px;font-size:.62rem;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:#22c55e}
+
+/* ───────────────────────── PROSE ───────────────────────── */
+.gp-prose{min-width:0;max-width:820px}
+.gp-prose h2{font-family:var(--font-serif);font-size:clamp(1.5rem,1.1rem + 1.5vw,2.25rem);font-weight:700;color:var(--color-text);margin-top:var(--space-10);padding-top:var(--space-6);border-top:1px solid var(--color-border);line-height:1.2;letter-spacing:-.01em;scroll-margin-top:72px}
+.gp-prose h2:first-of-type{border-top:none;margin-top:0;padding-top:0}
+.gp-prose h3{font-family:var(--font-serif);font-size:clamp(1.2rem,1rem + .7vw,1.5rem);font-weight:700;color:var(--color-text);margin-top:var(--space-6);line-height:1.3;letter-spacing:-.01em}
+.gp-prose h4{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-top:var(--space-5);margin-bottom:var(--space-2)}
+.gp-prose p{font-size:var(--text-base);color:var(--color-text);line-height:1.78;max-width:72ch;margin-top:var(--space-4)}
+.gp-prose h2+p,.gp-prose h3+p,.gp-prose h4+p{margin-top:var(--space-3)}
+.gp-prose strong{color:var(--color-text);font-weight:700}
+.gp-prose em{font-style:italic;color:var(--color-text)}
+.gp-prose a{color:var(--color-primary);text-decoration:underline;text-underline-offset:2px}
+.gp-prose a:hover{color:var(--color-primary-hover)}
+.gp-prose ul,.gp-prose ol{padding-left:var(--space-5);margin-top:var(--space-4);display:flex;flex-direction:column;gap:var(--space-2)}
+.gp-prose li{font-size:var(--text-base);color:var(--color-text);line-height:1.7;max-width:70ch}
+.gp-prose li::marker{color:var(--color-gold-bright)}
+
+/* tables */
+.gp-table-wrap{margin:var(--space-5) 0;border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;background:var(--color-surface)}
+.gp-table-wrap--scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+table.gp-table{width:100%;border-collapse:collapse;font-size:var(--text-sm)}
+table.gp-table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-3) var(--space-4);background:var(--color-surface-offset);border-bottom:1px solid var(--color-border);white-space:nowrap}
+table.gp-table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text-muted);vertical-align:middle}
+table.gp-table tr:last-child td{border-bottom:none}
+table.gp-table tbody tr{transition:background var(--transition)}
+table.gp-table tbody tr:hover{background:var(--color-surface-offset)}
+table.gp-table td:first-child,table.gp-table th:first-child{color:var(--color-text);font-weight:600}
+
+/* hallmark pill */
+.hmark{display:inline-flex;align-items:center;padding:2px 8px;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:.04em;font-family:var(--font-display)}
+
+/* callouts */
+.info-callout{background:color-mix(in oklch,var(--color-primary) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 20%,var(--color-border));border-left:3px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.info-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;max-width:none}
+.info-callout p+p{margin-top:var(--space-3)}
+.info-callout strong{color:var(--color-text)}
+.info-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0;gap:var(--space-2)}
+.info-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65}
+.warning-callout{background:color-mix(in oklch,#f59e0b 8%,var(--color-surface));border:1px solid color-mix(in oklch,#f59e0b 25%,var(--color-border));border-left:3px solid #f59e0b;border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.warning-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;max-width:none}
+.warning-callout p+p{margin-top:var(--space-3)}
+.warning-callout strong{color:var(--color-text)}
+.warning-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0;gap:var(--space-2)}
+.warning-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65}
+
+/* country cards */
+.country-card{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-5) 0;transition:box-shadow var(--transition),transform var(--transition)}
+.country-card:hover{box-shadow:var(--shadow-md);transform:translateY(-1px)}
+.country-card__header{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
+.country-card__crest{flex-shrink:0;width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:var(--radius-md);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));color:var(--color-gold-bright)}
+.country-card__name{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-text)}
+.country-card p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-top:var(--space-3);max-width:none}
+.country-card p:first-of-type{margin-top:0}
+.country-card strong{color:var(--color-text)}
+
+/* assay office emblem grid */
+.assay-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:620px){.assay-grid{grid-template-columns:repeat(4,1fr)}}
+.assay-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-4);text-align:center;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.assay-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 45%,var(--color-border));transform:translateY(-3px);box-shadow:var(--shadow-md)}
+.assay-card__emblem{width:64px;height:64px;margin:0 auto var(--space-3);border-radius:var(--radius-full);display:flex;align-items:center;justify-content:center;background:radial-gradient(circle at 35% 30%,color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-surface-offset)),var(--color-surface-offset));border:1.5px solid color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));color:var(--color-gold-bright)}
+.assay-card__emblem svg{width:34px;height:34px}
+.assay-card__office{font-family:var(--font-serif);font-size:var(--text-base);font-weight:700;color:var(--color-text)}
+.assay-card__symbol{font-size:var(--text-xs);color:var(--color-gold-bright);font-weight:600;margin-top:2px}
+.assay-card__note{font-size:.72rem;color:var(--color-text-muted);margin-top:var(--space-2);line-height:1.5}
+
+/* step list */
+.step-list{list-style:none;padding:0;margin:var(--space-6) 0;display:flex;flex-direction:column;gap:var(--space-4)}
+.step-block{display:flex;align-items:flex-start;gap:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);transition:border-color var(--transition),transform var(--transition)}
+.step-block:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));transform:translateX(2px)}
+.step-number{flex-shrink:0;width:38px;height:38px;border-radius:var(--radius-full);background:linear-gradient(135deg,var(--color-gold-bright),#b07a00);color:#0f0e0c;font-weight:700;font-size:var(--text-base);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
+.step-content{flex:1;min-width:0}
+.step-content strong{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
+.step-content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0;max-width:none}
+
+/* info example callout */
+.example-box{background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-5) 0}
+.example-box p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;max-width:none}
+.example-box p+p,.example-box ul{margin-top:var(--space-3)}
+.example-box ul{padding-left:var(--space-5);display:flex;flex-direction:column;gap:var(--space-2)}
+.example-box li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
+.example-box strong{color:var(--color-text)}
+
+/* CTA box */
+.cta-box{background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface)),color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface-offset)));border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-6);margin:var(--space-8) 0}
+.cta-box h3{font-family:var(--font-serif);font-size:var(--text-lg);color:var(--color-text);margin:0 0 var(--space-2)}
+.cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-4);max-width:60ch}
+.cta-btn{display:inline-flex;align-items:center;gap:var(--space-1);padding:var(--space-3) var(--space-5);background:var(--color-primary);color:#fff!important;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none;transition:background .15s,transform .15s}
+.cta-btn:hover,.cta-btn:visited{background:var(--color-primary-hover);color:#fff!important;text-decoration:none}
+.cta-btn:hover{transform:translateX(2px)}
+
+/* disclaimer */
+.disclaimer-box{background:var(--color-surface-alt);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
+.disclaimer-box strong{color:var(--color-text);font-weight:700}
+
+/* ───────────────────────── LIVE HALLMARK VALUE DECODER ───────────────────────── */
+.hv{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);margin:var(--space-6) 0;box-shadow:var(--shadow-sm);scroll-margin-top:72px;position:relative;overflow:hidden}
+.hv::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,transparent,var(--color-gold-bright),transparent);opacity:.7}
+@media(min-width:560px){.hv{padding:var(--space-6)}}
+.hv__head{display:flex;flex-direction:column;gap:var(--space-4);margin-bottom:var(--space-5)}
+@media(min-width:720px){.hv__head{flex-direction:row;align-items:flex-start;justify-content:space-between;gap:var(--space-6)}}
+.hv__intro{flex:1;min-width:0}
+.hv__eyebrow{display:inline-flex;align-items:center;gap:8px;font-size:.62rem;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.hv__title{font-family:var(--font-serif);font-size:var(--text-lg);font-weight:700;color:var(--color-text);line-height:1.2;margin:0}
+.hv__sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin-top:var(--space-2);max-width:52ch}
+.hv__spot{flex-shrink:0;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);min-width:200px}
+.hv__spot-head{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);margin-bottom:6px}
+.hv__spot-label{font-size:.62rem;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.hv__spot-price{font-family:var(--font-serif);font-size:1.75rem;font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;line-height:1.1;letter-spacing:-.01em}
+.hv__spot-unit{font-size:var(--text-xs);color:var(--color-text-muted);font-weight:600}
+.hv__spot-meta{font-size:.66rem;color:var(--color-text-faint);margin-top:6px;display:flex;align-items:center;gap:5px;flex-wrap:wrap}
+.hv__spot-fx{font-size:.7rem;color:var(--color-text-muted);margin-top:4px;font-variant-numeric:tabular-nums}
+.hv__weight{display:flex;align-items:flex-end;flex-wrap:wrap;gap:var(--space-3);padding:var(--space-4);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);margin-bottom:var(--space-5)}
+.hv__weight-field{display:flex;flex-direction:column;gap:6px;flex:1;min-width:150px}
+.hv__weight-label{font-size:var(--text-xs);font-weight:700;color:var(--color-text);text-transform:uppercase;letter-spacing:.04em}
+.hv__weight-input-wrap{position:relative;display:flex;align-items:center}
+.hv__weight-input{width:100%;padding:12px 44px 12px 14px;font-size:var(--text-base);font-weight:600;color:var(--color-text);background:var(--color-surface);border:1.5px solid var(--color-border);border-radius:var(--radius-md);min-height:48px;font-variant-numeric:tabular-nums;-moz-appearance:textfield}
+.hv__weight-input::-webkit-outer-spin-button,.hv__weight-input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
+.hv__weight-input:focus{outline:none;border-color:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+.hv__weight-suffix{position:absolute;right:14px;font-size:var(--text-sm);color:var(--color-text-muted);font-weight:600;pointer-events:none}
+.hv__presets{display:flex;flex-wrap:wrap;gap:6px}
+.hv__preset{padding:8px 12px;font-size:var(--text-xs);font-weight:700;color:var(--color-text-muted);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-full);cursor:pointer;min-height:40px;transition:color var(--transition),background var(--transition),border-color var(--transition)}
+.hv__preset:hover{color:var(--color-gold-bright);border-color:var(--color-gold-bright)}
+.hv__preset:active{transform:scale(.96)}
+.hv__grid{display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:520px){.hv__grid{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:900px){.hv__grid{grid-template-columns:repeat(3,1fr)}}
+.hv__card{position:relative;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.hv__card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 45%,var(--color-border));transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.hv__card::after{content:"";position:absolute;top:-20px;right:-20px;width:80px;height:80px;background:radial-gradient(closest-side,color-mix(in oklch,var(--color-gold-bright) 16%,transparent),transparent 70%);pointer-events:none}
+.hv__card-top{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px}
+.hv__mark{font-family:var(--font-display);font-size:1.4rem;font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:.02em;line-height:1}
+.hv__karat{font-size:10px;font-weight:700;letter-spacing:.08em;color:var(--color-text-muted);text-transform:uppercase;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px 9px}
+.hv__card-note{font-size:.72rem;color:var(--color-text-muted);margin-bottom:var(--space-3);line-height:1.4;min-height:2em}
+.hv__card-price{font-family:var(--font-serif);font-size:1.55rem;font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;line-height:1.1;letter-spacing:-.01em}
+.hv__card-per{font-size:.62rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--color-text-faint);margin-top:3px}
+.hv__card-fx{font-size:.72rem;color:var(--color-text-muted);margin-top:6px;font-variant-numeric:tabular-nums}
+.hv__card-total{font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);margin-top:var(--space-2);padding-top:var(--space-2);border-top:1px dashed var(--color-border);font-variant-numeric:tabular-nums}
+.hv__foot{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-top:var(--space-5);padding-top:var(--space-4);border-top:1px solid var(--color-divider);font-size:.7rem;color:var(--color-text-faint);line-height:1.5}
+.hv__foot a{color:var(--color-text-muted);text-decoration:underline;text-underline-offset:2px}
+.hv__foot a:hover{color:var(--color-gold-bright)}
+
+/* ───────────────────────── FAQ ACCORDION ───────────────────────── */
+.gp-faq{margin-top:var(--space-5);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;background:var(--color-surface)}
+.gp-faq__item{border-bottom:1px solid var(--color-border)}
+.gp-faq__item:last-child{border-bottom:none}
+.gp-faq__question{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);width:100%;padding:var(--space-4) var(--space-5);text-align:left;font-size:var(--text-base);font-weight:600;color:var(--color-text);background:none;cursor:pointer;transition:background var(--transition),color var(--transition);min-height:60px;font-family:var(--font-body);border:none}
+.gp-faq__question:hover{background:var(--color-surface-offset)}
+.gp-faq__question[aria-expanded="true"]{color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface))}
+.gp-faq__chevron{flex-shrink:0;transition:transform var(--transition);color:var(--color-text-muted)}
+.gp-faq__question[aria-expanded="true"] .gp-faq__chevron{transform:rotate(180deg);color:var(--color-gold-bright)}
+.gp-faq__answer{padding:0 var(--space-5) var(--space-5);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
+.gp-faq__answer p{margin:0;max-width:70ch}
+.gp-faq__answer strong{color:var(--color-text)}
+.gp-faq__answer em{font-style:italic}
+
+/* ───────────────────────── RELATED + FOOTER ───────────────────────── */
+.related-guides-section{max-width:1200px;margin:0 auto var(--space-12);padding:0 var(--space-4)}
+.related-guides-section h2{font-family:var(--font-serif);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-5);letter-spacing:-.01em}
+.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4)}
+.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition),transform var(--transition);color:var(--color-text)}
+.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);color:var(--color-text);transform:translateY(-2px)}
+.related-card__tag{display:block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.related-card__title{font-size:var(--text-base);font-weight:700;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+.related-card__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6}
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
 .footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
 @media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
@@ -133,114 +373,16 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
-.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom{max-width:1200px;margin:var(--space-6) auto 0;padding:var(--space-4) var(--space-4) 0;border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
-.breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
-.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
-.breadcrumb a:hover{color:var(--color-primary)}
-.breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.article-wrap{max-width:1200px;margin:0 auto;padding:var(--space-6) var(--space-4) var(--space-16)}
-.article-tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-article.article-wrap .article-title,h1.article-title{font-family:var(--font-display)!important;font-size:clamp(1.75rem,3.5vw,2.75rem)!important;font-weight:700!important;line-height:1.15!important;margin:var(--space-2) 0 var(--space-5)!important;color:var(--color-text)!important}
-.article-byline{font-size:var(--text-sm);color:var(--color-text-muted);display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin-bottom:var(--space-6);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
-.article-byline a{color:var(--color-primary);text-decoration:none;font-weight:500}
-.article-byline a:hover{text-decoration:underline}
-.prose{max-width:860px}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose h4{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-5) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose sup{font-size:.7em;vertical-align:super;color:var(--color-text-faint)}
-.prose table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
-.prose table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-3) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.prose table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.prose table tr:last-child td{border-bottom:none}
-.prose table td:first-child,.prose table th:first-child{padding-left:0;color:var(--color-text)}
-.cta-box{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-8) 0}
-.cta-box h3{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:0 0 var(--space-2)}
-.cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-4)}
-.cta-btn{display:inline-flex;align-items:center;gap:var(--space-1);padding:var(--space-2) var(--space-5);background:var(--color-primary);color:#fff!important;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none;transition:background .15s}
-.cta-btn:hover,.cta-btn:visited{background:var(--color-primary-hover);color:#fff!important;text-decoration:none}
-.share-buttons{display:flex;flex-wrap:wrap;gap:var(--space-2);margin:var(--space-6) 0}
-.share-btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);border:1px solid var(--color-border);border-radius:var(--radius-full);background:var(--color-surface);color:var(--color-text-muted);font-size:var(--text-sm);font-weight:500;text-decoration:none;transition:border-color .15s,color .15s;white-space:nowrap}
-.share-btn:hover{border-color:var(--color-primary);color:var(--color-primary)}
-.disclaimer-box{background:var(--color-surface-alt,#f4f3ef);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
-.disclaimer-box strong{color:var(--color-text);font-weight:700}
-.related-guides-section{max-width:860px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
-.related-guides-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-4)}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4)}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);color:var(--color-text)}
-.related-card__tag{display:block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-.exec-summary{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0}
-.exec-summary-intro{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-5)}
-.exec-summary-intro strong{color:var(--color-text)}
-.exec-summary-stats{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-4)}
-.exec-stat{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4)}
-.exec-stat-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.exec-stat-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;margin-top:var(--space-1);line-height:1.2}
-.info-callout{background:color-mix(in oklch,var(--color-primary) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 20%,var(--color-border));border-left:3px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
-.info-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
-.info-callout p+p{margin-top:var(--space-3)}
-.info-callout strong{color:var(--color-text)}
-.info-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0}
-.info-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
-.warning-callout{background:color-mix(in oklch,#f59e0b 8%,var(--color-surface));border:1px solid color-mix(in oklch,#f59e0b 25%,var(--color-border));border-left:3px solid #f59e0b;border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
-.warning-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
-.warning-callout p+p{margin-top:var(--space-3)}
-.warning-callout strong{color:var(--color-text)}
-.warning-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0}
-.warning-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
-.faq-accordion{margin:var(--space-4) 0}
-details.faq-item{border:1px solid var(--color-border);border-radius:var(--radius-lg);margin-bottom:var(--space-2);overflow:hidden;background:var(--color-surface)}
-details.faq-item summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;gap:var(--space-3);transition:background .15s}
-details.faq-item summary::-webkit-details-marker{display:none}
-details.faq-item summary:hover{background:var(--color-surface-offset)}
-.faq-chevron{flex-shrink:0;transition:transform .2s;color:var(--color-text-muted)}
-details.faq-item[open] .faq-chevron{transform:rotate(180deg)}
-details.faq-item[open]>summary{background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
-.faq-body{padding:var(--space-4) var(--space-5);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
-.faq-body p{margin:0;max-width:none}
-.faq-body p+p{margin-top:var(--space-3)}
-.faq-body strong{color:var(--color-text)}
-/* STEP BLOCKS */
-.step-list{list-style:none;padding:0;margin:var(--space-6) 0;display:flex;flex-direction:column;gap:var(--space-4)}
-.step-block{display:flex;align-items:flex-start;gap:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.step-number{flex-shrink:0;width:36px;height:36px;border-radius:var(--radius-full);background:var(--color-primary);color:#fff;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
-.step-content{flex:1;min-width:0}
-.step-content strong{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
-.step-content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0;max-width:none}
-/* COUNTRY CARDS — international hallmark sections */
-.country-card{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0;transition:box-shadow var(--transition)}
-.country-card:hover{box-shadow:var(--shadow-md)}
-.country-card__header{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
-.country-card__name{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text)}
-.country-card p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4);max-width:none}
-.country-card p:last-child{margin-bottom:0}
-.country-card strong{color:var(--color-text)}
-.country-card table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-3) 0}
-.country-card table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-3) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.country-card table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.country-card table tr:last-child td{border-bottom:none}
-.country-card table td:first-child,.country-card table th:first-child{padding-left:0;color:var(--color-text)}
-/* HALLMARK PILL — inline fineness badge */
-.hmark{display:inline-flex;align-items:center;padding:2px 8px;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:.04em;font-family:var(--font-display)}
 </style>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
 </head>
 <body>
+<div id="gp-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Reading progress"></div>
+
 <nav class="site-nav" role="navigation" aria-label="Main navigation">
   <div class="nav-inner">
     <a href="/" class="nav-logo" aria-label="GoldPriceTools Home">
@@ -288,7 +430,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
       <li class="mega-nav__item" role="none"><a href="/about" class="mega-nav__trigger mega-nav__trigger--link">About</a></li>
     </ul>
     <div class="nav-actions">
-      <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark/light mode">
+      <button class="theme-toggle" id="themeToggle" data-theme-toggle aria-label="Toggle dark/light mode">
         <svg id="iconSun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
         <svg id="iconMoon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
       </button>
@@ -310,43 +452,228 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
   </div>
 </div>
 
-<div class="breadcrumb-wrap">
-  <nav aria-label="Breadcrumb">
-    <ol class="breadcrumb">
-      <li><a href="/">Home</a></li>
-      <li><a href="/guides/">Guides</a></li>
-      <li aria-current="page">Gold Hallmarks Explained</li>
+<!-- ───────────────────────── HERO ───────────────────────── -->
+<header class="gp-hero">
+  <div class="gp-hero__bg" aria-hidden="true">
+    <div class="gp-hero__grid"></div>
+    <div class="gp-hero__orb gp-hero__orb--1"></div>
+    <div class="gp-hero__orb gp-hero__orb--2"></div>
+  </div>
+  <div class="gp-hero__content">
+    <nav class="gp-breadcrumb" aria-label="Breadcrumb">
+      <a href="/">Home</a>
+      <span class="gp-breadcrumb-sep" aria-hidden="true">/</span>
+      <a href="/guides/">Guides</a>
+      <span class="gp-breadcrumb-sep" aria-hidden="true">/</span>
+      <span class="gp-breadcrumb-current" aria-current="page">Gold Hallmarks Explained</span>
+    </nav>
+    <div class="gp-hero__tag">Identification Guide <span class="gp-hero__tag-year">&middot; 2026 Edition</span></div>
+    <h1 class="gp-hero__title">Gold Hallmarks <em>Explained</em>: The Complete Identification Guide</h1>
+    <p class="gp-hero__lead">Pick up almost any piece of gold jewellery, look closely, and you will find a tiny constellation of stamps in the metal — a number, a small symbol, perhaps a heraldic animal. These are gold hallmarks, and they are <strong>one of the most useful and underappreciated pieces of information in the jewellery world.</strong> This guide covers everything: British, European, Russian, Fabergé, Indian, Middle Eastern and Chinese marks — plus the live value of every fineness.</p>
+    <div class="gp-hero__meta">
+      <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
+      <span class="meta-sep">&middot;</span>
+      <span>Published <time datetime="2026-05-08">8 May 2026</time></span>
+      <span class="meta-sep">&middot;</span>
+      <span>Updated <time datetime="2026-06-10">10 June 2026</time></span>
+      <span class="meta-sep">&middot;</span>
+      <span>21 min read</span>
+    </div>
+    <div class="gp-hero__cards" role="region" aria-label="Key hallmarking facts">
+      <div class="gp-hero__card">
+        <div class="gp-hero__card-label">UK law since</div>
+        <div class="gp-hero__card-value">1300</div>
+        <div class="gp-hero__card-sub">Edward I's decree</div>
+      </div>
+      <div class="gp-hero__card">
+        <div class="gp-hero__card-label">UK assay offices</div>
+        <div class="gp-hero__card-value">4 Active</div>
+        <div class="gp-hero__card-sub">London &middot; B'ham &middot; Sheffield &middot; Edinburgh</div>
+      </div>
+      <div class="gp-hero__card">
+        <div class="gp-hero__card-label">UK gold standards</div>
+        <div class="gp-hero__card-value">7 Purities</div>
+        <div class="gp-hero__card-sub">9ct through 24ct</div>
+      </div>
+      <div class="gp-hero__card">
+        <div class="gp-hero__card-label">CCM treaty members</div>
+        <div class="gp-hero__card-value">19 Countries</div>
+        <div class="gp-hero__card-sub">Mutual recognition</div>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- ───────────────────────── MOBILE TOC ───────────────────────── -->
+<div class="gp-toc-mobile">
+  <button class="gp-toc-toggle" id="tocToggle" aria-expanded="false" aria-controls="tocMobile">
+    <svg class="gp-toc-toggle__icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+    In this guide
+    <svg class="gp-toc-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+  </button>
+  <nav id="tocMobile" class="gp-toc-nav--mobile" aria-label="Article sections" hidden>
+    <ol>
+      <li><a href="#what-is">What Is a Gold Hallmark?</a></li>
+      <li><a href="#live-value">Live Value by Fineness Mark</a></li>
+      <li><a href="#british-system">The British Hallmarking System</a></li>
+      <li><a href="#where-to-find">Where to Find Hallmarks</a></li>
+      <li><a href="#reading-a-mark">Reading a Complete Mark</a></li>
+      <li><a href="#antique">Antique Gold Hallmarks</a></li>
+      <li><a href="#european">European Hallmarks</a></li>
+      <li><a href="#russian">Russian Hallmarks</a></li>
+      <li><a href="#faberge">Fabergé Hallmarks</a></li>
+      <li><a href="#india">India: The BIS System</a></li>
+      <li><a href="#middle-east">Middle Eastern &amp; Arabic</a></li>
+      <li><a href="#chinese">Chinese Hallmarks</a></li>
+      <li><a href="#white-gold">White Gold Hallmarks</a></li>
+      <li><a href="#pocket-watches">Gold Pocket Watches</a></li>
+      <li><a href="#how-to-identify">How to Identify a Mark</a></li>
+      <li><a href="#faq">FAQ</a></li>
     </ol>
   </nav>
 </div>
 
-<article class="article-wrap">
-  <div class="article-tag">Identification Guide</div>
-  <h1 class="article-title">Gold Hallmarks Explained — The Complete Identification Guide (2026)</h1>
-  <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
-    <span>&middot;</span>
-    <time datetime="2026-06-10">Updated 8 May 2026</time>
-    <span>&middot;</span>
-    <span>21 min read</span>
-  </div>
+<!-- ───────────────────────── LAYOUT ───────────────────────── -->
+<div class="gp-layout">
+  <aside class="gp-sidebar">
+    <nav class="gp-toc" aria-label="Table of contents">
+      <div class="gp-toc__header">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+        Contents
+      </div>
+      <ul class="gp-toc__list">
+        <li><a href="#what-is" class="gp-toc__link">What Is a Gold Hallmark?</a></li>
+        <li><a href="#live-value" class="gp-toc__link">Live Value by Fineness</a></li>
+        <li><a href="#british-system" class="gp-toc__link">The British System</a></li>
+        <li><a href="#where-to-find" class="gp-toc__link">Where to Find Marks</a></li>
+        <li><a href="#reading-a-mark" class="gp-toc__link">Reading a Mark</a></li>
+        <li><a href="#antique" class="gp-toc__link">Antique Hallmarks</a></li>
+        <li><a href="#rare-marks" class="gp-toc__link">Rare &amp; Unusual Marks</a></li>
+        <li><a href="#european" class="gp-toc__link">European Hallmarks</a></li>
+        <li><a href="#russian" class="gp-toc__link">Russian Hallmarks</a></li>
+        <li><a href="#faberge" class="gp-toc__link">Fabergé Hallmarks</a></li>
+        <li><a href="#india" class="gp-toc__link">India: BIS System</a></li>
+        <li><a href="#middle-east" class="gp-toc__link">Middle Eastern Marks</a></li>
+        <li><a href="#chinese" class="gp-toc__link">Chinese Hallmarks</a></li>
+        <li><a href="#white-gold" class="gp-toc__link">White Gold Hallmarks</a></li>
+        <li><a href="#pocket-watches" class="gp-toc__link">Gold Pocket Watches</a></li>
+        <li><a href="#foreign-in-uk" class="gp-toc__link">Foreign Marks in the UK</a></li>
+        <li><a href="#how-to-identify" class="gp-toc__link">How to Identify a Mark</a></li>
+        <li><a href="#faq" class="gp-toc__link">FAQ</a></li>
+      </ul>
+      <div class="gp-toc__spot" aria-live="polite">
+        <div class="gp-toc__spot-head">
+          <span class="gp-toc__spot-title">Live Gold Price</span>
+          <span class="gp-live-chip"><span class="live-dot"></span>Live</span>
+        </div>
+        <div class="gp-toc__spot-rows">
+          <div class="gp-toc__spot-row"><span class="gp-toc__spot-label">24K / oz (USD)</span><span class="gp-toc__spot-value" id="spotGoldOz">&mdash;</span></div>
+          <div class="gp-toc__spot-row"><span class="gp-toc__spot-label">24K / gram</span><span class="gp-toc__spot-value" id="spotGold24g">&mdash;</span></div>
+          <div class="gp-toc__spot-row"><span class="gp-toc__spot-label">18K / gram</span><span class="gp-toc__spot-value" id="spotGold18g">&mdash;</span></div>
+        </div>
+      </div>
+    </nav>
+  </aside>
 
-  <div class="exec-summary">
-    <p class="exec-summary-intro">Pick up almost any piece of gold jewellery and look closely — with good light and perhaps a magnifying glass — and you will find a tiny constellation of stamps somewhere on the metal. A number. A small symbol. Maybe a heraldic animal so small it seems impossible to have been stamped there at all. These are gold hallmarks, and they are <strong>one of the most useful and underappreciated pieces of information in the jewellery world.</strong> This guide covers everything — from the basics of the British system through European, Russian, Fabergé, Indian, Middle Eastern, and Chinese marks.</p>
-    <div class="exec-summary-stats">
-      <div class="exec-stat"><div class="exec-stat-label">UK law since</div><div class="exec-stat-value">1300</div></div>
-      <div class="exec-stat"><div class="exec-stat-label">UK assay offices</div><div class="exec-stat-value">4 active</div></div>
-      <div class="exec-stat"><div class="exec-stat-label">UK gold standards</div><div class="exec-stat-value">7 purities</div></div>
-      <div class="exec-stat"><div class="exec-stat-label">CCM treaty members</div><div class="exec-stat-value">19 countries</div></div>
-    </div>
-  </div>
-
-  <div class="prose">
+  <article class="gp-prose">
 
     <h2 id="what-is">What Is a Gold Hallmark?</h2>
     <p>A gold hallmark is an official mark stamped onto a piece of gold jewellery or metalwork by an independent testing body — called an assay office — after the item has been chemically tested and confirmed to meet a legal standard of purity.</p>
     <p>The word itself has a very specific origin. From the 16th century onwards, goldsmiths in London were required to bring their work to Goldsmiths' Hall on Foster Lane, where it would be tested and, if it met the required standard, struck with an official mark. That mark — applied at the Hall — became known as a "hall mark." The name stuck, and today it is used worldwide to describe any official precious metal certification stamp.</p>
     <p>The purpose has always been the same: <strong>consumer protection.</strong> Gold can be alloyed with cheaper metals at any proportion — a piece that looks like solid 18-karat gold could be 9-karat, or less. Without an independent test, a buyer has no way to verify what they are actually purchasing. Hallmarks solve that problem by transferring the verification to an independent, legally accountable body whose mark carries legal weight.</p>
+
+    <!-- ───────── LIVE HALLMARK VALUE DECODER ───────── -->
+    <section class="hv" id="live-value" aria-label="Live gold value by fineness mark">
+      <div class="hv__head">
+        <div class="hv__intro">
+          <div class="hv__eyebrow"><span class="live-dot"></span>Live Tool</div>
+          <h2 class="hv__title" style="border:none;margin:0;padding:0;font-size:var(--text-lg)">What Each Fineness Mark Is Worth Today</h2>
+          <p class="hv__sub">The fineness number is the single most useful hallmark — it tells you the gold content. Here is the live melt value per gram for every common gold fineness, priced from the LBMA spot in <strong>US dollars</strong> (the world's benchmark), with GBP &amp; EUR for reference. Type your item's weight to value it instantly.</p>
+        </div>
+        <div class="hv__spot">
+          <div class="hv__spot-head">
+            <span class="hv__spot-label">Gold Spot &middot; 24K</span>
+            <span class="gp-live-chip"><span class="live-dot"></span>Live</span>
+          </div>
+          <div class="hv__spot-price"><span id="hvSpotOz">&mdash;</span></div>
+          <div class="hv__spot-unit">per troy ounce (USD)</div>
+          <div class="hv__spot-fx" id="hvSpotGram">&mdash; / gram</div>
+          <div class="hv__spot-meta"><span class="live-dot"></span>Updated <span id="hvUpdated">just now</span> &middot; refreshes in <span id="hvCountdown">60</span>s</div>
+        </div>
+      </div>
+
+      <div class="hv__weight">
+        <div class="hv__weight-field">
+          <label class="hv__weight-label" for="hvWeight">Your item's weight (optional)</label>
+          <div class="hv__weight-input-wrap">
+            <input class="hv__weight-input" type="number" inputmode="decimal" min="0" step="0.01" placeholder="e.g. 10" id="hvWeight" aria-label="Item weight in grams">
+            <span class="hv__weight-suffix" aria-hidden="true">grams</span>
+          </div>
+        </div>
+        <div class="hv__presets" role="group" aria-label="Quick weight presets">
+          <button type="button" class="hv__preset" data-grams="3.5">Ring 3.5g</button>
+          <button type="button" class="hv__preset" data-grams="7.32">Sovereign</button>
+          <button type="button" class="hv__preset" data-grams="10">10g</button>
+          <button type="button" class="hv__preset" data-grams="31.1035">1 oz</button>
+        </div>
+      </div>
+
+      <div class="hv__grid" role="list">
+        <div class="hv__card" role="listitem" data-purity="0.375">
+          <div class="hv__card-top"><span class="hv__mark">375</span><span class="hv__karat">9K</span></div>
+          <div class="hv__card-note">Most common UK jewellery standard</div>
+          <div class="hv__card-price" id="hv-375-usd">&mdash;</div>
+          <div class="hv__card-per">per gram &middot; USD</div>
+          <div class="hv__card-fx" id="hv-375-fx">&mdash;</div>
+          <div class="hv__card-total" id="hv-375-total" hidden></div>
+        </div>
+        <div class="hv__card" role="listitem" data-purity="0.5833">
+          <div class="hv__card-top"><span class="hv__mark">585</span><span class="hv__karat">14K</span></div>
+          <div class="hv__card-note">Popular across the USA &amp; Europe</div>
+          <div class="hv__card-price" id="hv-585-usd">&mdash;</div>
+          <div class="hv__card-per">per gram &middot; USD</div>
+          <div class="hv__card-fx" id="hv-585-fx">&mdash;</div>
+          <div class="hv__card-total" id="hv-585-total" hidden></div>
+        </div>
+        <div class="hv__card" role="listitem" data-purity="0.75">
+          <div class="hv__card-top"><span class="hv__mark">750</span><span class="hv__karat">18K</span></div>
+          <div class="hv__card-note">The fine jewellery standard</div>
+          <div class="hv__card-price" id="hv-750-usd">&mdash;</div>
+          <div class="hv__card-per">per gram &middot; USD</div>
+          <div class="hv__card-fx" id="hv-750-fx">&mdash;</div>
+          <div class="hv__card-total" id="hv-750-total" hidden></div>
+        </div>
+        <div class="hv__card" role="listitem" data-purity="0.875">
+          <div class="hv__card-top"><span class="hv__mark">875</span><span class="hv__karat">21K</span></div>
+          <div class="hv__card-note">Dominant Gulf &amp; Middle East standard</div>
+          <div class="hv__card-price" id="hv-875-usd">&mdash;</div>
+          <div class="hv__card-per">per gram &middot; USD</div>
+          <div class="hv__card-fx" id="hv-875-fx">&mdash;</div>
+          <div class="hv__card-total" id="hv-875-total" hidden></div>
+        </div>
+        <div class="hv__card" role="listitem" data-purity="0.9167">
+          <div class="hv__card-top"><span class="hv__mark">916</span><span class="hv__karat">22K</span></div>
+          <div class="hv__card-note">Traditional &amp; South Asian gold</div>
+          <div class="hv__card-price" id="hv-916-usd">&mdash;</div>
+          <div class="hv__card-per">per gram &middot; USD</div>
+          <div class="hv__card-fx" id="hv-916-fx">&mdash;</div>
+          <div class="hv__card-total" id="hv-916-total" hidden></div>
+        </div>
+        <div class="hv__card" role="listitem" data-purity="0.999">
+          <div class="hv__card-top"><span class="hv__mark">999</span><span class="hv__karat">24K</span></div>
+          <div class="hv__card-note">Pure investment-grade gold</div>
+          <div class="hv__card-price" id="hv-999-usd">&mdash;</div>
+          <div class="hv__card-per">per gram &middot; USD</div>
+          <div class="hv__card-fx" id="hv-999-fx">&mdash;</div>
+          <div class="hv__card-total" id="hv-999-total" hidden></div>
+        </div>
+      </div>
+
+      <div class="hv__foot">
+        <span class="live-dot"></span>
+        <span>Live LBMA spot via <a href="https://www.gold-api.com" rel="noopener" target="_blank">gold-api.com</a> &middot; FX via <a href="https://www.frankfurter.dev" rel="noopener" target="_blank">Frankfurter</a> (ECB) &middot; refreshes every 60s. Melt value = weight &times; fineness &times; spot. Dealers typically pay 70–90% of melt. USD is the primary benchmark.</span>
+      </div>
+    </section>
 
     <h2 id="british-system">The British Hallmarking System: The World's Most Rigorous</h2>
     <p>The United Kingdom operates the oldest and most comprehensive hallmarking system in the world. British hallmarking dates back to <strong>1300</strong>, when Edward I decreed that all gold and silver must be assayed before sale. In 1478, the date letter system was introduced in London, allowing items to be dated to within a year. By 1757, counterfeiting a hallmark had become a felony punishable by death — reflecting just how seriously the system was taken.</p>
@@ -360,31 +687,58 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <h4>2. The Fineness Mark (Purity Mark)</h4>
     <p>The fineness mark tells you the gold content of the item, expressed in parts per thousand — a system called millesimal fineness. Common UK gold fineness marks are:</p>
-    <table>
-      <thead><tr><th>Mark</th><th>Carat</th><th>Gold Content</th><th>Use</th></tr></thead>
-      <tbody>
-        <tr><td><span class="hmark">999</span></td><td>24ct</td><td>99.9%</td><td>Investment bars &amp; coins</td></tr>
-        <tr><td><span class="hmark">990</span></td><td>23.76ct</td><td>99.0%</td><td>Rare; used in some specialist jewellery</td></tr>
-        <tr><td><span class="hmark">958</span></td><td>23ct (Britannia)</td><td>95.8%</td><td>Specialist commemorative pieces</td></tr>
-        <tr><td><span class="hmark">916</span></td><td>22ct</td><td>91.6%</td><td>Traditional UK wedding rings</td></tr>
-        <tr><td><span class="hmark">750</span></td><td>18ct</td><td>75.0%</td><td>Fine jewellery standard</td></tr>
-        <tr><td><span class="hmark">585</span></td><td>14ct</td><td>58.5%</td><td>Popular in USA &amp; Europe</td></tr>
-        <tr><td><span class="hmark">375</span></td><td>9ct</td><td>37.5%</td><td>Most common UK jewellery</td></tr>
-      </tbody>
-    </table>
+    <div class="gp-table-wrap gp-table-wrap--scroll">
+      <table class="gp-table">
+        <thead><tr><th>Mark</th><th>Carat</th><th>Gold Content</th><th>Use</th></tr></thead>
+        <tbody>
+          <tr><td><span class="hmark">999</span></td><td>24ct</td><td>99.9%</td><td>Investment bars &amp; coins</td></tr>
+          <tr><td><span class="hmark">990</span></td><td>23.76ct</td><td>99.0%</td><td>Rare; used in some specialist jewellery</td></tr>
+          <tr><td><span class="hmark">958</span></td><td>23ct (Britannia)</td><td>95.8%</td><td>Specialist commemorative pieces</td></tr>
+          <tr><td><span class="hmark">916</span></td><td>22ct</td><td>91.6%</td><td>Traditional UK wedding rings</td></tr>
+          <tr><td><span class="hmark">750</span></td><td>18ct</td><td>75.0%</td><td>Fine jewellery standard</td></tr>
+          <tr><td><span class="hmark">585</span></td><td>14ct</td><td>58.5%</td><td>Popular in USA &amp; Europe</td></tr>
+          <tr><td><span class="hmark">375</span></td><td>9ct</td><td>37.5%</td><td>Most common UK jewellery</td></tr>
+        </tbody>
+      </table>
+    </div>
     <p>Prior to 1975, UK gold hallmarks used a different system — a crown (indicating gold) plus the carat numeral (9, 15, 18, 22). If you find this combination on an older piece, it is the pre-decimal British purity mark. The change to millesimal fineness brought the UK into line with international standards.</p>
 
     <h4>3. The Assay Office Mark</h4>
     <p>The assay office mark is perhaps the most visually distinctive part of a British hallmark — each of the four active UK assay offices uses a unique heraldic symbol:</p>
-    <table>
-      <thead><tr><th>Symbol</th><th>Assay Office</th><th>Notes</th></tr></thead>
-      <tbody>
-        <tr><td>Leopard's head</td><td>London</td><td>Used since the 13th century; originally facing right, now facing left</td></tr>
-        <tr><td>Anchor</td><td>Birmingham</td><td>Established 1773; the anchor is displayed on its side</td></tr>
-        <tr><td>Yorkshire rose / Crown</td><td>Sheffield</td><td>Uses a rose or crown (pre-2019) / rosette</td></tr>
-        <tr><td>Castle</td><td>Edinburgh</td><td>A three-towered castle; Scotland's oldest assay office</td></tr>
-      </tbody>
-    </table>
+    <div class="assay-grid" role="list">
+      <div class="assay-card" role="listitem">
+        <div class="assay-card__emblem" aria-hidden="true">
+          <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 13l-3-6 7 4"/><path d="M33 13l3-6-7 4"/><circle cx="24" cy="27" r="12"/><circle cx="19.5" cy="24" r="1.4" fill="currentColor" stroke="none"/><circle cx="28.5" cy="24" r="1.4" fill="currentColor" stroke="none"/><path d="M24 28l-2.2 2.4h4.4z" fill="currentColor" stroke="none"/><path d="M21 32q3 2.4 6 0"/></svg>
+        </div>
+        <div class="assay-card__office">London</div>
+        <div class="assay-card__symbol">Leopard's Head</div>
+        <div class="assay-card__note">Used since the 13th century; now faces left</div>
+      </div>
+      <div class="assay-card" role="listitem">
+        <div class="assay-card__emblem" aria-hidden="true">
+          <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="24" cy="10" r="3.5"/><line x1="24" y1="13.5" x2="24" y2="39"/><line x1="15" y1="20" x2="33" y2="20"/><path d="M10 28a14 14 0 0 0 28 0"/><line x1="10" y1="28" x2="10" y2="24"/><line x1="38" y1="28" x2="38" y2="24"/></svg>
+        </div>
+        <div class="assay-card__office">Birmingham</div>
+        <div class="assay-card__symbol">Anchor</div>
+        <div class="assay-card__note">Established 1773; shown on its side</div>
+      </div>
+      <div class="assay-card" role="listitem">
+        <div class="assay-card__emblem" aria-hidden="true">
+          <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="24" cy="24" r="4.5"/><path d="M24 19.5c2-6 9-6 9 0"/><path d="M28.5 22c5.5-2.5 9 3.5 4 7"/><path d="M28 27c4.5 4 0 9.5-4 6.5"/><path d="M20 27c-4.5 4 0 9.5 4 6.5"/><path d="M19.5 22c-5.5-2.5-9 3.5-4 7"/></svg>
+        </div>
+        <div class="assay-card__office">Sheffield</div>
+        <div class="assay-card__symbol">Yorkshire Rose</div>
+        <div class="assay-card__note">A rose or crown (pre-2019) / rosette</div>
+      </div>
+      <div class="assay-card" role="listitem">
+        <div class="assay-card__emblem" aria-hidden="true">
+          <svg viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 39V21l3 2 3-4 3 4 3-5 3 5 3-4 3 4 3-2v18z"/><line x1="9" y1="39" x2="39" y2="39"/><path d="M21 39v-7a3 3 0 0 1 6 0v7"/><rect x="14.5" y="27" width="4" height="4"/><rect x="29.5" y="27" width="4" height="4"/></svg>
+        </div>
+        <div class="assay-card__office">Edinburgh</div>
+        <div class="assay-card__symbol">Castle</div>
+        <div class="assay-card__note">Three-towered; Scotland's oldest office</div>
+      </div>
+    </div>
     <p>A fifth office — Chester — operated until 1962, using a sword with three wheatsheaves. Dublin's office (using a crowned harp) was active until 1923. Both are perfectly valid historical hallmarks encountered on antique pieces.</p>
 
     <h4>4. The Date Letter (Optional since 1998)</h4>
@@ -405,9 +759,8 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <h2 id="reading-a-mark">Reading a Complete British Hallmark</h2>
     <p>To make this concrete, here is how to read a complete hallmark on a hypothetical gold ring:</p>
-
-    <div class="info-callout">
-      <p><strong>Example:</strong> A ring with the following marks inside the band: <strong>AT</strong> (in a shield) · <span class="hmark">750</span> · Leopard's head · Letter <strong>N</strong> in a plain square.</p>
+    <div class="example-box">
+      <p><strong>Example:</strong> A ring with the following marks inside the band: <strong>AT</strong> (in a shield) &middot; <span class="hmark">750</span> &middot; Leopard's head &middot; Letter <strong>N</strong> in a plain square.</p>
       <ul>
         <li><strong>AT</strong> — the sponsor's mark (the maker's registered initials)</li>
         <li><strong>750</strong> — 18-carat gold (75% pure gold)</li>
@@ -451,25 +804,29 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <div class="country-card">
       <div class="country-card__header">
+        <span class="country-card__crest" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12c4-2 6-2 9 0s5 2 9 0"/><path d="M3 12c2-1 3-3 3-5"/><path d="M21 12c-2-1-3-3-3-5"/><circle cx="12" cy="7" r="1.5"/></svg></span>
         <div class="country-card__name">French Gold Hallmarks</div>
       </div>
       <p>France developed one of the most elegant hallmarking systems in the world, built around pictorial symbols rather than numbers. The system was standardised in 1838 and remains largely unchanged today.</p>
-      <table>
-        <thead><tr><th>Symbol</th><th>Metal / Standard</th><th>Meaning</th></tr></thead>
-        <tbody>
-          <tr><td>Eagle's head (facing left)</td><td>18K gold (750)</td><td>National guarantee mark since 1838 — the most commonly encountered French gold mark</td></tr>
-          <tr><td>Seahorse</td><td>24K gold (999)</td><td>Used for high-purity / investment-grade gold pieces</td></tr>
-          <tr><td>Scallop shell</td><td>14K gold (585)</td><td>Introduced post-World War I</td></tr>
-          <tr><td>Clover / Trefoil</td><td>9K gold (375)</td><td>Primarily for export pieces</td></tr>
-          <tr><td>Owl</td><td>Import mark</td><td>Applied to foreign items imported into France — confirms sold in France, not made there</td></tr>
-          <tr><td>Lozenge (diamond shape)</td><td>Maker's mark</td><td>Identifies the manufacturer; compulsory on all French pieces</td></tr>
-        </tbody>
-      </table>
+      <div class="gp-table-wrap gp-table-wrap--scroll">
+        <table class="gp-table">
+          <thead><tr><th>Symbol</th><th>Metal / Standard</th><th>Meaning</th></tr></thead>
+          <tbody>
+            <tr><td>Eagle's head (facing left)</td><td>18K gold (750)</td><td>National guarantee mark since 1838 — the most commonly encountered French gold mark</td></tr>
+            <tr><td>Seahorse</td><td>24K gold (999)</td><td>Used for high-purity / investment-grade gold pieces</td></tr>
+            <tr><td>Scallop shell</td><td>14K gold (585)</td><td>Introduced post-World War I</td></tr>
+            <tr><td>Clover / Trefoil</td><td>9K gold (375)</td><td>Primarily for export pieces</td></tr>
+            <tr><td>Owl</td><td>Import mark</td><td>Applied to foreign items imported into France — confirms sold in France, not made there</td></tr>
+            <tr><td>Lozenge (diamond shape)</td><td>Maker's mark</td><td>Identifies the manufacturer; compulsory on all French pieces</td></tr>
+          </tbody>
+        </table>
+      </div>
       <p>The <strong>eagle's head</strong> is the mark most collectors and buyers encounter on antique French jewellery — tiny, discreet, but decisive. It appears on virtually all 18-karat French gold from 1838 onwards. Historically, different animals were used for 18K gold at different periods — the horse's head, rhinoceros head, and even the weevil were all used before the standardisation of the eagle. The <strong>owl mark</strong> on a piece confirms it was sold in France but made elsewhere.</p>
     </div>
 
     <div class="country-card">
       <div class="country-card__header">
+        <span class="country-card__crest" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 7a6 6 0 1 0 0 10 7 7 0 0 1 0-10z"/><path d="M19 9l1-1M19 15l1 1"/></svg></span>
         <div class="country-card__name">German Gold Hallmarks</div>
       </div>
       <p>Germany does not operate a compulsory government hallmarking system for gold. Instead, manufacturers use the millesimal fineness system (<span class="hmark">375</span> <span class="hmark">585</span> <span class="hmark">750</span> <span class="hmark">999</span>) with their own maker's marks. The <strong>crescent moon and crown</strong> symbol was historically used as the German assay guarantee mark for gold and silver. Items carrying this symbol alongside a fineness number are reliably identifiable as German-certified precious metal.</p>
@@ -477,6 +834,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <div class="country-card">
       <div class="country-card__header">
+        <span class="country-card__crest" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 12h8M12 8v8"/></svg></span>
         <div class="country-card__name">Italian Gold Hallmarks</div>
       </div>
       <p>Italy has one of the world's most prolific gold jewellery manufacturing industries — Arezzo, Vicenza, and Valenza are among the world's leading production centres — but Italy does not require government assay hallmarking in the same way the UK does. Italian pieces carry a <strong>maker's mark</strong> (a number identifying the manufacturer, registered with the state) and a <strong>fineness mark</strong> (<span class="hmark">375</span> <span class="hmark">585</span> <span class="hmark">750</span> <span class="hmark">999</span>). The shape of the cartouche around the fineness mark differs: pieces above 750 fineness use a star-shaped or oval cartouche; pieces at or below 750 use a different shape.</p>
@@ -485,24 +843,28 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <div class="country-card">
       <div class="country-card__header">
+        <span class="country-card__crest" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="6" width="16" height="12" rx="2"/><path d="M4 10h16"/></svg></span>
         <div class="country-card__name">Spanish Gold Hallmarks</div>
       </div>
       <p>Spain operates a dual hallmarking system: government assay offices in major regions certify gold, and manufacturers must also register their mark. The system uses millesimal fineness (<span class="hmark">375</span> <span class="hmark">585</span> <span class="hmark">750</span>) with regional assay codes that make Spanish gold particularly informative for tracing provenance:</p>
-      <table>
-        <thead><tr><th>Code</th><th>Region</th></tr></thead>
-        <tbody>
-          <tr><td>V1</td><td>Valencia</td></tr>
-          <tr><td>M1</td><td>Madrid</td></tr>
-          <tr><td>A1</td><td>Andalusia</td></tr>
-          <tr><td>G1</td><td>Galicia</td></tr>
-          <tr><td>C1 / C2</td><td>Catalonia</td></tr>
-          <tr><td>B2</td><td>Balearic Islands</td></tr>
-        </tbody>
-      </table>
+      <div class="gp-table-wrap gp-table-wrap--scroll">
+        <table class="gp-table">
+          <thead><tr><th>Code</th><th>Region</th></tr></thead>
+          <tbody>
+            <tr><td>V1</td><td>Valencia</td></tr>
+            <tr><td>M1</td><td>Madrid</td></tr>
+            <tr><td>A1</td><td>Andalusia</td></tr>
+            <tr><td>G1</td><td>Galicia</td></tr>
+            <tr><td>C1 / C2</td><td>Catalonia</td></tr>
+            <tr><td>B2</td><td>Balearic Islands</td></tr>
+          </tbody>
+        </table>
+      </div>
     </div>
 
     <div class="country-card">
       <div class="country-card__header">
+        <span class="country-card__crest" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4v6c0 3 2 5 5 5s5-2 5-5V4"/><path d="M9 20h6M12 15v5"/></svg></span>
         <div class="country-card__name">Swiss Gold Hallmarks</div>
       </div>
       <p>Switzerland introduced gold hallmarking in 1880. Swiss pieces carry a fineness mark alongside an assay office mark and maker's mark. The most distinctive Swiss hallmark symbols are the <strong>squirrel</strong> (for gold 585/14K and above, used since 1934) and the <strong>Helvetia head</strong> (for 18ct, 750 fineness). Swiss watch cases are a rich area for hallmark study — the combination of maker's code, fineness, and assay office mark allows detailed authentication of both case and movement.</p>
@@ -510,6 +872,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <div class="country-card">
       <div class="country-card__header">
+        <span class="country-card__crest" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l2 5h5l-4 3.5L17 17l-5-3-5 3 2-5.5L5 8h5z"/></svg></span>
         <div class="country-card__name">Austrian Gold Hallmarks</div>
       </div>
       <p>Austria uses the Convention Common Control Mark alongside national marks, and uses a <strong>shield</strong> format for its assay marks. Austrian pieces typically carry millesimal fineness numbers alongside a letter-and-number code identifying the assay district. Vienna was historically one of Europe's most important centres of fine goldsmithing, and antique Austrian pieces with clear assay marks are common in specialist markets.</p>
@@ -517,6 +880,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <div class="country-card">
       <div class="country-card__header">
+        <span class="country-card__crest" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14c3 0 4-4 8-4s5 4 8 4"/><path d="M4 14c3 0 4 4 8 4s5-4 8-4"/><circle cx="17" cy="11" r="0.8" fill="currentColor" stroke="none"/></svg></span>
         <div class="country-card__name">Dutch Gold Hallmarks</div>
       </div>
       <p>The Netherlands uses a <strong>lion rampant</strong> alongside the fineness number. The <strong>fish</strong> symbol appears on Dutch import marks, serving a similar function to the French owl — indicating an item was imported for sale in the Netherlands. Dutch pieces also carry a maker's mark and a millesimal fineness number. The Netherlands has a long tradition of fine goldsmithing, particularly in Amsterdam.</p>
@@ -527,15 +891,17 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <h3>Pre-Revolutionary Russia (Before 1917)</h3>
     <p>Imperial Russian gold was marked using the <strong>zolotnik system</strong> — a unit of purity based on a traditional Russian weight. The numeral appears alongside a city crest identifying the assay office location. <strong>St. Petersburg</strong> pieces carry two crossed anchors and a sceptre; <strong>Moscow</strong> pieces show St. George slaying the dragon.</p>
-    <table>
-      <thead><tr><th>Zolotnik Mark</th><th>Modern Equivalent</th><th>Fineness</th></tr></thead>
-      <tbody>
-        <tr><td><span class="hmark">56</span></td><td>14K gold</td><td>583 / 585</td></tr>
-        <tr><td><span class="hmark">72</span></td><td>18K gold</td><td>750</td></tr>
-        <tr><td><span class="hmark">92</span></td><td>22K gold</td><td>916</td></tr>
-        <tr><td><span class="hmark">96</span></td><td>24K gold</td><td>999</td></tr>
-      </tbody>
-    </table>
+    <div class="gp-table-wrap gp-table-wrap--scroll">
+      <table class="gp-table">
+        <thead><tr><th>Zolotnik Mark</th><th>Modern Equivalent</th><th>Fineness</th></tr></thead>
+        <tbody>
+          <tr><td><span class="hmark">56</span></td><td>14K gold</td><td>583 / 585</td></tr>
+          <tr><td><span class="hmark">72</span></td><td>18K gold</td><td>750</td></tr>
+          <tr><td><span class="hmark">92</span></td><td>22K gold</td><td>916</td></tr>
+          <tr><td><span class="hmark">96</span></td><td>24K gold</td><td>999</td></tr>
+        </tbody>
+      </table>
+    </div>
     <p>From <strong>1899</strong>, the iconic <strong>kokoshnik mark</strong> was introduced — a woman's head shown in left profile wearing a traditional kokoshnik headdress. This single mark replaced the old city crests, combining purity and assay location into one symbol. A Greek letter next to the kokoshnik identifies the specific assay office — the letter Iota (І) indicates St. Petersburg.</p>
     <p>The kokoshnik is one of the most important dating tools for Russian antiques. Its presence confirms a piece was made <strong>in 1899 or later</strong>. Its absence — with a city crest instead — indicates pre-1899 manufacture.</p>
 
@@ -582,15 +948,17 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <h2 id="middle-east">Middle Eastern and Arabic Gold Hallmarks</h2>
     <p>Gold is central to the culture and economy of the Middle East — Dubai is one of the world's most important gold trading hubs. All gold sold legally in the UAE must be marked with official purity stamps applied after testing by government-approved bodies. The most common karats in the region are:</p>
-    <table>
-      <thead><tr><th>Mark</th><th>Karat</th><th>Purity</th><th>Notes</th></tr></thead>
-      <tbody>
-        <tr><td><span class="hmark">999</span></td><td>24K</td><td>99.9%</td><td>Pure investment gold</td></tr>
-        <tr><td><span class="hmark">916</span></td><td>22K</td><td>91.6%</td><td>Traditional Middle Eastern jewellery standard</td></tr>
-        <tr><td><span class="hmark">875</span></td><td>21K</td><td>87.5%</td><td>Dominant Gulf standard — most distinctive regional identifier</td></tr>
-        <tr><td><span class="hmark">750</span></td><td>18K</td><td>75.0%</td><td>Modern, Western-influenced designs</td></tr>
-      </tbody>
-    </table>
+    <div class="gp-table-wrap gp-table-wrap--scroll">
+      <table class="gp-table">
+        <thead><tr><th>Mark</th><th>Karat</th><th>Purity</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td><span class="hmark">999</span></td><td>24K</td><td>99.9%</td><td>Pure investment gold</td></tr>
+          <tr><td><span class="hmark">916</span></td><td>22K</td><td>91.6%</td><td>Traditional Middle Eastern jewellery standard</td></tr>
+          <tr><td><span class="hmark">875</span></td><td>21K</td><td>87.5%</td><td>Dominant Gulf standard — most distinctive regional identifier</td></tr>
+          <tr><td><span class="hmark">750</span></td><td>18K</td><td>75.0%</td><td>Modern, Western-influenced designs</td></tr>
+        </tbody>
+      </table>
+    </div>
     <p>The <span class="hmark">875</span> fineness mark is one of the clearest indicators of Middle Eastern origin when encountered on gold in Western markets. Saudi Arabia and Egypt follow the same conventions — Egyptian gold is typically <span class="hmark">750</span> or <span class="hmark">875</span> and carries an official government assay stamp alongside the fineness mark.</p>
 
     <h2 id="chinese">Chinese Gold Hallmarks</h2>
@@ -629,7 +997,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 
     <div class="cta-box">
       <h3>Know Your Gold's Melt Value Before You Buy or Sell</h3>
-      <p>Once you've identified the fineness mark on your gold, use our free calculator to find out exactly what it's worth at today's live spot price.</p>
+      <p>Once you've identified the fineness mark on your gold, use our free calculator to find out exactly what it's worth at today's live spot price — in USD, GBP, EUR and INR.</p>
       <a href="/scrap-gold-calculator" class="cta-btn">Calculate Gold Value &rarr;</a>
     </div>
 
@@ -680,52 +1048,51 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     </ol>
 
     <h2 id="faq">Frequently Asked Questions</h2>
-    <div class="faq-accordion">
-      <div class="faq-item">
-        <h3>What do gold hallmarks mean?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Gold hallmarks are official stamps applied by an independent assay office after testing, confirming the item's gold content (purity), the identity of the maker, and where it was tested. They are a legal guarantee of quality. In the UK, any item described as gold and weighing more than one gram must be hallmarked before sale.</p></div>
+    <div class="gp-faq">
+      <div class="gp-faq__item">
+        <button class="gp-faq__question" aria-expanded="false">What do gold hallmarks mean?<svg class="gp-faq__chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg></button>
+        <div class="gp-faq__answer" hidden><p>Gold hallmarks are official stamps applied by an independent assay office after testing, confirming the item's gold content (purity), the identity of the maker, and where it was tested. They are a legal guarantee of quality. In the UK, any item described as gold and weighing more than one gram must be hallmarked before sale.</p></div>
       </div>
-      <div class="faq-item">
-        <h3>What are the most common UK gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>The most commonly encountered UK gold hallmarks are the fineness marks <strong>375</strong> (9ct), <strong>585</strong> (14ct), and <strong>750</strong> (18ct), combined with an assay office symbol (leopard's head for London, anchor for Birmingham, castle for Edinburgh) and the maker's mark. The 375 / 9ct standard is by far the most common standard in everyday UK gold jewellery.</p></div>
+      <div class="gp-faq__item">
+        <button class="gp-faq__question" aria-expanded="false">What are the most common UK gold hallmarks?<svg class="gp-faq__chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg></button>
+        <div class="gp-faq__answer" hidden><p>The most commonly encountered UK gold hallmarks are the fineness marks <strong>375</strong> (9ct), <strong>585</strong> (14ct), and <strong>750</strong> (18ct), combined with an assay office symbol (leopard's head for London, anchor for Birmingham, castle for Edinburgh) and the maker's mark. The 375 / 9ct standard is by far the most common standard in everyday UK gold jewellery.</p></div>
       </div>
-      <div class="faq-item">
-        <h3>How do I identify antique gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Look for the pre-1975 UK crown-plus-numeral system (e.g., a crown with "18" for 18ct gold), date letters that allow precise year-dating, and assay office marks that include the now-closed Chester office (sword with wheatsheaves). <em>Bradbury's Book of Hallmarks</em> is the standard reference for antique British marks. Finding a 15ct mark dates a piece to between 1854 and 1932.</p></div>
+      <div class="gp-faq__item">
+        <button class="gp-faq__question" aria-expanded="false">How do I identify antique gold hallmarks?<svg class="gp-faq__chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg></button>
+        <div class="gp-faq__answer" hidden><p>Look for the pre-1975 UK crown-plus-numeral system (e.g., a crown with "18" for 18ct gold), date letters that allow precise year-dating, and assay office marks that include the now-closed Chester office (sword with wheatsheaves). <em>Bradbury's Book of Hallmarks</em> is the standard reference for antique British marks. Finding a 15ct mark dates a piece to between 1854 and 1932.</p></div>
       </div>
-      <div class="faq-item">
-        <h3>What are the French gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>The <strong>eagle's head</strong> (facing left) is the French guarantee mark for 18K gold and has been in use since 1838. The <strong>scallop shell</strong> indicates 14K gold; the <strong>clover (trefoil)</strong> indicates 9K gold. The <strong>owl</strong> appears on foreign items imported into France. A lozenge-shaped mark is the maker's mark, compulsory on all French pieces.</p></div>
+      <div class="gp-faq__item">
+        <button class="gp-faq__question" aria-expanded="false">What are the French gold hallmarks?<svg class="gp-faq__chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg></button>
+        <div class="gp-faq__answer" hidden><p>The <strong>eagle's head</strong> (facing left) is the French guarantee mark for 18K gold and has been in use since 1838. The <strong>scallop shell</strong> indicates 14K gold; the <strong>clover (trefoil)</strong> indicates 9K gold. The <strong>owl</strong> appears on foreign items imported into France. A lozenge-shaped mark is the maker's mark, compulsory on all French pieces.</p></div>
       </div>
-      <div class="faq-item">
-        <h3>What are Russian gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Pre-1917 Russian gold uses the <strong>zolotnik system</strong> — the number 56 for 14K gold, 72 for 18K — alongside a city crest (St. Petersburg or Moscow) or, from 1899, a <strong>kokoshnik mark</strong> (woman's head in profile wearing a headdress). Soviet era pieces (1917–1991) use a hammer and sickle mark with millesimal fineness — 583 for 14K.</p></div>
+      <div class="gp-faq__item">
+        <button class="gp-faq__question" aria-expanded="false">What are Russian gold hallmarks?<svg class="gp-faq__chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg></button>
+        <div class="gp-faq__answer" hidden><p>Pre-1917 Russian gold uses the <strong>zolotnik system</strong> — the number 56 for 14K gold, 72 for 18K — alongside a city crest (St. Petersburg or Moscow) or, from 1899, a <strong>kokoshnik mark</strong> (woman's head in profile wearing a headdress). Soviet era pieces (1917–1991) use a hammer and sickle mark with millesimal fineness — 583 for 14K.</p></div>
       </div>
-      <div class="faq-item">
-        <h3>What are Fabergé gold hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Authentic Fabergé pieces carry the government assay mark (city crest or kokoshnik), the <strong>specific workmaster's initials</strong> (HW for Wigström, MP for Perchin, EK for Kollin), and the Fabergé firm name in Cyrillic or Latin script. Moscow branch pieces also carry the <strong>double-headed eagle</strong> of the Imperial Warrant. Fakes are common — incorrect mark combinations are the most reliable red flag.</p></div>
+      <div class="gp-faq__item">
+        <button class="gp-faq__question" aria-expanded="false">What are Fabergé gold hallmarks?<svg class="gp-faq__chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg></button>
+        <div class="gp-faq__answer" hidden><p>Authentic Fabergé pieces carry the government assay mark (city crest or kokoshnik), the <strong>specific workmaster's initials</strong> (HW for Wigström, MP for Perchin, EK for Kollin), and the Fabergé firm name in Cyrillic or Latin script. Moscow branch pieces also carry the <strong>double-headed eagle</strong> of the Imperial Warrant. Fakes are common — incorrect mark combinations are the most reliable red flag.</p></div>
       </div>
-      <div class="faq-item">
-        <h3>What is the BIS hallmark on Indian gold?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>The BIS (Bureau of Indian Standards) hallmark has been mandatory in India since 2021. It consists of a <strong>BIS triangle logo</strong>, a purity mark (22K916, 18K750, or 14K585), an assay centre code, and a <strong>six-digit HUID number</strong> that can be verified instantly via the BIS Care government app. Only HUID-marked jewellery can be sold by registered Indian jewellers since April 2023.</p></div>
+      <div class="gp-faq__item">
+        <button class="gp-faq__question" aria-expanded="false">What is the BIS hallmark on Indian gold?<svg class="gp-faq__chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg></button>
+        <div class="gp-faq__answer" hidden><p>The BIS (Bureau of Indian Standards) hallmark has been mandatory in India since 2021. It consists of a <strong>BIS triangle logo</strong>, a purity mark (22K916, 18K750, or 14K585), an assay centre code, and a <strong>six-digit HUID number</strong> that can be verified instantly via the BIS Care government app. Only HUID-marked jewellery can be sold by registered Indian jewellers since April 2023.</p></div>
       </div>
-      <div class="faq-item">
-        <h3>Do white gold pieces have different hallmarks?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>No — white gold carries <strong>identical hallmarks to yellow gold</strong>. A white gold ring hallmarked 750 is 18-carat gold; the hallmark identifies purity regardless of the metal's colour. There is no special "WG" mark or separate white gold standard. If a white-coloured piece carries 375, 585, or 750 with a UK assay office mark, it is hallmarked solid white gold.</p></div>
+      <div class="gp-faq__item">
+        <button class="gp-faq__question" aria-expanded="false">Do white gold pieces have different hallmarks?<svg class="gp-faq__chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg></button>
+        <div class="gp-faq__answer" hidden><p>No — white gold carries <strong>identical hallmarks to yellow gold</strong>. A white gold ring hallmarked 750 is 18-carat gold; the hallmark identifies purity regardless of the metal's colour. There is no special "WG" mark or separate white gold standard. If a white-coloured piece carries 375, 585, or 750 with a UK assay office mark, it is hallmarked solid white gold.</p></div>
       </div>
-      <div class="faq-item">
-        <h3>What does 875 mean on gold jewellery?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p><strong>875</strong> is the millesimal fineness mark for 21-karat gold (87.5% pure). It is most commonly associated with Middle Eastern jewellery — particularly from the UAE, Saudi Arabia, and Egypt — and is one of the clearest regional identifiers when encountered on gold in Western markets. You will rarely see 875 on British-made gold jewellery.</p></div>
+      <div class="gp-faq__item">
+        <button class="gp-faq__question" aria-expanded="false">What does 875 mean on gold jewellery?<svg class="gp-faq__chevron" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg></button>
+        <div class="gp-faq__answer" hidden><p><strong>875</strong> is the millesimal fineness mark for 21-karat gold (87.5% pure). It is most commonly associated with Middle Eastern jewellery — particularly from the UAE, Saudi Arabia, and Egypt — and is one of the clearest regional identifiers when encountered on gold in Western markets. You will rarely see 875 on British-made gold jewellery.</p></div>
       </div>
     </div>
 
-  </div><!-- /prose -->
+    <div class="disclaimer-box">
+      <strong>Editorial note:</strong> This guide reflects hallmarking systems as of 2026. Regulations and standards are subject to change. Live gold values shown above are derived from the LBMA spot price in US dollars and are for guidance only. For formal authentication of valuable antique pieces, consult a qualified jewellery appraiser or contact the relevant assay office directly.
+    </div>
 
-  <div class="disclaimer-box">
-    <strong>Editorial note:</strong> This guide reflects hallmarking systems as of 2026. Regulations and standards are subject to change. For formal authentication of valuable antique pieces, consult a qualified jewellery appraiser or contact the relevant assay office directly.
-  </div>
-
-</article>
+  </article>
+</div>
 
 <section class="related-guides-section">
   <h2>Related Gold &amp; Silver Guides</h2>
@@ -775,10 +1142,9 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li></li>
-        <li></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        
       </ul>
     </div>
     <div class="footer-col">
@@ -827,38 +1193,261 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
   </div>
 </footer>
 
+<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+
+<!-- ───────────────────────── LIVE ENGINE + INTERACTIONS ───────────────────────── -->
 <script>
 (function(){
+  'use strict';
+  // Shared with the rest of the site: LBMA spot via gold-api.com (XAU), FX via Frankfurter (ECB).
+  // Constants mirror the scrap-gold-calculator & karat price pages so per-gram values match site-wide.
+  var TROY_OZ = 31.1035;          // grams per troy ounce
+  var REFRESH_MS = 60000;         // 60s, matching all live pages
+  var SPOT_URL = 'https://api.gold-api.com/price/XAU';
+  var FX_URL = 'https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR,INR';
+
+  // Fineness mark -> purity (karat fraction, identical to site convention)
+  var FINENESS = [
+    {mark:'375', purity:0.375},
+    {mark:'585', purity:0.5833},
+    {mark:'750', purity:0.75},
+    {mark:'875', purity:0.875},
+    {mark:'916', purity:0.9167},
+    {mark:'999', purity:0.999}
+  ];
+
+  // Global live state (back-compat with other listeners)
+  window._spotUSD = window._spotUSD || null;
+  window._gbpusd = window._gbpusd || 0.79;
+  window._eurusd = window._eurusd || 0.92;
+  window._usdinr = window._usdinr || 83.5;
+  var lastFetchTs = 0;
+
+  var fmtUSD = new Intl.NumberFormat('en-US',{style:'currency',currency:'USD',minimumFractionDigits:2,maximumFractionDigits:2});
+  var fmtGBP = new Intl.NumberFormat('en-GB',{style:'currency',currency:'GBP',minimumFractionDigits:2,maximumFractionDigits:2});
+  var fmtEUR = new Intl.NumberFormat('en-IE',{style:'currency',currency:'EUR',minimumFractionDigits:2,maximumFractionDigits:2});
+
+  function $(id){return document.getElementById(id);}
+  function setText(id,val){var e=$(id); if(e) e.textContent=val;}
+
+  function getWeight(){
+    var w = $('hvWeight');
+    if(!w) return 0;
+    var v = parseFloat(w.value);
+    return (isNaN(v) || v < 0) ? 0 : v;
+  }
+
+  function render(){
+    var spot = window._spotUSD;
+    if(!spot) return;
+    var perGram24 = spot / TROY_OZ;
+    var weight = getWeight();
+
+    // Header spot pill (USD primary)
+    setText('hvSpotOz', fmtUSD.format(spot));
+    setText('hvSpotGram', fmtUSD.format(perGram24) + ' / gram');
+
+    // Sidebar mini-panel
+    setText('spotGoldOz', fmtUSD.format(spot));
+    setText('spotGold24g', fmtUSD.format(perGram24));
+    setText('spotGold18g', fmtUSD.format(perGram24 * 0.75));
+
+    // Fineness cards
+    FINENESS.forEach(function(f){
+      var pUSD = perGram24 * f.purity;
+      setText('hv-'+f.mark+'-usd', fmtUSD.format(pUSD));
+      setText('hv-'+f.mark+'-fx', '≈ ' + fmtGBP.format(pUSD*window._gbpusd) + ' · ' + fmtEUR.format(pUSD*window._eurusd));
+      var totalEl = $('hv-'+f.mark+'-total');
+      if(totalEl){
+        if(weight > 0){
+          var t = pUSD * weight;
+          totalEl.textContent = 'Your ' + (weight % 1 === 0 ? weight : weight.toFixed(2)) + 'g ≈ ' + fmtUSD.format(t);
+          totalEl.hidden = false;
+        } else {
+          totalEl.hidden = true;
+        }
+      }
+    });
+  }
+
+  function refreshStamp(){
+    if(!lastFetchTs) return;
+    var secs = Math.floor((Date.now() - lastFetchTs)/1000);
+    var rem = Math.max(0, Math.ceil((REFRESH_MS/1000) - secs));
+    setText('hvUpdated', secs < 5 ? 'just now' : (secs < 60 ? secs + 's ago' : Math.floor(secs/60) + 'm ago'));
+    setText('hvCountdown', rem);
+  }
+
+  function fetchFx(){
+    return fetch(FX_URL,{cache:'no-store'}).then(function(r){
+      if(!r.ok) throw new Error('FX '+r.status);
+      return r.json();
+    }).then(function(d){
+      if(d && d.rates){
+        window._gbpusd = d.rates.GBP || window._gbpusd;
+        window._eurusd = d.rates.EUR || window._eurusd;
+        window._usdinr = d.rates.INR || window._usdinr;
+      }
+    }).catch(function(e){ console.warn('FX fallback used', e); });
+  }
+
+  function fetchSpot(){
+    return fetch(SPOT_URL,{cache:'no-store'}).then(function(r){
+      if(!r.ok) throw new Error('Spot '+r.status);
+      return r.json();
+    }).then(function(d){
+      if(d && d.price){
+        window._spotUSD = d.price;
+        window._spot = d.price; // legacy alias
+        lastFetchTs = Date.now();
+        render();
+        refreshStamp();
+        window.dispatchEvent(new Event('goldprice_updated'));
+        if(typeof gtag === 'function') gtag('event','price_view',{metal:'gold',page:'gold-hallmarks-explained'});
+      }
+    }).catch(function(e){
+      console.warn('Spot fetch failed', e);
+      if(!window._spotUSD) setText('hvSpotOz','Unavailable');
+    });
+  }
+
+  // Weight input + presets
+  function initWeight(){
+    var w = $('hvWeight');
+    if(w) w.addEventListener('input', render);
+    document.querySelectorAll('.hv__preset').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        if(w){
+          w.value = btn.getAttribute('data-grams');
+          render();
+          w.focus();
+        }
+      });
+    });
+  }
+
+  // Reading progress bar
+  function initProgress(){
+    var bar = $('gp-progress');
+    if(!bar) return;
+    var update = function(){
+      var docH = document.documentElement.scrollHeight - window.innerHeight;
+      var pct = docH > 0 ? Math.min(100,(window.scrollY/docH)*100) : 0;
+      bar.style.width = pct + '%';
+      bar.setAttribute('aria-valuenow', Math.round(pct));
+    };
+    window.addEventListener('scroll', update, {passive:true});
+    update();
+  }
+
+  // TOC scroll-spy
+  function initTocHighlight(){
+    var links = document.querySelectorAll('.gp-toc__link');
+    if(!links.length || !('IntersectionObserver' in window)) return;
+    var map = Array.prototype.map.call(links, function(l){
+      var id = l.getAttribute('href').slice(1);
+      return {link:l, section:document.getElementById(id)};
+    }).filter(function(x){return x.section;});
+    if(!map.length) return;
+    var obs = new IntersectionObserver(function(entries){
+      entries.forEach(function(entry){
+        if(entry.isIntersecting){
+          links.forEach(function(l){l.classList.remove('active');});
+          var active = map.find(function(s){return s.section === entry.target;});
+          if(active) active.link.classList.add('active');
+        }
+      });
+    }, {rootMargin:'-72px 0px -65% 0px', threshold:0});
+    map.forEach(function(s){ obs.observe(s.section); });
+  }
+
+  // Mobile TOC toggle
+  function initMobileToc(){
+    var btn = $('tocToggle');
+    var nav = $('tocMobile');
+    if(!btn || !nav) return;
+    btn.addEventListener('click', function(){
+      var expanded = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', String(!expanded));
+      nav.hidden = expanded;
+    });
+    nav.querySelectorAll('a').forEach(function(link){
+      link.addEventListener('click', function(){
+        btn.setAttribute('aria-expanded','false');
+        nav.hidden = true;
+      });
+    });
+  }
+
+  // FAQ accordion
+  function initFaq(){
+    document.querySelectorAll('.gp-faq__question').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        var answer = btn.nextElementSibling;
+        var expanded = btn.getAttribute('aria-expanded') === 'true';
+        if(expanded){
+          btn.setAttribute('aria-expanded','false');
+          if(answer) answer.hidden = true;
+        } else {
+          btn.setAttribute('aria-expanded','true');
+          if(answer) answer.hidden = false;
+        }
+      });
+    });
+  }
+
+  // Deep-read analytics
+  function initDeepRead(){
+    var fired = false;
+    window.addEventListener('scroll', function(){
+      if(fired) return;
+      var sh = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+      if(sh > 0 && (window.scrollY/sh) > 0.75){
+        if(typeof gtag === 'function') gtag('event','guide_deep_read',{guide:'gold-hallmarks-explained'});
+        fired = true;
+      }
+    }, {passive:true});
+  }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    initWeight();
+    initProgress();
+    initTocHighlight();
+    initMobileToc();
+    initFaq();
+    initDeepRead();
+    Promise.all([fetchFx(), fetchSpot()]).catch(function(e){ console.warn('init', e); });
+    setInterval(fetchSpot, REFRESH_MS);
+    setInterval(refreshStamp, 1000);
+  });
+})();
+</script>
+
+<!-- ───────────────────────── THEME + NAV CHROME ───────────────────────── -->
+<script>(function(){
   var toggle=document.getElementById('themeToggle');
   var sun=document.getElementById('iconSun');
   var moon=document.getElementById('iconMoon');
   function applyTheme(t){
     document.documentElement.setAttribute('data-theme',t);
-    localStorage.setItem('gpt-theme',t);
+    try{localStorage.setItem('gpt-theme',t);}catch(e){}
     if(sun)sun.style.display=t==='dark'?'none':'block';
     if(moon)moon.style.display=t==='dark'?'block':'none';
   }
   var saved=localStorage.getItem('gpt-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
   applyTheme(saved);
   if(toggle)toggle.addEventListener('click',function(){applyTheme(document.documentElement.getAttribute('data-theme')==='dark'?'light':'dark');});
-  var ham=document.getElementById('hamburger');
-  var menu=document.getElementById('mobileMenu');
-  if(ham&&menu){
-    ham.addEventListener('click',function(){
-      var open=menu.classList.toggle('open');
-      ham.setAttribute('aria-expanded',open);
-      document.body.style.overflow=open?'hidden':'';
-    });
+  var ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
+  if(ham&&mob){
+    ham.addEventListener('click',function(){var o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});
+    document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});
   }
   document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){
-    btn.addEventListener('click',function(){
-      var items=this.nextElementSibling;
-      var expanded=this.getAttribute('aria-expanded')==='true';
-      this.setAttribute('aria-expanded',!expanded);
-      if(items)items.classList.toggle('open',!expanded);
-    });
+    btn.addEventListener('click',function(){var items=this.nextElementSibling;var expanded=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',!expanded);if(items)items.classList.toggle('open',!expanded);});
   });
-})();
-</script>
+  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();var p=this.nextElementSibling;if(!p)return;var o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');var t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
+  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');var t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');var t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
+})();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Full mobile-first redesign of **`/guides/gold-hallmarks-explained`**, elevating it to the site's premium guide template and adding a live, interactive value tool tied directly to the article's core subject (fineness marks). All existing copy and SEO are preserved.

## What changed

**Premium template (matches & extends `gold-purity-guide`)**
- Serif (Playfair Display) hero with radial-orb + grid backdrop, breadcrumb, eyebrow tag, byline, and 4 stat cards (1300 · 4 offices · 7 purities · 19 CCM members).
- Fixed reading-progress bar.
- Two-column layout at ≥1024px: sticky **sidebar TOC with scroll-spy** + a **live gold-spot mini-panel**; collapsible mobile TOC below the hero.

**NEW — Live "Hallmark Value Decoder"** (the standout element)
- Six fineness cards — **375 / 585 / 750 / 875 / 916 / 999** — each showing the live **USD** melt value per gram, with GBP/EUR for reference.
- A live spot pill (24K/oz, USD primary), "Live" indicator, and a 60s refresh countdown.
- A weight input (+ quick presets) that instantly values the user's own piece at every fineness.

**Visual upgrades**
- Assay-office emblem cards (inline SVG medallions) replacing a plain table.
- Restyled tables, country cards, callouts, and the 6-step identification method.
- **Fixed FAQ accordion** — the previous markup was broken (CSS targeted `<details>` but the HTML used `<div>`, so answers never collapsed). Now a proper accessible button/aria-expanded accordion.

## Data accuracy (cross-site consistency)

The live engine mirrors the canonical scrap-gold-calculator and karat price pages **exactly**, so per-gram values match site-wide to the cent:
- Spot: `api.gold-api.com/price/XAU` (LBMA) · FX: `api.frankfurter.dev` (ECB), fallbacks GBP 0.79 / EUR 0.92 / INR 83.5
- `troy oz = 31.1035`, `perGram24 = spot ÷ 31.1035`, purities 9K 0.375 / 14K 0.5833 / 18K 0.75 / 21K 0.875 / 22K 0.9167 / 24K 0.999
- 60s refresh, shared `window._spotUSD`, dispatches `goldprice_updated`
- **USD is the primary currency throughout**; other currencies are reference conversions.

## Accessibility & performance
- `aria-live` price regions, visible focus states, `prefers-reduced-motion`, 44px touch targets, mobile table overflow handled.
- No new external dependencies; all scripts inlined as on sibling pages.

## Verification
- ✅ `scripts/validate-jsonld.js` passes (Article / BreadcrumbList / FAQPage preserved)
- ✅ `node --check` on both inline script blocks
- ✅ Every element ID the JS writes to exists in the HTML
- ✅ All distinctive article content + all 9 FAQ entries preserved

> Note: live prices were verified for shape/endpoint parity only — the build host blocks outbound API calls, but the endpoints are identical to existing live pages and run client-side in the browser.

https://claude.ai/code/session_01TSrWBFC4ST36yuS8NYdWBj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSrWBFC4ST36yuS8NYdWBj)_