### PR TITLE
Redesign: How to Sell Gold Jewellery guide (premium editorial, USD primary)

### DIFF
--- a/guides/how-to-sell-gold-jewellery.html
+++ b/guides/how-to-sell-gold-jewellery.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>How to Sell Gold Jewellery &amp; Get the Best Price in 2026 | Complete Guide | GoldPriceTools</title>
 <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Find out how to sell gold jewellery for the best price in 2026. Compare buyers, calculate your gold's value, avoid scams, and get cash fast — complete guide.">
+<meta name="description" content="Find out how to sell gold jewellery for the best price in 2026. Compare buyers, calculate your gold's value in USD, avoid scams, and get cash fast — complete guide.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery">
 <link rel="alternate" hreflang="en" href="https://goldpricetools.com/guides/how-to-sell-gold-jewellery">
@@ -18,7 +18,7 @@
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="How to Sell Gold Jewellery &amp; Get the Best Price in 2026">
-<meta property="og:description" content="Find out how to sell gold jewellery for the best price in 2026. Compare buyers, calculate your gold's value, avoid scams, and get cash fast — complete guide.">
+<meta property="og:description" content="Find out how to sell gold jewellery for the best price in 2026. Compare buyers, calculate your gold's value in USD, avoid scams, and get cash fast — complete guide.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/how-to-sell-gold-jewellery">
 <meta property="og:site_name" content="GoldPriceTools">
@@ -28,9 +28,9 @@
 <meta property="og:image:alt" content="How to Sell Gold Jewellery — GoldPriceTools">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Sell Gold Jewellery — Get the Best Price in 2026","description":"Find out how to sell gold jewellery for the best price in 2026. Compare buyers, calculate your gold's value, avoid scams, and get cash fast — complete guide.","url":"https://goldpricetools.com/guides/how-to-sell-gold-jewellery","datePublished":"2026-04-24","dateModified":"2026-06-11T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-sell-gold-jewellery"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Sell Gold Jewellery — Get the Best Price in 2026","description":"Find out how to sell gold jewellery for the best price in 2026. Compare buyers, calculate your gold's value in USD, avoid scams, and get cash fast — complete guide.","url":"https://goldpricetools.com/guides/how-to-sell-gold-jewellery","datePublished":"2026-04-24","dateModified":"2026-06-11T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-to-sell-gold-jewellery"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"How to Sell Gold Jewellery","item":"https://goldpricetools.com/guides/how-to-sell-gold-jewellery"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How much can I sell my gold jewellery for?","acceptedAnswer":{"@type":"Answer","text":"Your payout depends on the weight, karat purity, and which buyer you choose. Use the formula: grams × (karat ÷ 24) × current spot price per gram to get the melt value. Competitive buyers will pay 75–95% of this figure."}},{"@type":"Question","name":"What is the best place to sell gold jewellery?","acceptedAnswer":{"@type":"Answer","text":"For standard scrap gold, specialist online gold buyers and dedicated gold dealers consistently pay the most — typically 80–95% of melt value. For wearable or designer pieces, local jewellers or luxury resale platforms will often pay more. For antique or high-value items, auction houses can achieve prices well above melt value."}},{"@type":"Question","name":"Where can I sell gold jewellery near me?","acceptedAnswer":{"@type":"Answer","text":"Local options include reputable jewellers, specialist bullion dealers, and established pawn shops (as a last resort). Search for gold dealers with strong Google Reviews or Trustpilot ratings in your city. Hatton Garden in London, 47th Street in New York, and similar jewellery districts concentrate specialist buyers who typically offer competitive rates."}},{"@type":"Question","name":"Can I sell gold jewellery online safely?","acceptedAnswer":{"@type":"Answer","text":"Yes — if you use an established buyer with clear published rates, free insured postal packaging, a transparent offer process, and a free returns policy if you decline. Always photograph and weigh items before posting, use tracked and insured delivery, and check independent reviews before sending anything."}},{"@type":"Question","name":"How do gold jewellery buyers calculate their price?","acceptedAnswer":{"@type":"Answer","text":"Buyers use the formula: weight × purity percentage × their buying price per gram (which is a percentage of the live spot price). The variation is entirely in that final percentage — the best buyers pay 85–95% of spot, while pawn shops may pay as little as 20–40%."}},{"@type":"Question","name":"Should I sell gold jewellery now or wait?","acceptedAnswer":{"@type":"Answer","text":"Gold prices are near all-time highs in 2026, making it an excellent time to sell for cash if you have unwanted jewellery. Major financial institutions forecast continued strength in gold prices through 2026 and 2027. If you need the cash or simply want to declutter, current prices represent an exceptional opportunity."}},{"@type":"Question","name":"Can I sell gold-plated jewellery?","acceptedAnswer":{"@type":"Answer","text":"Not to gold buyers — the gold content in plated jewellery is negligible and most specialist buyers will not purchase it as gold. Sell gold-plated pieces as jewellery on eBay, Vinted, or Facebook Marketplace, where private buyers value the aesthetic appeal rather than the metal content."}},{"@type":"Question","name":"What happens if I sell gold jewellery without a receipt?","acceptedAnswer":{"@type":"Answer","text":"In most countries, there is no legal requirement to have a purchase receipt to sell second-hand gold jewellery. Buyers are required by law in many jurisdictions to record the seller's identity as part of anti-money laundering regulations — this is standard and applies to everyone. The absence of a receipt does not affect your price."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How much can I sell my gold jewellery for?","acceptedAnswer":{"@type":"Answer","text":"Your payout depends on the weight, karat purity, and which buyer you choose. Use the formula: grams × (karat ÷ 24) × current spot price per gram to get the melt value in USD. Competitive buyers will pay 75–95% of this figure."}},{"@type":"Question","name":"What is the best place to sell gold jewellery?","acceptedAnswer":{"@type":"Answer","text":"For standard scrap gold, specialist online gold buyers and dedicated gold dealers consistently pay the most — typically 80–95% of melt value. For wearable or designer pieces, local jewellers or luxury resale platforms will often pay more. For antique or high-value items, auction houses can achieve prices well above melt value."}},{"@type":"Question","name":"Where can I sell gold jewellery near me?","acceptedAnswer":{"@type":"Answer","text":"Local options include reputable jewellers, specialist bullion dealers, and established pawn shops (as a last resort). Search for gold dealers with strong Google Reviews or Trustpilot ratings in your city. 47th Street in New York, Hatton Garden in London, and similar jewellery districts concentrate specialist buyers who typically offer competitive rates."}},{"@type":"Question","name":"Can I sell gold jewellery online safely?","acceptedAnswer":{"@type":"Answer","text":"Yes — if you use an established buyer with clear published rates, free insured postal packaging, a transparent offer process, and a free returns policy if you decline. Always photograph and weigh items before posting, use tracked and insured delivery, and check independent reviews before sending anything."}},{"@type":"Question","name":"How do gold jewellery buyers calculate their price?","acceptedAnswer":{"@type":"Answer","text":"Buyers use the formula: weight × purity percentage × their buying price per gram (which is a percentage of the live spot price in USD). The variation is entirely in that final percentage — the best buyers pay 85–95% of spot, while pawn shops may pay as little as 20–40%."}},{"@type":"Question","name":"Should I sell gold jewellery now or wait?","acceptedAnswer":{"@type":"Answer","text":"Gold prices are near all-time highs in 2026, making it an excellent time to sell for cash if you have unwanted jewellery. Major financial institutions forecast continued strength in gold prices through 2026 and 2027. If you need the cash or simply want to declutter, current prices represent an exceptional opportunity."}},{"@type":"Question","name":"Can I sell gold-plated jewellery?","acceptedAnswer":{"@type":"Answer","text":"Not to gold buyers — the gold content in plated jewellery is negligible and most specialist buyers will not purchase it as gold. Sell gold-plated pieces as jewellery on eBay, Vinted, or Facebook Marketplace, where private buyers value the aesthetic appeal rather than the metal content."}},{"@type":"Question","name":"What happens if I sell gold jewellery without a receipt?","acceptedAnswer":{"@type":"Answer","text":"In most countries, there is no legal requirement to have a purchase receipt to sell second-hand gold jewellery. Buyers are required by law in many jurisdictions to record the seller's identity as part of anti-money laundering regulations — this is standard and applies to everyone. The absence of a receipt does not affect your price."}}]}</script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
 <script>(function(){function signalGooglefcPresent(){if(!window.frames['googlefcPresent']){if(document.body){const iframe=document.createElement('iframe');iframe.style='width:0;height:0;border:none;z-index:-1000;left:-1000px;top:-1000px;';iframe.style.display='none';iframe.name='googlefcPresent';document.body.appendChild(iframe);}else{setTimeout(signalGooglefcPresent,0);}}}signalGooglefcPresent();})();</script>
@@ -39,39 +39,81 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.gold-api.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,500&display=swap" rel="stylesheet">
 <style>
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
-.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-alt:#f4f3ef;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+/* ============================================================
+   TOKENS
+   ============================================================ */
+:root,[data-theme="light"]{
+  --color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-alt:#f4f3ef;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;
+  --color-text:#28251d;--color-text-muted:#54514a;--color-text-faint:#8d8b84;--color-text-inverse:#f9f8f4;
+  --color-primary:#01696f;--color-primary-hover:#0c4e54;
+  --color-gold:#b07a00;--color-gold-bright:#c98a00;--color-gold-deep:#7a5400;
+  --color-silver:#6b7280;
+  --color-up:#15803d;--color-down:#b91c1c;
+  --shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);
+  --shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);
+  --shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);
+  --shadow-gold:0 12px 36px -10px color-mix(in oklch,var(--color-gold-bright) 35%,transparent);
+  --radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;
+  --space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--space-20:5rem;
+  --text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);
+  --text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);
+  --text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);
+  --text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);
+  --text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);
+  --text-2xl:clamp(2rem,1.4rem + 2.5vw,3.5rem);
+  --text-3xl:clamp(2.5rem,1.6rem + 3.5vw,4.5rem);
+  --font-body:'Inter','Helvetica Neue',sans-serif;
+  --font-display:'Playfair Display','IBM Plex Sans',serif;
+  --font-mono:'IBM Plex Sans','SF Mono',monospace;
+  --transition:180ms cubic-bezier(0.16,1,0.3,1);
+  --transition-slow:420ms cubic-bezier(0.22,1,0.36,1);
+}
+[data-theme="dark"]{
+  --color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;
+  --color-text:#e8e6e1;--color-text-muted:#a7a59f;--color-text-faint:#6a6862;--color-text-inverse:#1a1917;
+  --color-primary:#4f98a3;--color-primary-hover:#6ab3be;
+  --color-gold:#d19900;--color-gold-bright:#f0bb4a;--color-gold-deep:#a87800;
+  --color-silver:#9ca3af;
+  --color-up:#4ade80;--color-down:#f87171;
+  --shadow-sm:0 1px 2px oklch(0 0 0/0.3);
+  --shadow-md:0 4px 12px oklch(0 0 0/0.4);
+  --shadow-lg:0 12px 32px oklch(0 0 0/0.5);
+  --shadow-gold:0 16px 48px -12px color-mix(in oklch,var(--color-gold-bright) 25%,transparent);
+}
+/* ============================================================
+   BASE
+   ============================================================ */
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
-body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:90px}
+body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg);overflow-x:hidden}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
-h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.15}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
 :focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
-@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important;scroll-behavior:auto!important}html{scroll-behavior:auto}}
+/* ============================================================
+   SKIP LINK
+   ============================================================ */
+.skip-link{position:absolute;top:-40px;left:0;background:var(--color-primary);color:#fff;padding:8px 16px;z-index:1000;text-decoration:none;border-radius:0 0 var(--radius-md) 0;font-weight:600;font-size:var(--text-sm)}
+.skip-link:focus{top:0}
+/* ============================================================
+   READING PROGRESS BAR
+   ============================================================ */
+.read-progress{position:fixed;top:0;left:0;height:3px;width:0;background:linear-gradient(90deg,var(--color-gold-bright),var(--color-primary));z-index:250;transition:width 80ms linear;pointer-events:none}
+/* ============================================================
+   NAV (preserved from system)
+   ============================================================ */
+.site-nav{position:sticky;top:0;z-index:200;background:color-mix(in oklch,var(--color-surface) 92%,transparent);backdrop-filter:saturate(140%) blur(10px);-webkit-backdrop-filter:saturate(140%) blur(10px);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1240px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
 .mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
 .mega-nav__item{position:relative}
@@ -80,50 +122,360 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .mega-nav__trigger--link{text-decoration:none}
 .mega-nav__chevron{transition:transform .2s;flex-shrink:0}
 .mega-nav__trigger[aria-expanded="true"] .mega-nav__chevron{transform:rotate(180deg)}
-.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.12);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300;animation:megaFadeIn .15s ease-out}
+.mega-panel{display:none;position:absolute;top:calc(100% + 6px);left:50%;transform:translateX(-50%);min-width:420px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:0 8px 32px oklch(0 0 0/.18);padding:var(--space-4);gap:var(--space-4);flex-direction:row;z-index:300}
 .mega-panel--wide{min-width:640px}
 .mega-panel--blog{min-width:280px}
 .mega-nav__item:hover .mega-panel,.mega-panel.is-open{display:flex}
-@keyframes megaFadeIn{from{opacity:0;transform:translateX(-50%) translateY(-6px)}to{opacity:1;transform:translateX(-50%) translateY(0)}}
 .mega-panel__col{display:flex;flex-direction:column;gap:2px;min-width:140px}
 .mega-panel__col--blog{min-width:220px}
 .mega-panel__heading{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:4px 10px 8px}
 .mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
 .mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
 .mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
-.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
 .mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
+.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
+.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
+.mega-panel__cat-title{display:block;font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.mega-panel__cat-desc{display:block;font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.4}
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
 .nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
-.theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
+.theme-toggle{display:flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
 .theme-toggle:hover{color:var(--color-text);background:var(--color-surface-offset)}
-.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer}
+.hamburger{display:none;flex-direction:column;gap:4px;padding:var(--space-2);border-radius:var(--radius-md);background:none;border:none;cursor:pointer;min-width:44px;min-height:44px;align-items:center;justify-content:center}
 .hamburger span{display:block;width:20px;height:2px;background:var(--color-text);border-radius:2px;transition:transform .22s cubic-bezier(.4,0,.2,1),opacity .22s}
 .hamburger[aria-expanded="true"] span:nth-child(1){transform:translateY(6px) rotate(45deg)}
 .hamburger[aria-expanded="true"] span:nth-child(2){opacity:0;transform:scaleX(0)}
 .hamburger[aria-expanded="true"] span:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
-.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1)}
+.mobile-menu{display:none;position:fixed;top:56px;left:0;right:0;bottom:0;background:var(--color-surface);z-index:199;overflow-y:auto;-webkit-overflow-scrolling:touch;border-top:1px solid var(--color-border);transform:translateX(-100%);transition:transform .28s cubic-bezier(.4,0,.2,1);overscroll-behavior:contain}
 .mobile-menu.open{display:block;transform:translateX(0)}
 .mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
 .mobile-section{border-radius:var(--radius-md);overflow:hidden}
-.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s;min-height:44px}
 .mobile-section__toggle:hover{background:var(--color-surface-offset)}
 .mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
 .mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
 .mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
 .mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
 .mobile-section__items.open{display:flex}
-.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-sm);transition:color .12s,background .12s;min-height:44px;display:flex;align-items:center}
 .mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
 .mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
 .mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
-.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-md);min-height:44px;display:flex;align-items:center}
 .mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
-@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
+@media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}.mega-nav__trigger{min-height:44px}}
 @media(max-width:768px){.nav-logo span{display:none}}
-.ad-slot{min-height:0!important;margin:var(--space-2) 0}
-.ad-slot:not(:has(ins[data-ad-status])){border:none!important;background:none!important;padding:0!important;min-height:0!important;margin:0!important}
+.breadcrumb-wrap{max-width:1240px;margin:0 auto;padding:var(--space-3) var(--space-4) 0}
+.breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
+.breadcrumb li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
+.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
+.breadcrumb a:hover{color:var(--color-primary)}
+.breadcrumb li[aria-current="page"]{color:var(--color-text)}
+/* ============================================================
+   LAYOUT — Article + Sidebar
+   ============================================================ */
+.article-shell{max-width:1240px;margin:0 auto;padding:var(--space-4) var(--space-4) var(--space-16);display:grid;grid-template-columns:minmax(0,1fr);gap:var(--space-8)}
+@media(min-width:1080px){
+  .article-shell{grid-template-columns:minmax(0,1fr) 280px;gap:var(--space-12);padding-top:var(--space-6)}
+}
+.article-main{min-width:0}
+/* ============================================================
+   HERO — premium editorial
+   ============================================================ */
+.hero-card{position:relative;overflow:hidden;background:linear-gradient(155deg,color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface)) 0%,var(--color-surface) 55%,color-mix(in oklch,var(--color-primary) 4%,var(--color-surface)) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);padding:clamp(var(--space-6),4vw,var(--space-12));margin-bottom:var(--space-8)}
+.hero-card::before{content:"";position:absolute;inset:0;background:radial-gradient(ellipse 60% 40% at 90% 0%,color-mix(in oklch,var(--color-gold-bright) 14%,transparent),transparent 70%),radial-gradient(ellipse 40% 30% at 0% 100%,color-mix(in oklch,var(--color-primary) 12%,transparent),transparent 70%);pointer-events:none;z-index:0}
+.hero-card>*{position:relative;z-index:1}
+.hero-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.14em;color:var(--color-gold-bright);margin-bottom:var(--space-4);padding:6px 12px;border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));border-radius:var(--radius-full);background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface))}
+.hero-eyebrow .pulse{width:7px;height:7px;border-radius:50%;background:var(--color-up);box-shadow:0 0 0 0 color-mix(in oklch,var(--color-up) 60%,transparent);animation:pulse 1.8s infinite}
+@keyframes pulse{0%{box-shadow:0 0 0 0 color-mix(in oklch,var(--color-up) 70%,transparent)}70%{box-shadow:0 0 0 10px color-mix(in oklch,var(--color-up) 0%,transparent)}100%{box-shadow:0 0 0 0 color-mix(in oklch,var(--color-up) 0%,transparent)}}
+.hero-title{font-family:var(--font-display);font-weight:600;font-size:var(--text-3xl);line-height:1.05;letter-spacing:-.01em;color:var(--color-text);margin-bottom:var(--space-4);max-width:18ch}
+.hero-title em{font-style:italic;color:var(--color-gold-bright);font-weight:500}
+.hero-lede{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.65;max-width:62ch;margin-bottom:var(--space-6)}
+.hero-lede strong{color:var(--color-text);font-weight:600}
+.hero-byline{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-3);font-size:var(--text-xs);color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-bottom:var(--space-6);padding-bottom:var(--space-5);border-bottom:1px solid color-mix(in oklch,var(--color-border) 80%,transparent)}
+.hero-byline a{color:var(--color-text-muted);font-weight:500;text-transform:none;letter-spacing:0;font-size:var(--text-sm)}
+.hero-byline .dot{width:3px;height:3px;border-radius:50%;background:var(--color-text-faint)}
+/* Live spot block */
+.live-spot{display:grid;grid-template-columns:1fr;gap:var(--space-3);background:color-mix(in oklch,var(--color-bg) 60%,var(--color-surface));border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);margin-bottom:var(--space-5)}
+@media(min-width:520px){.live-spot{grid-template-columns:1fr 1fr 1fr;gap:var(--space-5)}}
+.live-spot-cell{display:flex;flex-direction:column;gap:var(--space-1)}
+.live-spot-cell+.live-spot-cell{padding-top:var(--space-3);border-top:1px solid var(--color-divider)}
+@media(min-width:520px){.live-spot-cell+.live-spot-cell{padding-top:0;padding-left:var(--space-5);border-top:none;border-left:1px solid var(--color-divider)}}
+.live-spot-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint)}
+.live-spot-value{font-family:var(--font-display);font-weight:600;font-size:clamp(1.5rem,3vw,2rem);color:var(--color-text);font-variant-numeric:tabular-nums;line-height:1.1}
+.live-spot-meta{font-size:var(--text-xs);color:var(--color-text-muted);display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.live-spot-change.up{color:var(--color-up);font-weight:600}
+.live-spot-change.down{color:var(--color-down);font-weight:600}
+.live-spot-cta{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);background:var(--color-gold-bright);color:var(--color-text-inverse);font-size:var(--text-sm);font-weight:600;border-radius:var(--radius-md);text-decoration:none;transition:transform var(--transition),box-shadow var(--transition);box-shadow:var(--shadow-gold);align-self:flex-start;margin-top:var(--space-2)}
+.live-spot-cta:hover{transform:translateY(-1px);color:var(--color-text-inverse);text-decoration:none;box-shadow:var(--shadow-gold),var(--shadow-md)}
+.live-spot-cta:visited{color:var(--color-text-inverse)}
+/* Hero stat grid */
+.hero-stats{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin-top:var(--space-5)}
+@media(min-width:640px){.hero-stats{grid-template-columns:repeat(4,1fr)}}
+.hero-stat{padding:var(--space-4);background:color-mix(in oklch,var(--color-surface) 65%,transparent);border:1px solid var(--color-border);border-radius:var(--radius-lg);transition:border-color var(--transition),transform var(--transition)}
+.hero-stat:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-1px)}
+.hero-stat-label{font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:6px}
+.hero-stat-value{font-family:var(--font-display);font-size:clamp(1.25rem,2.5vw,1.5rem);font-weight:600;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.15}
+.hero-stat-sub{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:4px}
+/* ============================================================
+   SIDEBAR / TOC
+   ============================================================ */
+.toc-aside{display:none}
+@media(min-width:1080px){
+  .toc-aside{display:block;position:sticky;top:80px;align-self:start;max-height:calc(100dvh - 100px);overflow-y:auto;padding:var(--space-2)}
+}
+.toc-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5)}
+.toc-heading{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-faint);margin-bottom:var(--space-3)}
+.toc-list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:2px}
+.toc-list a{display:block;padding:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);border-left:2px solid transparent;line-height:1.4;transition:color var(--transition),background var(--transition),border-color var(--transition)}
+.toc-list a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+.toc-list a.active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,transparent);font-weight:600}
+.toc-mini-cta{margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider);display:flex;flex-direction:column;gap:var(--space-2)}
+.toc-mini-cta strong{font-size:var(--text-sm);color:var(--color-text);font-weight:700}
+.toc-mini-cta span{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.5}
+.toc-mini-cta a{display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:var(--space-2) var(--space-3);background:var(--color-primary);color:#fff;font-size:var(--text-sm);font-weight:600;border-radius:var(--radius-md);text-decoration:none;margin-top:var(--space-1)}
+.toc-mini-cta a:hover{background:var(--color-primary-hover);color:#fff;text-decoration:none}
+/* ============================================================
+   PROSE (article body)
+   ============================================================ */
+.prose{max-width:760px}
+.prose h2{font-family:var(--font-display);font-weight:600;font-size:clamp(1.75rem,2.5vw,2.25rem);color:var(--color-text);margin:var(--space-12) 0 var(--space-4);line-height:1.15;letter-spacing:-.005em;scroll-margin-top:90px}
+.prose h2::before{content:"";display:block;width:36px;height:3px;background:linear-gradient(90deg,var(--color-gold-bright),transparent);border-radius:2px;margin-bottom:var(--space-3)}
+.prose h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:600;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
+.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
+.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
+.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
+.prose strong{color:var(--color-text);font-weight:600}
+.prose a{color:var(--color-primary);text-decoration:underline;text-underline-offset:3px;text-decoration-thickness:1px}
+.prose a:hover{color:var(--color-primary-hover);text-decoration-thickness:2px}
+.prose blockquote{margin:var(--space-6) 0;padding:var(--space-2) 0 var(--space-2) var(--space-5);border-left:3px solid var(--color-gold-bright);font-family:var(--font-display);font-style:italic;font-size:var(--text-lg);color:var(--color-text);line-height:1.5}
+/* Pull quote / drop cap */
+.lede-first::first-letter{font-family:var(--font-display);font-weight:600;float:left;font-size:3.6em;line-height:.9;margin:0.05em 0.12em 0 0;color:var(--color-gold-bright)}
+/* ============================================================
+   TABLES
+   ============================================================ */
+.table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch;margin:var(--space-5) 0 var(--space-6);border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface)}
+.prose table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:0}
+.prose table th{text-align:left;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-border);background:var(--color-surface-offset);white-space:nowrap}
+.prose table td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text-muted);vertical-align:middle;font-variant-numeric:tabular-nums}
+.prose table tr:last-child td{border-bottom:none}
+.prose table tr:hover td{background:color-mix(in oklch,var(--color-gold-bright) 4%,transparent)}
+.prose table td:first-child{color:var(--color-text);font-weight:500}
+.usd-val{color:var(--color-gold-bright);font-weight:600}
+/* ============================================================
+   KARAT REFERENCE GRID
+   ============================================================ */
+.karat-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--space-3);margin:var(--space-5) 0 var(--space-6)}
+@media(min-width:500px){.karat-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+@media(min-width:1080px){.karat-grid{grid-template-columns:repeat(3,minmax(0,1fr))}}
+.karat-tile{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4);position:relative;overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.karat-tile::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,var(--color-gold-deep) 0%,var(--color-gold-bright) var(--purity,50%),var(--color-border) var(--purity,50%));border-radius:2px}
+.karat-tile:hover{border-color:var(--color-gold-bright);transform:translateY(-2px);box-shadow:var(--shadow-md)}
+.karat-tile-name{font-family:var(--font-display);font-size:var(--text-xl);font-weight:600;color:var(--color-text);line-height:1;margin-top:var(--space-1)}
+.karat-tile-pct{font-size:var(--text-sm);font-weight:600;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;margin-top:6px}
+.karat-tile-hall{font-size:var(--text-xs);color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;margin-top:4px}
+.karat-tile-price{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:8px;padding-top:8px;border-top:1px solid var(--color-divider);font-variant-numeric:tabular-nums}
+.karat-tile-price strong{color:var(--color-gold-bright)}
+/* ============================================================
+   MINI CALCULATOR (inline)
+   ============================================================ */
+.mini-calc{background:linear-gradient(135deg,color-mix(in oklch,var(--color-primary) 4%,var(--color-surface)) 0%,var(--color-surface) 60%,color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface)) 100%);border:1px solid var(--color-border);border-radius:var(--radius-2xl);padding:clamp(var(--space-5),3vw,var(--space-8));margin:var(--space-8) 0;position:relative;overflow:hidden}
+.mini-calc::before{content:"";position:absolute;top:-40px;right:-40px;width:200px;height:200px;background:radial-gradient(circle,color-mix(in oklch,var(--color-gold-bright) 12%,transparent),transparent 70%);pointer-events:none}
+.mini-calc>*{position:relative}
+.mini-calc-header{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-3);flex-wrap:wrap;margin-bottom:var(--space-5)}
+.mini-calc-title{font-family:var(--font-display);font-size:var(--text-xl);font-weight:600;color:var(--color-text);line-height:1.15;margin-bottom:var(--space-1)}
+.mini-calc-sub{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.5}
+.mini-calc-live{display:inline-flex;align-items:center;gap:6px;padding:5px 10px;background:color-mix(in oklch,var(--color-up) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-up) 30%,var(--color-border));border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-up);white-space:nowrap}
+.mini-calc-live .pulse{width:6px;height:6px;border-radius:50%;background:var(--color-up);box-shadow:0 0 0 0 color-mix(in oklch,var(--color-up) 60%,transparent);animation:pulse 1.8s infinite}
+.mini-calc-grid{display:grid;grid-template-columns:minmax(0,1fr);gap:var(--space-4)}
+@media(min-width:720px){.mini-calc-grid{grid-template-columns:minmax(0,1.1fr) minmax(0,1fr);gap:var(--space-6)}}
+.mc-controls{display:flex;flex-direction:column;gap:var(--space-4);min-width:0}
+.mc-field-label{display:block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);margin-bottom:var(--space-2)}
+.mc-karat-chips{display:flex;flex-wrap:wrap;gap:6px}
+.mc-karat-chip{padding:8px 14px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);cursor:pointer;font-variant-numeric:tabular-nums;transition:all var(--transition);min-height:44px;min-width:54px}
+.mc-karat-chip:hover{border-color:var(--color-gold-bright);color:var(--color-text)}
+.mc-karat-chip.active{background:var(--color-gold-bright);border-color:var(--color-gold-bright);color:var(--color-text-inverse)}
+.mc-input-row{display:flex;gap:var(--space-2);min-width:0}
+.mc-input{flex:1;min-width:0;width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);color:var(--color-text);font-size:var(--text-base);font-weight:600;font-variant-numeric:tabular-nums;min-height:48px;font-family:inherit}
+.mc-input:focus-visible{outline:none;border-color:var(--color-primary);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-primary) 20%,transparent)}
+.mc-unit-toggle{display:inline-flex;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:3px;flex-shrink:0}
+.mc-unit-btn{padding:0 12px;background:none;border:none;color:var(--color-text-muted);font-size:var(--text-sm);font-weight:600;cursor:pointer;border-radius:var(--radius-sm);min-height:42px;min-width:44px;white-space:nowrap}
+.mc-unit-btn.active{background:var(--color-text);color:var(--color-bg)}
+.mc-buyer-select{width:100%;padding:var(--space-3) var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);color:var(--color-text);font-size:var(--text-base);font-weight:500;font-family:inherit;min-height:48px;cursor:pointer;appearance:none;background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none' stroke='%23999' stroke-width='2'><path d='M2 4l4 4 4-4'/></svg>");background-repeat:no-repeat;background-position:right 12px center;padding-right:36px}
+.mc-output{background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-4);min-height:240px;justify-content:center}
+.mc-out-row{display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);padding-bottom:var(--space-3);border-bottom:1px dashed var(--color-divider)}
+.mc-out-row:last-of-type{border-bottom:none;padding-bottom:0}
+.mc-out-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint)}
+.mc-out-value{font-family:var(--font-display);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;text-align:right}
+.mc-out-headline{font-size:clamp(2rem,4vw,2.75rem);line-height:1;color:var(--color-gold-bright)}
+.mc-out-melt{font-size:var(--text-lg)}
+.mc-out-rate{font-size:var(--text-sm);color:var(--color-text-muted);font-weight:500}
+.mc-foot{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:var(--space-3);margin-top:var(--space-4);padding-top:var(--space-4);border-top:1px solid var(--color-divider)}
+.mc-foot-meta{font-size:var(--text-xs);color:var(--color-text-muted);display:flex;align-items:center;gap:6px}
+.mc-foot a{display:inline-flex;align-items:center;gap:6px;padding:var(--space-2) var(--space-4);background:var(--color-primary);color:#fff;font-size:var(--text-sm);font-weight:600;border-radius:var(--radius-md);text-decoration:none}
+.mc-foot a:hover{background:var(--color-primary-hover);color:#fff;text-decoration:none}
+.mc-foot a:visited{color:#fff}
+/* ============================================================
+   CALLOUTS
+   ============================================================ */
+.callout{position:relative;padding:var(--space-5) var(--space-6) var(--space-5) var(--space-12);margin:var(--space-6) 0;border:1px solid var(--color-border);border-radius:var(--radius-lg);background:var(--color-surface)}
+.callout::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;border-radius:2px 0 0 2px}
+.callout-icon{position:absolute;left:var(--space-5);top:var(--space-5);width:24px;height:24px;display:flex;align-items:center;justify-content:center;border-radius:50%;flex-shrink:0}
+.callout-icon svg{width:14px;height:14px}
+.callout p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+.callout p+p{margin-top:var(--space-3)}
+.callout strong{color:var(--color-text)}
+.callout ul{margin:var(--space-3) 0 0;padding-left:var(--space-5)}
+.callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
+.callout--info{background:color-mix(in oklch,var(--color-primary) 5%,var(--color-surface))}
+.callout--info::before{background:var(--color-primary)}
+.callout--info .callout-icon{background:color-mix(in oklch,var(--color-primary) 20%,var(--color-surface));color:var(--color-primary)}
+.callout--warn{background:color-mix(in oklch,#f59e0b 5%,var(--color-surface))}
+.callout--warn::before{background:#f59e0b}
+.callout--warn .callout-icon{background:color-mix(in oklch,#f59e0b 20%,var(--color-surface));color:#f59e0b}
+.callout--gold{background:color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface))}
+.callout--gold::before{background:var(--color-gold-bright)}
+.callout--gold .callout-icon{background:color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-surface));color:var(--color-gold-bright)}
+.callout--danger{background:color-mix(in oklch,#dc2626 5%,var(--color-surface))}
+.callout--danger::before{background:#dc2626}
+.callout--danger .callout-icon{background:color-mix(in oklch,#dc2626 20%,var(--color-surface));color:#dc2626}
+/* ============================================================
+   PAYOUT METER (visual % bar)
+   ============================================================ */
+.payout-meter{margin:var(--space-4) 0;padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);display:flex;flex-direction:column;gap:var(--space-4)}
+.payout-meter-row{display:grid;grid-template-columns:1fr auto;align-items:center;gap:6px var(--space-3);row-gap:var(--space-1)}
+@media(min-width:520px){.payout-meter-row{grid-template-columns:180px 1fr 80px;gap:var(--space-3);row-gap:0}}
+.payout-meter-label{font-size:var(--text-sm);color:var(--color-text);font-weight:600;line-height:1.3}
+.payout-meter-bar{position:relative;height:8px;background:var(--color-surface-offset);border-radius:var(--radius-full);overflow:hidden;grid-column:1/-1}
+@media(min-width:520px){.payout-meter-bar{grid-column:2/3}}
+.payout-meter-fill{position:absolute;left:0;top:0;bottom:0;background:linear-gradient(90deg,var(--from,var(--color-gold-deep)),var(--to,var(--color-gold-bright)));border-radius:var(--radius-full);transition:width var(--transition-slow);transform-origin:left}
+.payout-meter-pct{font-size:var(--text-sm);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;text-align:right}
+.payout-meter-row--high .payout-meter-fill{--from:var(--color-up);--to:#86efac}
+.payout-meter-row--mid .payout-meter-fill{--from:var(--color-gold-deep);--to:var(--color-gold-bright)}
+.payout-meter-row--low .payout-meter-fill{--from:#dc2626;--to:#f87171}
+/* ============================================================
+   CHANNEL CARDS — Selling options
+   ============================================================ */
+.channel-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-6);margin:var(--space-6) 0;transition:border-color var(--transition),box-shadow var(--transition);position:relative;overflow:hidden}
+.channel-card::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;background:var(--accent,var(--color-primary))}
+.channel-card:hover{border-color:color-mix(in oklch,var(--accent,var(--color-primary)) 40%,var(--color-border));box-shadow:var(--shadow-md)}
+.channel-card--best{--accent:var(--color-up)}
+.channel-card--good{--accent:var(--color-primary)}
+.channel-card--mid{--accent:var(--color-gold-bright)}
+.channel-card--last{--accent:#dc2626}
+.channel-card__head{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-4);flex-wrap:wrap;margin-bottom:var(--space-4);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-divider)}
+.channel-card__head-text{flex:1;min-width:0}
+.channel-card__num{display:inline-block;font-family:var(--font-display);font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.1em;color:var(--accent,var(--color-primary));margin-bottom:6px}
+.channel-card__name{font-family:var(--font-display);font-size:var(--text-xl);font-weight:600;color:var(--color-text);margin-bottom:6px;line-height:1.15}
+.channel-card__tag{font-size:var(--text-sm);color:var(--color-text-muted);font-weight:500;line-height:1.4}
+.channel-card__badges{display:flex;flex-wrap:wrap;gap:var(--space-2);align-items:flex-start}
+.channel-badge{display:inline-flex;align-items:center;gap:6px;font-size:11px;font-weight:700;padding:5px 10px;border-radius:var(--radius-full);border:1px solid;white-space:nowrap;text-transform:uppercase;letter-spacing:.05em}
+.channel-badge--best{background:color-mix(in oklch,var(--color-up) 12%,var(--color-surface));border-color:color-mix(in oklch,var(--color-up) 35%,var(--color-border));color:var(--color-up)}
+.channel-badge--good{background:color-mix(in oklch,var(--color-primary) 12%,var(--color-surface));border-color:color-mix(in oklch,var(--color-primary) 35%,var(--color-border));color:var(--color-primary)}
+.channel-badge--mid{background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface));border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));color:var(--color-gold-bright)}
+.channel-badge--last{background:color-mix(in oklch,#dc2626 10%,var(--color-surface));border-color:color-mix(in oklch,#dc2626 30%,var(--color-border));color:#dc2626}
+.channel-card__body p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4);max-width:none}
+.channel-card__body p:last-child{margin-bottom:0}
+.channel-card__body ul{padding-left:var(--space-5);margin:var(--space-3) 0 var(--space-4)}
+.channel-card__body li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
+.channel-card__body strong{color:var(--color-text);font-weight:600}
+.channel-mini-bar{display:grid;grid-template-columns:1fr;align-items:center;gap:var(--space-2);padding:var(--space-3) var(--space-4);background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-md);margin-bottom:var(--space-4)}
+@media(min-width:500px){.channel-mini-bar{grid-template-columns:auto 1fr auto;gap:var(--space-3)}}
+.channel-mini-bar-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);white-space:nowrap}
+.channel-mini-bar-track{height:6px;background:var(--color-surface-offset);border-radius:var(--radius-full);position:relative;overflow:hidden;min-width:80px;width:100%}
+.channel-mini-bar-fill{position:absolute;left:0;top:0;bottom:0;background:linear-gradient(90deg,var(--accent,var(--color-primary)),color-mix(in oklch,var(--accent,var(--color-primary)) 60%,white));border-radius:var(--radius-full)}
+.channel-mini-bar-val{font-size:var(--text-sm);font-weight:700;color:var(--accent,var(--color-text));font-variant-numeric:tabular-nums;white-space:nowrap;justify-self:end}
+/* ============================================================
+   STEP TIMELINE
+   ============================================================ */
+.step-timeline{list-style:none;padding:0;margin:var(--space-6) 0;display:flex;flex-direction:column;gap:0;position:relative}
+.step-timeline::before{content:"";position:absolute;left:18px;top:18px;bottom:18px;width:2px;background:linear-gradient(180deg,var(--color-gold-bright),var(--color-primary));border-radius:2px;opacity:.5}
+.step-item{position:relative;padding-left:54px;padding-bottom:var(--space-5);min-height:60px}
+.step-item:last-child{padding-bottom:0}
+.step-marker{position:absolute;left:0;top:0;width:36px;height:36px;border-radius:50%;background:var(--color-surface);border:2px solid var(--color-gold-bright);color:var(--color-gold-bright);display:flex;align-items:center;justify-content:center;font-family:var(--font-display);font-weight:600;font-size:var(--text-sm);font-variant-numeric:tabular-nums;z-index:1;transition:transform var(--transition),background var(--transition),color var(--transition)}
+.step-item:hover .step-marker{background:var(--color-gold-bright);color:var(--color-text-inverse);transform:scale(1.05)}
+.step-content{padding:var(--space-4) var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);transition:border-color var(--transition)}
+.step-item:hover .step-content{border-color:var(--color-gold-bright)}
+.step-title{display:block;font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);margin-bottom:var(--space-2)}
+.step-content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0;max-width:none}
+/* ============================================================
+   TIPS NUMBERED LIST
+   ============================================================ */
+.tips-list{list-style:none;padding:0;margin:var(--space-5) 0;counter-reset:tips;display:grid;grid-template-columns:1fr;gap:var(--space-3)}
+@media(min-width:720px){.tips-list{grid-template-columns:1fr 1fr}}
+.tips-list li{counter-increment:tips;display:flex;align-items:flex-start;gap:var(--space-3);padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;max-width:none;transition:border-color var(--transition),transform var(--transition)}
+.tips-list li:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));transform:translateY(-2px)}
+.tips-list li::before{content:counter(tips,decimal-leading-zero);flex-shrink:0;font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;margin-top:-2px;min-width:28px}
+.tips-list strong{color:var(--color-text);font-weight:600;display:block;margin-bottom:4px}
+.tips-list a{color:var(--color-primary);text-decoration:underline}
+/* ============================================================
+   SCAM ALERTS
+   ============================================================ */
+.scam-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0}
+@media(min-width:720px){.scam-grid{grid-template-columns:1fr 1fr}}
+.scam-card{padding:var(--space-4) var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid #dc2626;border-radius:var(--radius-md);display:flex;flex-direction:column;gap:var(--space-2)}
+.scam-card-title{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-sm);font-weight:700;color:var(--color-text);line-height:1.3}
+.scam-card-icon{flex-shrink:0;width:22px;height:22px;border-radius:50%;background:color-mix(in oklch,#dc2626 18%,var(--color-surface));color:#dc2626;display:flex;align-items:center;justify-content:center}
+.scam-card-icon svg{width:13px;height:13px}
+.scam-card-desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
+.scam-card-desc strong{color:var(--color-text)}
+/* ============================================================
+   CTA BOX
+   ============================================================ */
+.cta-box{position:relative;overflow:hidden;background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface)) 0%,var(--color-surface) 60%,color-mix(in oklch,var(--color-primary) 8%,var(--color-surface)) 100%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));border-radius:var(--radius-2xl);padding:clamp(var(--space-5),3vw,var(--space-8));margin:var(--space-10) 0}
+.cta-box::before{content:"";position:absolute;top:-40px;right:-40px;width:240px;height:240px;background:radial-gradient(circle,color-mix(in oklch,var(--color-gold-bright) 15%,transparent),transparent 70%);pointer-events:none}
+.cta-box>*{position:relative}
+.cta-box h3{font-family:var(--font-display);font-weight:600;font-size:var(--text-xl);color:var(--color-text);margin:0 0 var(--space-3)}
+.cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-5);max-width:60ch}
+.cta-btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-3) var(--space-6);background:var(--color-gold-bright);color:var(--color-text-inverse)!important;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;text-decoration:none!important;transition:transform var(--transition),box-shadow var(--transition);box-shadow:var(--shadow-gold)}
+.cta-btn:hover,.cta-btn:visited{background:var(--color-gold-bright);color:var(--color-text-inverse)!important;text-decoration:none!important}
+.cta-btn:hover{transform:translateY(-1px);box-shadow:var(--shadow-gold),var(--shadow-md)}
+.cta-btn-secondary{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-3) var(--space-6);background:transparent;color:var(--color-text)!important;border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none!important;margin-left:var(--space-2)}
+.cta-btn-secondary:hover{border-color:var(--color-primary);color:var(--color-primary)!important;text-decoration:none!important}
+/* ============================================================
+   FAQ
+   ============================================================ */
+.faq-accordion{margin:var(--space-5) 0;display:flex;flex-direction:column;gap:var(--space-2)}
+details.faq-item{border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;background:var(--color-surface);transition:border-color var(--transition)}
+details.faq-item:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border))}
+details.faq-item summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;gap:var(--space-3);transition:background .15s}
+details.faq-item summary::-webkit-details-marker{display:none}
+details.faq-item summary:hover{background:var(--color-surface-offset)}
+.faq-chevron{flex-shrink:0;transition:transform .2s;color:var(--color-text-muted);width:18px;height:18px}
+details.faq-item[open] .faq-chevron{transform:rotate(180deg);color:var(--color-gold-bright)}
+details.faq-item[open]>summary{background:var(--color-surface-offset);border-bottom:1px solid var(--color-divider)}
+.faq-body{padding:var(--space-4) var(--space-5) var(--space-5);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
+.faq-body p{margin:0;max-width:none}
+.faq-body p+p{margin-top:var(--space-3)}
+.faq-body strong{color:var(--color-text)}
+/* ============================================================
+   SHARE BUTTONS
+   ============================================================ */
+.share-buttons{display:flex;flex-wrap:wrap;gap:var(--space-2);margin:var(--space-6) 0 var(--space-2)}
+.share-btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);border:1px solid var(--color-border);border-radius:var(--radius-full);background:var(--color-surface);color:var(--color-text-muted);font-size:var(--text-sm);font-weight:500;text-decoration:none;transition:border-color .15s,color .15s,background .15s;white-space:nowrap;min-height:40px}
+.share-btn:hover{border-color:var(--color-primary);color:var(--color-primary);background:color-mix(in oklch,var(--color-primary) 6%,var(--color-surface));text-decoration:none}
+/* ============================================================
+   DISCLAIMER + RELATED
+   ============================================================ */
+.disclaimer-box{background:var(--color-surface-alt,var(--color-surface-offset));border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
+.disclaimer-box strong{color:var(--color-text);font-weight:700}
+.related-section{max-width:1240px;margin:0 auto var(--space-12);padding:0 var(--space-4)}
+.related-section h2{font-family:var(--font-display);font-weight:600;font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-5);position:relative;padding-bottom:var(--space-3)}
+.related-section h2::after{content:"";position:absolute;left:0;bottom:0;width:48px;height:3px;background:linear-gradient(90deg,var(--color-gold-bright),transparent);border-radius:2px}
+.related-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4)}
+.related-card{display:flex;flex-direction:column;gap:var(--space-2);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition),transform var(--transition);color:var(--color-text)}
+.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);transform:translateY(-3px);color:var(--color-text);text-decoration:none}
+.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
+.related-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.3}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+.related-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.55}
+/* ============================================================
+   FOOTER
+   ============================================================ */
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
+.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start;max-width:1240px;margin:0 auto}
 @media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
 @media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
 .footer-brand-col{max-width:260px}
@@ -133,122 +485,40 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
-.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom{max-width:1240px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
-.breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
-.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
-.breadcrumb a:hover{color:var(--color-primary)}
-.breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.article-wrap{max-width:1200px;margin:0 auto;padding:var(--space-6) var(--space-4) var(--space-16)}
-.article-tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-article.article-wrap .article-title,h1.article-title{font-family:var(--font-display)!important;font-size:clamp(1.75rem,3.5vw,2.75rem)!important;font-weight:700!important;line-height:1.15!important;margin:var(--space-2) 0 var(--space-5)!important;color:var(--color-text)!important}
-.article-byline{font-size:var(--text-sm);color:var(--color-text-muted);display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin-bottom:var(--space-6);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
-.article-byline a{color:var(--color-primary);text-decoration:none;font-weight:500}
-.article-byline a:hover{text-decoration:underline}
-.prose{max-width:860px}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose sup{font-size:.7em;vertical-align:super;color:var(--color-text-faint)}
-.prose table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
-.prose table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-3) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.prose table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.prose table tr:last-child td{border-bottom:none}
-.prose table td:first-child,.prose table th:first-child{padding-left:0;color:var(--color-text)}
-.cta-box{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-8) 0}
-.cta-box h3{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:0 0 var(--space-2)}
-.cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-4)}
-.cta-btn{display:inline-flex;align-items:center;gap:var(--space-1);padding:var(--space-2) var(--space-5);background:var(--color-primary);color:#fff!important;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none;transition:background .15s}
-.cta-btn:hover,.cta-btn:visited{background:var(--color-primary-hover);color:#fff!important;text-decoration:none}
-.share-buttons{display:flex;flex-wrap:wrap;gap:var(--space-2);margin:var(--space-6) 0}
-.share-btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);border:1px solid var(--color-border);border-radius:var(--radius-full);background:var(--color-surface);color:var(--color-text-muted);font-size:var(--text-sm);font-weight:500;text-decoration:none;transition:border-color .15s,color .15s;white-space:nowrap}
-.share-btn:hover{border-color:var(--color-primary);color:var(--color-primary)}
-.disclaimer-box{background:var(--color-surface-alt,#f4f3ef);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
-.disclaimer-box strong{color:var(--color-text);font-weight:700}
-.related-guides-section{max-width:860px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
-.related-guides-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-4)}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4)}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);color:var(--color-text)}
-.related-card__tag{display:block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-.exec-summary{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0}
-.exec-summary-intro{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-5)}
-.exec-summary-intro strong{color:var(--color-text)}
-.exec-summary-stats{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-4)}
-.exec-stat{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4)}
-.exec-stat-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.exec-stat-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;margin-top:var(--space-1);line-height:1.2}
-.info-callout{background:color-mix(in oklch,var(--color-primary) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 20%,var(--color-border));border-left:3px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
-.info-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
-.info-callout p+p{margin-top:var(--space-3)}
-.info-callout strong{color:var(--color-text)}
-.stat-grid{display:flex;flex-wrap:wrap;gap:var(--space-3);margin:var(--space-4) 0}
-.stat-pill{background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-3) var(--space-5);text-align:center;min-width:110px}
-.stat-pill-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;display:block;line-height:1.2}
-.stat-pill-label{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:4px;display:block;line-height:1.4}
-.faq-accordion{margin:var(--space-4) 0}
-details.faq-item{border:1px solid var(--color-border);border-radius:var(--radius-lg);margin-bottom:var(--space-2);overflow:hidden;background:var(--color-surface)}
-details.faq-item summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;gap:var(--space-3);transition:background .15s}
-details.faq-item summary::-webkit-details-marker{display:none}
-details.faq-item summary:hover{background:var(--color-surface-offset)}
-.faq-chevron{flex-shrink:0;transition:transform .2s;color:var(--color-text-muted)}
-details.faq-item[open] .faq-chevron{transform:rotate(180deg)}
-details.faq-item[open]>summary{background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
-.faq-body{padding:var(--space-4) var(--space-5);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
-.faq-body p{margin:0;max-width:none}
-.faq-body p+p{margin-top:var(--space-3)}
-.faq-body strong{color:var(--color-text)}
-/* WARNING CALLOUT */
-.warning-callout{background:color-mix(in oklch,#f59e0b 8%,var(--color-surface));border:1px solid color-mix(in oklch,#f59e0b 25%,var(--color-border));border-left:3px solid #f59e0b;border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
-.warning-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
-.warning-callout p+p{margin-top:var(--space-3)}
-.warning-callout strong{color:var(--color-text)}
-.warning-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0}
-.warning-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
-/* CHANNEL CARDS — buyer type options */
-.channel-card{background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0;transition:box-shadow var(--transition)}
-.channel-card:hover{box-shadow:var(--shadow-md)}
-.channel-card__header{display:flex;align-items:flex-start;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3);margin-bottom:var(--space-4);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
-.channel-card__label{font-family:var(--font-display);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);flex-shrink:0}
-.channel-card__name{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin-bottom:var(--space-1)}
-.channel-card__tagline{font-size:var(--text-sm);color:var(--color-text-muted);font-weight:500}
-.channel-card p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4);max-width:none}
-.channel-card p:last-child{margin-bottom:0}
-.channel-card strong{color:var(--color-text)}
-.channel-card ul{padding-left:var(--space-5);margin:var(--space-3) 0 var(--space-4)}
-.channel-card li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-1)}
-.channel-badge{display:inline-flex;align-items:center;gap:4px;font-size:var(--text-xs);font-weight:700;padding:3px var(--space-2);border-radius:var(--radius-full);border:1px solid;white-space:nowrap}
-.channel-badge--best{background:color-mix(in oklch,var(--color-primary) 10%,var(--color-surface));border-color:color-mix(in oklch,var(--color-primary) 30%,var(--color-border));color:var(--color-primary)}
-.channel-badge--good{background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface));border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));color:var(--color-gold-bright)}
-.channel-badge--last{background:color-mix(in oklch,#f87171 10%,var(--color-surface));border-color:color-mix(in oklch,#f87171 30%,var(--color-border));color:#ef4444}
-/* STEP BLOCKS — how-to numbered steps */
-.step-list{list-style:none;padding:0;margin:var(--space-6) 0;display:flex;flex-direction:column;gap:var(--space-4)}
-.step-block{display:flex;align-items:flex-start;gap:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.step-number{flex-shrink:0;width:36px;height:36px;border-radius:var(--radius-full);background:var(--color-primary);color:#fff;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
-.step-content{flex:1;min-width:0}
-.step-content strong{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
-.step-content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0;max-width:none}
-/* TIPS CHECKLIST */
-.tips-list{list-style:none;padding:0;margin:var(--space-4) 0;counter-reset:tips-counter;display:flex;flex-direction:column;gap:var(--space-3)}
-.tips-list li{counter-increment:tips-counter;display:flex;align-items:flex-start;gap:var(--space-3);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;padding:var(--space-3) var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);max-width:none}
-.tips-list li::before{content:counter(tips-counter);flex-shrink:0;width:24px;height:24px;border-radius:var(--radius-full);background:color-mix(in oklch,var(--color-gold-bright) 15%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));color:var(--color-gold-bright);font-size:var(--text-xs);font-weight:700;display:flex;align-items:center;justify-content:center;margin-top:2px}
-.tips-list strong{color:var(--color-text)}
+/* ============================================================
+   FLOATING MOBILE CTA
+   ============================================================ */
+.float-cta{display:none;position:fixed;left:var(--space-3);right:var(--space-3);bottom:var(--space-3);z-index:180;padding:12px var(--space-4);background:color-mix(in oklch,var(--color-surface) 92%,transparent);backdrop-filter:saturate(160%) blur(14px);-webkit-backdrop-filter:saturate(160%) blur(14px);border:1px solid var(--color-border);border-radius:var(--radius-xl);align-items:center;justify-content:space-between;gap:var(--space-3);box-shadow:var(--shadow-lg);transform:translateY(120%);transition:transform var(--transition-slow)}
+.float-cta.is-visible{transform:translateY(0)}
+.float-cta-text{display:flex;flex-direction:column;gap:2px;min-width:0;flex:1}
+.float-cta-label{font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-faint);display:flex;align-items:center;gap:6px}
+.float-cta-label .pulse{width:6px;height:6px;border-radius:50%;background:var(--color-up);animation:pulse 1.8s infinite}
+.float-cta-value{font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.float-cta a{display:inline-flex;align-items:center;gap:6px;padding:10px var(--space-4);background:var(--color-gold-bright);color:var(--color-text-inverse)!important;font-size:var(--text-sm);font-weight:700;border-radius:var(--radius-md);text-decoration:none!important;white-space:nowrap;flex-shrink:0}
+.float-cta a:hover,.float-cta a:visited{background:var(--color-gold-bright);color:var(--color-text-inverse)!important;text-decoration:none!important}
+@media(max-width:768px){.float-cta{display:flex}}
+/* ============================================================
+   REVEAL ON SCROLL
+   ============================================================ */
+.reveal{opacity:0;transform:translateY(16px);transition:opacity var(--transition-slow),transform var(--transition-slow)}
+.reveal.in-view{opacity:1;transform:none}
+@media(prefers-reduced-motion:reduce){.reveal{opacity:1;transform:none}}
+/* ============================================================
+   AD SLOT
+   ============================================================ */
+.ad-slot{min-height:0!important;margin:var(--space-2) 0}
+.ad-slot:not(:has(ins[data-ad-status])){border:none!important;background:none!important;padding:0!important;min-height:0!important;margin:0!important}
 </style>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
 </head>
 <body>
+<a href="#main" class="skip-link">Skip to main content</a>
+<div class="read-progress" id="readProgress" aria-hidden="true"></div>
+
 <nav class="site-nav" role="navigation" aria-label="Main navigation">
   <div class="nav-inner">
     <a href="/" class="nav-logo" aria-label="GoldPriceTools Home">
@@ -324,343 +594,534 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
   </ol>
 </div>
 
-<article class="article-wrap" itemscope itemtype="https://schema.org/Article">
-  <div class="article-tag">Selling &amp; Testing</div>
-  <h1 class="article-title" itemprop="headline">How to Sell Gold Jewellery &mdash; Get the Best Price in 2026</h1>
-  <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
-    <span>&middot;</span>
-    <span>Updated <time datetime="2026-05-08T08:00:00Z" itemprop="dateModified">8 May 2026</time></span>
-    <span>&middot;</span>
-    <span>14 min read</span>
-  </div>
+<main id="main" class="article-shell">
+  <article class="article-main" itemscope itemtype="https://schema.org/Article">
 
-  <div class="prose">
-
-    <div class="exec-summary">
-      <p class="exec-summary-intro">Gold prices are sitting near all-time highs — above <strong>$4,700 per troy ounce</strong> as of May 2026, versus around $2,000 just two years ago. A broken chain in a drawer, a ring from a past relationship, a cluttered jewellery box of unworn items — all of these are worth significantly more today than at almost any previous point in history. But knowing your gold is worth something and actually getting a fair price for it are two very different things. This guide tells you exactly how to calculate your gold's value, where to sell it, and how to protect yourself from the scams that are common in this market.</p>
-      <div class="exec-summary-stats">
-        <div class="exec-stat"><div class="exec-stat-label">Gold price (May 2026)</div><div class="exec-stat-value">$4,700+/oz</div></div>
-        <div class="exec-stat"><div class="exec-stat-label">Best buyers pay</div><div class="exec-stat-value">80–98%</div></div>
-        <div class="exec-stat"><div class="exec-stat-label">Worst buyers pay</div><div class="exec-stat-value">20–40%</div></div>
-        <div class="exec-stat"><div class="exec-stat-label">Selling channels</div><div class="exec-stat-value">5 options</div></div>
+    <!-- HERO -->
+    <header class="hero-card reveal">
+      <span class="hero-eyebrow"><span class="pulse" aria-hidden="true"></span> Selling &amp; Testing · Updated 11 June 2026</span>
+      <h1 class="hero-title" itemprop="headline">How to Sell Gold Jewellery <em>and get the best price</em> in 2026</h1>
+      <p class="hero-lede">Gold is sitting near all-time highs and unwanted jewellery has never been more valuable. <strong>The catch:</strong> what you actually walk away with depends almost entirely on knowing your metal's real USD value before any buyer makes you an offer.</p>
+      <div class="hero-byline">
+        <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial</a></span>
+        <span class="dot" aria-hidden="true"></span>
+        <span>Updated <time datetime="2026-06-11T06:00:00Z" itemprop="dateModified">11 Jun 2026</time></span>
+        <span class="dot" aria-hidden="true"></span>
+        <span>14 min read</span>
       </div>
-    </div>
 
-    <h2>Is 2026 a Good Time to Sell Gold Jewellery?</h2>
-    <p>The short answer is yes — probably the best in a generation.</p>
-    <p>Gold surpassed $5,000 per ounce for the first time in history in early 2026, reaching an all-time high of <strong>$5,589.38 on 28 January 2026</strong>. Even after pulling back from that peak, prices remain extraordinarily elevated compared to any historical average. For sellers, this translates directly into higher cash offers for every gram of gold they bring to market.</p>
-    <p>That said, trying to time the exact peak is a fool's game. Analysts from J.P. Morgan, UBS, and Goldman Sachs have all published bullish forecasts for gold through 2026 and into 2027 — which means prices may continue rising. But for sellers who need the cash, or who simply have gold sitting unused, current prices represent a genuinely exceptional window that may not return for years.</p>
-    <p>One practical consideration: if you believe gold has further to run, keep it. If you have jewellery you genuinely do not want or need, sell it now while the market is this strong.</p>
-
-    <div class="stat-grid">
-      <div class="stat-pill"><span class="stat-pill-value">$5,589</span><span class="stat-pill-label">All-time high (Jan 2026)</span></div>
-      <div class="stat-pill"><span class="stat-pill-value">+135%</span><span class="stat-pill-label">Gold rise over 2 years</span></div>
-      <div class="stat-pill"><span class="stat-pill-value">$152</span><span class="stat-pill-label">Approx. per gram (May 2026)</span></div>
-    </div>
-
-    <h2>Step 1 &mdash; Know What Your Gold Is Actually Worth</h2>
-    <p>Before you approach a single buyer, you need to know the value of what you are selling. This one step alone separates sellers who get fair prices from those who get ripped off.</p>
-    <p>Gold jewellery value is determined by three things only: <strong>purity</strong> (how much of the piece is actually gold, measured in karats), <strong>weight</strong> (how many grams), and <strong>live spot price</strong> (the current global market price per gram of pure gold).</p>
-
-    <h3>Understanding Karats: What Do They Mean?</h3>
-    <p>The karat system tells you what proportion of your jewellery is pure gold. The rest is alloy metals — typically copper, silver, or zinc — added to improve durability.</p>
-    <div style="overflow-x:auto">
-      <table>
-        <thead><tr><th>Karat</th><th>Purity</th><th>Gold Content</th><th>Common Hallmarks</th></tr></thead>
-        <tbody>
-          <tr><td><strong>24K</strong></td><td>99.9% pure</td><td>99.9% gold</td><td>999</td></tr>
-          <tr><td><strong>22K</strong></td><td>91.6% pure</td><td>91.6% gold</td><td>916</td></tr>
-          <tr><td><strong>18K</strong></td><td>75.0% pure</td><td>75.0% gold</td><td>750</td></tr>
-          <tr><td><strong>14K</strong></td><td>58.5% pure</td><td>58.5% gold</td><td>585</td></tr>
-          <tr><td><strong>10K</strong></td><td>41.7% pure</td><td>41.7% gold</td><td>417</td></tr>
-          <tr><td><strong>9K</strong></td><td>37.5% pure</td><td>37.5% gold</td><td>375</td></tr>
-        </tbody>
-      </table>
-    </div>
-    <p>Most jewellery sold in the United States is 10K or 14K. In the UK, 9K is common for everyday jewellery. In India and the Middle East, 22K is most prevalent. In Europe, 18K is the most widely sold standard for fine jewellery.</p>
-
-    <div class="info-callout">
-      <p><strong>How to find your hallmark:</strong> Look for a small stamped number on the inside of a ring band, the clasp of a necklace, or the back of a pendant. This is your karat mark — the most important number in determining value. If you cannot find a hallmark, a reputable buyer will test the piece for free using acid testing or an XRF scanner.</p>
-    </div>
-
-    <h3>How to Calculate Your Gold's Value</h3>
-    <p>Once you know the karat and weight, calculating the melt value is straightforward:</p>
-    <p><strong>Gold Melt Value = Weight (grams) &times; Purity % &times; Current Gold Price per gram</strong></p>
-    <p><strong>Example 1 &mdash; 18K gold necklace, 8 grams:</strong><br>
-    Purity factor: 18 &divide; 24 = 0.75 &bull; Pure gold content: 8g &times; 0.75 = 6 grams &bull; At $152/gram: 6 &times; $152 = <strong>$912 melt value</strong></p>
-    <p><strong>Example 2 &mdash; 9K gold ring, 3.5 grams:</strong><br>
-    Purity factor: 9 &divide; 24 = 0.375 &bull; Pure gold content: 3.5g &times; 0.375 = 1.31 grams &bull; At $152/gram: 1.31 &times; $152 = <strong>$199 melt value</strong></p>
-    <p>The melt value is the ceiling — the theoretical maximum if someone paid you 100% of spot. In practice, buyers pay a percentage of melt value, and that percentage varies enormously depending on who you sell to. The melt value is your negotiating baseline.</p>
-
-    <h3>A Note on Gemstones and Clasps</h3>
-    <p>Most buyers calculate the weight of your gold after removing any stones, since gemstones are not gold. Some buyers will make a separate offer for diamonds or other precious stones, but for most standard pieces, gem value is often negligible unless you have certified, high-quality stones. Clasps, pins, and attachments made from lower-purity alloys or non-gold materials are similarly excluded from the gold calculation.</p>
-
-    <h2>Step 2 &mdash; Understand What Percentage Buyers Actually Pay</h2>
-    <p>Here is the number that most sellers do not know before they walk into their first buyer — and it costs them money. Every buyer applies a <strong>margin</strong> to the melt value, paying you a percentage of what the gold is worth and keeping the rest as profit or operating costs.</p>
-    <div style="overflow-x:auto">
-      <table>
-        <thead><tr><th>Buyer Type</th><th>Typical Payout (% of Melt Value)</th></tr></thead>
-        <tbody>
-          <tr><td>Pawn shops</td><td>20%&ndash;60%</td></tr>
-          <tr><td>High street jewellers</td><td>40%&ndash;75%</td></tr>
-          <tr><td>Average online buyers</td><td>60%&ndash;75%</td></tr>
-          <tr><td>Specialist gold buyers</td><td>75%&ndash;90%</td></tr>
-          <tr><td>Top competitive buyers</td><td>80%&ndash;98%</td></tr>
-        </tbody>
-      </table>
-    </div>
-    <p>This range is staggering. On a piece with a $1,000 melt value, the difference between a pawn shop offering 25% ($250) and a top online gold buyer offering 90% ($900) is <strong>$650 — for the exact same piece of gold</strong>. Getting three quotes takes an afternoon. That afternoon could be worth hundreds of dollars.</p>
-    <p>The practical lesson: always get multiple quotes before selling, and always calculate the melt value yourself first so you can immediately identify whether an offer is fair or exploitative.</p>
-
-    <h2>Step 3 &mdash; Know Where to Sell: All Your Options Compared</h2>
-
-    <!-- Option 1: Online Gold Buyers -->
-    <div class="channel-card" id="online-buyers">
-      <div class="channel-card__header">
-        <div>
-          <div class="channel-card__name">Option 1: Online Gold Buyers</div>
-          <div class="channel-card__tagline">Best for price on standard scrap jewellery</div>
+      <div class="live-spot" aria-live="polite">
+        <div class="live-spot-cell">
+          <span class="live-spot-label">Gold spot — live (USD)</span>
+          <span class="live-spot-value" id="heroSpotOz">$&mdash;<span style="font-size:.55em;color:var(--color-text-muted);font-weight:500"> / oz</span></span>
+          <span class="live-spot-meta"><span id="heroSpotChange" class="live-spot-change">&mdash;</span><span id="heroSpotUpdated">refreshing&hellip;</span></span>
         </div>
-        <span class="channel-badge channel-badge--best">Best for Price</span>
+        <div class="live-spot-cell">
+          <span class="live-spot-label">Per gram (24K)</span>
+          <span class="live-spot-value" id="heroSpotGram">$&mdash;<span style="font-size:.55em;color:var(--color-text-muted);font-weight:500"> /g</span></span>
+          <span class="live-spot-meta">Refreshes every 60s · USD primary</span>
+        </div>
+        <div class="live-spot-cell" style="justify-content:center">
+          <span class="live-spot-label">Open the tools</span>
+          <a class="live-spot-cta" href="/scrap-gold-calculator">Live Scrap Calculator <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 5l7 7-7 7"/></svg></a>
+        </div>
       </div>
-      <p>Dedicated online gold buyers are consistently the highest-paying channel for standard scrap gold jewellery. Because they operate at scale with lower overhead than physical shops, the best operators are able to pass more of the melt value back to sellers. The process typically works as follows:</p>
+
+      <div class="hero-stats">
+        <div class="hero-stat">
+          <div class="hero-stat-label">Best buyers pay</div>
+          <div class="hero-stat-value">80&ndash;98%</div>
+          <div class="hero-stat-sub">of melt value</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-label">Worst buyers pay</div>
+          <div class="hero-stat-value">20&ndash;40%</div>
+          <div class="hero-stat-sub">of melt value</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-label">All-time high</div>
+          <div class="hero-stat-value">$5,589</div>
+          <div class="hero-stat-sub">28 Jan 2026 · per oz</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-label">2-year rise</div>
+          <div class="hero-stat-value">+135%</div>
+          <div class="hero-stat-sub">vs. 2024 average</div>
+        </div>
+      </div>
+    </header>
+
+    <div class="prose">
+
+      <h2 id="timing" class="reveal">Is 2026 a good time to sell?</h2>
+      <p class="lede-first reveal">The short answer is <strong>yes</strong> — probably the best window in a generation. Gold crossed <strong>$5,000 per troy ounce for the first time in history</strong> in early 2026, peaking at $5,589.38 on 28 January. Even after pulling back from that peak, prices remain extraordinarily elevated compared to any historical average.</p>
+      <p class="reveal">Analysts at J.P. Morgan, UBS, and Goldman Sachs have all published bullish forecasts through 2026 into 2027 &mdash; meaning prices may continue climbing. But timing the absolute peak is a fool's game. If you have jewellery you genuinely don't want or wear, current prices represent an exceptional window that may not return for years.</p>
+
+      <div class="callout callout--gold reveal">
+        <div class="callout-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 8v4l3 3"/><circle cx="12" cy="12" r="9"/></svg></div>
+        <p><strong>Practical rule of thumb.</strong> If you believe gold has further to run and the piece has no emotional or daily use, you can hold. If you've been meaning to clear a drawer of broken chains, mismatched earrings, or rings from a past chapter &mdash; sell now while the market is this strong. The melt value alone, in USD, is the highest it has ever been.</p>
+      </div>
+
+      <h2 id="value" class="reveal">Step 1 &mdash; Know what your gold is actually worth</h2>
+      <p class="reveal">Before you approach a single buyer, you need to know the value of what you are selling. This one step alone separates sellers who get fair prices from those who get ripped off.</p>
+      <p class="reveal">Gold jewellery value is determined by three things only: <strong>purity</strong> (how much of the piece is actually gold, measured in karats), <strong>weight</strong> (how many grams), and <strong>live spot price</strong> (the current global market price per gram of pure gold, quoted in USD).</p>
+
+      <h3>Understanding karats: the only number that matters</h3>
+      <p>The karat system tells you what proportion of your jewellery is pure gold. The rest is alloy &mdash; typically copper, silver, or zinc &mdash; added for durability. Tap any tile to see today's per-gram USD value at that purity.</p>
+
+      <div class="karat-grid reveal" id="karatGrid">
+        <div class="karat-tile" style="--purity:37.5%">
+          <div class="karat-tile-name">9K</div>
+          <div class="karat-tile-pct">37.5% pure</div>
+          <div class="karat-tile-hall">Hallmark 375</div>
+          <div class="karat-tile-price">Per g <strong data-karat-price="0.375">$&mdash;</strong></div>
+        </div>
+        <div class="karat-tile" style="--purity:41.7%">
+          <div class="karat-tile-name">10K</div>
+          <div class="karat-tile-pct">41.7% pure</div>
+          <div class="karat-tile-hall">Hallmark 417</div>
+          <div class="karat-tile-price">Per g <strong data-karat-price="0.417">$&mdash;</strong></div>
+        </div>
+        <div class="karat-tile" style="--purity:58.5%">
+          <div class="karat-tile-name">14K</div>
+          <div class="karat-tile-pct">58.5% pure</div>
+          <div class="karat-tile-hall">Hallmark 585</div>
+          <div class="karat-tile-price">Per g <strong data-karat-price="0.585">$&mdash;</strong></div>
+        </div>
+        <div class="karat-tile" style="--purity:75%">
+          <div class="karat-tile-name">18K</div>
+          <div class="karat-tile-pct">75.0% pure</div>
+          <div class="karat-tile-hall">Hallmark 750</div>
+          <div class="karat-tile-price">Per g <strong data-karat-price="0.750">$&mdash;</strong></div>
+        </div>
+        <div class="karat-tile" style="--purity:91.7%">
+          <div class="karat-tile-name">22K</div>
+          <div class="karat-tile-pct">91.6% pure</div>
+          <div class="karat-tile-hall">Hallmark 916</div>
+          <div class="karat-tile-price">Per g <strong data-karat-price="0.916">$&mdash;</strong></div>
+        </div>
+        <div class="karat-tile" style="--purity:99.9%">
+          <div class="karat-tile-name">24K</div>
+          <div class="karat-tile-pct">99.9% pure</div>
+          <div class="karat-tile-hall">Hallmark 999</div>
+          <div class="karat-tile-price">Per g <strong data-karat-price="0.999">$&mdash;</strong></div>
+        </div>
+      </div>
+
+      <p>Most jewellery sold in the United States is 10K or 14K. In the UK, 9K is common for everyday jewellery. In India and the Middle East, 22K is most prevalent. In Europe, 18K is the most widely sold standard for fine jewellery.</p>
+
+      <div class="callout callout--info reveal">
+        <div class="callout-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h.01"/></svg></div>
+        <p><strong>How to find your hallmark.</strong> Look for a small stamped number on the inside of a ring band, the clasp of a necklace, or the back of a pendant. That stamp is the most important number in determining value. If you cannot find one, a reputable buyer will test the piece for free using acid testing or an XRF scanner.</p>
+      </div>
+
+      <h3>The melt-value formula</h3>
+      <p>Once you know the karat and weight, calculating the melt value is straightforward:</p>
+      <blockquote>Melt value (USD) = weight in grams &times; (karat &divide; 24) &times; current spot price per gram</blockquote>
+      <p><strong>Example 1 &mdash; 18K gold necklace, 8 grams:</strong><br>Purity factor: 18 &divide; 24 = 0.75 &bull; Pure gold content: 8g &times; 0.75 = 6g &bull; At <span data-karat-price="1.000" data-fmt="g">$&mdash;</span>/g &times; 6g = <strong><span data-example-melt="8,0.75">$&mdash;</span> melt value</strong></p>
+      <p><strong>Example 2 &mdash; 9K gold ring, 3.5 grams:</strong><br>Purity factor: 9 &divide; 24 = 0.375 &bull; Pure gold content: 3.5g &times; 0.375 = 1.31g &bull; At <span data-karat-price="1.000" data-fmt="g">$&mdash;</span>/g &times; 1.31g = <strong><span data-example-melt="3.5,0.375">$&mdash;</span> melt value</strong></p>
+      <p>The melt value is the ceiling &mdash; the theoretical maximum if someone paid you 100% of spot. In practice, buyers pay a percentage of melt value, and that percentage varies enormously depending on who you sell to. <strong>The melt value is your negotiating baseline.</strong></p>
+
+
+      <!-- INLINE MINI CALCULATOR -->
+      <section class="mini-calc reveal" aria-labelledby="miniCalcTitle">
+        <div class="mini-calc-header">
+          <div>
+            <h3 id="miniCalcTitle" class="mini-calc-title">Instant value estimator</h3>
+            <p class="mini-calc-sub">Pick a karat, enter a weight, and see a real-time USD melt value &amp; expected payout. Powered by the live spot price.</p>
+          </div>
+          <span class="mini-calc-live" aria-live="polite"><span class="pulse" aria-hidden="true"></span><span id="mcLiveStatus">Live · USD</span></span>
+        </div>
+
+        <div class="mini-calc-grid">
+          <div class="mc-controls">
+            <div>
+              <label class="mc-field-label" id="mcKaratLbl">Karat purity</label>
+              <div class="mc-karat-chips" role="radiogroup" aria-labelledby="mcKaratLbl" id="mcKaratChips">
+                <button type="button" class="mc-karat-chip" data-karat="9K" data-purity="0.375" role="radio" aria-checked="false">9K</button>
+                <button type="button" class="mc-karat-chip" data-karat="10K" data-purity="0.4167" role="radio" aria-checked="false">10K</button>
+                <button type="button" class="mc-karat-chip active" data-karat="14K" data-purity="0.5833" role="radio" aria-checked="true">14K</button>
+                <button type="button" class="mc-karat-chip" data-karat="18K" data-purity="0.75" role="radio" aria-checked="false">18K</button>
+                <button type="button" class="mc-karat-chip" data-karat="22K" data-purity="0.9167" role="radio" aria-checked="false">22K</button>
+                <button type="button" class="mc-karat-chip" data-karat="24K" data-purity="0.999" role="radio" aria-checked="false">24K</button>
+              </div>
+            </div>
+            <div>
+              <label class="mc-field-label" for="mcWeight">Weight</label>
+              <div class="mc-input-row">
+                <input id="mcWeight" class="mc-input" type="number" inputmode="decimal" min="0" step="0.1" placeholder="e.g. 5.4" value="5">
+                <div class="mc-unit-toggle" role="radiogroup" aria-label="Weight unit">
+                  <button type="button" class="mc-unit-btn active" data-unit="g">g</button>
+                  <button type="button" class="mc-unit-btn" data-unit="oz">oz</button>
+                </div>
+              </div>
+            </div>
+            <div>
+              <label class="mc-field-label" for="mcBuyer">Buyer type</label>
+              <select id="mcBuyer" class="mc-buyer-select">
+                <option value="0.90" data-label="Specialist online buyer">Specialist online buyer (~90% melt)</option>
+                <option value="0.85" data-label="Specialist dealer" selected>Specialist gold dealer (~85% melt)</option>
+                <option value="0.70" data-label="Local jeweller">Local jeweller (~70% melt)</option>
+                <option value="0.50" data-label="High street average">Average high street (~50% melt)</option>
+                <option value="0.35" data-label="Pawn shop">Pawn shop (~35% melt)</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="mc-output" aria-live="polite">
+            <div class="mc-out-row">
+              <span class="mc-out-label">Expected payout</span>
+              <span class="mc-out-value mc-out-headline" id="mcOffer">$&mdash;</span>
+            </div>
+            <div class="mc-out-row">
+              <span class="mc-out-label">Melt value (USD)</span>
+              <span class="mc-out-value mc-out-melt" id="mcMelt">$&mdash;</span>
+            </div>
+            <div class="mc-out-row">
+              <span class="mc-out-label">Pure gold content</span>
+              <span class="mc-out-value mc-out-rate" id="mcPure">&mdash; g</span>
+            </div>
+            <div class="mc-out-row">
+              <span class="mc-out-label">Live spot · per g (24K)</span>
+              <span class="mc-out-value mc-out-rate" id="mcSpot">$&mdash;</span>
+            </div>
+            <div class="mc-foot">
+              <span class="mc-foot-meta"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> <span id="mcUpdated">refreshing&hellip;</span></span>
+              <a href="/scrap-gold-calculator">Open full calculator <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 5l7 7-7 7"/></svg></a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <h3>A note on gemstones, clasps and damaged parts</h3>
+      <p>Most buyers calculate the weight of your gold <strong>after removing any stones</strong>, since gemstones are not gold. Some will make a separate offer for diamonds or precious stones, but for most standard pieces the gem value is negligible unless you have certified, high-quality stones. Clasps, pins, and attachments made from lower-purity alloys or non-gold materials are similarly excluded from the gold calculation.</p>
+
+      <h2 id="percentages" class="reveal">Step 2 &mdash; The percentage buyers actually pay</h2>
+      <p>Here is the number most sellers do not know before they walk into their first buyer &mdash; and it costs them money. Every buyer applies a <strong>margin</strong> to the melt value, paying you a percentage of what the gold is worth and keeping the rest as profit and operating cost.</p>
+
+      <div class="payout-meter reveal" role="img" aria-label="Typical payout percentages by buyer type">
+        <div class="payout-meter-row payout-meter-row--high" style="--w:89%">
+          <div class="payout-meter-label">Top competitive buyers</div>
+          <div class="payout-meter-bar"><div class="payout-meter-fill" style="width:89%"></div></div>
+          <div class="payout-meter-pct">80&ndash;98%</div>
+        </div>
+        <div class="payout-meter-row payout-meter-row--high" style="--w:82%">
+          <div class="payout-meter-label">Specialist gold buyers</div>
+          <div class="payout-meter-bar"><div class="payout-meter-fill" style="width:82%"></div></div>
+          <div class="payout-meter-pct">75&ndash;90%</div>
+        </div>
+        <div class="payout-meter-row payout-meter-row--mid" style="--w:67%">
+          <div class="payout-meter-label">Average online buyers</div>
+          <div class="payout-meter-bar"><div class="payout-meter-fill" style="width:67%"></div></div>
+          <div class="payout-meter-pct">60&ndash;75%</div>
+        </div>
+        <div class="payout-meter-row payout-meter-row--mid" style="--w:57%">
+          <div class="payout-meter-label">High street jewellers</div>
+          <div class="payout-meter-bar"><div class="payout-meter-fill" style="width:57%"></div></div>
+          <div class="payout-meter-pct">40&ndash;75%</div>
+        </div>
+        <div class="payout-meter-row payout-meter-row--low" style="--w:40%">
+          <div class="payout-meter-label">Pawn shops</div>
+          <div class="payout-meter-bar"><div class="payout-meter-fill" style="width:40%"></div></div>
+          <div class="payout-meter-pct">20&ndash;60%</div>
+        </div>
+      </div>
+
+      <p>This range is staggering. On a piece with a $1,000 melt value, the difference between a pawn shop offering 25% ($250) and a top online buyer offering 90% ($900) is <strong>$650 &mdash; for the exact same piece of gold</strong>. Getting three quotes takes an afternoon. That afternoon can be worth hundreds of dollars.</p>
+      <p>The practical lesson: <strong>always get multiple quotes</strong> before selling, and always calculate the melt value yourself first so you can immediately identify whether an offer is fair or exploitative.</p>
+
+
+      <h2 id="channels" class="reveal">Step 3 &mdash; Where to sell: all your options compared</h2>
+
+      <article class="channel-card channel-card--best reveal" id="online-buyers">
+        <header class="channel-card__head">
+          <div class="channel-card__head-text">
+            <div class="channel-card__num">Option 01</div>
+            <h3 class="channel-card__name">Online Gold Buyers</h3>
+            <p class="channel-card__tag">Best for price on standard scrap jewellery.</p>
+          </div>
+          <div class="channel-card__badges">
+            <span class="channel-badge channel-badge--best">Best for Price</span>
+          </div>
+        </header>
+        <div class="channel-mini-bar"><span class="channel-mini-bar-label">Typical payout</span><div class="channel-mini-bar-track"><div class="channel-mini-bar-fill" style="width:89%"></div></div><span class="channel-mini-bar-val">80&ndash;98%</span></div>
+        <div class="channel-card__body">
+          <p>Dedicated online gold buyers are consistently the highest-paying channel for standard scrap gold jewellery. Because they operate at scale with lower overhead than physical shops, the best operators pass more of the melt value back to sellers. The process typically works like this:</p>
+          <ul>
+            <li>Request a free insured postal kit from the buyer's website</li>
+            <li>Weigh, photograph, and list your items before sending</li>
+            <li>Post your gold using the prepaid, tracked, insured packaging</li>
+            <li>Receive a detailed offer (weight &times; purity &times; buyer's USD rate) within 24&ndash;48 hours</li>
+            <li>Accept or reject &mdash; if you reject, reputable buyers return your items free of charge</li>
+          </ul>
+          <p><strong>What to look for.</strong> Clear, published USD price per gram by karat <em>before</em> you send anything; free, fully insured postal service with tracked delivery; free returns within a specified cooling-off period; transparent breakdown of offer (weight, purity, price per gram, total); strong independent reviews on Trustpilot or Google.</p>
+          <p><strong>Examples in the US:</strong> Cash for Gold USA, APMEX scrap gold programme, Express Gold Cash, Worthy (for fine jewellery with gems).</p>
+          <p><strong>Examples in the UK:</strong> Hatton Garden Metals, Gold Traders UK, Lois Bullion, BullionByPost, Cash4Gold-Now.</p>
+          <p><strong>Best for:</strong> standard gold jewellery, broken pieces, mismatched earrings, chains without resale value beyond their gold content. Not ideal for designer or antique pieces that could command a premium above melt.</p>
+        </div>
+      </article>
+
+      <article class="channel-card channel-card--good reveal" id="local-jewellers">
+        <header class="channel-card__head">
+          <div class="channel-card__head-text">
+            <div class="channel-card__num">Option 02</div>
+            <h3 class="channel-card__name">Local Jewellers</h3>
+            <p class="channel-card__tag">Best for wearable, resellable pieces.</p>
+          </div>
+          <div class="channel-card__badges">
+            <span class="channel-badge channel-badge--good">Good Choice</span>
+          </div>
+        </header>
+        <div class="channel-mini-bar"><span class="channel-mini-bar-label">Typical payout</span><div class="channel-mini-bar-track"><div class="channel-mini-bar-fill" style="width:65%"></div></div><span class="channel-mini-bar-val">55&ndash;80%</span></div>
+        <div class="channel-card__body">
+          <p>Reputable local jewellers consistently outpay pawn shops and often match or beat online buyers for pieces that have resale value beyond the raw metal. A jeweller who can sell your ring in their case at retail will pay more for it than a buyer who can only melt it down.</p>
+          <p>If your piece is in good condition, has a recognised design, or comes from a known brand, a jeweller is often a better channel than a scrap buyer.</p>
+          <p><strong>Tip:</strong> Visit two or three local jewellers on the same day and compare written offers. Jewellers expect negotiation. Use one written offer as leverage with another. Phrases like &ldquo;I have another offer at $X &mdash; can you match that?&rdquo; are entirely reasonable and often effective.</p>
+          <p><strong>Best for:</strong> wearable, good-condition pieces; branded jewellery; pieces with quality gemstones; estate jewellery.</p>
+        </div>
+      </article>
+
+      <article class="channel-card channel-card--good reveal" id="auction-houses">
+        <header class="channel-card__head">
+          <div class="channel-card__head-text">
+            <div class="channel-card__num">Option 03</div>
+            <h3 class="channel-card__name">Auction Houses</h3>
+            <p class="channel-card__tag">Best for antique, designer or high-value pieces.</p>
+          </div>
+          <div class="channel-card__badges">
+            <span class="channel-badge channel-badge--good">High Value</span>
+          </div>
+        </header>
+        <div class="channel-mini-bar"><span class="channel-mini-bar-label">Net of commission</span><div class="channel-mini-bar-track"><div class="channel-mini-bar-fill" style="width:75%"></div></div><span class="channel-mini-bar-val">Above melt</span></div>
+        <div class="channel-card__body">
+          <p>If your jewellery is antique, vintage, from a luxury brand (Cartier, Van Cleef &amp; Arpels, Tiffany, Bulgari) or features exceptional gemstones, an auction house can achieve prices that dwarf both melt value and local retail offers. Competitive bidding between collectors can push prices far above anything a dealer will offer.</p>
+          <p><strong>Real-world example.</strong> An 18ct gold chain weighing 20g has a melt value around $3,040 at today's spot. A scrap buyer would pay roughly $2,432&ndash;$2,736 (80&ndash;90% of melt). At auction, a comparable chain in good condition recently achieved <strong>~29% above its scrap value</strong>.</p>
+          <p><strong>Top-tier:</strong> Sotheby's, Christie's, Bonhams and regional fine-art auction houses handle high-value jewellery regularly. Most offer free valuations.</p>
+          <p><strong>Mid-tier:</strong> regional and online-only auction platforms (including eBay's auction format) can achieve retail-adjacent prices for pieces in good condition.</p>
+          <p><strong>Note.</strong> Auction houses charge seller commission &mdash; typically 15&ndash;25% of the hammer price. Factor this into your net USD return.</p>
+        </div>
+      </article>
+
+      <article class="channel-card channel-card--mid reveal" id="ebay-marketplaces">
+        <header class="channel-card__head">
+          <div class="channel-card__head-text">
+            <div class="channel-card__num">Option 04</div>
+            <h3 class="channel-card__name">eBay &amp; Online Marketplaces</h3>
+            <p class="channel-card__tag">Best for niche, fashion and wearable pieces.</p>
+          </div>
+          <div class="channel-card__badges">
+            <span class="channel-badge channel-badge--mid">Wearable</span>
+          </div>
+        </header>
+        <div class="channel-mini-bar"><span class="channel-mini-bar-label">Reach</span><div class="channel-mini-bar-track"><div class="channel-mini-bar-fill" style="width:88%"></div></div><span class="channel-mini-bar-val">134M buyers</span></div>
+        <div class="channel-card__body">
+          <p>Selling gold jewellery directly on eBay puts you in front of 134 million active buyers globally &mdash; including private collectors who may pay above scrap for the right piece. Unique, vintage, or unusual pieces often command a premium here that no trade buyer would match.</p>
+          <p><strong>eBay fees for jewellery (USD):</strong> first 250 listings free; final value fee 6.5% on items priced $1,000&ndash;$7,500; 3% above $7,500.</p>
+          <p>Other platforms worth considering: <strong>Facebook Marketplace</strong> for local cash sales with no fees (apply personal-safety awareness when meeting strangers); <strong>Etsy</strong> for handmade or vintage pieces; <strong>Worthy</strong> for certified diamond jewellery.</p>
+          <p><strong>Best for:</strong> wearable pieces, jewellery with unique design or vintage appeal, items that a private buyer might value above melt.</p>
+          <p><strong>Not ideal for:</strong> broken pieces, mismatched sets, or damaged jewellery that a private buyer would not want to wear.</p>
+        </div>
+      </article>
+
+      <article class="channel-card channel-card--last reveal" id="pawn-shops">
+        <header class="channel-card__head">
+          <div class="channel-card__head-text">
+            <div class="channel-card__num">Option 05</div>
+            <h3 class="channel-card__name">Pawn Shops</h3>
+            <p class="channel-card__tag">Last resort &mdash; only if you need cash within the hour.</p>
+          </div>
+          <div class="channel-card__badges">
+            <span class="channel-badge channel-badge--last">Last Resort</span>
+          </div>
+        </header>
+        <div class="channel-mini-bar"><span class="channel-mini-bar-label">Typical payout</span><div class="channel-mini-bar-track"><div class="channel-mini-bar-fill" style="width:40%;background:linear-gradient(90deg,#dc2626,#f87171)"></div></div><span class="channel-mini-bar-val">20&ndash;60%</span></div>
+        <div class="channel-card__body">
+          <p>Pawn shops are convenient and fast, but they are the lowest-paying option for almost every category of gold jewellery. Their business model is built around short-term loans, not specialist precious-metals dealing &mdash; which means they apply wide margins to cover the uncertainty of their diverse inventory.</p>
+          <p>Reports indicate pawn shops may pay as little as <strong>20% of an item's melt value</strong>. Even the best pawn shops rarely exceed 60%. For context, that is less than half what the best online buyers pay for the same gold.</p>
+          <p><strong>Use a pawn shop only if:</strong> you need cash within the hour, cannot access a bank or online payment, or are in a location with no other options.</p>
+        </div>
+      </article>
+
+      <h2 id="online-process" class="reveal">How to sell gold jewellery online: a step-by-step process</h2>
+      <p>If you have decided that an online buyer is the right route for your gold, here is the full process from drawer to bank account:</p>
+      <ol class="step-timeline reveal" aria-label="Eight-step process for selling gold jewellery online">
+        <li class="step-item"><span class="step-marker">1</span><div class="step-content"><strong class="step-title">Weigh your items at home</strong><p>Use a digital kitchen scale accurate to 0.1 g. Weigh each piece separately and record it. This gives you a reference to cross-check the buyer's weighing when they confirm the offer.</p></div></li>
+        <li class="step-item"><span class="step-marker">2</span><div class="step-content"><strong class="step-title">Check the hallmarks</strong><p>Look for karat stamps (375 = 9K, 585 = 14K, 750 = 18K, 916 = 22K, 999 = 24K) on each piece. Record these alongside the weights.</p></div></li>
+        <li class="step-item"><span class="step-marker">3</span><div class="step-content"><strong class="step-title">Calculate the melt value in USD</strong><p>Use the formula above, or open the free <a href="/scrap-gold-calculator">scrap gold calculator</a>. This gives you a firm baseline to compare every offer against.</p></div></li>
+        <li class="step-item"><span class="step-marker">4</span><div class="step-content"><strong class="step-title">Photograph everything before posting</strong><p>Take clear photos of each item alongside a scale showing its weight. These photos are your evidence if there is any dispute about condition or weight on arrival.</p></div></li>
+        <li class="step-item"><span class="step-marker">5</span><div class="step-content"><strong class="step-title">Request free postal kits from two or three buyers</strong><p>There is no obligation to use them all, and comparing offers from multiple buyers is the single most effective way to maximise your return.</p></div></li>
+        <li class="step-item"><span class="step-marker">6</span><div class="step-content"><strong class="step-title">Send using the buyer's insured, tracked packaging</strong><p>Never send gold in your own envelope. Reputable buyers provide free, fully insured postal bags. Confirm the insurance covers the full USD value &mdash; some caps are lower than the gold value.</p></div></li>
+        <li class="step-item"><span class="step-marker">7</span><div class="step-content"><strong class="step-title">Review the offer and compare to your melt value</strong><p>A fair offer should be 75&ndash;95% of melt value. Below 70% &mdash; particularly from a well-resourced online buyer &mdash; is worth negotiating or declining.</p></div></li>
+        <li class="step-item"><span class="step-marker">8</span><div class="step-content"><strong class="step-title">Accept or decline</strong><p>Reputable buyers must return your items if you reject the offer, at no cost to you. Confirm this policy <em>before</em> sending.</p></div></li>
+      </ol>
+
+      <h2 id="plated" class="reveal">What about gold-plated jewellery?</h2>
+      <p>This is one of the most common sources of disappointment for first-time gold sellers &mdash; and it is worth addressing directly.</p>
+      <div class="callout callout--warn reveal">
+        <div class="callout-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 9v4M12 17h.01"/><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg></div>
+        <p><strong>Gold-plated jewellery is not solid gold</strong>, and most professional gold buyers will not purchase it as a gold piece. Gold plating is a thin coating of gold applied over a base metal (usually brass, copper, or silver). The amount of actual gold is so small that it has negligible value as scrap metal &mdash; a typical gold-plated necklace contains only ~0.05% gold by weight. If a buyer offers to purchase your plated jewellery by gram as though it were solid gold, that is a scam.</p>
+      </div>
+      <p><strong>What you can do with gold-plated jewellery:</strong></p>
       <ul>
-        <li>Request a free insured postal kit from the buyer's website</li>
-        <li>Weigh, photograph, and list your items before sending</li>
-        <li>Post your gold using the prepaid, tracked, insured packaging</li>
-        <li>Receive a detailed offer (weight &times; purity &times; buyer's rate) within 24&ndash;48 hours</li>
-        <li>Accept or reject &mdash; if you reject, reputable buyers return your items free of charge</li>
+        <li>Sell on eBay, Vinted, Depop, or Facebook Marketplace as jewellery &mdash; private buyers will pay for the piece's aesthetic appeal regardless of metal content</li>
+        <li>Sell to vintage or costume jewellery dealers</li>
+        <li>Upcycle or repurpose &mdash; craft markets value decorative pieces regardless of metal value</li>
       </ul>
-      <p><strong>What to look for in a reputable online buyer:</strong> Clear, published price per gram by karat before you send anything; free, fully insured postal service with tracked delivery; free returns within a specified cooling-off period; transparent breakdown of offer (weight, purity, price per gram, total); strong independent reviews on Trustpilot or Google.</p>
-      <p><strong>Online buyers in the US:</strong> Cash for Gold USA, APMEX scrap gold programme, Express Gold Cash, Worthy (for fine jewellery with gems)</p>
-      <p><strong>Online buyers in the UK:</strong> Hatton Garden Metals, Gold Traders UK, Lois Bullion, BullionByPost, Cash4Gold-Now</p>
-      <p><strong>Best for:</strong> Standard gold jewellery, broken pieces, mismatched earrings, chains without resale value beyond the gold content. Not ideal for designer or antique pieces that could command a premium above melt value.</p>
-    </div>
+      <p>Do not confuse gold-plated with <strong>gold-filled</strong>, which has a much thicker layer of gold bonded to a base metal core &mdash; typically 5% gold by weight. Some specialist buyers will purchase gold-filled items, though at a steep discount to solid gold.</p>
 
-    <!-- Option 2: Local Jewellers -->
-    <div class="channel-card" id="local-jewellers">
-      <div class="channel-card__header">
-        <div>
-          <div class="channel-card__name">Option 2: Local Jewellers</div>
-          <div class="channel-card__tagline">Best for wearable, resellable pieces</div>
+
+      <h2 id="realistic" class="reveal">Gold jewellery price: what you can realistically expect</h2>
+      <p>Realistic expected payouts for common jewellery types at <strong>today's live USD spot price</strong>, assuming a competitive buyer paying 85% of melt. The figures below update automatically as the gold price moves.</p>
+      <div class="table-wrap reveal">
+        <table>
+          <thead><tr><th>Item</th><th>Weight</th><th>Karat</th><th>Melt Value (USD)</th><th>Expected @ 85%</th></tr></thead>
+          <tbody id="payoutTbody">
+            <tr><td>Simple gold wedding band</td><td>3 g</td><td>18K</td><td class="usd-val" data-row-melt="3,0.75">$&mdash;</td><td class="usd-val" data-row-offer="3,0.75,0.85">$&mdash;</td></tr>
+            <tr><td>Gold chain necklace (medium)</td><td>8 g</td><td>9K</td><td class="usd-val" data-row-melt="8,0.375">$&mdash;</td><td class="usd-val" data-row-offer="8,0.375,0.85">$&mdash;</td></tr>
+            <tr><td>Gold ring with small stone</td><td>4 g</td><td>14K</td><td class="usd-val" data-row-melt="4,0.585">$&mdash;</td><td class="usd-val" data-row-offer="4,0.585,0.85">$&mdash;</td></tr>
+            <tr><td>Gold bracelet</td><td>12 g</td><td>18K</td><td class="usd-val" data-row-melt="12,0.75">$&mdash;</td><td class="usd-val" data-row-offer="12,0.75,0.85">$&mdash;</td></tr>
+            <tr><td>Gold earrings (pair)</td><td>3 g</td><td>22K</td><td class="usd-val" data-row-melt="3,0.916">$&mdash;</td><td class="usd-val" data-row-offer="3,0.916,0.85">$&mdash;</td></tr>
+            <tr><td>Large gold chain</td><td>20 g</td><td>18K</td><td class="usd-val" data-row-melt="20,0.75">$&mdash;</td><td class="usd-val" data-row-offer="20,0.75,0.85">$&mdash;</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p><em>Figures use the <strong>live 24K USD price per gram</strong>, refreshed every 60 seconds from gold-api.com (LBMA spot). Open the <a href="/scrap-gold-calculator">full scrap gold calculator</a> for per-piece detail and karat selection.</em></p>
+
+      <h2 id="scams" class="reveal">Scams to avoid: protect yourself when selling gold</h2>
+      <p>The gold-buying market contains a significant number of operators who rely on sellers not knowing the value of what they are selling. The most common 2026 scams to watch for:</p>
+
+      <div class="scam-grid reveal">
+        <div class="scam-card">
+          <div class="scam-card-title"><span class="scam-card-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="9"/><path d="M9 9l6 6M15 9l-6 6"/></svg></span> Lowball "per item" offers</div>
+          <p class="scam-card-desc">A buyer quotes a price <strong>per piece</strong> instead of per gram, hiding the calculation. Always ask for: weight &times; purity &times; price per gram = total. If they can't or won't show this, leave.</p>
         </div>
-        <span class="channel-badge channel-badge--good">Good Choice</span>
-      </div>
-      <p>Reputable local jewellers consistently outpay pawn shops and often match or beat online buyers for pieces that have resale value beyond the raw metal. A jeweller who can sell your ring or necklace in their case at retail will pay more for it than a buyer who can only melt it down.</p>
-      <p>If your piece is in good condition, has a recognised design, or comes from a known brand, a jeweller is often a better channel than a scrap buyer. They can evaluate the piece as a whole rather than reducing it to its metal content.</p>
-      <p><strong>Tip:</strong> Visit two or three local jewellers on the same day and compare written offers. Jewellers expect negotiation. Use one offer as leverage with another. Phrases like "I have another offer at $X — can you match that?" are entirely reasonable and often effective.</p>
-      <p><strong>Best for:</strong> Wearable, good-condition pieces; branded jewellery; pieces with quality gemstones; estate jewellery.</p>
-    </div>
-
-    <!-- Option 3: Auction Houses -->
-    <div class="channel-card" id="auction-houses">
-      <div class="channel-card__header">
-        <div>
-          <div class="channel-card__name">Option 3: Auction Houses</div>
-          <div class="channel-card__tagline">Best for antique, designer or high-value pieces</div>
+        <div class="scam-card">
+          <div class="scam-card-title"><span class="scam-card-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M6 6h12v12H6zM6 12h12"/></svg></span> Underweighting</div>
+          <p class="scam-card-desc">The buyer's scales "happen" to show your piece is lighter than your measurement at home. <strong>Weigh items before you go</strong> and insist on transparent, in-front-of-you weighing.</p>
         </div>
-        <span class="channel-badge channel-badge--good">High Value</span>
-      </div>
-      <p>If your jewellery is antique, vintage, from a luxury brand (Cartier, Van Cleef &amp; Arpels, Tiffany, Bulgari), or features exceptional gemstones, an auction house may achieve prices that dwarf both melt value and local retail offers. Competitive bidding between collectors can push prices far above anything a dealer will offer.</p>
-      <p>A real-world example: an 18ct gold chain weighing 20 grams has a melt value of around $2,280. A scrap buyer would pay approximately $1,824&ndash;$2,052. At auction, the same chain achieved $2,940 &mdash; 29% above its scrap value.</p>
-      <p><strong>For top-tier pieces:</strong> Sotheby's, Christie's, Bonhams, and regional fine art auction houses handle high-value jewellery regularly. Most offer free valuations.</p>
-      <p><strong>For mid-tier pieces:</strong> Regional and online-only auction platforms (including eBay auction format) can achieve retail-adjacent prices for pieces in good condition.</p>
-      <p><strong>Best for:</strong> Antique jewellery; designer or branded pieces; heirloom items with provenance; rings with certified diamonds.</p>
-      <p><strong>Note:</strong> Auction houses charge seller commission — typically 15&ndash;25% of the hammer price. Factor this into your net return calculation.</p>
-    </div>
-
-    <!-- Option 4: eBay and Online Marketplaces -->
-    <div class="channel-card" id="ebay-marketplaces">
-      <div class="channel-card__header">
-        <div>
-          <div class="channel-card__name">Option 4: eBay &amp; Online Marketplaces</div>
-          <div class="channel-card__tagline">Best for niche, fashion and wearable pieces</div>
+        <div class="scam-card">
+          <div class="scam-card-title"><span class="scam-card-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg></span> Purity downgrading</div>
+          <p class="scam-card-desc">"Testing" claims your 18K piece is only 14K. <strong>Ask to see the test</strong> performed in front of you. A legitimate XRF tester or acid test is quick and visible. Refusal is a red flag.</p>
         </div>
-        <span class="channel-badge channel-badge--good">Good Choice</span>
-      </div>
-      <p>Selling gold jewellery directly on eBay puts you in front of 134 million active buyers globally — including private collectors who may pay above scrap value for the right piece. Unique, vintage, or unusual pieces often command a premium here that no trade buyer would match.</p>
-      <p><strong>eBay fees for jewellery:</strong> Listings up to 250 items: free. Items priced $1,000&ndash;$7,500: 6.5% final value fee. Items priced above $7,500: 3% final value fee.</p>
-      <p>Other platforms worth considering: <strong>Facebook Marketplace</strong> for local cash sales with no fees (carry personal safety awareness when meeting strangers); <strong>Etsy</strong> for handmade or vintage pieces; <strong>Worthy</strong> for certified diamond jewellery.</p>
-      <p><strong>Best for:</strong> Wearable pieces; jewellery with unique design or vintage appeal; items that a private buyer might value above melt.</p>
-      <p><strong>Not ideal for:</strong> Broken pieces, mismatched sets, or damaged jewellery that a private buyer would not want to wear.</p>
-    </div>
-
-    <!-- Option 5: Pawn Shops -->
-    <div class="channel-card" id="pawn-shops">
-      <div class="channel-card__header">
-        <div>
-          <div class="channel-card__name">Option 5: Pawn Shops</div>
-          <div class="channel-card__tagline">Last resort — use only if you need cash immediately</div>
+        <div class="scam-card">
+          <div class="scam-card-title"><span class="scam-card-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M3 7l9 6 9-6"/><rect x="3" y="5" width="18" height="14" rx="2"/></svg></span> Postal scams</div>
+          <p class="scam-card-desc">You send your gold, receive a shockingly low offer, then discover returning items requires significant postage &mdash; or the company simply doesn't respond. Only use <strong>postal buyers with hundreds of verified reviews</strong>, a clear returns policy in writing, and free insured return postage.</p>
         </div>
-        <span class="channel-badge channel-badge--last">Last Resort</span>
+        <div class="scam-card">
+          <div class="scam-card-title"><span class="scam-card-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg></span> "Today only" pressure</div>
+          <p class="scam-card-desc">Any buyer who tells you their offer expires in minutes is using a manipulation tactic. <strong>A fair offer does not need to be rushed.</strong> Legitimate buyers are happy for you to shop around.</p>
+        </div>
+        <div class="scam-card">
+          <div class="scam-card-title"><span class="scam-card-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span> Hidden deductions</div>
+          <p class="scam-card-desc">An offer is quoted at $500, but payment arrives at $420 &mdash; deductions for "testing" or "processing" fees never disclosed upfront. <strong>Always confirm the net USD payout in writing</strong> before agreeing.</p>
+        </div>
+        <div class="scam-card">
+          <div class="scam-card-title"><span class="scam-card-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M3 21h18M5 21V8l7-5 7 5v13M9 21v-6h6v6"/></svg></span> Gold parties / travelling buyers</div>
+          <p class="scam-card-desc">Pop-up "cash for gold" events at hotels or community halls use social pressure and quick-turnaround formats to prevent comparison shopping. Prices are almost always <strong>significantly below</strong> what a specialist would pay.</p>
+        </div>
+        <div class="scam-card">
+          <div class="scam-card-title"><span class="scam-card-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg></span> Plated-as-gold pricing</div>
+          <p class="scam-card-desc">A buyer offers to purchase gold-<strong>plated</strong> jewellery at a per-gram rate as if it were solid. Real gold content in plating is negligible. This offer is a setup for an even smaller payout once "tests" come back.</p>
+        </div>
       </div>
-      <p>Pawn shops are convenient and fast, but they are the lowest-paying option for almost every category of gold jewellery. Their business model is built around short-term loans, not specialist precious metals dealing — which means they apply wide margins to cover the uncertainty of their diverse inventory.</p>
-      <p>Reports indicate pawn shops may pay as little as 20% of an item's melt value. Even the best pawn shops rarely exceed 60%. For context, that is less than half what the best online buyers pay for the same gold.</p>
-      <p><strong>Use a pawn shop only if:</strong> you need cash immediately (same hour), cannot access a bank or online payment, or are in a location with no other options.</p>
+
+      <h2 id="beyond-melt" class="reveal">Selling second-hand gold jewellery: beyond the melt value</h2>
+      <p>Not all gold is created equal when it comes to resale. Before deciding on a buyer, ask yourself:</p>
+      <p><strong>Is this piece from a recognised designer or brand?</strong> Cartier, Tiffany, David Yurman, Bulgari &mdash; branded jewellery commands significant premiums in the resale market. A certified Cartier Love bracelet in 18K weighing 30g has a melt value around <span data-example-melt="30,0.75">$&mdash;</span>. A second-hand luxury reseller might offer <strong>$4,500&ndash;$6,500</strong> for the same piece as a branded item.</p>
+      <p><strong>Is this piece antique or vintage?</strong> Pre-1940s jewellery, Art Deco pieces, Victorian gold, Edwardian settings &mdash; these often attract collector premiums that far exceed metal content. An auction house valuation costs nothing and could reveal a piece is worth multiples of its melt value.</p>
+      <p><strong>Is this piece in excellent condition?</strong> Jewellery that is clean, undamaged, and retains its original design is worth more to a jeweller or private buyer than to a refiner. Light cleaning before valuation &mdash; but not polishing that could remove hallmarks &mdash; is worthwhile.</p>
+      <div class="callout callout--info reveal">
+        <div class="callout-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01"/></svg></div>
+        <p><strong>Second-hand luxury resale platforms</strong> for designer gold jewellery include: The RealReal, Vestiaire Collective, Worthy, and I Do Now I Don't (for bridal jewellery). Commissions typically run 20&ndash;30%, but the premiums over melt value often make these platforms worthwhile for the right pieces.</p>
+      </div>
+
+      <h2 id="tips" class="reveal">The expert's checklist: ten tips to maximise your payout</h2>
+      <p>Here are the ten steps that separate sellers who get excellent prices from those who walk away disappointed:</p>
+      <ol class="tips-list reveal">
+        <li><div><strong>Weigh every item at home</strong>on a digital scale before approaching any buyer. Record each piece separately with its hallmark karat.</div></li>
+        <li><div><strong>Calculate the melt value in USD</strong>using the formula: grams &times; (karat &divide; 24) &times; current price per gram. Use our free <a href="/scrap-gold-calculator">scrap gold calculator</a>.</div></li>
+        <li><div><strong>Get a minimum of three quotes</strong>&mdash; from at least one online buyer, one local jeweller, and one other specialist. Prices can legitimately vary by 20&ndash;30%+ on identical items.</div></li>
+        <li><div><strong>Separate pieces by category</strong>&mdash; fine jewellery goes to a jeweller or auction house; plain scrap gold goes to a specialist buyer; designer or antique pieces get their own assessment first.</div></li>
+        <li><div><strong>Know that gold-plated is negligible</strong>&mdash; route plated pieces to private resale platforms instead of gold buyers.</div></li>
+        <li><div><strong>Time your sale</strong>&mdash; selling when gold is near recent highs maximises your USD return. Check the live spot on the day you plan to sell.</div></li>
+        <li><div><strong>Negotiate</strong>&mdash; most buyers expect it. Use competing offers as leverage. Even 2&ndash;3% improvement is real money at today's prices.</div></li>
+        <li><div><strong>Never accept a "per item" offer</strong>without asking for the per gram breakdown. If a buyer cannot explain their calculation transparently, the offer is almost certainly unfair.</div></li>
+        <li><div><strong>For postal sales: photograph, weigh, insure everything</strong>before it leaves your hands. Use fully insured tracked delivery &mdash; not a standard letter.</div></li>
+        <li><div><strong>For high-value pieces, get a pro appraisal first</strong>&mdash; a $50 appraisal from a certified gemologist can reveal whether a piece is worth selling as jewellery or as scrap. That distinction can be worth thousands.</div></li>
+      </ol>
+
+      <section class="cta-box reveal">
+        <h3>See your gold's value, in USD, right now</h3>
+        <p>Open the live Scrap Gold Calculator. Enter weight and karat, pick a buyer type, and see exactly what your piece is worth at this minute's gold price &mdash; with FX conversion to GBP, EUR, INR and more available.</p>
+        <a href="/scrap-gold-calculator" class="cta-btn">Open Scrap Gold Calculator <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 5l7 7-7 7"/></svg></a>
+        <a href="/where-to-sell-gold-silver" class="cta-btn-secondary">Compare Buyers</a>
+      </section>
+
+      <h2 id="faq" class="reveal">Frequently asked questions</h2>
+      <div class="faq-accordion reveal">
+        <details class="faq-item"><summary>How much can I sell my gold jewellery for?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary><div class="faq-body"><p>Your payout depends on weight, karat purity, and which buyer you choose. Use the formula: grams &times; (karat &divide; 24) &times; current USD spot price per gram to get melt value. Competitive buyers will pay 75&ndash;95% of this figure. Our <a href="/scrap-gold-calculator">interactive gold jewellery calculator</a> gives you an instant live estimate.</p></div></details>
+        <details class="faq-item"><summary>What is the best place to sell gold jewellery?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary><div class="faq-body"><p>For standard scrap gold, specialist online gold buyers and dedicated gold dealers consistently pay the most &mdash; typically 80&ndash;95% of melt value in USD. For wearable or designer pieces, local jewellers or luxury resale platforms will often pay more. For antique or high-value items, auction houses can achieve prices well above melt value.</p></div></details>
+        <details class="faq-item"><summary>Where can I sell gold jewellery near me?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary><div class="faq-body"><p>Local options include reputable jewellers, specialist bullion dealers, and established pawn shops (as a last resort). Search for gold dealers with strong Google Reviews or Trustpilot ratings. 47th Street in New York, Hatton Garden in London, and similar jewellery districts in major cities concentrate specialist buyers who typically offer competitive rates.</p></div></details>
+        <details class="faq-item"><summary>Can I sell gold jewellery online safely?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary><div class="faq-body"><p>Yes &mdash; if you use an established buyer with clear published USD rates, free insured postal packaging, a transparent offer process, and a free returns policy if you decline. Always photograph and weigh items before posting, use tracked and insured delivery, and check independent reviews before sending anything.</p></div></details>
+        <details class="faq-item"><summary>How do gold jewellery buyers calculate their price?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary><div class="faq-body"><p>Buyers use the formula: weight &times; purity percentage &times; their buying price per gram (a percentage of the live USD spot price). The variation is entirely in that final percentage &mdash; the best buyers pay 85&ndash;95% of spot, while pawn shops may pay as little as 20&ndash;40%.</p></div></details>
+        <details class="faq-item"><summary>Should I sell gold jewellery now or wait?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary><div class="faq-body"><p>Gold prices are near all-time highs in 2026, making it an excellent time to sell for cash if you have unwanted jewellery. Major financial institutions forecast continued strength through 2026 and 2027, so waiting could be rewarding &mdash; but there is no guarantee. If you need the cash or simply want to declutter, current USD prices represent an exceptional opportunity.</p></div></details>
+        <details class="faq-item"><summary>Can I sell gold-plated jewellery?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary><div class="faq-body"><p>Not to gold buyers &mdash; the gold content in plated jewellery is negligible and most specialist buyers will not purchase it as gold. Sell gold-plated pieces as jewellery on eBay, Vinted, or Facebook Marketplace, where private buyers value the aesthetic appeal rather than the metal content.</p></div></details>
+        <details class="faq-item"><summary>What happens if I sell gold jewellery without a receipt?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary><div class="faq-body"><p>In most countries, there is no legal requirement to have a purchase receipt to sell second-hand gold jewellery. Buyers are required by law in many jurisdictions to record the seller's identity (name, address, ID) as part of anti-money-laundering regulations &mdash; this is standard and applies to everyone. The absence of a receipt does not affect your USD price.</p></div></details>
+      </div>
+
+      <h2 id="bottom-line" class="reveal">The bottom line</h2>
+      <p>Selling gold jewellery in 2026 is one of the most financially rewarding decisions many people can make with unwanted or broken items they already own. The gold price has never been higher in USD terms. The online market has never been more competitive or accessible. And the gap between what informed sellers receive and what uninformed sellers accept has never been clearer.</p>
+      <p>The sellers who do best do three things: they <strong>know their gold's melt value</strong> before they talk to any buyer, they <strong>get multiple competing quotes</strong>, and they <strong>match the type of piece to the right channel</strong>. A plain 9K chain goes to a specialist scrap buyer. A Cartier ring goes to a luxury resale platform. An Art Deco brooch goes to an auction house for valuation first.</p>
+      <p>Everything else &mdash; the negotiation, the timing, the fraud avoidance &mdash; flows naturally from those three principles. Know what you have. Know what it is worth in USD. Know who will pay you the most for it.</p>
+
+      <div class="share-buttons">
+        <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/how-to-sell-gold-jewellery&text=How+to+sell+gold+jewellery+for+the+best+price+in+2026" class="share-btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg> Share on X</a>
+        <a href="https://www.facebook.com/sharer/sharer.php?u=https://goldpricetools.com/guides/how-to-sell-gold-jewellery" class="share-btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg> Facebook</a>
+        <a href="https://api.whatsapp.com/send?text=How+to+sell+gold+jewellery+for+the+best+price+in+2026%20https://goldpricetools.com/guides/how-to-sell-gold-jewellery" class="share-btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413z"/></svg> WhatsApp</a>
+        <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://goldpricetools.com/guides/how-to-sell-gold-jewellery" class="share-btn" target="_blank" rel="noopener noreferrer"><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg> LinkedIn</a>
+      </div>
+
+      <div class="disclaimer-box">
+        <strong>Disclaimer:</strong> All prices, calculations, and tables on this page recompute against the live USD gold spot price (refreshed every 60 seconds via gold-api.com / LBMA). Figures are indicative and change continuously with the market. Always confirm the exact buyer payout in writing before completing a sale. This article is for informational purposes only and does not constitute financial advice.
+      </div>
+
+    </div><!-- /.prose -->
+  </article>
+
+  <!-- TOC sidebar (desktop only) -->
+  <aside class="toc-aside" aria-label="On this page">
+    <div class="toc-card">
+      <div class="toc-heading">On this page</div>
+      <ol class="toc-list" id="tocList">
+        <li><a href="#timing">Is 2026 a good time to sell?</a></li>
+        <li><a href="#value">Step 1 &mdash; Know your gold's value</a></li>
+        <li><a href="#percentages">Step 2 &mdash; Payout percentages</a></li>
+        <li><a href="#channels">Step 3 &mdash; Where to sell</a></li>
+        <li><a href="#online-process">Selling online: 8-step process</a></li>
+        <li><a href="#plated">What about gold-plated?</a></li>
+        <li><a href="#realistic">Realistic payout table</a></li>
+        <li><a href="#scams">Scams to avoid</a></li>
+        <li><a href="#beyond-melt">Beyond melt value</a></li>
+        <li><a href="#tips">Expert's checklist</a></li>
+        <li><a href="#faq">Frequently asked questions</a></li>
+        <li><a href="#bottom-line">The bottom line</a></li>
+      </ol>
+      <div class="toc-mini-cta">
+        <strong id="tocLivePrice">Gold: $&mdash; / oz</strong>
+        <span id="tocLivePerGram">Per g (24K): $&mdash;</span>
+        <a href="/scrap-gold-calculator">Open Calculator <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 5l7 7-7 7"/></svg></a>
+      </div>
     </div>
+  </aside>
+</main>
 
-    <h2>How to Sell Gold Jewellery Online: A Step-by-Step Process</h2>
-    <p>If you have decided that an online buyer is the right route for your gold, here is the complete process:</p>
-    <ol class="step-list">
-      <li class="step-block"><div class="step-number">1</div><div class="step-content"><strong>Weigh your items at home</strong><p>Use a digital kitchen scale accurate to 0.1 grams. Weigh each piece separately and record it. This gives you a reference to cross-check the buyer's weighing when they confirm the offer.</p></div></li>
-      <li class="step-block"><div class="step-number">2</div><div class="step-content"><strong>Check the hallmarks</strong><p>Look for karat stamps (375 = 9K, 585 = 14K, 750 = 18K, 916 = 22K, 999 = 24K) on each piece. Record these alongside the weights.</p></div></li>
-      <li class="step-block"><div class="step-number">3</div><div class="step-content"><strong>Calculate the melt value</strong><p>Use the formula from Step 1 of this guide, or use a free online <a href="/scrap-gold-calculator">scrap gold calculator</a>. This gives you a firm baseline to compare all offers against.</p></div></li>
-      <li class="step-block"><div class="step-number">4</div><div class="step-content"><strong>Photograph everything before posting</strong><p>Take clear photos of each item alongside a scale showing its weight. These photos are your evidence if there is any dispute about condition or weight on arrival.</p></div></li>
-      <li class="step-block"><div class="step-number">5</div><div class="step-content"><strong>Request free postal kits from two or three buyers simultaneously</strong><p>There is no obligation to use them all, and comparing offers from multiple buyers is the single most effective way to maximise your return.</p></div></li>
-      <li class="step-block"><div class="step-number">6</div><div class="step-content"><strong>Send using the buyer's insured, tracked packaging</strong><p>Never send gold in your own envelope. Reputable buyers provide free, fully insured postal bags. Make sure the insurance covers the full value — some caps are lower than the gold value.</p></div></li>
-      <li class="step-block"><div class="step-number">7</div><div class="step-content"><strong>Review the offer and compare to your melt value</strong><p>A fair offer should be 75&ndash;95% of melt value. Below 70% — particularly from a well-resourced online buyer — is worth negotiating or declining.</p></div></li>
-      <li class="step-block"><div class="step-number">8</div><div class="step-content"><strong>Accept or decline</strong><p>Reputable buyers must return your items if you reject the offer, at no cost to you. Confirm this policy before sending.</p></div></li>
-    </ol>
-
-    <h2>What About Gold-Plated Jewellery?</h2>
-    <p>This is one of the most common sources of disappointment for first-time gold sellers — and it is worth addressing directly.</p>
-    <div class="warning-callout">
-      <p><strong>Gold-plated jewellery is not solid gold</strong>, and most professional gold buyers will not purchase it as a gold piece. Gold plating is a thin coating of gold applied over a base metal (usually brass, copper, or silver). The amount of actual gold in a plated piece is so small that it has negligible value as scrap metal. A typical gold-plated necklace contains only 0.05% or less of actual gold by weight. If someone offers to buy your gold-plated jewellery by gram as though it were solid gold, that is a scam.</p>
-    </div>
-    <p><strong>What you can do with gold-plated jewellery:</strong></p>
-    <ul>
-      <li>Sell on eBay, Vinted, Depop, or Facebook Marketplace as jewellery — private buyers will pay for the piece's aesthetic appeal regardless of metal content</li>
-      <li>Sell to vintage or costume jewellery dealers</li>
-      <li>Upcycle or repurpose — craft markets value decorative pieces regardless of metal value</li>
-    </ul>
-    <p>Do not confuse gold-plated with <strong>gold-filled</strong>, which has a much thicker layer of gold bonded to a base metal core — typically 5% gold by weight. Some specialist buyers will purchase gold-filled items, though at a steep discount to solid gold.</p>
-
-    <h2>Gold Jewellery Price: What You Can Realistically Expect</h2>
-    <p>Here are realistic expected payouts for common jewellery types at current gold prices (May 2026), assuming a competitive buyer paying 85% of melt value:</p>
-    <div style="overflow-x:auto">
-      <table>
-        <thead><tr><th>Item</th><th>Approx. Weight</th><th>Karat</th><th>Melt Value (USD)</th><th>Expected at 85%</th></tr></thead>
-        <tbody>
-          <tr><td>Simple gold wedding band</td><td>3g</td><td>18K</td><td>$342</td><td>~$291</td></tr>
-          <tr><td>Gold chain necklace (medium)</td><td>8g</td><td>9K</td><td>$172</td><td>~$146</td></tr>
-          <tr><td>Gold ring with small stone</td><td>4g</td><td>14K</td><td>$356</td><td>~$303</td></tr>
-          <tr><td>Gold bracelet</td><td>12g</td><td>18K</td><td>$1,368</td><td>~$1,163</td></tr>
-          <tr><td>Gold earrings (pair)</td><td>3g</td><td>22K</td><td>$422</td><td>~$359</td></tr>
-          <tr><td>Large gold chain</td><td>20g</td><td>18K</td><td>$2,280</td><td>~$1,938</td></tr>
-        </tbody>
-      </table>
-    </div>
-    <p><em>These figures use an indicative 24K price of $152/gram as of May 2026. Use a <a href="/scrap-gold-calculator">live scrap gold calculator</a> for current figures before selling.</em></p>
-
-    <h2>Scams to Avoid: Protect Yourself When Selling Gold</h2>
-    <p>The gold buying market contains a significant number of operators who rely on sellers not knowing the value of what they are selling. Here are the most common scams in 2026:</p>
-    <div class="warning-callout">
-      <p><strong>Warning signs that should prompt you to walk away:</strong></p>
-      <ul>
-        <li><strong>Lowball offers without explanation.</strong> A buyer quotes a price per item rather than per gram, making the calculation opaque. Always ask for the breakdown: weight &times; purity &times; price per gram = total. If a buyer cannot or will not show you this calculation, leave.</li>
-        <li><strong>Underweighting.</strong> The buyer's scales "happen" to show your piece is lighter than your own measurement at home. Always weigh items before you go and insist on transparent, in-front-of-you weighing.</li>
-        <li><strong>Purity downgrading.</strong> The buyer claims your 18K piece is only 14K after "testing." Ask to see the test performed in front of you. A legitimate XRF tester or acid test is quick and visible. If a buyer refuses, be very sceptical.</li>
-        <li><strong>Postal scams.</strong> You send your gold, receive a shockingly low offer, and discover returning items requires significant postage — or the company is unresponsive. Only use postal gold buyers with hundreds of verified reviews, a clear returns policy in writing, and free insured return postage.</li>
-        <li><strong>"Today only" pressure tactics.</strong> Any buyer who tells you their offer expires in minutes is using a manipulation tactic. A fair offer does not need to be rushed. Legitimate buyers are happy for you to shop around.</li>
-        <li><strong>Hidden deductions.</strong> An offer is made for $500, but payment arrives at $420 — deductions for "testing fees" or "processing fees" never disclosed upfront. Always confirm the total net payout in writing before agreeing to any sale.</li>
-        <li><strong>Gold party / travelling buyers.</strong> Pop-up "cash for gold" events at hotels or community halls use social pressure and quick-turnaround formats to prevent comparison shopping. The prices at these events are almost always significantly below what a specialist buyer would pay.</li>
-      </ul>
-    </div>
-
-    <h2>Selling Second-Hand Gold Jewellery: Beyond the Melt Value</h2>
-    <p>Not all gold is created equal when it comes to resale. Before deciding on a buyer, ask yourself:</p>
-    <p><strong>Is this piece from a recognised designer or brand?</strong> Cartier, Tiffany, David Yurman, Bulgari — branded jewellery commands significant premiums in the resale market. A certified Cartier Love bracelet in 18K gold weighing 30 grams has a melt value of around $3,420. A second-hand luxury reseller might offer $4,500&ndash;$6,000 for the same piece as a branded item.</p>
-    <p><strong>Is this piece antique or vintage?</strong> Pre-1940s jewellery, Art Deco pieces, Victorian gold, Edwardian settings — these often attract collector premiums that far exceed their metal content. An auction house valuation costs nothing and could reveal a piece is worth multiples of its melt value.</p>
-    <p><strong>Is this piece in excellent condition?</strong> Jewellery that is clean, undamaged, and retains its original design is worth more to a jeweller or private buyer than to a refiner. Light cleaning before valuation — but not polishing that could remove hallmarks — is worthwhile.</p>
-    <div class="info-callout">
-      <p><strong>Second-hand luxury resale platforms</strong> for designer gold jewellery include: The RealReal, Vestiaire Collective, Worthy, and I Do Now I Don't (for bridal jewellery). Commissions typically run 20&ndash;30%, but the premiums over melt value often make these platforms worthwhile for the right pieces.</p>
-    </div>
-
-    <h2>Tips to Maximise What You Get: The Expert's Checklist</h2>
-    <p>Here are the ten steps that separate sellers who get excellent prices from those who walk away disappointed:</p>
-    <ol class="tips-list">
-      <li><strong>Weigh every item at home</strong> on a digital scale before approaching any buyer. Record each piece separately with its hallmark karat.</li>
-      <li><strong>Calculate the melt value</strong> using the formula: grams &times; (karat &divide; 24) &times; current gold price per gram. Use our free <a href="/scrap-gold-calculator">scrap gold calculator</a> for convenience.</li>
-      <li><strong>Get a minimum of three quotes</strong> — from at least one online buyer, one local jeweller, and one other specialist. Prices can legitimately vary by 20&ndash;30% or more for identical items.</li>
-      <li><strong>Separate pieces by category.</strong> Fine jewellery goes to a jeweller or auction house for valuation. Plain scrap gold goes to a specialist buyer. Designer or antique pieces get their own assessment first.</li>
-      <li><strong>Know that gold-plated jewellery has negligible scrap value</strong> — route it to private resale platforms instead.</li>
-      <li><strong>Time your sale strategically.</strong> Selling when gold prices are near recent highs maximises your return. Check the live spot price on the day you plan to sell, as buyers' offers move daily with the market.</li>
-      <li><strong>Negotiate.</strong> Most buyers expect it. Use competing offers as leverage. Even a 2&ndash;3% improvement is real money when gold is $152 per gram.</li>
-      <li><strong>Never accept a "per item" offer</strong> without asking for the per gram breakdown. If a buyer cannot explain their calculation transparently, the offer is almost certainly unfair.</li>
-      <li><strong>For postal sales: photograph, weigh, and insure everything</strong> before it leaves your hands. Use fully insured tracked delivery — not a standard letter.</li>
-      <li><strong>For high-value or unusual pieces, get a professional appraisal first.</strong> A $50 appraisal from a certified gemologist can reveal whether a piece is worth selling as jewellery or as scrap — and that distinction can be worth thousands.</li>
-    </ol>
-
-    <div class="cta-box">
-      <h3>Calculate Your Gold's Value Now</h3>
-      <p>Use our free scrap gold calculator to get an instant live estimate based on today's gold price. Enter your karat and weight to see the melt value in seconds.</p>
-      <a href="/scrap-gold-calculator" class="cta-btn">Open Scrap Gold Calculator &rarr;</a>
-    </div>
-
-    <h2>Frequently Asked Questions</h2>
-    <div class="faq-accordion">
-
-      <div class="faq-item">
-        <h3>How much can I sell my gold jewellery for?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Your payout depends on the weight, karat purity, and which buyer you choose. Use the formula: grams &times; (karat &divide; 24) &times; current spot price per gram to get the melt value. Competitive buyers will pay 75&ndash;95% of this figure. Our <a href="/scrap-gold-calculator">interactive gold jewellery calculator</a> gives you an instant live estimate.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>What is the best place to sell gold jewellery?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>For standard scrap gold, specialist online gold buyers and dedicated gold dealers consistently pay the most — typically 80&ndash;95% of melt value. For wearable or designer pieces, local jewellers or luxury resale platforms will often pay more. For antique or high-value items, auction houses can achieve prices well above melt value.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>Where can I sell gold jewellery near me?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Local options include reputable jewellers, specialist bullion dealers, and established pawn shops (as a last resort). Search for gold dealers with strong Google Reviews or Trustpilot ratings in your city. Hatton Garden in London, 47th Street in New York, and similar jewellery districts in major cities concentrate specialist buyers who typically offer competitive rates.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>Can I sell gold jewellery online safely?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Yes — if you use an established buyer with clear published rates, free insured postal packaging, a transparent offer process, and a free returns policy if you decline the offer. Always photograph and weigh items before posting, use tracked and insured delivery, and check independent reviews before sending anything.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>How do gold jewellery buyers calculate their price?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Buyers use the formula: weight &times; purity percentage &times; their buying price per gram (which is a percentage of the live spot price). The variation is entirely in that final percentage &mdash; the best buyers pay 85&ndash;95% of spot, while pawn shops may pay as little as 20&ndash;40%.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>Should I sell gold jewellery now or wait?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Gold prices are near all-time highs in 2026, making it an excellent time to sell for cash if you have unwanted jewellery. Major financial institutions forecast continued strength through 2026 and 2027, so waiting could also be rewarding — but there is no guarantee. If you need the cash or simply want to declutter, current prices represent an exceptional opportunity.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>Can I sell gold-plated jewellery?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Not to gold buyers — the gold content in plated jewellery is negligible and most specialist buyers will not purchase it as gold. Sell gold-plated pieces as jewellery on eBay, Vinted, or Facebook Marketplace, where private buyers value the aesthetic appeal rather than the metal content.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>What happens if I sell gold jewellery without a receipt?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>In most countries, there is no legal requirement to have a purchase receipt to sell second-hand gold jewellery. You own the item and are free to sell it. Buyers are required by law in many jurisdictions to record the seller's identity (name, address, ID) as part of anti-money laundering regulations — this is standard and applies to everyone. The absence of a receipt does not affect your price.</p></div>
-      </div>
-
-    </div>
-
-    <h2>The Bottom Line</h2>
-    <p>Selling gold jewellery in 2026 is one of the most financially rewarding decisions many people can make with unwanted or broken items they already own. The gold price has never been higher. The online market has never been more competitive or accessible. And the gap between what informed sellers receive and what uninformed sellers accept has never been clearer.</p>
-    <p>The sellers who do best are the ones who do three things: they know their gold's melt value before they talk to any buyer, they get multiple competing quotes, and they match the type of piece to the right selling channel. A plain 9K gold chain goes to a specialist scrap buyer. A Cartier ring goes to a luxury resale platform. An Art Deco brooch goes to an auction house for valuation first.</p>
-    <p>Everything else — the negotiation, the timing, the fraud avoidance — flows naturally from those three principles. Know what you have. Know what it is worth. Know who will pay you the most for it.</p>
-
-    <div class="share-buttons">
-      <a href="https://twitter.com/intent/tweet?url=https://goldpricetools.com/guides/how-to-sell-gold-jewellery&text=How+to+sell+gold+jewellery+for+the+best+price+in+2026" class="share-btn" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg> Share on X</a>
-      <a href="https://www.facebook.com/sharer/sharer.php?u=https://goldpricetools.com/guides/how-to-sell-gold-jewellery" class="share-btn" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg> Facebook</a>
-      <a href="https://api.whatsapp.com/send?text=How+to+sell+gold+jewellery+for+the+best+price+in+2026%20https://goldpricetools.com/guides/how-to-sell-gold-jewellery" class="share-btn" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg> WhatsApp</a>
-      <a href="https://www.linkedin.com/sharing/share-offsite/?url=https://goldpricetools.com/guides/how-to-sell-gold-jewellery" class="share-btn" target="_blank" rel="noopener noreferrer"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg> LinkedIn</a>
-    </div>
-
-  </div><!-- /prose -->
-</article>
-
-<div style="max-width:860px;margin:0 auto;padding:0 var(--space-4)">
-  <div class="disclaimer-box">
-    <strong>Disclaimer:</strong> Prices cited are indicative as of May 2026 and change daily with the gold spot price. Always use a live gold calculator for current figures before selling. This article is for informational purposes only and does not constitute financial advice. Always verify current details directly with buyers.
-  </div>
-</div>
-
-<section class="related-guides-section">
-  <h2>Related Guides</h2>
-  <div class="related-guides-grid">
+<section class="related-section">
+  <h2>Related guides</h2>
+  <div class="related-grid">
     <a href="/scrap-gold-calculator" class="related-card">
       <span class="related-card__tag">Calculator</span>
-      <div class="related-card__title">Scrap Gold Calculator — Live Price</div>
-      <div class="related-card__desc">Calculate your gold's melt value instantly using today's live spot price.</div>
+      <div class="related-card__title">Scrap Gold Calculator &mdash; Live USD</div>
+      <div class="related-card__desc">Calculate your gold's melt value instantly using today's live USD spot price.</div>
     </a>
     <a href="/where-to-sell-gold-silver" class="related-card">
       <span class="related-card__tag">Selling</span>
@@ -670,7 +1131,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     <a href="/guides/gold-hallmarks-explained" class="related-card">
       <span class="related-card__tag">Guide</span>
       <div class="related-card__title">Gold Hallmarks Explained</div>
-      <div class="related-card__desc">Decode the stamps on your jewellery — 375, 585, 750, 916 and what they mean for value.</div>
+      <div class="related-card__desc">Decode the stamps on your jewellery &mdash; 375, 585, 750, 916 and what they mean for value.</div>
     </a>
     <a href="/guides/how-much-is-a-gold-ring-worth" class="related-card">
       <span class="related-card__tag">Guide</span>
@@ -680,7 +1141,7 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     <a href="/guides/how-to-test-if-gold-is-real" class="related-card">
       <span class="related-card__tag">Testing</span>
       <div class="related-card__title">How to Test If Gold Is Real</div>
-      <div class="related-card__desc">Six ways to test gold at home — from the magnet test to acid testing — explained.</div>
+      <div class="related-card__desc">Six ways to test gold at home &mdash; from the magnet test to acid testing &mdash; explained.</div>
     </a>
     <a href="/guides/what-is-best-time-to-sell-scrap-gold" class="related-card">
       <span class="related-card__tag">Strategy</span>
@@ -697,9 +1158,9 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
         <img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools" loading="lazy" onerror="this.style.display='none'">
         <span style="margin-left:8px;font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright)">GoldPriceTools</span>
       </a>
-      <p class="footer-brand">Live gold &amp; silver prices, scrap calculators, and expert guides for precious metals investors and sellers.</p>
+      <p class="footer-brand">Live gold &amp; silver prices, scrap calculators, and expert guides for precious-metals investors and sellers. USD primary.</p>
     </div>
-    <div class="footer-col"><h4>Gold Prices</h4><ul><li></li><li></li><li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li><li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li><li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li><li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li></ul></div>
+    <div class="footer-col"><h4>Gold Prices</h4><ul><li><a href="/9k-gold-price-per-gram">9K Gold Per Gram</a></li><li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li><li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li><li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li></ul></div>
     <div class="footer-col"><h4>Calculators</h4><ul><li><a href="/scrap-gold-calculator">Scrap Gold Calculator</a></li><li><a href="/gold-bar-value">Gold Bar Value</a></li><li><a href="/zakat-gold-silver-calculator">Zakat Calculator</a></li><li><a href="/how-many-grams-in-troy-ounce">Troy Ounce Converter</a></li><li><a href="/silver-coins-calculator">Silver Coins Calculator</a></li></ul></div>
     <div class="footer-col"><h4>Guides</h4><ul><li><a href="/guides/selling-testing/">Selling &amp; Testing</a></li><li><a href="/guides/buying-investing/">Buying &amp; Investing</a></li><li><a href="/guides/market-prices/">Market &amp; Prices</a></li><li><a href="/guides/deep-dives/">Deep Dives</a></li><li><a href="/guides/">All Guides</a></li></ul></div>
     <div class="footer-col"><h4>Selling</h4><ul><li><a href="/where-to-sell-gold-silver">Where to Sell Gold</a></li><li><a href="/guides/how-to-sell-gold-jewellery">Sell Gold Jewellery</a></li><li><a href="/guides/what-is-best-time-to-sell-scrap-gold">Best Time to Sell</a></li><li><a href="/guides/gold-hallmarks-explained">Gold Hallmarks Explained</a></li></ul></div>
@@ -707,52 +1168,338 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
   </div>
   <div class="footer-bottom">
     <span>&copy; 2026 GoldPriceTools. All rights reserved.</span>
-    <span>Prices are indicative only. Not financial advice.</span>
+    <span>Prices are indicative only. Not financial advice. USD primary.</span>
   </div>
 </footer>
 
+<!-- Floating mobile CTA -->
+<aside class="float-cta" id="floatCta" aria-hidden="true">
+  <div class="float-cta-text">
+    <span class="float-cta-label"><span class="pulse" aria-hidden="true"></span> Live gold · USD</span>
+    <span class="float-cta-value" id="floatSpot">$&mdash; / oz</span>
+  </div>
+  <a href="/scrap-gold-calculator">Calculate <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 5l7 7-7 7"/></svg></a>
+</aside>
+
+
 <script>
+/* ============================================================
+   THEME TOGGLE + MOBILE NAV
+   ============================================================ */
 (function(){
-  const btn=document.querySelector('[data-theme-toggle]');
-  if(btn)btn.addEventListener('click',function(){
-    const h=document.documentElement;
-    const t=h.getAttribute('data-theme')==='dark'?'light':'dark';
-    h.setAttribute('data-theme',t);
-    localStorage.setItem('gpt-theme',t);
-  });
-  const ham=document.getElementById('hamburger');
-  const mob=document.getElementById('mobileMenu');
+  var root=document.documentElement;
+  var btn=document.querySelector('[data-theme-toggle]');
+  if(btn){
+    btn.addEventListener('click',function(){
+      var t=root.getAttribute('data-theme')==='dark'?'light':'dark';
+      root.setAttribute('data-theme',t);
+      try{localStorage.setItem('gpt-theme',t);}catch(e){}
+    });
+  }
+  var ham=document.getElementById('hamburger');
+  var mob=document.getElementById('mobileMenu');
   if(ham&&mob){
     ham.addEventListener('click',function(){
-      const open=mob.classList.toggle('open');
+      var open=mob.classList.toggle('open');
       ham.setAttribute('aria-expanded',open);
       document.body.style.overflow=open?'hidden':'';
+    });
+    document.addEventListener('click',function(e){
+      if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){
+        mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';
+      }
     });
   }
   document.querySelectorAll('.mobile-section__toggle').forEach(function(t){
     t.addEventListener('click',function(){
-      const items=this.nextElementSibling;
-      const open=items.classList.toggle('open');
+      var items=this.nextElementSibling;
+      var open=items.classList.toggle('open');
       this.setAttribute('aria-expanded',open);
     });
   });
   document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){
     t.addEventListener('click',function(e){
       e.stopPropagation();
-      const panel=this.nextElementSibling;
-      if(!panel)return;
-      const open=panel.classList.toggle('is-open');
+      var p=this.nextElementSibling;if(!p)return;
+      var open=p.classList.toggle('is-open');
       this.setAttribute('aria-expanded',open);
+      document.querySelectorAll('.mega-panel.is-open').forEach(function(x){
+        if(x!==p){x.classList.remove('is-open');var t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}
+      });
     });
   });
-  document.addEventListener('click',function(){
-    document.querySelectorAll('.mega-panel.is-open').forEach(function(p){
-      p.classList.remove('is-open');
-      const t=p.previousElementSibling;
-      if(t)t.setAttribute('aria-expanded','false');
-    });
+  document.addEventListener('click',function(e){
+    if(!e.target.closest('.mega-nav__item')){
+      document.querySelectorAll('.mega-panel.is-open').forEach(function(p){
+        p.classList.remove('is-open');var t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');
+      });
+    }
+  });
+  document.addEventListener('keydown',function(e){
+    if(e.key==='Escape'){
+      document.querySelectorAll('.mega-panel.is-open').forEach(function(p){
+        p.classList.remove('is-open');var t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}
+      });
+      if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}
+    }
   });
 })();
 </script>
+
+<script>
+/* ============================================================
+   LIVE GOLD SPOT — single source of truth across the page
+   Source: gold-api.com (LBMA spot, USD/oz). Refresh every 60s.
+   USD is the primary currency. All examples & tables recompute
+   automatically off the live spot.
+   ============================================================ */
+(function(){
+  var TROY=31.1034768;
+  var REFRESH_MS=60000;
+  var state={spotOz:null,spotPrevClose:null,perGram:null,ts:null};
+
+  function fmtUSD(n,opts){
+    if(n==null||isNaN(n))return '$—';
+    var o=opts||{};
+    var dec=o.dec!=null?o.dec:(n>=1000?0:2);
+    return '$'+n.toLocaleString('en-US',{minimumFractionDigits:dec,maximumFractionDigits:dec});
+  }
+  function paint(){
+    if(state.spotOz==null)return;
+    var spot=state.spotOz;
+    var perG=spot/TROY;
+    state.perGram=perG;
+
+    /* Hero */
+    var heroOz=document.getElementById('heroSpotOz');
+    if(heroOz)heroOz.innerHTML=fmtUSD(spot,{dec:2})+'<span style="font-size:.55em;color:var(--color-text-muted);font-weight:500"> / oz</span>';
+    var heroG=document.getElementById('heroSpotGram');
+    if(heroG)heroG.innerHTML=fmtUSD(perG,{dec:2})+'<span style="font-size:.55em;color:var(--color-text-muted);font-weight:500"> /g</span>';
+
+    /* Change vs prev close */
+    var changeEl=document.getElementById('heroSpotChange');
+    if(changeEl && state.spotPrevClose){
+      var diff=spot-state.spotPrevClose;
+      var pct=(diff/state.spotPrevClose)*100;
+      var up=diff>=0;
+      changeEl.className='live-spot-change '+(up?'up':'down');
+      changeEl.innerHTML=(up?'▲':'▼')+' '+fmtUSD(Math.abs(diff),{dec:2})+' ('+(up?'+':'-')+Math.abs(pct).toFixed(2)+'%)';
+    }
+
+    /* Updated timestamp */
+    var upd=document.getElementById('heroSpotUpdated');
+    if(upd){
+      var d=new Date(state.ts);
+      upd.textContent='· Updated '+d.toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit',hour12:false});
+    }
+
+    /* Karat tiles per-gram */
+    document.querySelectorAll('[data-karat-price]').forEach(function(el){
+      var purity=parseFloat(el.getAttribute('data-karat-price'));
+      var v=perG*purity;
+      var fmt=el.getAttribute('data-fmt');
+      el.textContent=fmtUSD(v,{dec:2});
+      if(fmt==='g')el.textContent=fmtUSD(v,{dec:2});
+    });
+
+    /* Example melt-value inline placeholders e.g. data-example-melt="8,0.75" */
+    document.querySelectorAll('[data-example-melt]').forEach(function(el){
+      var parts=el.getAttribute('data-example-melt').split(',');
+      var grams=parseFloat(parts[0]);
+      var purity=parseFloat(parts[1]);
+      var melt=grams*purity*perG;
+      el.textContent=fmtUSD(melt,{dec:0});
+    });
+
+    /* Realistic payout table — melt + 85% offer */
+    document.querySelectorAll('[data-row-melt]').forEach(function(el){
+      var parts=el.getAttribute('data-row-melt').split(',');
+      var g=parseFloat(parts[0]),p=parseFloat(parts[1]);
+      el.textContent=fmtUSD(g*p*perG,{dec:0});
+    });
+    document.querySelectorAll('[data-row-offer]').forEach(function(el){
+      var parts=el.getAttribute('data-row-offer').split(',');
+      var g=parseFloat(parts[0]),p=parseFloat(parts[1]),r=parseFloat(parts[2]);
+      el.textContent=fmtUSD(g*p*perG*r,{dec:0});
+    });
+
+    /* Floating CTA */
+    var floatSpot=document.getElementById('floatSpot');
+    if(floatSpot)floatSpot.textContent=fmtUSD(spot,{dec:0})+' / oz · '+fmtUSD(perG,{dec:2})+'/g';
+
+    /* TOC mini cta */
+    var tlp=document.getElementById('tocLivePrice');
+    if(tlp)tlp.textContent='Gold: '+fmtUSD(spot,{dec:0})+' / oz';
+    var tpg=document.getElementById('tocLivePerGram');
+    if(tpg)tpg.textContent='Per g (24K): '+fmtUSD(perG,{dec:2});
+
+    /* Mini calculator recompute */
+    if(window._miniCalcRecompute)window._miniCalcRecompute();
+
+    window.dispatchEvent(new CustomEvent('goldprice_updated',{detail:{spot:spot,perGram:perG,ts:state.ts}}));
+  }
+
+  async function fetchSpot(){
+    try{
+      var r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
+      if(!r.ok)throw new Error('Spot HTTP '+r.status);
+      var d=await r.json();
+      state.spotOz=d.price;
+      state.spotPrevClose=d.prev_close_price||state.spotPrevClose;
+      state.ts=Date.now();
+      paint();
+      if(typeof gtag!=='undefined')gtag('event','price_view',{metal:'gold',page:'sell-gold-jewellery'});
+    }catch(e){
+      console.warn('Gold price API unavailable',e);
+      var updEl=document.getElementById('heroSpotUpdated');
+      if(updEl && state.spotOz==null)updEl.textContent='· live feed unavailable — refreshing';
+    }
+  }
+  window._gptSpotState=state;
+  document.addEventListener('DOMContentLoaded',function(){
+    fetchSpot();
+    setInterval(fetchSpot,REFRESH_MS);
+  });
+})();
+</script>
+
+<script>
+/* ============================================================
+   MINI CALCULATOR — uses live spot, USD primary
+   ============================================================ */
+(function(){
+  var TROY=31.1034768;
+  var weightEl=document.getElementById('mcWeight');
+  var buyerEl=document.getElementById('mcBuyer');
+  var meltEl=document.getElementById('mcMelt');
+  var offerEl=document.getElementById('mcOffer');
+  var pureEl=document.getElementById('mcPure');
+  var spotEl=document.getElementById('mcSpot');
+  var updEl=document.getElementById('mcUpdated');
+  if(!weightEl||!buyerEl||!meltEl||!offerEl)return;
+
+  var unit='g';
+  var purity=0.5833;
+
+  function fmt(n){
+    if(n==null||isNaN(n))return '$—';
+    var dec=n>=1000?0:2;
+    return '$'+n.toLocaleString('en-US',{minimumFractionDigits:dec,maximumFractionDigits:dec});
+  }
+
+  function recompute(){
+    var s=(window._gptSpotState||{}).spotOz;
+    if(s==null){
+      meltEl.textContent='$—';offerEl.textContent='$—';pureEl.textContent='— g';spotEl.textContent='$—';
+      if(updEl)updEl.textContent='waiting for live spot…';
+      return;
+    }
+    var perG=s/TROY;
+    var w=parseFloat(weightEl.value)||0;
+    if(unit==='oz')w=w*TROY;
+    var pureG=w*purity;
+    var melt=pureG*perG;
+    var rate=parseFloat(buyerEl.value)||0.85;
+    var offer=melt*rate;
+    meltEl.textContent=fmt(melt);
+    offerEl.textContent=fmt(offer);
+    pureEl.textContent=pureG.toFixed(2)+' g';
+    spotEl.textContent=fmt(perG);
+    if(updEl){
+      var d=new Date((window._gptSpotState||{}).ts||Date.now());
+      updEl.textContent='Live · '+d.toLocaleTimeString('en-US',{hour:'2-digit',minute:'2-digit',hour12:false});
+    }
+  }
+  window._miniCalcRecompute=recompute;
+
+  /* Karat chips */
+  document.querySelectorAll('#mcKaratChips .mc-karat-chip').forEach(function(c){
+    c.addEventListener('click',function(){
+      document.querySelectorAll('#mcKaratChips .mc-karat-chip').forEach(function(x){
+        x.classList.remove('active');x.setAttribute('aria-checked','false');
+      });
+      this.classList.add('active');this.setAttribute('aria-checked','true');
+      purity=parseFloat(this.getAttribute('data-purity'));
+      recompute();
+    });
+  });
+
+  /* Unit toggle */
+  document.querySelectorAll('.mc-unit-btn').forEach(function(b){
+    b.addEventListener('click',function(){
+      document.querySelectorAll('.mc-unit-btn').forEach(function(x){x.classList.remove('active');});
+      this.classList.add('active');
+      unit=this.getAttribute('data-unit');
+      recompute();
+    });
+  });
+
+  weightEl.addEventListener('input',recompute);
+  buyerEl.addEventListener('change',recompute);
+  window.addEventListener('goldprice_updated',recompute);
+  document.addEventListener('DOMContentLoaded',recompute);
+})();
+</script>
+
+<script>
+/* ============================================================
+   READING PROGRESS + SCROLL-SPY TOC + REVEAL + FLOAT CTA
+   ============================================================ */
+(function(){
+  var bar=document.getElementById('readProgress');
+  var floatCta=document.getElementById('floatCta');
+  var tocLinks=Array.prototype.slice.call(document.querySelectorAll('#tocList a'));
+  var headings=tocLinks.map(function(a){return document.getElementById(a.getAttribute('href').slice(1));}).filter(Boolean);
+
+  var ticking=false;
+  function onScroll(){
+    if(ticking)return;
+    ticking=true;
+    requestAnimationFrame(function(){
+      var doc=document.documentElement;
+      var max=doc.scrollHeight-doc.clientHeight;
+      var pct=max>0?(window.scrollY/max)*100:0;
+      if(bar)bar.style.width=pct+'%';
+
+      /* float CTA appears after hero passes top */
+      if(floatCta){
+        if(window.scrollY>360){floatCta.classList.add('is-visible');floatCta.setAttribute('aria-hidden','false');}
+        else{floatCta.classList.remove('is-visible');floatCta.setAttribute('aria-hidden','true');}
+      }
+
+      /* TOC scroll-spy: highlight last heading whose top is above 120px */
+      var active=null;
+      for(var i=0;i<headings.length;i++){
+        var rect=headings[i].getBoundingClientRect();
+        if(rect.top<=140)active=i;
+      }
+      tocLinks.forEach(function(a,i){a.classList.toggle('active',i===active);});
+      ticking=false;
+    });
+  }
+  window.addEventListener('scroll',onScroll,{passive:true});
+  window.addEventListener('resize',onScroll);
+  document.addEventListener('DOMContentLoaded',onScroll);
+
+  /* Reveal on scroll — with safety net so non-scrolling renders still show content */
+  var reduced=matchMedia('(prefers-reduced-motion:reduce)').matches;
+  var allReveal=document.querySelectorAll('.reveal');
+  if('IntersectionObserver' in window && !reduced){
+    var io=new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(e.isIntersecting){e.target.classList.add('in-view');io.unobserve(e.target);}
+      });
+    },{rootMargin:'0px 0px -8% 0px',threshold:0.05});
+    allReveal.forEach(function(el){io.observe(el);});
+    /* Safety: after 2.5s any still-hidden element gets revealed so screenshot tools, print, and SEO crawlers always see content */
+    setTimeout(function(){allReveal.forEach(function(el){el.classList.add('in-view');});},2500);
+  }else{
+    allReveal.forEach(function(el){el.classList.add('in-view');});
+  }
+})();
+</script>
+
+<script>if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary

Full UI/UX redesign of `/guides/how-to-sell-gold-jewellery` using the `ui-ux-pro-max` design system. The page goes from a static editorial to a **live, interactive selling guide** with USD as the primary currency and real-time price data wired through the same `api.gold-api.com` endpoint already used by the Scrap Gold Calculator — so every number on the page matches the rest of the site to the cent.

### Design system applied
- **Style:** Premium editorial with subtle liquid gold-on-warm accents
- **Type:** `Playfair Display` (display) + `Inter` (body) — luxury/editorial pairing
- **Color:** Existing brand tokens (gold-bright, primary teal, warm bg) extended with up/down semantics and decorative gradients
- **Pattern:** Storytelling + feature-rich + interactive tool inline

### What changed
- **Mobile-first hero card** with editorial headline (italic gold accent), eyebrow with live pulse, drop cap on the lede
- **Live USD spot ticker** in hero (oz + per gram) refreshing every 60s — same source as the calculator
- **Reading progress bar** + **desktop sticky TOC** with scroll-spy + mini USD price block at the bottom of the TOC
- **Inline mini-calculator** (karat chips, weight g/oz toggle, buyer dropdown) — recomputes live against the same spot
- **Karat reference grid** with live per-gram USD price under each purity (9K → 24K)
- **Step 2 payout meters** — color-graded horizontal bars (green/gold/red) showing 20–98% range visually
- **5 channel cards** (Online Buyers → Pawn Shops) with accent borders, badges, and per-channel mini payout meters
- **8-step timeline** for the online-selling process with marker dots and connector line
- **Scam-alert grid** — 8 cards with SVG icons (no emojis)
- **Realistic payouts table** with `data-row-melt`/`data-row-offer` attributes that recompute against live spot
- **Floating mobile CTA** with live USD price → links to Scrap Calculator
- **Reveal-on-scroll** animation, respects `prefers-reduced-motion`, with a 2.5s safety net so screenshot/SEO tools always see full content
- Date refreshed to **11 Jun 2026**

### Currency & data accuracy
- **USD `$` is the primary currency** across hero, calculator, tables, examples, and FAQ
- Single live source of truth: `https://api.gold-api.com/price/XAU` (LBMA spot), polled every 60s — identical to `scrap-gold-calculator.html`
- All inline examples (e.g. "18K 8g = $X melt") and the payouts table rows are bound to `data-*` attributes that recompute on each spot update
- Troy-ounce → gram conversion uses 31.1034768 g/oz across the page

### Verified end-to-end (Playwright)
With mocked spot of `$4,712.50/oz`:
- Hero: `$4,712.50/oz`, `$151.51/g`, change ▲ `$32.50 (+0.69%)` vs prev close
- Karat tiles: 9K = `$56.82/g`, 14K = `$88.63/g`, 18K = `$113.63/g`, 24K = `$151.36/g`
- Mini-calc (14K, 5g, 85% buyer): Pure `2.92g`, Melt `$441.88`, Offer `$375.60`
- Mini-calc (18K, 10g, 85% buyer): Melt `$1,136`, Offer `$965.88`
- Table row (3g 18K @ 85%): Melt `$341`, Offer `$290`
- Floating CTA on scroll: `$4,713/oz · $151.51/g`
- TOC scroll-spy: active item updates on scroll

### Responsive verified
- iPhone 14 Pro (390px): no horizontal overflow, all touch targets ≥ 44px
- Tablet 768px: hero stat grid switches to 4-col, channel cards full-width
- Desktop 1440px: article + sticky TOC sidebar, sections render cleanly
- Light + dark mode both verified

## Test plan
- [ ] Open https://goldpricetools.com/guides/how-to-sell-gold-jewellery after deploy
- [ ] Verify the hero live spot price matches the homepage ticker and the scrap calculator (USD)
- [ ] Confirm the per-gram value = spot/oz ÷ 31.1035
- [ ] Use the inline mini-calculator: change karat, weight, buyer — values update instantly
- [ ] Confirm the realistic payouts table updates after a refresh
- [ ] Mobile: scroll past the hero — floating CTA appears with live price; tap → calculator opens
- [ ] Desktop: scroll the article — TOC items highlight as their section enters view
- [ ] Toggle dark/light theme — colors remain accessible (contrast ≥ 4.5:1 body text)
- [ ] Run with `prefers-reduced-motion: reduce` — animations disabled, content fully visible

https://claude.ai/code/session_019PSKQGEUjfxxRtEjCBejKj

---
_Generated by [Claude Code](https://claude.ai/code/session_019PSKQGEUjfxxRtEjCBejKj)_