### PR TITLE
Redesign: Best Time to Sell Scrap Gold guide (premium editorial, USD-first, live tools)

### DIFF
--- a/guides/what-is-best-time-to-sell-scrap-gold.html
+++ b/guides/what-is-best-time-to-sell-scrap-gold.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>When Is the Best Time to Sell Scrap Gold? Market Timing Guide 2026 | GoldPriceTools</title>
 <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Is now a good time to sell scrap gold? Find out how gold market timing works, when prices peak, where to get the best price, and how much your scrap gold is worth.">
+<meta name="description" content="Is now a good time to sell scrap gold? See live USD gold prices, how market timing and seasonal patterns work, where to get the highest payout, and what your scrap gold is worth per gram — with a live calculator.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold">
 <link rel="alternate" hreflang="en" href="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold">
@@ -18,7 +18,7 @@
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="When Is the Best Time to Sell Scrap Gold? Market Timing Guide 2026">
-<meta property="og:description" content="Is now a good time to sell scrap gold? Find out how gold market timing works, when prices peak, where to get the best price, and how much your scrap gold is worth.">
+<meta property="og:description" content="Is now a good time to sell scrap gold? See live USD gold prices, how timing and seasonal patterns work, where to get the highest payout, and what your scrap gold is worth per gram.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold">
 <meta property="og:site_name" content="GoldPriceTools">
@@ -28,9 +28,9 @@
 <meta property="og:image:alt" content="When Is the Best Time to Sell Scrap Gold — GoldPriceTools">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"When Is the Best Time to Sell Scrap Gold? (2026 Guide)","description":"Is now a good time to sell scrap gold? Find out how gold market timing works, when prices peak, where to get the best price, and how much your scrap gold is worth.","url":"https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold","datePublished":"2026-05-08","dateModified":"2026-06-13T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"When Is the Best Time to Sell Scrap Gold? (2026 Guide)","description":"Is now a good time to sell scrap gold? See live USD gold prices, how market timing and seasonal patterns work, where to get the highest payout, and what your scrap gold is worth per gram.","url":"https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold","datePublished":"2026-05-08","dateModified":"2026-06-13T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"When Is the Best Time to Sell Scrap Gold?","item":"https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is now a good time to sell gold in 2026?","acceptedAnswer":{"@type":"Answer","text":"Yes. Gold prices are near all-time highs in both USD ($4,742/oz) and GBP (£3,472/oz) as of May 2026. For scrap gold and unwanted jewellery, current prices represent a generational selling opportunity. Institutional forecasts from JP Morgan and Deutsche Bank suggest further upside is possible, though this is uncertain."}},{"@type":"Question","name":"How much is scrap gold worth per gram in the UK?","acceptedAnswer":{"@type":"Answer","text":"As of May 2026, scrap gold melt values are approximately: 9ct — £41.87/g; 14ct — £65.32/g; 18ct — £83.75/g; 22ct — £102.28/g; 24ct — £111.55/g. Most good buyers pay 80–95% of these melt values."}},{"@type":"Question","name":"What is the best place to sell scrap gold?","acceptedAnswer":{"@type":"Answer","text":"Specialist online gold buyers and bullion dealers with direct refinery access consistently offer the highest payout rates — typically 85–95% of melt value. Local jewellers and pawn shops typically pay 40–75% of melt value. For pieces with potential collector or antique value, an auction house is worth considering before committing to a scrap sale."}},{"@type":"Question","name":"How do I sell scrap gold online?","acceptedAnswer":{"@type":"Answer","text":"Request a free insured postal kit from a reputable specialist buyer, package your gold carefully, send via tracked insured delivery, receive an offer within 24–48 hours, and accept payment by bank transfer or have items returned. Always weigh and calculate your melt value first to evaluate any offer you receive."}},{"@type":"Question","name":"Is scrap gold worth anything?","acceptedAnswer":{"@type":"Answer","text":"Very much so at current prices. A plain 9ct gold ring weighing 4 grams has a scrap value of approximately £142 at 85% melt value payout. A 10-gram 18ct chain is worth approximately £712. Even small quantities of scrap gold are worth real money at 2026 prices."}},{"@type":"Question","name":"What time does the gold rate change daily?","acceptedAnswer":{"@type":"Answer","text":"The gold spot price changes continuously during market hours (Sunday 22:00 to Friday 22:00 UK time). The LBMA sets official benchmark fix prices at 10:30 AM and 3:00 PM London time on weekdays, and most UK scrap gold buyers update their published rates based on these benchmarks."}},{"@type":"Question","name":"Should I sell my gold for scrap or at auction?","acceptedAnswer":{"@type":"Answer","text":"It depends on the piece. Plain, mass-produced, or broken gold is almost always best sold as scrap — there is no collector premium to capture. Antique, hallmarked, signed, or historically significant pieces can achieve prices well above melt value at auction. If you are uncertain, a free auction house valuation is the quickest way to find out."}},{"@type":"Question","name":"Where can I find scrap gold buyers near me?","acceptedAnswer":{"@type":"Answer","text":"Search 'scrap gold buyers near me' to find local gold dealers, jewellers, and bullion shops. In the UK, Hatton Garden (London) and Birmingham's Jewellery Quarter are national hubs. Online specialist buyers are often the better choice on price regardless of your location, as they offer insured postal services and publish live rates."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is now a good time to sell gold in 2026?","acceptedAnswer":{"@type":"Answer","text":"Yes. Gold is trading near all-time highs in USD — around $4,750 per troy ounce as of mid-2026, not far below the January 2026 record of $5,589/oz. For scrap gold and unwanted jewelry, current prices represent a generational selling opportunity. Institutional forecasts from JP Morgan and Deutsche Bank suggest further upside is possible, though that is uncertain. For gold you do not need, there is no compelling reason to wait."}},{"@type":"Question","name":"How much is scrap gold worth per gram?","acceptedAnswer":{"@type":"Answer","text":"At a representative spot price near $4,750/oz, approximate melt values per gram are: 9K — $57/g; 10K — $64/g; 14K — $89/g; 18K — $115/g; 22K — $140/g; 24K — $153/g. Most reputable buyers pay 70–92% of these melt values. Use our scrap gold calculator for exact live figures at the current USD spot price, refreshed every 60 seconds."}},{"@type":"Question","name":"What is the best place to sell scrap gold?","acceptedAnswer":{"@type":"Answer","text":"Specialist online gold buyers and bullion dealers with direct refinery access consistently offer the highest payout rates — typically 85–95% of melt value. Local jewelers and pawn shops typically pay 40–75% of melt value. For pieces with potential collector or antique value, an auction house is worth considering before committing to a scrap sale."}},{"@type":"Question","name":"How do I sell scrap gold online?","acceptedAnswer":{"@type":"Answer","text":"Request a free insured mail-in kit from a reputable specialist buyer, package your gold carefully, send it via tracked and insured delivery, receive an offer within 24–48 hours, and accept payment by bank transfer or have your items returned. Always weigh your gold and calculate its melt value first so you can evaluate any offer. Getting quotes from two or three buyers takes about twenty minutes and often adds meaningful value."}},{"@type":"Question","name":"Is scrap gold worth anything?","acceptedAnswer":{"@type":"Answer","text":"Very much so at current prices. A plain 9K gold ring weighing 4 grams has a scrap value of roughly $195 at an 85% payout. A 10-gram 18K chain is worth around $975. Even small quantities of scrap gold — including dental gold and broken pieces — are worth real money at 2026 prices."}},{"@type":"Question","name":"What time does the gold rate change daily?","acceptedAnswer":{"@type":"Answer","text":"The gold spot price changes continuously during market hours (Sunday evening to Friday evening, New York time). There is no single daily change time — prices move every second in response to trades, news, and economic data. However, the LBMA sets official benchmark fix prices at 10:30 AM and 3:00 PM London time on weekdays, and most gold buyers update their published rates against these benchmarks."}},{"@type":"Question","name":"Should I sell my gold for scrap or at auction?","acceptedAnswer":{"@type":"Answer","text":"It depends on the piece. Plain, mass-produced, or broken gold is almost always best sold as scrap — there is no collector premium to capture. Antique, hallmarked, signed, or historically significant pieces can achieve prices well above melt value at auction. If you are uncertain, a free auction-house valuation is the quickest way to find out."}},{"@type":"Question","name":"Where can I find scrap gold buyers near me?","acceptedAnswer":{"@type":"Answer","text":"Search 'scrap gold buyers near me' to find local gold dealers, jewelers, and bullion shops. In the US, New York's Diamond District (47th Street) and major-city bullion dealers are hubs; in the UK, London's Hatton Garden and Birmingham's Jewellery Quarter. Online specialist buyers are often the better choice on price regardless of your location, as they offer insured shipping, publish live rates, and have verifiable reviews."}}]}</script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
 <script>(function(){function signalGooglefcPresent(){if(!window.frames['googlefcPresent']){if(document.body){const iframe=document.createElement('iframe');iframe.style='width:0;height:0;border:none;z-index:-1000;left:-1000px;top:-1000px;';iframe.style.display='none';iframe.name='googlefcPresent';document.body.appendChild(iframe);}else{setTimeout(signalGooglefcPresent,0);}}}signalGooglefcPresent();})();</script>
@@ -39,37 +39,32 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.gold-api.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
 <style>
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-alt:#f4f3ef;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+/* ── DESIGN TOKENS ── kept compatible with site-wide variables ── */
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-alt:#f4f3ef;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#5c5b56;--color-text-faint:#8b8a85;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#c8830a;--color-silver:#6b7280;--color-rose:#b85850;--color-emerald:#0a8060;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--shadow-glow:0 0 0 1px oklch(0.7 0.15 80/0.2),0 8px 24px oklch(0.7 0.15 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--text-3xl:clamp(2.5rem,1.6rem + 3.5vw,4.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-editorial:'Playfair Display','Georgia',serif;--transition:180ms cubic-bezier(0.16,1,0.3,1);--transition-slow:320ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#e8e6e1;--color-text-muted:#a3a09a;--color-text-faint:#6c6a65;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#d19900;--color-gold-bright:#f0c14b;--color-silver:#c0c4cb;--color-rose:#e88a82;--color-emerald:#5fc59f;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5);--shadow-glow:0 0 0 1px oklch(0.78 0.16 80/0.25),0 8px 32px oklch(0.78 0.16 80/0.15)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:84px}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
-h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.15}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
 :focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
-@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important;scroll-behavior:auto!important}}
+/* ── NAV ── */
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+.site-nav{position:sticky;top:0;z-index:200;background:color-mix(in oklch,var(--color-surface) 92%,transparent);backdrop-filter:saturate(180%) blur(14px);-webkit-backdrop-filter:saturate(180%) blur(14px);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1280px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
 .mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
 .mega-nav__item{position:relative}
@@ -89,7 +84,6 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
 .mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
 .mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
-.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
 .mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
 .nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
 .theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
@@ -120,139 +114,306 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 @media(max-width:768px){.nav-logo span{display:none}}
 .ad-slot{min-height:0!important;margin:var(--space-2) 0}
 .ad-slot:not(:has(ins[data-ad-status])){border:none!important;background:none!important;padding:0!important;min-height:0!important;margin:0!important}
+.scroll-progress{position:fixed;top:56px;left:0;right:0;height:2px;background:transparent;z-index:198;pointer-events:none}
+.scroll-progress__fill{height:100%;width:0;background:linear-gradient(90deg,var(--color-gold-bright),var(--color-gold),var(--color-rose));transition:width 80ms linear;box-shadow:0 0 8px color-mix(in oklch,var(--color-gold-bright) 60%,transparent)}
+/* ── BREADCRUMB ── */
+.breadcrumb-wrap{max-width:1280px;margin:0 auto;padding:var(--space-3) var(--space-4)}
+.breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
+.breadcrumb li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
+.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
+.breadcrumb a:hover{color:var(--color-primary)}
+.breadcrumb li[aria-current="page"]{color:var(--color-text)}
+/* ── ARTICLE LAYOUT ── */
+.article-shell{max-width:1280px;margin:0 auto;padding:0 var(--space-4) var(--space-16);position:relative}
+@media(min-width:1024px){.article-shell{display:grid;grid-template-columns:240px minmax(0,1fr);gap:var(--space-10);align-items:flex-start;padding:0 var(--space-6) var(--space-16)}}
+/* ── HERO ── */
+.hero-wrap{margin:0 0 var(--space-6);grid-column:1/-1}
+.hero-tag{display:inline-flex;align-items:center;gap:8px;padding:5px 12px;background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright)}
+.hero-tag::before{content:"";display:block;width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);box-shadow:0 0 8px var(--color-gold-bright)}
+.hero-title{font-family:var(--font-editorial);font-size:var(--text-3xl);font-weight:600;line-height:1.05;letter-spacing:-0.02em;color:var(--color-text);margin:var(--space-4) 0 var(--space-3);max-width:18ch}
+.hero-title em{font-style:italic;color:var(--color-gold-bright);font-weight:500}
+.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.6;max-width:64ch;margin-bottom:var(--space-5)}
+.hero-byline{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-3);font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6)}
+.hero-byline a{color:var(--color-text-muted);font-weight:500;text-decoration:none}
+.hero-byline a:hover{color:var(--color-primary)}
+.hero-byline-dot{width:3px;height:3px;border-radius:50%;background:var(--color-text-faint)}
+/* ── BENTO HERO GRID ── */
+.bento-hero{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-6)}
+@media(min-width:560px){.bento-hero{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:960px){.bento-hero{grid-template-columns:repeat(6,1fr);grid-auto-rows:minmax(132px,auto)}}
+.bento-cell{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.bento-cell:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));transform:translateY(-1px);box-shadow:var(--shadow-md)}
+.bento-cell__label{display:flex;align-items:center;gap:8px;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.bento-cell__value{font-family:var(--font-editorial);font-size:clamp(1.6rem,1rem + 2.2vw,2.25rem);font-weight:600;color:var(--color-text);line-height:1;font-variant-numeric:tabular-nums;letter-spacing:-0.02em}
+.bento-cell__value-em{color:var(--color-gold-bright)}
+.bento-cell__caption{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-2);line-height:1.5}
+@media(min-width:960px){.bento-a{grid-column:4/5}.bento-b{grid-column:5/6}.bento-c{grid-column:6/7}.bento-d{grid-column:4/7;grid-row:2}}
+.bento-d{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface))}
+.bento-d::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;border-radius:var(--radius-xl) var(--radius-xl) 0 0;background:linear-gradient(90deg,#f0c14b,#d19900,#b07a00)}
+/* live spot price hero card */
+.bento-spot{grid-column:1/-1;background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface)),color-mix(in oklch,var(--color-rose) 6%,var(--color-surface)));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));display:flex;flex-direction:column;justify-content:space-between;min-height:160px}
+@media(min-width:960px){.bento-spot{grid-column:1/4;grid-row:span 2;padding:var(--space-6)}}
+.bento-spot__head{display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-3)}
+.bento-spot__title{font-family:var(--font-display);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted)}
+.bento-spot__price{font-family:var(--font-editorial);font-size:clamp(2.25rem,1.4rem + 3.5vw,3.5rem);font-weight:600;color:var(--color-text);line-height:1;letter-spacing:-0.02em;font-variant-numeric:tabular-nums;margin:var(--space-4) 0 var(--space-2)}
+.bento-spot__delta{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-sm);font-weight:600;font-variant-numeric:tabular-nums}
+.bento-spot__delta--up{color:var(--color-emerald)}
+.bento-spot__delta--down{color:var(--color-rose)}
+.bento-spot__meta{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3);display:flex;flex-wrap:wrap;gap:var(--space-3)}
+.live-pill{display:inline-flex;align-items:center;gap:6px;padding:4px 9px;background:color-mix(in oklch,var(--color-emerald) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-emerald) 28%,var(--color-border));border-radius:var(--radius-full);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-emerald);white-space:nowrap}
+.live-pill__dot{width:6px;height:6px;border-radius:50%;background:var(--color-emerald);animation:livePulse 1.8s infinite}
+@keyframes livePulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.55;transform:scale(.85)}}
+.live-pill--idle{color:var(--color-text-muted);background:var(--color-surface-offset);border-color:var(--color-border)}
+.live-pill--idle .live-pill__dot{background:var(--color-text-faint);animation:none}
+.live-pill--error{color:var(--color-rose);background:color-mix(in oklch,var(--color-rose) 10%,var(--color-surface));border-color:color-mix(in oklch,var(--color-rose) 30%,var(--color-border))}
+.live-pill--error .live-pill__dot{background:var(--color-rose);animation:none}
+/* ── SIDEBAR TOC ── */
+.toc{display:none}
+@media(min-width:1024px){.toc{display:block;position:sticky;top:84px;align-self:flex-start;max-height:calc(100dvh - 100px);overflow-y:auto;padding:var(--space-4) var(--space-3) var(--space-4) 0;border-right:1px solid var(--color-divider);scrollbar-width:thin;scrollbar-color:var(--color-border) transparent}}
+.toc__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-faint);margin-bottom:var(--space-3);padding-left:var(--space-3)}
+.toc__list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:1px;counter-reset:toc}
+.toc__list a{display:block;padding:8px 12px;font-size:13px;font-weight:500;color:var(--color-text-muted);text-decoration:none;border-left:2px solid transparent;border-radius:0 var(--radius-sm) var(--radius-sm) 0;transition:color var(--transition),border-color var(--transition),background var(--transition);line-height:1.35}
+.toc__list a:hover{color:var(--color-text);background:var(--color-surface-offset);border-left-color:var(--color-border)}
+.toc__list a.is-active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));font-weight:600}
+.toc-fab{position:fixed;bottom:20px;right:20px;width:auto;height:52px;padding:0 var(--space-5);border-radius:var(--radius-full);background:var(--color-text);color:var(--color-bg);border:none;cursor:pointer;display:inline-flex;gap:8px;align-items:center;justify-content:center;font-size:var(--text-sm);font-weight:700;z-index:150;box-shadow:var(--shadow-lg);transition:transform var(--transition)}
+.toc-fab:hover{transform:translateY(-2px)}
+@media(min-width:1024px){.toc-fab{display:none}}
+.toc-sheet{position:fixed;inset:0;background:color-mix(in oklch,var(--color-bg) 80%,transparent);backdrop-filter:blur(8px);z-index:201;display:none;align-items:flex-end;justify-content:center}
+.toc-sheet.is-open{display:flex;animation:fadeIn .2s ease-out}
+@keyframes fadeIn{from{opacity:0}to{opacity:1}}
+.toc-sheet__panel{width:100%;max-width:560px;max-height:80dvh;background:var(--color-surface);border-radius:var(--radius-xl) var(--radius-xl) 0 0;padding:var(--space-5) var(--space-4) var(--space-6);overflow-y:auto;animation:slideUp .25s cubic-bezier(.16,1,.3,1)}
+@keyframes slideUp{from{transform:translateY(40px)}to{transform:translateY(0)}}
+.toc-sheet__head{display:flex;justify-content:space-between;align-items:center;margin-bottom:var(--space-4);padding-bottom:var(--space-3);border-bottom:1px solid var(--color-border)}
+.toc-sheet__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text)}
+.toc-sheet__close{width:36px;height:36px;border-radius:50%;background:var(--color-surface-offset);display:flex;align-items:center;justify-content:center}
+.toc-sheet__list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:2px}
+.toc-sheet__list a{padding:12px 14px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);min-height:44px;display:flex;align-items:center}
+.toc-sheet__list a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+/* ── PROSE ── */
+.prose-main{min-width:0;grid-column:2}
+@media(max-width:1023px){.prose-main{grid-column:1}}
+.prose{max-width:760px}
+.prose h2{font-family:var(--font-editorial);font-size:clamp(1.5rem,1.1rem + 1.5vw,2.25rem);font-weight:600;color:var(--color-text);margin:var(--space-12) 0 var(--space-3);line-height:1.15;letter-spacing:-0.015em;scroll-margin-top:90px}
+.prose h2 .h2-num{display:inline-block;font-family:var(--font-display);font-size:0.4em;font-weight:700;color:var(--color-gold-bright);vertical-align:super;margin-right:8px;letter-spacing:.06em}
+.prose h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-8) 0 var(--space-2)}
+.prose h4{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-5) 0 var(--space-2)}
+.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
+.prose p.prose-lede{font-family:var(--font-editorial);font-size:clamp(1.125rem,0.9rem + 1vw,1.375rem);font-weight:500;color:var(--color-text);line-height:1.5;letter-spacing:-0.01em;margin-bottom:var(--space-5)}
+.prose p.prose-lede::first-letter{font-family:var(--font-editorial);font-size:3em;float:left;line-height:0.85;padding:6px 12px 0 0;color:var(--color-gold-bright);font-weight:600}
+.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
+.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
+.prose strong{color:var(--color-text);font-weight:600}
+.prose a{color:var(--color-primary);text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;text-decoration-color:color-mix(in oklch,var(--color-primary) 40%,transparent)}
+.prose a:hover{color:var(--color-primary-hover);text-decoration-color:currentColor}
+.hmark{display:inline-flex;align-items:center;padding:2px 8px;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:.04em;font-family:var(--font-display)}
+/* ── PROSE TABLE ── */
+.table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch;margin:var(--space-5) 0 var(--space-6);border:1px solid var(--color-border);border-radius:var(--radius-xl);background:var(--color-surface)}
+.table-scroll table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:0;min-width:520px}
+.table-scroll th{text-align:left;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-4) var(--space-4);border-bottom:2px solid var(--color-border);background:var(--color-surface-offset)}
+.table-scroll td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text-muted);vertical-align:middle;line-height:1.5}
+.table-scroll tr:last-child td{border-bottom:none}
+.table-scroll td:first-child,.table-scroll th:first-child{color:var(--color-text);font-weight:600}
+.table-scroll td .usd{color:var(--color-gold-bright);font-weight:700;font-variant-numeric:tabular-nums;font-family:var(--font-display)}
+/* ── EXEC / CALLOUTS / PULL-QUOTE / STEPS ── */
+.exec-summary{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.exec-summary p{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:0;max-width:none}
+.exec-summary strong{color:var(--color-gold-bright)}
+.info-callout{background:color-mix(in oklch,var(--color-primary) 7%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 18%,var(--color-border));border-left:3px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.info-callout::before{content:"i";display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:50%;background:var(--color-primary);color:#fff;font-family:var(--font-editorial);font-style:italic;font-weight:700;font-size:13px;margin-right:8px;float:left}
+.info-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
+.info-callout p+p{margin-top:var(--space-3);clear:both}
+.info-callout strong{color:var(--color-text)}
+.warning-callout{background:color-mix(in oklch,var(--color-rose) 7%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-rose) 20%,var(--color-border));border-left:3px solid var(--color-rose);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.warning-callout::before{content:"!";display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:50%;background:var(--color-rose);color:#fff;font-weight:700;font-size:13px;margin-right:8px;float:left}
+.warning-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
+.warning-callout p+p{margin-top:var(--space-3);clear:both}
+.warning-callout strong{color:var(--color-text)}
+.pull-quote{font-family:var(--font-editorial);font-size:clamp(1.25rem,1rem + 1.5vw,1.875rem);font-weight:500;color:var(--color-text);line-height:1.3;letter-spacing:-0.015em;border-left:3px solid var(--color-gold-bright);padding:var(--space-2) 0 var(--space-2) var(--space-5);margin:var(--space-8) 0;max-width:60ch;font-style:italic}
+.pull-quote::before{content:"\201C";font-size:1.5em;color:var(--color-gold-bright);line-height:1;margin-right:4px;display:inline-block;transform:translateY(8px);font-style:normal}
+.step-list{list-style:none;padding:0;margin:var(--space-6) 0;display:flex;flex-direction:column;gap:var(--space-3)}
+.step-block{display:flex;align-items:flex-start;gap:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);transition:border-color var(--transition),box-shadow var(--transition)}
+.step-block:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));box-shadow:var(--shadow-sm)}
+.step-number{flex-shrink:0;width:38px;height:38px;border-radius:var(--radius-full);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));color:var(--color-gold-bright);font-weight:700;font-size:var(--text-base);display:flex;align-items:center;justify-content:center;font-family:var(--font-editorial);border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border))}
+.step-content{flex:1;min-width:0}
+.step-content strong{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:4px}
+.step-content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+/* ── SEASONAL DEMAND CHART (signature) ── */
+.season-chart{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);padding:var(--space-5);margin:var(--space-6) 0}
+@media(min-width:640px){.season-chart{padding:var(--space-6)}}
+.season-chart__head{display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-3);flex-wrap:wrap;margin-bottom:var(--space-5)}
+.season-chart__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0}
+.season-chart__caption{font-size:11px;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;font-weight:600;margin-top:4px}
+.season-legend{display:flex;flex-wrap:wrap;gap:var(--space-3)}
+.season-legend span{display:inline-flex;align-items:center;gap:6px;font-size:11px;font-weight:600;color:var(--color-text-muted)}
+.season-legend i{width:10px;height:10px;border-radius:3px;display:block}
+.season-i--strong{background:var(--color-emerald)}
+.season-i--soft{background:var(--color-silver)}
+.season-i--mid{background:var(--color-gold-bright)}
+.season-bars{display:grid;grid-template-columns:repeat(12,1fr);gap:6px;align-items:stretch;height:216px;margin-top:var(--space-4)}
+@media(max-width:520px){.season-bars{height:188px;gap:3px}}
+.season-bar{display:grid;grid-template-rows:14px 1fr 14px;justify-items:center;align-items:end;gap:5px;height:100%;min-width:0}
+.season-bar__col{grid-row:2;align-self:end;width:100%;max-width:34px;height:0;border-radius:var(--radius-sm) var(--radius-sm) 0 0;transition:height 900ms cubic-bezier(.16,1,.3,1)}
+.season-chart.is-in .season-bar__col{height:var(--h)}
+.season-bar__val{grid-row:1}
+.season-bar__m{grid-row:3}
+.season-bar--strong .season-bar__col{background:linear-gradient(180deg,var(--color-emerald),color-mix(in oklch,var(--color-emerald) 55%,transparent))}
+.season-bar--soft .season-bar__col{background:linear-gradient(180deg,var(--color-silver),color-mix(in oklch,var(--color-silver) 45%,transparent))}
+.season-bar--mid .season-bar__col{background:linear-gradient(180deg,var(--color-gold-bright),color-mix(in oklch,var(--color-gold-bright) 50%,transparent))}
+.season-bar__val{font-size:10px;font-weight:700;color:var(--color-text-muted);font-variant-numeric:tabular-nums;font-family:var(--font-display);opacity:0;transition:opacity 600ms ease 500ms}
+.season-chart.is-in .season-bar__val{opacity:1}
+@media(max-width:520px){.season-bar__val{display:none}}
+.season-bar__m{font-size:10px;font-weight:600;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.03em}
+.season-chart__foot{font-size:11px;color:var(--color-text-faint);margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-divider);line-height:1.5}
+.season-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0 var(--space-6)}
+@media(min-width:560px){.season-grid{grid-template-columns:repeat(2,1fr)}}
+.season-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);transition:border-color var(--transition),box-shadow var(--transition)}
+.season-card:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 28%,var(--color-border));box-shadow:var(--shadow-sm)}
+.season-card__header{display:flex;flex-direction:column;gap:6px;margin-bottom:var(--space-3)}
+.season-card__period{display:inline-flex;align-items:center;gap:6px;align-self:flex-start;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;padding:3px 9px;border-radius:var(--radius-full)}
+.season-card__period::before{content:"";width:6px;height:6px;border-radius:50%;background:currentColor}
+.season-card__period--strong{color:var(--color-emerald);background:color-mix(in oklch,var(--color-emerald) 12%,var(--color-surface-offset))}
+.season-card__period--soft{color:var(--color-silver);background:color-mix(in oklch,var(--color-silver) 14%,var(--color-surface-offset))}
+.season-card__period--recovery{color:var(--color-primary);background:color-mix(in oklch,var(--color-primary) 12%,var(--color-surface-offset))}
+.season-card__name{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text)}
+.season-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0;max-width:none}
+.season-card strong{color:var(--color-text);font-weight:600}
+/* ── SCENARIO SPLIT ── */
+.split-grid{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0 var(--space-6)}
+@media(min-width:560px){.split-grid{grid-template-columns:repeat(2,1fr)}}
+.split-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);position:relative;overflow:hidden}
+.split-card::before{content:"";position:absolute;top:0;left:0;right:0;height:3px}
+.split-card--up::before{background:var(--color-emerald)}
+.split-card--down::before{background:var(--color-rose)}
+.split-card__tag{display:inline-flex;align-items:center;gap:6px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;margin-bottom:var(--space-2)}
+.split-card--up .split-card__tag{color:var(--color-emerald)}
+.split-card--down .split-card__tag{color:var(--color-rose)}
+.split-card__head{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:6px}
+.split-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0;max-width:none}
+/* ── PAYOUT COMPARISON ── */
+.acc-compare{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);padding:var(--space-5);margin:var(--space-6) 0}
+@media(min-width:640px){.acc-compare{padding:var(--space-6)}}
+.acc-compare__head{display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-3);flex-wrap:wrap;margin-bottom:var(--space-4)}
+.acc-compare__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0}
+.acc-compare__caption{font-size:11px;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;font-weight:600;margin-top:4px}
+.acc-tabs{display:inline-flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px;gap:2px}
+.acc-tab{padding:7px 14px;font-size:12px;font-weight:600;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-full);cursor:pointer;min-height:36px;white-space:nowrap}
+.acc-tab:hover{color:var(--color-text)}
+.acc-tab.is-active{background:var(--color-gold-bright);color:#1a1410}
+.acc-list{display:flex;flex-direction:column;gap:var(--space-3)}
+.acc-row{display:grid;grid-template-columns:1fr;gap:6px}
+.acc-row__top{display:flex;align-items:baseline;justify-content:space-between;gap:var(--space-3)}
+.acc-row__name{font-size:var(--text-sm);font-weight:600;color:var(--color-text);display:flex;align-items:center;gap:8px;min-width:0}
+.acc-row__rank{font-family:var(--font-display);font-size:11px;font-weight:700;color:var(--color-text-faint);font-variant-numeric:tabular-nums;flex-shrink:0}
+.acc-row__score{font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;flex-shrink:0}
+.acc-row__tier{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;padding:2px 7px;border-radius:var(--radius-full)}
+.acc-track{height:10px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);overflow:hidden}
+.acc-fill{height:100%;width:0;border-radius:var(--radius-full);transition:width 1000ms cubic-bezier(.16,1,.3,1)}
+.acc-compare.is-in .acc-fill{width:var(--w)}
+.acc--high .acc-fill,.acc--high .acc-row__tier{background:var(--color-emerald)}
+.acc--high .acc-row__tier{color:#06281e}
+.acc--medium .acc-fill,.acc--medium .acc-row__tier{background:#e0a020}
+.acc--medium .acc-row__tier{color:#2a1c00}
+.acc--low .acc-fill,.acc--low .acc-row__tier{background:var(--color-rose)}
+.acc--low .acc-row__tier{color:#2c0d0a}
+.acc--pro .acc-fill,.acc--pro .acc-row__tier{background:var(--color-primary)}
+.acc--pro .acc-row__tier{color:#04211f}
+.acc-compare__foot{font-size:11px;color:var(--color-text-faint);margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-divider);line-height:1.5}
+/* ── FAQ ── */
+.faq-accordion{display:flex;flex-direction:column;gap:var(--space-2);margin:var(--space-4) 0}
+details.faq-item{border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;background:var(--color-surface);transition:border-color var(--transition)}
+details.faq-item:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border))}
+details.faq-item[open]{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border))}
+details.faq-item summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;gap:var(--space-3);transition:background .15s;min-height:56px}
+details.faq-item summary::-webkit-details-marker,details.faq-item summary::marker{display:none}
+details.faq-item summary:hover{background:var(--color-surface-offset)}
+.faq-chevron{flex-shrink:0;transition:transform .2s;color:var(--color-gold-bright);width:18px;height:18px}
+details.faq-item[open] .faq-chevron{transform:rotate(180deg)}
+details.faq-item[open]>summary{background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
+.faq-body{padding:var(--space-4) var(--space-5) var(--space-5);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
+.faq-body p{margin:0;max-width:none;font-size:var(--text-sm);line-height:1.7}
+.faq-body p+p{margin-top:var(--space-3)}
+.faq-body strong{color:var(--color-text);font-weight:600}
+/* ── LIVE CALCULATOR ── */
+.gf-calc{position:relative;background:linear-gradient(160deg,color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface)),var(--color-surface) 60%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-radius:var(--radius-2xl);padding:var(--space-5);margin:var(--space-6) 0;overflow:hidden}
+@media(min-width:640px){.gf-calc{padding:var(--space-6)}}
+.gf-calc::after{content:"";position:absolute;top:-40%;right:-20%;width:60%;height:120%;background:radial-gradient(ellipse,color-mix(in oklch,var(--color-gold-bright) 14%,transparent),transparent 70%);pointer-events:none;z-index:0}
+.gf-calc>*{position:relative;z-index:1}
+.gf-calc__head{display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-3);margin-bottom:var(--space-5);flex-wrap:wrap}
+.gf-calc__title-block{flex:1;min-width:200px}
+.gf-calc__eyebrow{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:6px}
+.gf-calc__title{font-family:var(--font-editorial);font-size:clamp(1.25rem,1rem + 1vw,1.625rem);font-weight:600;color:var(--color-text);line-height:1.2;letter-spacing:-0.015em;margin:0}
+.gf-calc__sub{font-size:var(--text-sm);color:var(--color-text-muted);margin-top:6px;line-height:1.55;max-width:52ch}
+.gf-calc__grid{display:grid;grid-template-columns:1fr;gap:var(--space-5)}
+@media(min-width:768px){.gf-calc__grid{grid-template-columns:1fr 1fr;gap:var(--space-6)}}
+.gf-calc__controls{display:flex;flex-direction:column;gap:var(--space-4)}
+.gf-field{display:flex;flex-direction:column;gap:var(--space-2)}
+.gf-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.gf-unit-toggle{display:flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);overflow:hidden}
+.gf-unit-btn{flex:1;padding:10px var(--space-3);font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);border:none;background:none;cursor:pointer;text-align:center;min-height:44px}
+.gf-unit-btn.is-active{background:var(--color-gold-bright);color:#1a1410}
+.gf-input{width:100%;padding:12px var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:500;color:var(--color-text);outline:none;font-variant-numeric:tabular-nums;min-height:48px;transition:border-color var(--transition),box-shadow var(--transition)}
+.gf-input:focus{border-color:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+.gf-karat-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
+.gf-karat-btn{padding:10px 6px;font-size:var(--text-xs);font-weight:700;color:var(--color-text-muted);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface);cursor:pointer;text-align:center;min-height:44px;display:flex;align-items:center;justify-content:center;font-family:var(--font-display);letter-spacing:.04em}
+.gf-karat-btn:hover{border-color:var(--color-gold-bright);color:var(--color-gold-bright)}
+.gf-karat-btn.is-active{background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface-offset));border-color:var(--color-gold-bright);color:var(--color-gold-bright)}
+.gf-select{width:100%;padding:12px var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-family:var(--font-body);font-size:var(--text-sm);color:var(--color-text);outline:none;cursor:pointer;min-height:44px}
+.gf-select:focus{border-color:var(--color-gold-bright)}
+.gf-calc__result{background:var(--color-bg);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-4)}
+.gf-result-primary{background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 24%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);text-align:center}
+.gf-result-primary__label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:8px}
+.gf-result-primary__value{font-family:var(--font-editorial);font-size:clamp(1.875rem,1.2rem + 2.5vw,2.625rem);font-weight:600;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;letter-spacing:-0.02em}
+.gf-result-primary__note{font-size:11px;color:var(--color-text-faint);margin-top:8px}
+.gf-result-offer{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4);text-align:center}
+.gf-result-offer__label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:4px}
+.gf-result-offer__value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.gf-stats{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-2)}
+.gf-stat{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3);text-align:left}
+.gf-stat__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);margin-bottom:4px}
+.gf-stat__value{font-size:var(--text-sm);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;font-family:var(--font-display)}
+.gf-placeholder{display:flex;align-items:center;justify-content:center;flex:1;min-height:200px;color:var(--color-text-faint);font-size:var(--text-sm);text-align:center;padding:var(--space-6);background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-lg)}
+.gf-spot-line{font-size:11px;color:var(--color-text-faint);text-align:center;padding-top:var(--space-3);border-top:1px solid var(--color-divider);font-variant-numeric:tabular-nums}
+.gf-spot-line strong{color:var(--color-text-muted);font-family:var(--font-display)}
+/* ── CTA / DISCLAIMER / RELATED / FOOTER ── */
+.cta-box{background:linear-gradient(135deg,color-mix(in oklch,var(--color-primary) 12%,var(--color-surface)),color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface)));border:1px solid color-mix(in oklch,var(--color-primary) 25%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-6);margin:var(--space-8) 0}
+.cta-box h3{font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:600;color:var(--color-text);margin:0 0 var(--space-2)!important}
+.cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-4);max-width:none}
+.cta-btn{display:inline-flex;align-items:center;gap:8px;padding:12px var(--space-5);background:var(--color-primary);color:#fff!important;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none!important;transition:background var(--transition),transform var(--transition);min-height:44px}
+.cta-btn:hover,.cta-btn:visited{background:var(--color-primary-hover);color:#fff!important;text-decoration:none!important;transform:translateY(-1px)}
+.cta-btn svg{transition:transform var(--transition)}
+.cta-btn:hover svg{transform:translateX(3px)}
+.disclaimer-box{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
+.disclaimer-box strong{color:var(--color-text);font-weight:600}
+.related-section{max-width:1280px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+@media(min-width:1024px){.related-section{padding:0 var(--space-6)}}
+.related-section__head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:var(--space-5);flex-wrap:wrap;gap:var(--space-3)}
+.related-section__head h2{font-family:var(--font-editorial);font-size:var(--text-xl);font-weight:600;color:var(--color-text);margin:0;letter-spacing:-0.015em}
+.related-section__head p{font-size:var(--text-sm);color:var(--color-text-muted);margin:0}
+.related-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:var(--space-4)}
+.related-card{display:flex;flex-direction:column;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition),transform var(--transition);min-height:160px}
+.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);color:var(--color-text);transform:translateY(-2px)}
+.related-card__tag{display:inline-flex;align-items:center;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.related-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);line-height:1.3;margin-bottom:var(--space-2)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+.related-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6;margin-top:auto}
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
+.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start;max-width:1280px;margin:0 auto}
 @media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
 @media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
 .footer-brand-col{max-width:260px}
 .footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col{min-width:0}
-.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:8px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
-.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom{max-width:1280px;margin:0 auto;padding:var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
-.breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
-.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
-.breadcrumb a:hover{color:var(--color-primary)}
-.breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.article-wrap{max-width:1200px;margin:0 auto;padding:var(--space-6) var(--space-4) var(--space-16)}
-.article-tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-article.article-wrap .article-title,h1.article-title{font-family:var(--font-display)!important;font-size:clamp(1.75rem,3.5vw,2.75rem)!important;font-weight:700!important;line-height:1.15!important;margin:var(--space-2) 0 var(--space-5)!important;color:var(--color-text)!important}
-.article-byline{font-size:var(--text-sm);color:var(--color-text-muted);display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin-bottom:var(--space-6);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
-.article-byline a{color:var(--color-primary);text-decoration:none;font-weight:500}
-.article-byline a:hover{text-decoration:underline}
-.prose{max-width:860px}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose h4{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-5) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose sup{font-size:.7em;vertical-align:super;color:var(--color-text-faint)}
-.prose table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
-.prose table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-3) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.prose table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.prose table tr:last-child td{border-bottom:none}
-.prose table td:first-child,.prose table th:first-child{padding-left:0;color:var(--color-text)}
-.table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch;margin:var(--space-4) 0 var(--space-6)}
-.table-scroll table{margin:0;min-width:560px}
-.cta-box{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-8) 0}
-.cta-box h3{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:0 0 var(--space-2)}
-.cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-4)}
-.cta-btn{display:inline-flex;align-items:center;gap:var(--space-1);padding:var(--space-2) var(--space-5);background:var(--color-primary);color:#fff!important;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none;transition:background .15s}
-.cta-btn:hover,.cta-btn:visited{background:var(--color-primary-hover);color:#fff!important;text-decoration:none}
-.disclaimer-box{background:var(--color-surface-alt,#f4f3ef);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
-.disclaimer-box strong{color:var(--color-text);font-weight:700}
-.related-guides-section{max-width:860px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
-.related-guides-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-4)}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4)}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);color:var(--color-text)}
-.related-card__tag{display:block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-.exec-summary{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0}
-.exec-summary-intro{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-5)}
-.exec-summary-intro strong{color:var(--color-text)}
-.exec-summary-stats{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-4)}
-.exec-stat{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4)}
-.exec-stat-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.exec-stat-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;margin-top:var(--space-1);line-height:1.2}
-.info-callout{background:color-mix(in oklch,var(--color-primary) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 20%,var(--color-border));border-left:3px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
-.info-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
-.info-callout p+p{margin-top:var(--space-3)}
-.info-callout strong{color:var(--color-text)}
-.info-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0}
-.info-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
-.warning-callout{background:color-mix(in oklch,#f59e0b 8%,var(--color-surface));border:1px solid color-mix(in oklch,#f59e0b 25%,var(--color-border));border-left:3px solid #f59e0b;border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
-.warning-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
-.warning-callout p+p{margin-top:var(--space-3)}
-.warning-callout strong{color:var(--color-text)}
-.warning-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0}
-.warning-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
-.faq-accordion{margin:var(--space-4) 0}
-details.faq-item{border:1px solid var(--color-border);border-radius:var(--radius-lg);margin-bottom:var(--space-2);overflow:hidden;background:var(--color-surface)}
-details.faq-item summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;gap:var(--space-3);transition:background .15s}
-details.faq-item summary::-webkit-details-marker{display:none}
-details.faq-item summary:hover{background:var(--color-surface-offset)}
-.faq-chevron{flex-shrink:0;transition:transform .2s;color:var(--color-text-muted)}
-details.faq-item[open] .faq-chevron{transform:rotate(180deg)}
-details.faq-item[open]>summary{background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
-.faq-body{padding:var(--space-4) var(--space-5);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
-.faq-body p{margin:0;max-width:none}
-.faq-body p+p{margin-top:var(--space-3)}
-.faq-body strong{color:var(--color-text)}
-.step-list{list-style:none;padding:0;margin:var(--space-6) 0;display:flex;flex-direction:column;gap:var(--space-4)}
-.step-block{display:flex;align-items:flex-start;gap:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.step-number{flex-shrink:0;width:36px;height:36px;border-radius:var(--radius-full);background:var(--color-primary);color:#fff;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
-.step-content{flex:1;min-width:0}
-.step-content strong{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
-.step-content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0;max-width:none}
-.hmark{display:inline-flex;align-items:center;padding:2px 8px;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:.04em;font-family:var(--font-display)}
-/* Season cards — seasonal pattern periods */
-.season-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin:var(--space-6) 0}
-.season-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);transition:box-shadow var(--transition)}
-.season-card:hover{box-shadow:var(--shadow-md)}
-.season-card__header{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3)}
-.season-card__period{display:inline-flex;align-items:center;padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.05em;flex-shrink:0}
-.season-card__period--strong{background:color-mix(in oklch,#22c55e 12%,var(--color-surface-offset));color:#16a34a;border:1px solid color-mix(in oklch,#22c55e 25%,var(--color-border))}
-[data-theme="dark"] .season-card__period--strong{color:#4ade80}
-.season-card__period--soft{background:color-mix(in oklch,#f59e0b 12%,var(--color-surface-offset));color:#d97706;border:1px solid color-mix(in oklch,#f59e0b 25%,var(--color-border))}
-[data-theme="dark"] .season-card__period--soft{color:#fbbf24}
-.season-card__period--recovery{background:color-mix(in oklch,var(--color-primary) 12%,var(--color-surface-offset));color:var(--color-primary);border:1px solid color-mix(in oklch,var(--color-primary) 25%,var(--color-border))}
-.season-card__name{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text)}
-.season-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
-.season-card strong{color:var(--color-text)}
-/* Buyer option cards */
-.buyer-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:var(--space-4);margin:var(--space-6) 0}
-.buyer-option{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);transition:border-color var(--transition),box-shadow var(--transition)}
-.buyer-option:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.buyer-option__header{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-3);margin-bottom:var(--space-3)}
-.buyer-option__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);line-height:1.3}
-.buyer-payout{display:inline-flex;align-items:center;padding:var(--space-1) var(--space-3);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:700;white-space:nowrap;flex-shrink:0}
-.buyer-payout--high{background:color-mix(in oklch,#22c55e 12%,var(--color-surface-offset));color:#16a34a;border:1px solid color-mix(in oklch,#22c55e 25%,var(--color-border))}
-[data-theme="dark"] .buyer-payout--high{color:#4ade80}
-.buyer-payout--mid{background:color-mix(in oklch,#f59e0b 12%,var(--color-surface-offset));color:#d97706;border:1px solid color-mix(in oklch,#f59e0b 25%,var(--color-border))}
-[data-theme="dark"] .buyer-payout--mid{color:#fbbf24}
-.buyer-payout--low{background:color-mix(in oklch,#ef4444 12%,var(--color-surface-offset));color:#dc2626;border:1px solid color-mix(in oklch,#ef4444 25%,var(--color-border))}
-[data-theme="dark"] .buyer-payout--low{color:#f87171}
-.buyer-payout--variable{background:color-mix(in oklch,var(--color-primary) 12%,var(--color-surface-offset));color:var(--color-primary);border:1px solid color-mix(in oklch,var(--color-primary) 25%,var(--color-border))}
-.buyer-option p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-3);max-width:none}
-.buyer-option p:last-child{margin-bottom:0}
-.buyer-option ul{padding-left:var(--space-5);margin:0}
-.buyer-option li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-1)}
-.buyer-option strong{color:var(--color-text)}
+/* ── REVEAL ── */
+.reveal{opacity:0;transform:translateY(14px);transition:opacity 520ms cubic-bezier(0.16,1,0.3,1),transform 520ms cubic-bezier(0.16,1,0.3,1)}
+.reveal.is-in{opacity:1;transform:translateY(0)}
+@media(prefers-reduced-motion:reduce){.reveal{opacity:1;transform:none;transition:none}.season-bar__col,.acc-fill{transition:none}}
 </style>
-<link rel="stylesheet" href="/assets/site.css">
-<!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
 </head>
 <body>
@@ -304,8 +465,8 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     </ul>
     <div class="nav-actions">
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark/light mode">
-        <svg id="iconSun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-        <svg id="iconMoon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        <svg id="iconSun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        <svg id="iconMoon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
       </button>
       <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
         <span></span><span></span><span></span>
@@ -313,6 +474,8 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     </div>
   </div>
 </nav>
+
+<div class="scroll-progress" aria-hidden="true"><div class="scroll-progress__fill" id="scrollProgressFill"></div></div>
 
 <div id="mobileMenu" class="mobile-menu" aria-label="Mobile navigation">
   <div class="mobile-menu__inner">
@@ -346,377 +509,579 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
   </nav>
 </div>
 
-<article class="article-wrap">
-  <div class="article-tag">Guide</div>
-  <h1 class="article-title">When Is the Best Time to Sell Scrap Gold? (2026 Guide)</h1>
-  <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
-    <span>&middot;</span>
-    <time datetime="2026-06-13">8 May 2026</time>
-    <span>&middot;</span>
-    <span>18 min read</span>
+<div class="article-shell">
+  <aside class="toc" aria-label="Article sections">
+    <div class="toc__label">In this guide</div>
+    <ol class="toc__list" id="tocList">
+      <li><a href="#prices">Where Prices Stand</a></li>
+      <li><a href="#is-now">Is Now a Good Time?</a></li>
+      <li><a href="#wait">Should You Wait?</a></li>
+      <li><a href="#timing">When the Rate Changes</a></li>
+      <li><a href="#seasonal">Seasonal Patterns</a></li>
+      <li><a href="#worth">What It's Worth</a></li>
+      <li><a href="#where-to-sell">Where to Sell</a></li>
+      <li><a href="#best-price">Get the Best Price</a></li>
+      <li><a href="#auction">Scrap vs Auction</a></li>
+      <li><a href="#bottom-line">The Bottom Line</a></li>
+      <li><a href="#faq">FAQ</a></li>
+    </ol>
+  </aside>
+
+  <main class="prose-main">
+    <header class="hero-wrap">
+      <span class="hero-tag">Market Timing &middot; 2026 Edition</span>
+      <h1 class="hero-title">When Is the Best Time to Sell <em>Scrap Gold?</em></h1>
+      <p class="hero-sub">Gold is trading near record highs in US dollars. Here is how market timing actually works — the daily rate, the seasonal patterns, where to get the highest payout, and what your scrap gold is worth right now, valued live in USD.</p>
+      <div class="hero-byline">
+        <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
+        <span class="hero-byline-dot"></span>
+        <time datetime="2026-06-13">Updated 13 June 2026</time>
+        <span class="hero-byline-dot"></span>
+        <span>14 min read</span>
+      </div>
+
+      <div class="bento-hero">
+        <div class="bento-cell bento-spot reveal">
+          <div class="bento-spot__head">
+            <div class="bento-spot__title">Live Gold Spot &middot; USD / troy oz</div>
+            <span class="live-pill live-pill--idle" id="heroLive">
+              <span class="live-pill__dot"></span>
+              <span id="heroLiveText">Connecting</span>
+            </span>
+          </div>
+          <div class="bento-spot__price" id="heroSpotPrice">$&mdash;,&mdash;&mdash;&mdash;</div>
+          <div>
+            <span class="bento-spot__delta bento-spot__delta--up" id="heroSpotDelta" hidden>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 15l7-7 7 7"/></svg>
+              <span id="heroSpotDeltaText">&mdash;</span>
+            </span>
+          </div>
+          <div class="bento-spot__meta">
+            <span>Per gram (24K) <strong id="heroSpotPerGram" style="color:var(--color-text)">$&mdash;</strong></span>
+            <span>Updated <span id="heroSpotUpdated">just now</span></span>
+          </div>
+        </div>
+        <div class="bento-cell bento-a reveal">
+          <div class="bento-cell__label">2026 record high</div>
+          <div class="bento-cell__value"><span class="bento-cell__value-em">$5,589</span></div>
+          <div class="bento-cell__caption">Per troy oz &middot; January 2026 ATH</div>
+        </div>
+        <div class="bento-cell bento-b reveal">
+          <div class="bento-cell__label">Top dealer payout</div>
+          <div class="bento-cell__value">92<span class="bento-cell__value-em" style="font-size:.6em">%</span></div>
+          <div class="bento-cell__caption">Specialist buyers, of melt value</div>
+        </div>
+        <div class="bento-cell bento-c reveal">
+          <div class="bento-cell__label">Seasonal low</div>
+          <div class="bento-cell__value">Jul</div>
+          <div class="bento-cell__caption">Historically the softest month</div>
+        </div>
+        <div class="bento-cell bento-d reveal">
+          <div>
+            <div class="bento-cell__label" style="color:var(--color-gold-bright)">2026 verdict</div>
+            <div class="bento-cell__value">A strong window to sell</div>
+            <div class="bento-cell__caption">Near record USD highs &middot; for gold you don't need</div>
+          </div>
+          <span class="live-pill" style="background:color-mix(in oklch,var(--color-emerald) 12%,var(--color-surface));color:var(--color-emerald)"><span class="live-pill__dot"></span>Sell</span>
+        </div>
+      </div>
+    </header>
+
+    <div class="prose">
+
+      <p class="prose-lede reveal">There is a gold ring sitting in a drawer somewhere that you have been meaning to do something about for three years. Or a tangle of broken chains. Or earrings from an ex you kept telling yourself you would sell eventually. If you have ever wondered whether now is actually a good time — the answer in 2026 is that conditions are about as favourable as they have ever been.</p>
+
+      <p class="reveal">But "the price is high" is not the same as knowing whether to sell today, wait until autumn, or hold out for an even higher number next year. Gold market timing is real, and understanding how it works — both on the macro scale and the day-to-day level — is the difference between a solid deal and leaving money on the table.</p>
+
+      <div class="exec-summary reveal">
+        <p>This guide covers it all in <strong>US dollars</strong>: where gold prices stand and where they may be headed, what the seasonal patterns actually show, <strong>when during the day the gold rate changes</strong> and why it matters, where to sell for the highest payout, and the practical details most guides skip. Every figure can be checked against the live spot price above and the calculator below.</p>
+      </div>
+
+      <h2 id="prices" class="reveal"><span class="h2-num">01</span>Where Gold Prices Stand Right Now</h2>
+      <p class="reveal">Before talking about timing, you need the baseline — and the baseline in 2026 is extraordinary.</p>
+      <p class="reveal">Gold reached an all-time high of <strong>$5,589 per troy ounce</strong> in January 2026, then pulled back and has traded broadly in the <strong>$4,700&ndash;$5,000</strong> range through the spring. That means scrap gold melt values per gram, before any buyer margin, currently sit near the following at a representative spot price around <strong>$4,750/oz</strong> &mdash; check the live calculator for the exact figure right now:</p>
+
+      <div class="table-scroll reveal">
+        <table>
+          <thead>
+            <tr>
+              <th>Karat</th>
+              <th>Purity</th>
+              <th>Melt value per gram (USD, approx.)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td><span class="hmark">9K</span></td><td>37.5%</td><td><span class="usd">$57</span></td></tr>
+            <tr><td><span class="hmark">10K</span></td><td>41.7%</td><td><span class="usd">$64</span></td></tr>
+            <tr><td><span class="hmark">14K</span></td><td>58.3%</td><td><span class="usd">$89</span></td></tr>
+            <tr><td><span class="hmark">18K</span></td><td>75.0%</td><td><span class="usd">$115</span></td></tr>
+            <tr><td><span class="hmark">22K</span></td><td>91.7%</td><td><span class="usd">$140</span></td></tr>
+            <tr><td><span class="hmark">24K</span></td><td>99.9%</td><td><span class="usd">$153</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p class="reveal">These are melt values &mdash; what the gold itself is worth before the buyer takes their margin. Most reputable buyers pay <strong>70&ndash;92% of melt value</strong>. So a <span class="hmark">14K</span> gold bracelet weighing 10 grams (melt value roughly $890) would typically draw an offer between <strong>$625 and $820</strong>, with specialist buyers at the top of that range.</p>
+      <p class="reveal">For historical context: a year ago that same bracelet would have fetched around $560; two years ago, closer to $420. The gold in ordinary household jewelry has effectively doubled or trebled in value over thirty-six months.</p>
+
+      <div class="cta-box reveal">
+        <h3>Calculate Your Scrap Gold Value</h3>
+        <p>Enter your gold's karat and weight to find its live melt value at today's USD spot price &mdash; updated every 60 seconds.</p>
+        <a href="/scrap-gold-calculator" class="cta-btn">Open Scrap Gold Calculator <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </div>
+
+      <h2 id="is-now" class="reveal"><span class="h2-num">02</span>Is Now a Good Time to Sell Gold?</h2>
+      <p class="reveal">For scrap gold sellers &mdash; people selling unwanted jewelry, broken pieces, or items they no longer use &mdash; the honest answer is yes, <strong>2026 is an excellent time</strong>.</p>
+      <p class="reveal">Here is why that answer is fairly clear:</p>
+      <ul class="reveal">
+        <li><strong>You are not giving up future use.</strong> Scrap gold is, by definition, gold you do not need. A broken chain, a single earring, an inherited ring that has sat in a box for a decade &mdash; none of these are serving you. Selling them at record-high prices is straightforwardly sensible.</li>
+        <li><strong>Prices are near historic highs.</strong> Gold is not at its absolute January 2026 peak, but it remains close. The gap to the all-time high is roughly 15&ndash;20% &mdash; and while prices could rise further, they could equally pull back. Nobody rings a bell at the top of any market.</li>
+        <li><strong>The structural drivers remain in place.</strong> Major institutions including JP Morgan, Deutsche Bank and UBS hold bullish outlooks through 2026&ndash;2027. The core reasons &mdash; central-bank buying, persistent inflation concerns, geopolitical instability, and ongoing dollar dynamics &mdash; have not resolved. That supports elevated prices, though exactly where they go from here is genuinely uncertain.</li>
+      </ul>
+
+      <div class="info-callout reveal">
+        <p><strong>The counterargument is real but weak for scrap sellers.</strong> The case for waiting is essentially: what if prices go higher? JP Morgan's forecast of $5,055&ndash;$6,300 by year-end is plausible. But gold could equally drop to $4,000 on a dollar recovery or a surprise rate move. For scrap gold you do not need, the risk of waiting is asymmetric in a way that rarely favours the seller.</p>
+      </div>
+
+      <h2 id="wait" class="reveal"><span class="h2-num">03</span>Should You Wait for a Higher Price?</h2>
+      <p class="reveal">The question "should I sell now or wait?" comes up constantly, and the answer depends heavily on what you are selling and why.</p>
+      <p class="reveal">For broken jewelry, single earrings, dental gold, and pieces you genuinely have no use for, the rational answer is nearly always to <strong>sell at a good price rather than trying to time the market precisely</strong>. You are not invested in gold as a strategy &mdash; you have gold through happenstance. Trading an accidental position like an investment adds complexity to what is fundamentally a decluttering exercise.</p>
+
+      <div class="split-grid reveal">
+        <div class="split-card split-card--up">
+          <div class="split-card__tag"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M5 15l7-7 7 7"/></svg>If you wait and price rises</div>
+          <div class="split-card__head">You leave a little on the table</div>
+          <p>If gold climbs from ~$4,750 to JP Morgan's $6,300 target, a $1,000 lot might have fetched roughly $1,325 instead. A real gain &mdash; but only realised if you sell at the new peak, which nobody can time reliably.</p>
+        </div>
+        <div class="split-card split-card--down">
+          <div class="split-card__tag"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M19 9l-7 7-7-7"/></svg>If you wait and price falls</div>
+          <div class="split-card__head">You give back a sure thing</div>
+          <p>A pullback to $4,000 turns that same $1,000 lot into roughly $840. You held an illiquid drawer item through a drawdown for nothing &mdash; the classic downside of trying to time a position you never chose to hold.</p>
+        </div>
+      </div>
+
+      <p class="reveal">The practical approach most sellers find useful: <strong>set a floor, not a target.</strong> Decide what your items are worth at today's prices. If you receive a solid offer above that floor, accept it. Do not hold out indefinitely for a number that may never arrive. For investment-grade gold &mdash; coins, bars, deliberate holdings &mdash; the calculation is different, and this article is less relevant.</p>
+
+      <h2 id="timing" class="reveal"><span class="h2-num">04</span>Gold Market Timing: When Does the Rate Change?</h2>
+      <p class="reveal">"At what time does the gold price change?" is a common question, and the answer comes down to how gold markets actually work.</p>
+      <p class="reveal">Gold trades on the global over-the-counter market and on exchanges including COMEX in New York and the Shanghai Gold Exchange. The spot market is open roughly 23 hours a day, five days a week &mdash; from Sunday evening through Friday evening (New York time), with only a brief daily maintenance pause. The gold price is therefore <strong>changing continuously during market hours</strong>, not once per day.</p>
+
+      <h3 class="reveal">The LBMA Gold Price Fix</h3>
+      <p class="reveal">The London Bullion Market Association sets an official benchmark twice daily &mdash; at <strong>10:30 AM and 3:00 PM London time</strong>. These are the AM and PM fixes, and most of the world's gold transactions, including scrap purchases from the public, are priced against them. When a buyer advertises rates, they typically base them on the most recent fix, so published rates <strong>update twice a day on working days</strong>. On volatile days, some buyers update more often.</p>
+
+      <h3 class="reveal">The London&ndash;New York Overlap Window</h3>
+      <p class="reveal">The most actively traded window is the <strong>London&ndash;New York overlap, roughly 8:00 AM to noon US Eastern time (1:00&ndash;5:00 PM London)</strong>. During these hours both the London OTC market and COMEX are simultaneously active, creating the day's highest liquidity and tightest spreads.</p>
+
+      <div class="info-callout reveal">
+        <p><strong>Practical note for sellers:</strong> If gold has had a strong day &mdash; up 1&ndash;2% &mdash; and you are mid-sale, it is worth asking whether the buyer's quoted rate reflects today's price or yesterday's close. Reputable buyers will tell you honestly. On stable days (which is most days) this is a non-issue. The bigger variable is not time of day but <strong>choice of buyer</strong> &mdash; worth far more attention than micro-timing your transaction.</p>
+      </div>
+
+      <h2 id="seasonal" class="reveal"><span class="h2-num">05</span>Seasonal Gold Price Patterns: What the Data Shows</h2>
+      <p class="reveal">Gold follows a loose seasonal rhythm &mdash; loose enough to be interesting, not reliable enough to build a selling strategy around. Across several decades, historical data shows these recurring tendencies in relative demand:</p>
+
+      <div class="season-chart reveal" id="seasonChart" role="img" aria-label="Illustrative gold seasonal demand index by month: January 78, February 82, March 80, April 64, May 58, June 48, July 42, August 60, September 88, October 90, November 74, December 70 out of 100. Strength peaks in Q1 and again in September and October, with a summer low in July.">
+        <div class="season-chart__head">
+          <div>
+            <h3 class="season-chart__title">Gold's seasonal demand rhythm</h3>
+            <div class="season-chart__caption">Relative historical strength &middot; 0&ndash;100 index &middot; illustrative multi-decade tendency</div>
+          </div>
+          <div class="season-legend" aria-hidden="true">
+            <span><i class="season-i--strong"></i>Strong</span>
+            <span><i class="season-i--mid"></i>Mixed</span>
+            <span><i class="season-i--soft"></i>Soft</span>
+          </div>
+        </div>
+        <div class="season-bars">
+          <div class="season-bar season-bar--strong" style="--h:78%"><span class="season-bar__val">78</span><span class="season-bar__col"></span><span class="season-bar__m">Jan</span></div>
+          <div class="season-bar season-bar--strong" style="--h:82%"><span class="season-bar__val">82</span><span class="season-bar__col"></span><span class="season-bar__m">Feb</span></div>
+          <div class="season-bar season-bar--strong" style="--h:80%"><span class="season-bar__val">80</span><span class="season-bar__col"></span><span class="season-bar__m">Mar</span></div>
+          <div class="season-bar season-bar--mid" style="--h:64%"><span class="season-bar__val">64</span><span class="season-bar__col"></span><span class="season-bar__m">Apr</span></div>
+          <div class="season-bar season-bar--soft" style="--h:58%"><span class="season-bar__val">58</span><span class="season-bar__col"></span><span class="season-bar__m">May</span></div>
+          <div class="season-bar season-bar--soft" style="--h:48%"><span class="season-bar__val">48</span><span class="season-bar__col"></span><span class="season-bar__m">Jun</span></div>
+          <div class="season-bar season-bar--soft" style="--h:42%"><span class="season-bar__val">42</span><span class="season-bar__col"></span><span class="season-bar__m">Jul</span></div>
+          <div class="season-bar season-bar--mid" style="--h:60%"><span class="season-bar__val">60</span><span class="season-bar__col"></span><span class="season-bar__m">Aug</span></div>
+          <div class="season-bar season-bar--strong" style="--h:88%"><span class="season-bar__val">88</span><span class="season-bar__col"></span><span class="season-bar__m">Sep</span></div>
+          <div class="season-bar season-bar--strong" style="--h:90%"><span class="season-bar__val">90</span><span class="season-bar__col"></span><span class="season-bar__m">Oct</span></div>
+          <div class="season-bar season-bar--mid" style="--h:74%"><span class="season-bar__val">74</span><span class="season-bar__col"></span><span class="season-bar__m">Nov</span></div>
+          <div class="season-bar season-bar--mid" style="--h:70%"><span class="season-bar__val">70</span><span class="season-bar__col"></span><span class="season-bar__m">Dec</span></div>
+        </div>
+        <p class="season-chart__foot">Illustrative index based on long-run seasonal tendencies in gold demand, not a forecast. In any given year, macro events routinely override the pattern entirely.</p>
+      </div>
+
+      <div class="season-grid reveal">
+        <div class="season-card">
+          <div class="season-card__header">
+            <span class="season-card__period season-card__period--strong">Typically Strong</span>
+            <div class="season-card__name">Q1 &middot; Jan to Mar</div>
+          </div>
+          <p>Fresh investment inflows at the start of the year, demand ahead of <strong>Chinese New Year</strong> (late January or February), and momentum from the prior year-end combine to push prices higher in many years.</p>
+        </div>
+        <div class="season-card">
+          <div class="season-card__header">
+            <span class="season-card__period season-card__period--soft">Typically Soft</span>
+            <div class="season-card__name">Summer &middot; Jun &amp; Jul</div>
+          </div>
+          <p>Historically the softer period. Volumes thin out as institutional participants take summer leave, and the big demand events are months away. <strong>Early July is often the seasonal low point</strong>.</p>
+        </div>
+        <div class="season-card">
+          <div class="season-card__header">
+            <span class="season-card__period season-card__period--recovery">Recovery</span>
+            <div class="season-card__name">Autumn &middot; Aug to Nov</div>
+          </div>
+          <p>Demand recovers through this window, driven by the <strong>Indian festival and wedding season</strong> (Diwali, Dussehra), renewed institutional activity, and anticipation of the year-end buying periods.</p>
+        </div>
+        <div class="season-card">
+          <div class="season-card__header">
+            <span class="season-card__period season-card__period--strong">Historically Strong</span>
+            <div class="season-card__name">Sep &amp; Oct</div>
+          </div>
+          <p>Two of the <strong>stronger months for gold demand</strong>, frequently showing above-average price performance in years when no larger market factor is overriding the seasonal pattern.</p>
+        </div>
+      </div>
+
+      <div class="warning-callout reveal">
+        <p><strong>Important caveat:</strong> These seasonal tendencies are real in aggregate across many years, but they are weak and frequently overwhelmed by bigger factors. In 2025, gold rose dramatically all year regardless of seasonality. In 2020, COVID disrupted every conventional pattern. In any year with major geopolitical events, Fed decisions, or data surprises, seasonal tendencies are simply noise.</p>
+        <p>The practical conclusion: <strong>do not hold off selling for months hoping to catch a seasonal peak.</strong> The seasonal premium, at best, is a few percentage points; the risk of prices moving against you over the same window is larger. Seasonal awareness is a tiebreaker, not a strategy.</p>
+      </div>
+
+      <h2 id="worth" class="reveal"><span class="h2-num">06</span>How Much Is Scrap Gold Worth in 2026?</h2>
+      <p class="reveal">The value of scrap gold depends on two things you can look up in five minutes: the current spot price and the karat of your gold. The tool below pulls the <strong>live USD gold spot price</strong> from our market feed &mdash; refreshed every 60 seconds &mdash; and shows both the theoretical melt value and a realistic dealer offer range in your choice of currency, with USD as the default.</p>
+
+      <div class="gf-calc reveal" id="gtCalc">
+        <div class="gf-calc__head">
+          <div class="gf-calc__title-block">
+            <div class="gf-calc__eyebrow">Live Tool &middot; Updates every 60 seconds</div>
+            <h3 class="gf-calc__title">Scrap Gold Melt &amp; Offer Calculator</h3>
+            <p class="gf-calc__sub">Enter your piece's weight and karat. We multiply by the gold purity, apply the live USD spot price, and show the realistic buyer offer.</p>
+          </div>
+          <span class="live-pill live-pill--idle" id="gtLive">
+            <span class="live-pill__dot"></span>
+            <span id="gtLiveText">Connecting</span>
+          </span>
+        </div>
+
+        <div class="gf-calc__grid">
+          <div class="gf-calc__controls">
+            <div class="gf-field">
+              <label class="gf-label" for="gtWeight">Total weight</label>
+              <div class="gf-unit-toggle" role="group" aria-label="Weight unit">
+                <button type="button" class="gf-unit-btn is-active" data-unit="g">Grams (g)</button>
+                <button type="button" class="gf-unit-btn" data-unit="oz">Troy oz</button>
+              </div>
+              <input class="gf-input" type="number" id="gtWeight" placeholder="e.g. 10" min="0" step="0.1" inputmode="decimal" aria-label="Total weight">
+            </div>
+
+            <div class="gf-field">
+              <span class="gf-label">Karat (purity)</span>
+              <div class="gf-karat-grid" role="group" aria-label="Karat selector">
+                <button type="button" class="gf-karat-btn" data-karat="9K" data-purity="0.375">9K</button>
+                <button type="button" class="gf-karat-btn" data-karat="10K" data-purity="0.4167">10K</button>
+                <button type="button" class="gf-karat-btn" data-karat="12K" data-purity="0.5">12K</button>
+                <button type="button" class="gf-karat-btn is-active" data-karat="14K" data-purity="0.5833">14K</button>
+                <button type="button" class="gf-karat-btn" data-karat="18K" data-purity="0.75">18K</button>
+                <button type="button" class="gf-karat-btn" data-karat="22K" data-purity="0.9167">22K</button>
+                <button type="button" class="gf-karat-btn" data-karat="24K" data-purity="0.999">24K</button>
+              </div>
+            </div>
+
+            <div class="gf-field">
+              <label class="gf-label" for="gtCurrency">Display currency</label>
+              <select class="gf-select" id="gtCurrency">
+                <option value="USD" selected>USD &middot; US Dollar (primary)</option>
+                <option value="EUR">EUR &middot; Euro</option>
+                <option value="GBP">GBP &middot; British Pound</option>
+                <option value="CAD">CAD &middot; Canadian Dollar</option>
+                <option value="AUD">AUD &middot; Australian Dollar</option>
+                <option value="INR">INR &middot; Indian Rupee</option>
+                <option value="AED">AED &middot; UAE Dirham</option>
+                <option value="JPY">JPY &middot; Japanese Yen</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="gf-calc__result">
+            <div id="gtPlaceholder" class="gf-placeholder">Enter a weight to see the live melt value and realistic offer range.</div>
+            <div id="gtOutput" style="display:none;flex-direction:column;gap:var(--space-4)">
+              <div class="gf-result-primary">
+                <div class="gf-result-primary__label">Theoretical melt value</div>
+                <div class="gf-result-primary__value" id="gtMeltValue">$0.00</div>
+                <div class="gf-result-primary__note">Pure-gold content &times; live spot price</div>
+              </div>
+              <div class="gf-result-offer">
+                <div class="gf-result-offer__label">Realistic dealer offer (70&ndash;92% of melt)</div>
+                <div class="gf-result-offer__value" id="gtOfferValue">$0 &ndash; $0</div>
+              </div>
+              <div class="gf-stats">
+                <div class="gf-stat">
+                  <div class="gf-stat__label">Fine gold content</div>
+                  <div class="gf-stat__value" id="gtPureGrams">&mdash; g</div>
+                </div>
+                <div class="gf-stat">
+                  <div class="gf-stat__label">Price / gram (this karat)</div>
+                  <div class="gf-stat__value" id="gtPricePerGram">$&mdash;</div>
+                </div>
+              </div>
+              <div class="gf-spot-line">Live spot <strong id="gtSpotLine">$&mdash; / oz</strong> &middot; updated <span id="gtUpdated">&mdash;</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p class="reveal">For quick reference, here is what common items are worth at a representative spot near $4,750/oz, assuming an <strong>85% specialist payout</strong>. Treat these as illustrative &mdash; the live tool above shows exact current values:</p>
+
+      <div class="table-scroll reveal">
+        <table style="min-width:600px">
+          <thead>
+            <tr>
+              <th>Item</th>
+              <th>Typical Weight</th>
+              <th>Karat</th>
+              <th>Approx. Payout (USD)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Plain ring (band)</td><td>3&ndash;5g</td><td><span class="hmark">9K</span></td><td><span class="usd">$145&ndash;$245</span></td></tr>
+            <tr><td>Necklace / chain</td><td>5&ndash;10g</td><td><span class="hmark">9K</span></td><td><span class="usd">$245&ndash;$485</span></td></tr>
+            <tr><td>Bracelet</td><td>8&ndash;15g</td><td><span class="hmark">9K</span></td><td><span class="usd">$390&ndash;$730</span></td></tr>
+            <tr><td>Earrings (pair)</td><td>2&ndash;4g</td><td><span class="hmark">18K</span></td><td><span class="usd">$195&ndash;$390</span></td></tr>
+            <tr><td>Wedding ring</td><td>4&ndash;7g</td><td><span class="hmark">18K</span></td><td><span class="usd">$390&ndash;$680</span></td></tr>
+            <tr><td>Bangle</td><td>8&ndash;15g</td><td><span class="hmark">22K</span></td><td><span class="usd">$950&ndash;$1,785</span></td></tr>
+            <tr><td>Gold sovereign coin</td><td>~8g gold</td><td><span class="hmark">22K</span></td><td><span class="usd">~$950</span></td></tr>
+            <tr><td>Dental crown</td><td>2&ndash;4g</td><td>~16K</td><td><span class="usd">$175&ndash;$345</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="reveal">Pawn shops and storefront "cash for gold" operations typically pay <strong>40&ndash;65% of melt value</strong> &mdash; a meaningful difference on larger quantities, and the single biggest reason to compare buyers before you sell.</p>
+
+      <h2 id="where-to-sell" class="reveal"><span class="h2-num">07</span>Where to Sell Scrap Gold: Payouts Compared</h2>
+      <p class="reveal">Where you sell matters as much as when. Getting the timing right and then accepting 50% of melt from an opportunistic buyer wastes the whole advantage. Here is roughly what each channel pays, as a share of melt value:</p>
+
+      <div class="acc-compare reveal" id="payoutCompare">
+        <div class="acc-compare__head">
+          <div>
+            <h3 class="acc-compare__title">Typical payout by buyer type</h3>
+            <div class="acc-compare__caption">% of melt value &middot; higher is better for you</div>
+          </div>
+          <div class="acc-tabs" role="group" aria-label="Filter buyers">
+            <button type="button" class="acc-tab is-active" data-filter="all" aria-pressed="true">All</button>
+            <button type="button" class="acc-tab" data-filter="online" aria-pressed="false">Online</button>
+            <button type="button" class="acc-tab" data-filter="inperson" aria-pressed="false">In person</button>
+          </div>
+        </div>
+        <div class="acc-list">
+          <div class="acc-row acc--high" data-tier="online" style="--w:95%">
+            <div class="acc-row__top">
+              <span class="acc-row__name"><span class="acc-row__rank">01</span>Specialist online gold buyers &amp; refiners <span class="acc-row__tier">Top</span></span>
+              <span class="acc-row__score">85&ndash;95%</span>
+            </div>
+            <div class="acc-track"><div class="acc-fill"></div></div>
+          </div>
+          <div class="acc-row acc--high" data-tier="inperson" style="--w:92%">
+            <div class="acc-row__top">
+              <span class="acc-row__name"><span class="acc-row__rank">02</span>Specialist dealers (in person) <span class="acc-row__tier">High</span></span>
+              <span class="acc-row__score">82&ndash;92%</span>
+            </div>
+            <div class="acc-track"><div class="acc-fill"></div></div>
+          </div>
+          <div class="acc-row acc--medium" data-tier="inperson" style="--w:75%">
+            <div class="acc-row__top">
+              <span class="acc-row__name"><span class="acc-row__rank">03</span>Local jewelers <span class="acc-row__tier">Mixed</span></span>
+              <span class="acc-row__score">55&ndash;75%</span>
+            </div>
+            <div class="acc-track"><div class="acc-fill"></div></div>
+          </div>
+          <div class="acc-row acc--low" data-tier="inperson" style="--w:65%">
+            <div class="acc-row__top">
+              <span class="acc-row__name"><span class="acc-row__rank">04</span>Pawn shops <span class="acc-row__tier">Low</span></span>
+              <span class="acc-row__score">40&ndash;65%</span>
+            </div>
+            <div class="acc-track"><div class="acc-fill"></div></div>
+          </div>
+          <div class="acc-row acc--low" data-tier="online" style="--w:55%">
+            <div class="acc-row__top">
+              <span class="acc-row__name"><span class="acc-row__rank">05</span>Mail-in "cash for gold" promos <span class="acc-row__tier">Low</span></span>
+              <span class="acc-row__score">35&ndash;55%</span>
+            </div>
+            <div class="acc-track"><div class="acc-fill"></div></div>
+          </div>
+        </div>
+        <p class="acc-compare__foot">Specialist online buyers and refiners with direct refinery access lead on price because they cut out the middleman. Auction houses sit outside this scale &mdash; for antique or collectible pieces they can pay well <em>above</em> melt (see below).</p>
+      </div>
+
+      <h4 class="reveal">How the leading channels work</h4>
+      <ul class="reveal">
+        <li><strong>Specialist online buyers &amp; refiners</strong> &mdash; request a free insured mail-in pack, send via tracked, insured delivery (USPS Registered Mail, UPS, or Royal Mail Special Delivery), receive an offer within 24&ndash;48 hours, and accept payment by bank transfer &mdash; or have items returned free of charge. Best for all karats, mixed lots, dental gold, and broken pieces. Verify the buyer's reviews independently before sending anything.</li>
+        <li><strong>In-person specialist dealers</strong> &mdash; bullion dealers with in-house refinery links offer rates comparable to the best online buyers, with same-day assessment and payment. In the US, the New York Diamond District (47th Street) and major-city dealers; in the UK, London's Hatton Garden and Birmingham's Jewellery Quarter. For larger quantities, in-person dealers may negotiate above their published rates.</li>
+        <li><strong>Local jewelers</strong> &mdash; competitive for pieces in good, resellable condition (they value them as jewelry, not just metal), but weaker on plain broken scrap, which they must sell on to a wholesaler.</li>
+        <li><strong>Online marketplaces (eBay etc.)</strong> &mdash; possible for unusual lots with collector interest, but selling fees, bargain hunters, payment disputes, and shipping risk make it a poor default for ordinary scrap.</li>
+      </ul>
+
+      <h2 id="best-price" class="reveal"><span class="h2-num">08</span>How to Get the Best Price When You Sell</h2>
+      <p class="reveal">Beyond choosing the right buyer type, a few habits make a real difference to what you receive:</p>
+
+      <ul class="step-list reveal">
+        <li class="step-block">
+          <div class="step-number">1</div>
+          <div class="step-content">
+            <strong>Know your melt value before approaching anyone</strong>
+            <p>Use a live <a href="/scrap-gold-calculator">scrap gold calculator</a> to find what your gold is worth at today's USD spot price. Weight &times; purity fraction &times; price per gram = melt value. An offer at 90% of melt is excellent; an offer at 50% deserves to be declined.</p>
+          </div>
+        </li>
+        <li class="step-block">
+          <div class="step-number">2</div>
+          <div class="step-content">
+            <strong>Weigh everything yourself first</strong>
+            <p>A kitchen scale accurate to 0.1 grams costs about $10. Weigh each karat separately and record the results. When a buyer weighs your items, confirm their numbers match yours &mdash; discrepancies over 0.2&ndash;0.3 grams should prompt a question.</p>
+          </div>
+        </li>
+        <li class="step-block">
+          <div class="step-number">3</div>
+          <div class="step-content">
+            <strong>Get at least two quotes</strong>
+            <p>The spread between buyers can be striking. Sending photos and weights to two or three specialists before deciding costs nothing and takes twenty minutes. On a $650 lot, the gap between a 75% and a 92% payout is over $110 &mdash; found money for minimal effort.</p>
+          </div>
+        </li>
+        <li class="step-block">
+          <div class="step-number">4</div>
+          <div class="step-content">
+            <strong>Don't mix karats</strong>
+            <p>Keep <span class="hmark">9K</span>, <span class="hmark">14K</span>, and <span class="hmark">18K</span> pieces separate. Buyers price each karat individually; presenting them mixed makes it easier for a buyer to apply the lowest rate to the whole lot.</p>
+          </div>
+        </li>
+        <li class="step-block">
+          <div class="step-number">5</div>
+          <div class="step-content">
+            <strong>Check whether any item has non-scrap value</strong>
+            <p>Before submitting a lot, look at each piece. Antique and hallmarked items, branded pieces (Tiffany, Cartier, Georg Jensen), and coins with numismatic interest should be assessed by a specialist first. Melt value is always the floor; for special pieces it should not be the ceiling.</p>
+          </div>
+        </li>
+      </ul>
+
+      <h2 id="auction" class="reveal"><span class="h2-num">09</span>Scrap Gold vs. Auction: When the Math Changes</h2>
+      <p class="reveal">Most broken or plain scrap gold is genuinely best sold for its metal value &mdash; there is no premium available elsewhere. But specific categories leave real money behind when sold as scrap:</p>
+      <ul class="reveal">
+        <li><strong>Antique hallmarked pieces</strong> with clear date letters and assay marks &mdash; particularly Victorian and Edwardian jewelry &mdash; attract collector interest beyond their metal value.</li>
+        <li><strong>Georgian jewelry</strong> (pre-1837) is rare enough that even modest pieces regularly sell at auction above melt.</li>
+        <li><strong>Signed pieces</strong> from known makers may be identifiable through maker's marks and carry collector value.</li>
+        <li><strong>Gold coins with numismatic interest</strong> &mdash; older sovereigns and foreign coins in good condition &mdash; should be appraised by a coin specialist before being sold as bullion.</li>
+        <li><strong>Pieces with intact gemstones</strong> &mdash; a genuine diamond, sapphire, or ruby is worth more than the gold alone, even if the setting is damaged.</li>
+      </ul>
+      <p class="reveal">If you are unsure whether a piece qualifies, a fifteen-minute visit to a reputable auction house's free valuation day will answer the question quickly.</p>
+
+      <h2 id="bottom-line" class="reveal"><span class="h2-num">10</span>The Bottom Line: Is Now a Good Time?</h2>
+      <p class="reveal">For gold you genuinely do not need &mdash; broken jewelry, single pieces, inherited items you have no connection to &mdash; <strong>2026 is one of the best selling environments in living memory</strong>.</p>
+
+      <div class="pull-quote reveal">If someone offered to buy something you do not want, at the best price it has ever commanded, would you say yes? For most scrap gold sellers, the answer is straightforward.</div>
+
+      <p class="reveal">Gold is near all-time highs in US dollars. The structural factors supporting the price &mdash; central-bank demand, geopolitical uncertainty, inflation sensitivity &mdash; remain intact, and institutional forecasts suggest it could go higher still. But for a private seller with no ongoing use for their gold, "could go higher" is not a reason to wait indefinitely. Set your floor against the live price, get two or three quotes, and sell to whoever pays closest to melt.</p>
+
+      <h2 id="faq" class="reveal"><span class="h2-num">11</span>Frequently Asked Questions</h2>
+      <div class="faq-accordion reveal">
+        <details class="faq-item">
+          <summary>Is now a good time to sell gold in 2026?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>Yes. Gold is trading near all-time highs in USD &mdash; around <strong>$4,750 per troy ounce</strong> as of mid-2026, not far below the January 2026 record of $5,589/oz. For scrap gold and unwanted jewelry, current prices are a generational selling opportunity. Forecasts from JP Morgan and Deutsche Bank suggest further upside is possible, though uncertain. For gold you do not need, there is no compelling reason to wait.</p></div>
+        </details>
+        <details class="faq-item">
+          <summary>How much is scrap gold worth per gram?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>At a representative spot near $4,750/oz, approximate melt values per gram are: <span class="hmark">9K</span> &mdash; $57/g; <span class="hmark">10K</span> &mdash; $64/g; <span class="hmark">14K</span> &mdash; $89/g; <span class="hmark">18K</span> &mdash; $115/g; <span class="hmark">22K</span> &mdash; $140/g; <span class="hmark">24K</span> &mdash; $153/g. Most buyers pay 70&ndash;92% of these melt values. Use our <a href="/scrap-gold-calculator">scrap gold calculator</a> for exact live figures at the current USD spot price, refreshed every 60 seconds.</p></div>
+        </details>
+        <details class="faq-item">
+          <summary>What is the best place to sell scrap gold?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>Specialist online gold buyers and bullion dealers with direct refinery access consistently offer the highest payouts &mdash; typically <strong>85&ndash;95% of melt value</strong>. Local jewelers and pawn shops typically pay 40&ndash;75%. For pieces with potential collector or antique value, an auction house is worth considering before committing to a scrap sale.</p></div>
+        </details>
+        <details class="faq-item">
+          <summary>How do I sell scrap gold online?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>Request a free insured mail-in kit from a reputable specialist buyer, package your gold carefully, send it via tracked and insured delivery, receive an offer within 24&ndash;48 hours, and accept payment by bank transfer or have items returned. <strong>Always weigh and calculate your melt value first</strong> so you can evaluate any offer. Getting quotes from two or three buyers takes twenty minutes and often adds meaningful value.</p></div>
+        </details>
+        <details class="faq-item">
+          <summary>Is scrap gold worth anything?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>Very much so at current prices. A plain <span class="hmark">9K</span> gold ring weighing 4 grams has a scrap value of roughly <strong>$195 at an 85% payout</strong>. A 10-gram <span class="hmark">18K</span> chain is worth around $975. Even small quantities &mdash; including dental gold and broken pieces &mdash; are worth real money at 2026 prices.</p></div>
+        </details>
+        <details class="faq-item">
+          <summary>What time does the gold rate change daily?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>The gold spot price changes <strong>continuously during market hours</strong> (Sunday evening to Friday evening, New York time). There is no single daily "change time" &mdash; prices move every second in response to trades, news, and data. However, the LBMA sets official benchmark fixes at <strong>10:30 AM and 3:00 PM London time</strong> on weekdays, and most buyers update their published rates against these benchmarks.</p></div>
+        </details>
+        <details class="faq-item">
+          <summary>Should I sell my gold for scrap or at auction?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>It depends on the piece. Plain, mass-produced, or broken gold is almost always best sold as scrap &mdash; there is no collector premium to capture. Antique, hallmarked, signed, or historically significant pieces can achieve prices well above melt value at auction. <strong>If you are uncertain, a free auction-house valuation</strong> is the quickest way to find out.</p></div>
+        </details>
+        <details class="faq-item">
+          <summary>Where can I find scrap gold buyers near me?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>Search "scrap gold buyers near me" to find local gold dealers, jewelers, and bullion shops. In the US, <strong>New York's Diamond District (47th Street)</strong> and major-city bullion dealers are hubs; in the UK, <strong>London's Hatton Garden</strong> and Birmingham's Jewellery Quarter. Online specialist buyers are often the better choice on price regardless of location, as they offer insured shipping, publish live rates, and have verifiable reviews.</p></div>
+        </details>
+      </div>
+
+    </div><!-- /prose -->
+
+    <div class="disclaimer-box">
+      <strong>Editorial note:</strong> Live gold spot prices are quoted in USD, sourced from gold-api.com and refreshed every 60 seconds; conversions to other currencies are indicative. Per-gram and item values are illustrative at a representative spot price near $4,750/oz and change continuously &mdash; always use the live calculator for current melt values before selling. This article is for informational purposes only and is not financial advice.
+    </div>
+  </main>
+</div>
+
+<button class="toc-fab" id="tocFab" aria-label="Open table of contents" aria-expanded="false">
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+  Contents
+</button>
+<div class="toc-sheet" id="tocSheet" role="dialog" aria-modal="true" aria-label="Table of contents">
+  <div class="toc-sheet__panel">
+    <div class="toc-sheet__head">
+      <span class="toc-sheet__title">In this guide</span>
+      <button class="toc-sheet__close" id="tocSheetClose" aria-label="Close table of contents">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+    </div>
+    <ol class="toc-sheet__list">
+      <li><a href="#prices">01 &middot; Where Prices Stand</a></li>
+      <li><a href="#is-now">02 &middot; Is Now a Good Time?</a></li>
+      <li><a href="#wait">03 &middot; Should You Wait?</a></li>
+      <li><a href="#timing">04 &middot; When the Rate Changes</a></li>
+      <li><a href="#seasonal">05 &middot; Seasonal Patterns</a></li>
+      <li><a href="#worth">06 &middot; What It's Worth</a></li>
+      <li><a href="#where-to-sell">07 &middot; Where to Sell</a></li>
+      <li><a href="#best-price">08 &middot; Get the Best Price</a></li>
+      <li><a href="#auction">09 &middot; Scrap vs Auction</a></li>
+      <li><a href="#bottom-line">10 &middot; The Bottom Line</a></li>
+      <li><a href="#faq">11 &middot; FAQ</a></li>
+    </ol>
   </div>
+</div>
 
-  <div class="prose">
-
-    <p>There is a gold ring sitting in a drawer somewhere that you have been meaning to do something about for three years. Or a tangle of broken chains. Or the set of earrings from an ex-partner that you kept telling yourself you would sell eventually. If you are one of the millions of people who have spent any time wondering whether now is actually a good time to do it — the answer in 2026 is that conditions are about as favourable as they have been in modern history.</p>
-    <p>But saying "the price is high" is not the same as knowing whether to sell today, wait until autumn, or hold out for an even higher price next year. Gold market timing is a real thing, and understanding how it works — both on the macro scale and the day-to-day level — is the difference between getting a solid deal and leaving meaningful money on the table.</p>
-
-    <div class="exec-summary">
-      <p class="exec-summary-intro">This guide covers everything: where gold prices stand and where they are headed, what the seasonal patterns actually show, <strong>when during the day the gold rate changes</strong> and why it matters, where to sell for the best price, and the practical things that most guides forget to mention.</p>
-      <div class="exec-summary-stats">
-        <div class="exec-stat">
-          <div class="exec-stat-label">2026 Gold ATH</div>
-          <div class="exec-stat-value">$5,589/oz</div>
-        </div>
-        <div class="exec-stat">
-          <div class="exec-stat-label">GBP Price (May 2026)</div>
-          <div class="exec-stat-value">~£3,472/oz</div>
-        </div>
-        <div class="exec-stat">
-          <div class="exec-stat-label">Best payout rate</div>
-          <div class="exec-stat-value">85–95%</div>
-        </div>
-        <div class="exec-stat">
-          <div class="exec-stat-label">LBMA Fix Times</div>
-          <div class="exec-stat-value">10:30 &amp; 15:00</div>
-        </div>
-      </div>
-    </div>
-
-    <h2 id="prices">Where Gold Prices Stand Right Now</h2>
-    <p>Before talking about timing, you need to understand the baseline — and the baseline in 2026 is extraordinary.</p>
-    <p>Gold reached an all-time high of <strong>$5,589.38 per troy ounce</strong> in January 2026, then pulled back and has been trading in the $4,700–$5,000 range through the spring. In sterling terms, the peak hit £4,068 per ounce on 2nd March 2026, before settling back to approximately <strong>£3,472 per troy ounce</strong> as of late April.<sup>1</sup> That means current scrap gold prices per gram, before buyer margins, are approximately:</p>
-
-    <div class="table-scroll">
-      <table>
-        <thead>
-          <tr>
-            <th>Carat</th>
-            <th>Scrap Price Per Gram (GBP, approx.)</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr><td><span class="hmark">9ct</span></td><td>£41.87<sup>3</sup></td></tr>
-          <tr><td><span class="hmark">14ct</span></td><td>£65.32<sup>3</sup></td></tr>
-          <tr><td><span class="hmark">18ct</span></td><td>£83.75<sup>3</sup></td></tr>
-          <tr><td><span class="hmark">22ct</span></td><td>£102.28<sup>3</sup></td></tr>
-          <tr><td><span class="hmark">24ct</span></td><td>£111.55<sup>3</sup></td></tr>
-        </tbody>
-      </table>
-    </div>
-
-    <p>These are melt values — what the gold itself is worth before the buyer takes their margin. Most reputable specialist buyers pay <strong>80–95% of melt value</strong>. That means for a <span class="hmark">9ct</span> gold bracelet weighing 10 grams, a good buyer is likely to offer you somewhere between <strong>£335 and £398</strong>.<sup>3</sup></p>
-    <p>To put these numbers in historical context: a year ago, the same 9ct bracelet would have fetched around £260. Two years ago, around £200. The price has moved so significantly that the gold in ordinary household jewellery has effectively doubled or trebled in value in the space of thirty-six months.<sup>4</sup></p>
-
-    <div class="cta-box">
-      <h3>Calculate Your Scrap Gold Value</h3>
-      <p>Enter your gold's karat and weight to find its live melt value at today's spot price — updated every 60 seconds.</p>
-      <a href="/scrap-gold-calculator" class="cta-btn">Open Scrap Gold Calculator &rarr;</a>
-    </div>
-
-    <h2 id="is-now-good">Is Now a Good Time to Sell Gold?</h2>
-    <p>For scrap gold sellers — people selling unwanted jewellery, broken pieces, or items they no longer use — the honest answer is yes, <strong>2026 is an excellent time</strong>.<sup>1</sup></p>
-    <p>Here is why that answer is fairly clear:</p>
-    <ul>
-      <li><strong>You are not giving up future use.</strong> Scrap gold is, by definition, gold you do not need. An intact, wearable piece you love is a different conversation. But a broken chain, a single earring, an inherited ring that has been in a box for a decade — none of these are serving you. Selling them now at record-high prices is straightforwardly sensible.</li>
-      <li><strong>Prices are near historic highs.</strong> Gold is not at its absolute January 2026 peak, but it remains close to it. The gap between today's price and the all-time high is roughly 15–20% — and while prices could continue rising, they could equally pull back. Nobody rings a bell at the top of any market.</li>
-      <li><strong>The structural drivers remain in place.</strong> Major financial institutions including JP Morgan, Deutsche Bank, and UBS all maintain bullish outlooks for gold through 2026 and 2027. The core reasons — central bank buying, persistent inflation concerns, geopolitical instability, and ongoing dollar weakness — have not resolved. This supports the view that prices are likely to remain elevated, though exactly where they go from here is genuinely uncertain.<sup>6</sup></li>
-    </ul>
-
-    <div class="info-callout">
-      <p><strong>The counterargument is real but not compelling for scrap sellers.</strong> The case for waiting is essentially: what if prices go higher? JP Morgan's forecast of $5,055–$6,300 by year-end is plausible. If gold reaches $6,300 and you sold at today's price, you would have received less than you could have. But gold could equally drop to $4,000 on a geopolitical shift, a strong dollar recovery, or a surprise rate move. For scrap gold you do not need, the risk of waiting is asymmetric in a way that rarely favours the seller.<sup>7</sup></p>
-    </div>
-
-    <h2 id="wait">Should You Wait for a Higher Price? The Honest Assessment</h2>
-    <p>The question "should I sell my gold now or wait?" comes up constantly, and the answer depends heavily on what you are selling and why.</p>
-    <p>For broken jewellery, single earrings, dental gold, and pieces you genuinely have no use for, the rational answer is nearly always to <strong>sell at a good price rather than trying to time the market precisely</strong>. The reason is simple: you are not invested in gold as a strategy. You have gold through happenstance — inheritance, gifts, relationships, purchases that no longer reflect who you are. Trying to trade your accidental gold position like an investment is adding a layer of complexity to what is fundamentally a decluttering exercise.<sup>1</sup></p>
-    <p>For investment-grade gold — coins, bars, deliberate holdings — the calculation is different, and this article is less relevant.</p>
-    <p>The practical approach most sellers find useful: <strong>set a floor price rather than a target.</strong> Decide what your items are worth at today's prices. If you receive a solid offer above that floor, accept it. Do not hold out indefinitely for a price that may or may not materialise.</p>
-
-    <h2 id="timing">Gold Market Timing: When Does the Gold Rate Change?</h2>
-    <p>The question "at what time does the gold price change?" is common, and the answer involves understanding how gold markets actually work.</p>
-    <p>Gold trades on the global over-the-counter (OTC) market and on exchanges including COMEX in New York and the Shanghai Gold Exchange. The spot market is open approximately 23 hours a day, five days a week — from Sunday evening through Friday evening UK time, with only a brief daily maintenance pause.<sup>9</sup> This means the gold price is <strong>changing continuously during market hours</strong>, not just once per day.</p>
-
-    <h3>The LBMA Gold Price Fix</h3>
-    <p>The London Bullion Market Association (LBMA) sets an official benchmark price for gold twice daily — at <strong>10:30 AM and 3:00 PM London time (GMT)</strong>. These are known as the AM and PM fixes. Most of the world's gold transactions, including scrap gold purchases from the public, are priced against these benchmarks.<sup>9</sup></p>
-    <p>When a scrap gold buyer advertises their rates, they typically base them on the most recent LBMA fix. That means their published rates <strong>update twice a day on working days</strong>. On volatile price days, some buyers will update more frequently to protect their margins.</p>
-
-    <h3>The London–New York Overlap Window</h3>
-    <p>For those interested in understanding when gold prices are most actively traded, the most significant window is the <strong>London–New York overlap, roughly 1:00 PM to 5:00 PM UK time</strong>. During these four hours, both the London OTC market and the New York COMEX exchange are simultaneously active, creating the highest liquidity of the trading day and the tightest bid-ask spreads.<sup>9</sup></p>
-
-    <div class="info-callout">
-      <p><strong>Practical note for UK scrap sellers:</strong> If gold has had a notably strong day — up 1–2% — and you are in the middle of a sale discussion, it is worth asking whether the buyer's quoted rate reflects today's price or is based on yesterday's close. Reputable buyers will tell you honestly. On stable market days (which is most days), this is a non-issue. The bigger variable is not time of day but <strong>choice of buyer</strong>, which is worth far more attention than micro-timing your transaction.</p>
-    </div>
-
-    <h2 id="seasonal">Seasonal Gold Price Patterns: What the Data Shows</h2>
-    <p>Gold prices follow a loose seasonal pattern — loose enough to be interesting but not reliable enough to build a selling strategy around. Historical price data over several decades shows these recurring tendencies:</p>
-
-    <div class="season-grid">
-      <div class="season-card">
-        <div class="season-card__header">
-          <span class="season-card__period season-card__period--strong">Typically Strong</span>
-          <div class="season-card__name">Q1 — Jan to Mar</div>
-        </div>
-        <p>Fresh investment inflows at the start of the new financial year, demand ahead of <strong>Chinese New Year</strong> (usually late January or February), and continued momentum from the previous year's end combine to push prices higher in many years.<sup>12</sup></p>
-      </div>
-      <div class="season-card">
-        <div class="season-card__header">
-          <span class="season-card__period season-card__period--soft">Typically Soft</span>
-          <div class="season-card__name">Summer — Jun &amp; Jul</div>
-        </div>
-        <p>Historically a softer period. Trading volumes thin out as institutional participants take summer leave, and the big seasonal demand events — Chinese New Year, Indian wedding season, Christmas — are all months away. <strong>Early July is sometimes described as the seasonal low point</strong> in gold markets.<sup>5</sup></p>
-      </div>
-      <div class="season-card">
-        <div class="season-card__header">
-          <span class="season-card__period season-card__period--recovery">Recovery</span>
-          <div class="season-card__name">Autumn — Aug to Nov</div>
-        </div>
-        <p>Demand tends to recover through this period, driven by the <strong>Indian festival and wedding season</strong> (Diwali, Dussehra), increased institutional activity as portfolio managers position for the year ahead, and building anticipation for the Christmas and Chinese New Year buying periods.<sup>13</sup></p>
-      </div>
-      <div class="season-card">
-        <div class="season-card__header">
-          <span class="season-card__period season-card__period--strong">Historically Strong</span>
-          <div class="season-card__name">Sep &amp; Oct</div>
-        </div>
-        <p>Historically two of the <strong>stronger months for gold demand</strong>, frequently showing above-average price performance in years when no other major market factor is overriding the seasonal pattern.<sup>5</sup></p>
-      </div>
-    </div>
-
-    <div class="warning-callout">
-      <p><strong>Important caveat:</strong> These seasonal tendencies are real in aggregate across many years of data, but they are weak and frequently overwhelmed by more significant factors. In 2025, gold rose dramatically throughout the year despite whatever seasonal patterns were supposed to apply. In 2020, COVID disrupted every conventional seasonal pattern. In any year with significant geopolitical events, Federal Reserve decisions, or major economic data surprises, seasonal tendencies are simply irrelevant noise.<sup>8</sup></p>
-      <p>The practical conclusion for most scrap gold sellers: <strong>do not hold off selling for months hoping to catch a seasonal peak.</strong> The seasonal premium, even in the best-case scenario, is a few percentage points at most. The risk of prices moving against you over a similar period is larger. Seasonal awareness is a tiebreaker, not a strategy.</p>
-    </div>
-
-    <h2 id="worth">How Much Is Scrap Gold Worth in 2026?</h2>
-    <p>The value of scrap gold depends on two things you can look up in five minutes: the current spot price and the karat of your gold. Here is what May 2026 prices look like in practice, at approximately <strong>85% buyer payout</strong>:<sup>3</sup></p>
-
-    <div class="table-scroll">
-      <table style="min-width:640px">
-        <thead>
-          <tr>
-            <th>Item</th>
-            <th>Typical Weight</th>
-            <th>Karat</th>
-            <th>Approximate Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr><td>9ct ring (plain band)</td><td>3–5g</td><td><span class="hmark">9ct</span></td><td>£107–£178</td></tr>
-          <tr><td>9ct necklace</td><td>5–10g</td><td><span class="hmark">9ct</span></td><td>£178–£356</td></tr>
-          <tr><td>9ct gold bracelet</td><td>8–15g</td><td><span class="hmark">9ct</span></td><td>£285–£534</td></tr>
-          <tr><td>18ct earrings (pair)</td><td>2–4g</td><td><span class="hmark">18ct</span></td><td>£142–£284</td></tr>
-          <tr><td>18ct wedding ring</td><td>4–7g</td><td><span class="hmark">18ct</span></td><td>£284–£498</td></tr>
-          <tr><td>22ct bangle</td><td>8–15g</td><td><span class="hmark">22ct</span></td><td>£700–£1,313</td></tr>
-          <tr><td>Gold sovereign coin</td><td>~8g gold content</td><td><span class="hmark">22ct</span></td><td>~£700</td></tr>
-          <tr><td>Single gold crown (dental)</td><td>2–4g</td><td>~16ct avg</td><td>£114–£228</td></tr>
-        </tbody>
-      </table>
-    </div>
-
-    <p>These estimates assume a reputable buyer paying approximately 85% of melt value, which is broadly achievable through specialist online or bullion dealer channels. Pawn shops and cash-for-gold high street operations typically pay <strong>40–65% of melt value</strong> — a meaningful difference on larger quantities.<sup>15</sup></p>
-
-    <h2 id="where-to-sell">Where to Sell Scrap Gold: Your Options Compared</h2>
-    <p>Where you sell is as important as when you sell. Getting the timing right but then accepting 50% of melt value from an opportunistic buyer wastes the advantage entirely.</p>
-
-    <div class="buyer-grid">
-      <div class="buyer-option">
-        <div class="buyer-option__header">
-          <div class="buyer-option__title">Specialist Online Gold Buyers</div>
-          <span class="buyer-payout buyer-payout--high">85–95%</span>
-        </div>
-        <p>Companies whose sole business is purchasing and refining precious metals from private sellers consistently offer the <strong>highest payout rates for scrap gold</strong>. Request a free insured postal pack, send via Royal Mail tracked and insured delivery, receive an offer within 24–48 hours, and accept payment by bank transfer within 24 hours of acceptance — or have your items returned free of charge.<sup>16</sup></p>
-        <ul>
-          <li>Well-regarded UK buyers: Hatton Garden Metals, The Pure Gold Company, Gold Traders, Cash4Gold-Now</li>
-          <li>Best for: all karat levels, mixed lots, dental gold, broken pieces</li>
-          <li>Verify independently via Trustpilot before sending any items</li>
-        </ul>
-      </div>
-      <div class="buyer-option">
-        <div class="buyer-option__header">
-          <div class="buyer-option__title">Specialist Gold Dealers (In-Person)</div>
-          <span class="buyer-payout buyer-payout--high">82–92%</span>
-        </div>
-        <p>Bullion dealers with in-house refinery connections — including those in <strong>Hatton Garden (London)</strong> and <strong>Birmingham's Jewellery Quarter</strong> — offer rates comparable to the best online buyers, with the advantage of same-day assessment and payment. For larger quantities, in-person dealers may negotiate above their standard published rates.<sup>16</sup></p>
-        <ul>
-          <li>Best for: larger volumes, bullion coins, when you want in-person assessment</li>
-          <li>Can compare multiple dealers in the same area on the same day</li>
-        </ul>
-      </div>
-      <div class="buyer-option">
-        <div class="buyer-option__header">
-          <div class="buyer-option__title">Local Jewellers</div>
-          <span class="buyer-payout buyer-payout--mid">55–75%</span>
-        </div>
-        <p>Local jewellers will test and value your gold. For pieces in good condition with genuine resale potential they can be competitive — because they are assessing the piece as sellable jewellery rather than just as metal. For <strong>broken items or lower-quality scrap</strong>, they tend to pay less than specialist buyers because they must sell scrap on to a wholesale buyer.<sup>20</sup></p>
-        <ul>
-          <li>Best for: good condition vintage pieces, branded jewellery, pieces with stones</li>
-          <li>Not optimal for plain broken scrap</li>
-        </ul>
-      </div>
-      <div class="buyer-option">
-        <div class="buyer-option__header">
-          <div class="buyer-option__title">Auction Houses</div>
-          <span class="buyer-payout buyer-payout--variable">Variable / above melt</span>
-        </div>
-        <p>For antique, vintage, designer, or collectible gold pieces, an auction is worth considering before committing to a scrap sale. Auction estimates can <strong>significantly exceed melt value</strong> when pieces have historical interest, brand association, or craftsmanship value that a standard buyer would not credit.<sup>21</sup></p>
-        <ul>
-          <li>Best for: antique jewellery, Victorian &amp; Edwardian pieces, signed or branded items, coins with numismatic value</li>
-          <li>Most major auction houses offer free valuation days</li>
-        </ul>
-      </div>
-      <div class="buyer-option">
-        <div class="buyer-option__header">
-          <div class="buyer-option__title">Selling on eBay</div>
-          <span class="buyer-payout buyer-payout--low">Not recommended</span>
-        </div>
-        <p>Selling scrap gold on eBay is an option some sellers explore, particularly for larger mixed lots. The reality is complicated: eBay charges selling fees, listings attract a mix of genuine buyers and bargain hunters, and the category has a higher rate of problematic transactions — non-paying buyers, disputes, and secure shipping complications.<sup>22</sup></p>
-        <ul>
-          <li>For smaller quantities: effort rarely justifies marginal price improvement</li>
-          <li>For unusual lots with genuine collector interest: occasionally produces better results</li>
-          <li>As a default route: not the best way to sell for most sellers</li>
-        </ul>
-      </div>
-    </div>
-
-    <h2 id="best-price">How to Get the Best Price When You Sell</h2>
-    <p>Beyond choosing the right buyer type, a few practices make a meaningful difference to what you receive:</p>
-
-    <ul class="step-list">
-      <li class="step-block">
-        <div class="step-number">1</div>
-        <div class="step-content">
-          <strong>Know your melt value before approaching anyone</strong>
-          <p>Use a live <a href="/scrap-gold-calculator">scrap gold calculator</a> to work out what your gold is worth at today's spot price. Weight × purity fraction × today's price per gram = melt value. This gives you the reference point against which to evaluate any offer. An offer at 85% of melt value is excellent; an offer at 50% deserves to be declined.</p>
-        </div>
-      </li>
-      <li class="step-block">
-        <div class="step-number">2</div>
-        <div class="step-content">
-          <strong>Weigh everything yourself first</strong>
-          <p>A kitchen scale accurate to 0.1 grams costs around £8 online. Weigh each karat separately and record the results. When a buyer weighs your items, you can confirm their numbers match yours — discrepancies of more than 0.2–0.3 grams should prompt a question.</p>
-        </div>
-      </li>
-      <li class="step-block">
-        <div class="step-number">3</div>
-        <div class="step-content">
-          <strong>Get at least two quotes</strong>
-          <p>The difference between buyers can be striking. Sending photos and weights to two or three specialist buyers before deciding costs nothing and takes twenty minutes. On a £500 lot, the difference between an 80% payout and a 92% payout is £60 — found money for minimal effort.</p>
-        </div>
-      </li>
-      <li class="step-block">
-        <div class="step-number">4</div>
-        <div class="step-content">
-          <strong>Do not mix karats</strong>
-          <p>Keep <span class="hmark">9ct</span>, <span class="hmark">14ct</span>, and <span class="hmark">18ct</span> pieces separate. Buyers will identify each karat individually and price accordingly. Presenting them mixed makes it easier for a buyer to apply the lowest karat rate to the entire lot.</p>
-        </div>
-      </li>
-      <li class="step-block">
-        <div class="step-number">5</div>
-        <div class="step-content">
-          <strong>Consider whether any items have non-scrap value</strong>
-          <p>Before submitting a lot for scrap, look at each piece individually. Antique pieces, hallmarked Victorian jewellery, branded pieces (Tiffany, Cartier, Georg Jensen), and coins with clear numismatic interest should be assessed by a specialist before being sold as scrap. Melt value is always the floor; for special pieces, it should not be the ceiling.</p>
-        </div>
-      </li>
-    </ul>
-
-    <h2 id="auction">Scrap Gold vs. Auction: When the Calculation Changes</h2>
-    <p>Most broken or plain scrap gold is genuinely best sold for its metal value — there is no premium available elsewhere. But there are specific categories where selling as scrap leaves real money behind:<sup>20</sup></p>
-    <ul>
-      <li><strong>Antique hallmarked pieces</strong> with clear date letters and assay office marks — particularly Victorian and Edwardian jewellery — attract collector interest beyond their metal value</li>
-      <li><strong>Georgian jewellery</strong> (pre-1837) is rare enough that even modest pieces regularly sell at auction above melt value</li>
-      <li><strong>Signed pieces</strong> from known makers — silversmiths, design houses, regional goldsmiths — may be identifiable through sponsor marks and have collector value</li>
-      <li><strong>Gold coins with numismatic interest</strong> — particularly pre-decimal sovereigns and older foreign coins in good condition — should be appraised by a coin specialist before being sold as bullion</li>
-      <li><strong>Gold pieces with intact significant gemstones</strong> — a piece set with a genuine diamond, sapphire, or ruby is worth more than the gold alone, even if the metal setting is damaged</li>
-    </ul>
-    <p>If you are unsure whether a piece falls into these categories, a fifteen-minute visit to a reputable auction house's valuation day (most major auction houses offer these free) will answer the question quickly.</p>
-
-    <h2 id="gold-rate-timing">When the Gold Rate Changes: A Practical Note for Sellers</h2>
-    <p>Several people searching "at what time does gold rate change" or "what time does the gold price change daily" are trying to understand whether there is a specific moment to call a buyer or check a price to get the best rate.</p>
-    <p>The practical answer for UK scrap sellers: prices are typically updated by buyers at the start of the business day based on the overnight and early-morning spot price, and sometimes updated again in the afternoon following the <strong>3:00 PM LBMA fix</strong>. On days when gold has moved strongly in either direction, buyers may update rates multiple times.<sup>9</sup></p>
-    <p>If gold has had a notably strong day and you are in the middle of a sale discussion, it is worth asking whether the buyer's quoted rate reflects today's price or is based on yesterday's close. Reputable buyers will tell you honestly. On stable market days (which is most days), this is a non-issue.</p>
-
-    <h2 id="bottom-line">The Bottom Line: Is Now a Good Time to Sell Scrap Gold?</h2>
-    <p>For gold you genuinely do not need — broken jewellery, single pieces, inherited items you have no connection to — <strong>2026 is one of the best selling environments in living memory</strong>.<sup>1</sup></p>
-    <p>Gold is near all-time highs in both USD and GBP terms. The structural factors supporting the price — central bank demand, geopolitical uncertainty, inflation sensitivity — remain intact. Institutional forecasts from JP Morgan, Deutsche Bank, and UBS suggest prices could go higher still. But for a private seller with no ongoing use for their gold, "could go higher" is not sufficient reason to wait indefinitely.<sup>6</sup></p>
-    <p>The cleaner question is this: if someone offered to buy something you do not want, at the best price it has commanded in history, would you say yes? For most scrap gold sellers, the answer is straightforward.</p>
-
-    <h2 id="faq">Frequently Asked Questions</h2>
-    <div class="faq-accordion">
-      <div class="faq-item">
-        <h3>Is now a good time to sell gold in 2026?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Yes. Gold prices are near all-time highs in both USD (~$4,742/oz) and GBP (~£3,472/oz) as of May 2026. For scrap gold and unwanted jewellery, current prices represent a generational selling opportunity. Institutional forecasts from JP Morgan and Deutsche Bank suggest further upside is possible, though this is uncertain. For gold you do not need, there is no compelling reason to wait.<sup>1</sup></p></div>
-      </div>
-      <div class="faq-item">
-        <h3>How much is scrap gold worth per gram in the UK?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>As of May 2026, approximate scrap gold melt values are: <span class="hmark">9ct</span> — £41.87/g; <span class="hmark">14ct</span> — £65.32/g; <span class="hmark">18ct</span> — £83.75/g; <span class="hmark">22ct</span> — £102.28/g; <span class="hmark">24ct</span> — £111.55/g. Most good buyers pay 80–95% of these melt values. Use our <a href="/scrap-gold-calculator">scrap gold calculator</a> for live figures updated with today's spot price.<sup>3</sup></p></div>
-      </div>
-      <div class="faq-item">
-        <h3>What is the best place to sell scrap gold?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Specialist online gold buyers and bullion dealers with direct refinery access consistently offer the highest payout rates — typically <strong>85–95% of melt value</strong>. Local jewellers and pawn shops typically pay 40–75% of melt value. For pieces with potential collector or antique value, an auction house is worth considering before committing to a scrap sale.<sup>16</sup></p></div>
-      </div>
-      <div class="faq-item">
-        <h3>How do I sell scrap gold online?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Request a free insured postal kit from a reputable specialist buyer, package your gold carefully, send via tracked insured delivery, receive an offer within 24–48 hours, and accept payment by bank transfer or have items returned. <strong>Always weigh and calculate your melt value first</strong> to evaluate any offer you receive. Getting quotes from two or three buyers before deciding takes twenty minutes and often adds meaningful value.<sup>16</sup></p></div>
-      </div>
-      <div class="faq-item">
-        <h3>Is scrap gold worth anything?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Very much so at current prices. A plain <span class="hmark">9ct</span> gold ring weighing 4 grams has a scrap value of approximately <strong>£142 at 85% melt value payout</strong>. A 10-gram <span class="hmark">18ct</span> chain is worth approximately £712. Even small quantities of scrap gold — including dental gold and broken pieces — are worth real money at 2026 prices.<sup>3</sup></p></div>
-      </div>
-      <div class="faq-item">
-        <h3>What time does the gold rate change daily?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>The gold spot price changes <strong>continuously during market hours</strong> (Sunday 22:00 to Friday 22:00 UK time). There is no single daily "change time" — prices fluctuate every second in response to trades, news, and economic data. However, the LBMA sets official benchmark fix prices at <strong>10:30 AM and 3:00 PM London time</strong> on weekdays, and most UK scrap gold buyers update their published rates based on these benchmarks.<sup>9</sup></p></div>
-      </div>
-      <div class="faq-item">
-        <h3>Should I sell my gold for scrap or at auction?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>It depends on the piece. Plain, mass-produced, or broken gold is almost always best sold as scrap — there is no collector premium to capture. Antique, hallmarked, signed, or historically significant pieces can achieve prices well above melt value at auction. <strong>If you are uncertain, a free auction house valuation day</strong> is the quickest way to find out — most major auction houses offer these without obligation.<sup>20</sup></p></div>
-      </div>
-      <div class="faq-item">
-        <h3>Where can I find scrap gold buyers near me?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Search "scrap gold buyers near me" to find local gold dealers, jewellers, and bullion shops. In the UK, <strong>Hatton Garden (London)</strong> and <strong>Birmingham's Jewellery Quarter</strong> are national hubs with multiple competing dealers. Online specialist buyers are often the better choice on price regardless of your location, as they offer insured postal services, publish live rates, and have Trustpilot reviews you can verify independently.<sup>16</sup></p></div>
-      </div>
-    </div>
-
-  </div><!-- /prose -->
-
-  <div class="disclaimer-box">
-    <strong>Editorial note:</strong> Gold prices quoted are indicative as of May 2026 and change daily with the gold spot price. Always use a live scrap gold calculator to check current melt values before selling. This article is for informational purposes only and does not constitute financial advice.
+<section class="related-section">
+  <div class="related-section__head">
+    <h2>Related Gold &amp; Silver Guides</h2>
+    <p>Keep going with the tools and guides our readers reach for next.</p>
   </div>
-
-</article>
-
-<section class="related-guides-section">
-  <h2>Related Gold &amp; Silver Guides</h2>
-  <div class="related-guides-grid">
+  <div class="related-grid">
+    <a href="/scrap-gold-calculator" class="related-card">
+      <span class="related-card__tag">Tool</span>
+      <div class="related-card__title">Scrap Gold Calculator</div>
+      <div class="related-card__desc">Enter karat and weight to find your gold's live melt value at today's USD spot price.</div>
+    </a>
     <a href="/guides/how-to-sell-gold-jewellery" class="related-card">
       <span class="related-card__tag">Guide</span>
       <div class="related-card__title">How to Sell Gold Jewellery</div>
-      <div class="related-card__desc">Get the best price for your gold jewellery — which buyers pay more, how to compare offers, and what to avoid.</div>
+      <div class="related-card__desc">Get the best price for your gold &mdash; which buyers pay more, how to compare offers, and what to avoid.</div>
     </a>
     <a href="/guides/how-to-test-if-gold-is-real" class="related-card">
       <span class="related-card__tag">Guide</span>
       <div class="related-card__title">How to Test If Gold Is Real</div>
-      <div class="related-card__desc">10 methods ranked by accuracy — from acid kits and hallmark checks to the magnet test and professional XRF.</div>
+      <div class="related-card__desc">10 methods ranked by accuracy &mdash; from acid kits and hallmark checks to the magnet test and pro XRF.</div>
     </a>
     <a href="/guides/gold-hallmarks-explained" class="related-card">
       <span class="related-card__tag">Guide</span>
       <div class="related-card__title">Gold Hallmarks Explained</div>
-      <div class="related-card__desc">UK, European, antique and foreign hallmarks decoded — symbols, date letters, assay office marks explained.</div>
+      <div class="related-card__desc">US, UK, European and antique hallmarks decoded &mdash; symbols, meanings and how to identify them.</div>
     </a>
-    <a href="/scrap-gold-calculator" class="related-card">
-      <span class="related-card__tag">Tool</span>
-      <div class="related-card__title">Scrap Gold Calculator</div>
-      <div class="related-card__desc">Enter your gold's karat and weight to find its live melt value at today's spot price — updated every 60 seconds.</div>
-    </a>
-    <a href="/guides/difference-between-gold-filled-and-gold-plated" class="related-card">
+    <a href="/guides/gold-price-prediction-2026" class="related-card">
       <span class="related-card__tag">Guide</span>
-      <div class="related-card__title">Gold Filled vs Gold Plated</div>
-      <div class="related-card__desc">The difference between solid gold, gold filled, and gold plated — durability, value, and tarnishing explained.</div>
+      <div class="related-card__title">Gold Price Prediction 2026</div>
+      <div class="related-card__desc">Where the major banks see gold heading this year &mdash; forecasts, drivers, and the risks to each call.</div>
     </a>
-    <a href="/guides/gold-purity-guide" class="related-card">
+    <a href="/guides/how-much-is-a-gold-ring-worth" class="related-card">
       <span class="related-card__tag">Guide</span>
-      <div class="related-card__title">Gold Purity Guide</div>
-      <div class="related-card__desc">9K to 24K explained — what each karat means for value, durability, and jewellery type.</div>
+      <div class="related-card__title">How Much Is a Gold Ring Worth?</div>
+      <div class="related-card__desc">Work out the real scrap and resale value of a gold ring by karat, weight, and current spot price.</div>
     </a>
   </div>
 </section>
@@ -728,15 +1093,14 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
         <img src="https://assets.goldpricetools.com/logo.svg" width="28" height="28" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright)">GoldPriceTools</span>
       </a>
-      <p class="footer-brand">Live gold and silver prices. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver prices. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Updated every 60 seconds.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li></li>
-        <li></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        
       </ul>
     </div>
     <div class="footer-col">
@@ -781,11 +1145,12 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
   </div>
   <div class="footer-bottom">
     <span>&copy; 2026 GoldPriceTools. All rights reserved.</span>
-    <span>Prices sourced via LBMA. Not financial advice.</span>
+    <span>Prices sourced via LBMA &middot; gold-api.com. Not financial advice.</span>
   </div>
 </footer>
 
 <script>
+/* Theme + nav + mobile menu (site standard) */
 (function(){
   var toggle=document.getElementById('themeToggle');
   var sun=document.getElementById('iconSun');
@@ -816,6 +1181,303 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
       if(items)items.classList.toggle('open',!expanded);
     });
   });
+})();
+</script>
+
+<script>
+/* Scroll progress, reveal-on-scroll, TOC active state, mobile TOC sheet, payout filter */
+(function(){
+  var fill=document.getElementById('scrollProgressFill');
+  function updateProgress(){
+    var h=document.documentElement;
+    var max=h.scrollHeight-h.clientHeight;
+    var pct=max>0?(h.scrollTop/max)*100:0;
+    if(fill)fill.style.width=pct+'%';
+  }
+  window.addEventListener('scroll',updateProgress,{passive:true});
+  window.addEventListener('resize',updateProgress);
+  updateProgress();
+
+  var reduced=matchMedia('(prefers-reduced-motion:reduce)').matches;
+  if(reduced){
+    document.querySelectorAll('.reveal').forEach(function(el){el.classList.add('is-in');});
+  } else if('IntersectionObserver' in window){
+    var io=new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(e.isIntersecting){e.target.classList.add('is-in');io.unobserve(e.target);}
+      });
+    },{rootMargin:'0px 0px -8% 0px',threshold:0.12});
+    document.querySelectorAll('.reveal').forEach(function(el){io.observe(el);});
+  } else {
+    document.querySelectorAll('.reveal').forEach(function(el){el.classList.add('is-in');});
+  }
+
+  var tocLinks=document.querySelectorAll('#tocList a');
+  var headings=Array.prototype.map.call(tocLinks,function(a){
+    var id=a.getAttribute('href').slice(1);
+    return {a:a,el:document.getElementById(id)};
+  }).filter(function(o){return o.el;});
+  function syncToc(){
+    var y=window.scrollY+120;
+    var current=null;
+    headings.forEach(function(o){
+      if(o.el.offsetTop<=y)current=o.a;
+    });
+    tocLinks.forEach(function(a){a.classList.remove('is-active');});
+    if(current)current.classList.add('is-active');
+  }
+  window.addEventListener('scroll',syncToc,{passive:true});
+  syncToc();
+
+  var fab=document.getElementById('tocFab');
+  var sheet=document.getElementById('tocSheet');
+  var closeBtn=document.getElementById('tocSheetClose');
+  function openSheet(){sheet.classList.add('is-open');fab.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}
+  function closeSheet(){sheet.classList.remove('is-open');fab.setAttribute('aria-expanded','false');document.body.style.overflow='';}
+  if(fab)fab.addEventListener('click',openSheet);
+  if(closeBtn)closeBtn.addEventListener('click',closeSheet);
+  if(sheet)sheet.addEventListener('click',function(e){if(e.target===sheet)closeSheet();});
+  document.querySelectorAll('.toc-sheet__list a').forEach(function(a){a.addEventListener('click',closeSheet);});
+
+  /* Payout comparison filter tabs */
+  document.querySelectorAll('.acc-tab').forEach(function(tab){
+    tab.addEventListener('click',function(){
+      document.querySelectorAll('.acc-tab').forEach(function(t){t.classList.remove('is-active');t.setAttribute('aria-pressed','false');});
+      this.classList.add('is-active');this.setAttribute('aria-pressed','true');
+      var f=this.dataset.filter;
+      document.querySelectorAll('#payoutCompare .acc-row').forEach(function(r){
+        r.style.display=(f==='all'||r.dataset.tier===f)?'':'none';
+      });
+    });
+  });
+})();
+</script>
+
+<script>
+/* ── LIVE PRICE FEED ──
+   Endpoint: api.gold-api.com/price/XAU (USD per troy oz, no API key)
+   FX:       api.goldpricetoolsworker.io/fx (USD basis)
+   Refresh:  60 seconds  ·  Primary currency: USD $
+*/
+window._spot=null;
+window._spotPrev=null;
+window._spotTs=null;
+window._fx={USD:1};
+(function(){
+  var FALLBACK_FX={USD:1,EUR:0.92,GBP:0.79,CAD:1.38,AUD:1.55,INR:83.5,AED:3.673,JPY:153.8};
+  Object.keys(FALLBACK_FX).forEach(function(k){window._fx[k]=FALLBACK_FX[k];});
+
+  async function fetchFx(){
+    try{
+      var r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});
+      if(!r.ok)throw new Error('fx '+r.status);
+      var d=await r.json();
+      if(d&&typeof d==='object'){
+        if(d.GBPUSD)window._fx.GBP=d.GBPUSD;
+        if(d.EURUSD)window._fx.EUR=d.EURUSD;
+        if(d.USDEUR)window._fx.EUR=d.USDEUR;
+        if(d.USDGBP)window._fx.GBP=d.USDGBP;
+        ['EUR','GBP','CAD','AUD','INR','AED','JPY'].forEach(function(k){
+          if(d[k])window._fx[k]=d[k];
+        });
+      }
+    }catch(e){/* keep fallback */}
+  }
+
+  async function fetchSpot(){
+    try{
+      var r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
+      if(!r.ok)throw new Error('spot '+r.status);
+      var d=await r.json();
+      if(d&&typeof d.price==='number'){
+        window._spotPrev=window._spot;
+        window._spot=d.price;
+        if(typeof d.prev_close_price==='number')window._spotPrev=d.prev_close_price;
+        window._spotTs=Date.now();
+        window.dispatchEvent(new Event('goldprice_updated'));
+      } else {
+        window.dispatchEvent(new Event('goldprice_error'));
+      }
+    }catch(e){
+      window.dispatchEvent(new Event('goldprice_error'));
+    }
+  }
+
+  fetchFx();
+  fetchSpot();
+  setInterval(fetchSpot,60000);
+  setInterval(fetchFx,15*60*1000);
+})();
+</script>
+
+<script>
+/* ── HERO live spot card binding ── */
+(function(){
+  var TROY=31.1035;
+  var priceEl=document.getElementById('heroSpotPrice');
+  var deltaEl=document.getElementById('heroSpotDelta');
+  var deltaText=document.getElementById('heroSpotDeltaText');
+  var gramEl=document.getElementById('heroSpotPerGram');
+  var updatedEl=document.getElementById('heroSpotUpdated');
+  var liveBadge=document.getElementById('heroLive');
+  var liveText=document.getElementById('heroLiveText');
+
+  function fmtUSD(v,d){return '$'+v.toLocaleString('en-US',{minimumFractionDigits:d!=null?d:2,maximumFractionDigits:d!=null?d:2});}
+  function fmtRel(ts){
+    if(!ts)return 'just now';
+    var s=Math.floor((Date.now()-ts)/1000);
+    if(s<5)return 'just now';
+    if(s<60)return s+'s ago';
+    if(s<3600)return Math.floor(s/60)+'m ago';
+    return Math.floor(s/3600)+'h ago';
+  }
+  function render(){
+    if(!window._spot)return;
+    priceEl.textContent=fmtUSD(window._spot,2);
+    var gram=window._spot/TROY;
+    gramEl.textContent=fmtUSD(gram,2);
+    if(window._spotPrev&&window._spotPrev!==window._spot){
+      var diff=window._spot-window._spotPrev;
+      var pct=(diff/window._spotPrev)*100;
+      deltaEl.hidden=false;
+      deltaEl.classList.remove('bento-spot__delta--up','bento-spot__delta--down');
+      deltaEl.classList.add(diff>=0?'bento-spot__delta--up':'bento-spot__delta--down');
+      var arrow=deltaEl.querySelector('svg');
+      if(arrow)arrow.style.transform=diff>=0?'rotate(0deg)':'rotate(180deg)';
+      var sign=diff>=0?'+':'';
+      deltaText.textContent=sign+fmtUSD(Math.abs(diff),2)+' ('+sign+pct.toFixed(2)+'%) vs prev close';
+    }
+    updatedEl.textContent=fmtRel(window._spotTs);
+    liveBadge.classList.remove('live-pill--idle','live-pill--error');
+    liveText.textContent='Live';
+  }
+  function errored(){
+    liveBadge.classList.add('live-pill--error');
+    liveBadge.classList.remove('live-pill--idle');
+    liveText.textContent='Reconnecting';
+  }
+  window.addEventListener('goldprice_updated',render);
+  window.addEventListener('goldprice_error',errored);
+  setInterval(function(){if(window._spotTs)updatedEl.textContent=fmtRel(window._spotTs);},5000);
+})();
+</script>
+
+<script>
+/* ── SCRAP GOLD MELT & OFFER CALCULATOR ── USD primary ── matches scrap-gold-calculator.html (70–92% payout) ── */
+(function(){
+  var TROY=31.1035;
+  var CURR={
+    USD:{sym:'$',locale:'en-US',decimals:2},
+    EUR:{sym:'€',locale:'en-GB',decimals:2},
+    GBP:{sym:'£',locale:'en-GB',decimals:2},
+    CAD:{sym:'C$',locale:'en-CA',decimals:2},
+    AUD:{sym:'A$',locale:'en-AU',decimals:2},
+    INR:{sym:'₹',locale:'en-IN',decimals:0},
+    AED:{sym:'د.إ ',locale:'en-AE',decimals:2},
+    JPY:{sym:'¥',locale:'ja-JP',decimals:0}
+  };
+  var unit='g';
+  var purity=0.5833;
+
+  var weightEl=document.getElementById('gtWeight');
+  var currSel=document.getElementById('gtCurrency');
+  var placeholder=document.getElementById('gtPlaceholder');
+  var output=document.getElementById('gtOutput');
+  var meltEl=document.getElementById('gtMeltValue');
+  var offerEl=document.getElementById('gtOfferValue');
+  var pureGramsEl=document.getElementById('gtPureGrams');
+  var pricePerGramEl=document.getElementById('gtPricePerGram');
+  var spotLineEl=document.getElementById('gtSpotLine');
+  var updatedEl=document.getElementById('gtUpdated');
+  var liveBadge=document.getElementById('gtLive');
+  var liveText=document.getElementById('gtLiveText');
+
+  document.querySelectorAll('#gtCalc .gf-unit-btn').forEach(function(b){
+    b.addEventListener('click',function(){
+      document.querySelectorAll('#gtCalc .gf-unit-btn').forEach(function(x){x.classList.remove('is-active');});
+      this.classList.add('is-active');
+      unit=this.dataset.unit;
+      calc();
+    });
+  });
+  document.querySelectorAll('#gtCalc .gf-karat-btn').forEach(function(b){
+    b.addEventListener('click',function(){
+      document.querySelectorAll('#gtCalc .gf-karat-btn').forEach(function(x){x.classList.remove('is-active');});
+      this.classList.add('is-active');
+      purity=parseFloat(this.dataset.purity);
+      calc();
+    });
+  });
+  if(currSel)currSel.addEventListener('change',calc);
+  if(weightEl)weightEl.addEventListener('input',calc);
+
+  function fmt(c,v){
+    var info=CURR[c]||CURR.USD;
+    var n=Math.max(0,v).toLocaleString(info.locale,{minimumFractionDigits:info.decimals,maximumFractionDigits:info.decimals});
+    return info.sym+n;
+  }
+  function fmtRel(ts){
+    if(!ts)return '—';
+    var s=Math.floor((Date.now()-ts)/1000);
+    if(s<5)return 'just now';
+    if(s<60)return s+'s ago';
+    if(s<3600)return Math.floor(s/60)+'m ago';
+    return Math.floor(s/3600)+'h ago';
+  }
+
+  function calc(){
+    if(!window._spot){
+      placeholder.style.display='flex';
+      placeholder.textContent='Waiting for live spot price…';
+      output.style.display='none';
+      return;
+    }
+    var raw=parseFloat(weightEl.value);
+    if(!isFinite(raw)||raw<=0){
+      placeholder.style.display='flex';
+      placeholder.textContent='Enter a weight to see the live melt value and realistic offer range.';
+      output.style.display='none';
+      return;
+    }
+    placeholder.style.display='none';
+    output.style.display='flex';
+
+    var weightG=unit==='oz'?raw*TROY:raw;
+    var fineGoldG=weightG*purity;
+
+    var spotUsdPerGram=window._spot/TROY;
+    var meltUsd=fineGoldG*spotUsdPerGram;
+
+    var c=currSel.value;
+    var fxRate=(window._fx&&window._fx[c])?window._fx[c]:1;
+    var meltLocal=meltUsd*fxRate;
+    var pricePerGramLocal=spotUsdPerGram*purity*fxRate;
+
+    var offerLow=meltLocal*0.70;
+    var offerHigh=meltLocal*0.92;
+
+    meltEl.textContent=fmt(c,meltLocal);
+    offerEl.textContent=fmt(c,offerLow)+' – '+fmt(c,offerHigh);
+    pureGramsEl.textContent=fineGoldG.toFixed(3)+' g';
+    pricePerGramEl.textContent=fmt(c,pricePerGramLocal);
+    spotLineEl.textContent='$'+window._spot.toFixed(2)+' / oz';
+    updatedEl.textContent=fmtRel(window._spotTs);
+
+    liveBadge.classList.remove('live-pill--idle','live-pill--error');
+    liveText.textContent='Live';
+  }
+
+  window.addEventListener('goldprice_updated',function(){
+    liveBadge.classList.remove('live-pill--idle','live-pill--error');
+    liveText.textContent='Live';
+    calc();
+  });
+  window.addEventListener('goldprice_error',function(){
+    liveBadge.classList.remove('live-pill--idle');
+    liveBadge.classList.add('live-pill--error');
+    liveText.textContent='Reconnecting';
+  });
+  setInterval(function(){if(window._spotTs&&output.style.display==='flex')updatedEl.textContent=fmtRel(window._spotTs);},5000);
 })();
 </script>
 </body>


### PR DESCRIPTION
## What & why

Full UI/UX redesign of **`/guides/what-is-best-time-to-sell-scrap-gold`** ([live page](https://goldpricetools.com/guides/what-is-best-time-to-sell-scrap-gold)), bringing it onto the site's current **premium editorial** standard (the pattern already shipped on *How to Test If Gold Is Real*, *How to Sell Gold Jewellery*, etc.). Designed mobile-first and scaling cleanly to any device. The previous version was GBP-led and on the older, lighter template; this rebuild is **USD-first** and data-accurate against the site's live tools.

Design direction was grounded with the **ui-ux-pro-max** skill (OLED dark mode, gold-primary, live market indicators, editorial type, high contrast).

## Highlights

**Three signature, data-driven components**
- **Bento-grid hero** with a **live USD gold-spot card** — `api.gold-api.com/price/XAU`, 60s refresh, Δ vs previous close, $/g (24K) — plus market-timing stat cells and a 2026 "verdict" cell.
- **Seasonal-demand bar chart** — animated 12-month strength index visualising the article's core timing thesis. Bars use a dedicated grid track so heights never overflow; `role="img"` with the full series described for screen readers; Q1–Q4 tendency cards beneath.
- **Where-to-sell payout comparison** — animated %-of-melt bars with All / Online / In-person filter tabs.

**Live USD calculator (accuracy matched across the site)**
- Karat selector + weight + **8-currency conversion, USD default**.
- `TROY=31.1035`, identical purity fractions, and **70–92% dealer-offer range to match the canonical `scrap-gold-calculator.html`** so figures agree across the site.
- Graceful degradation when the feed is unavailable (placeholder + "Reconnecting" state).

**Currency**
- **USD $ primary** in all prose, tables, FAQ and JSON-LD; other currencies appear only as conversions. Illustrative figures (~$4,750/oz) clearly labelled, with the live tool as the source of truth.

**Scaffold / a11y / SEO**
- Sidebar TOC + mobile FAB/sheet, scroll-progress bar, scroll-reveal sections, `prefers-reduced-motion` fallbacks, 44px touch targets, visible focus rings.
- Canonical/OG/hreflang preserved; **Article / Breadcrumb / FAQ JSON-LD rewritten USD-first**, FAQ schema synced 1:1 to the visible accordion.
- Inherits the corrected footer (fixes two empty `<li>` items present in the prior version).

## Validation
- `node scripts/validate-jsonld.js` → **PASSED** (225 blocks / 82 files).
- Tag balance verified; **8 FAQ `<details>` = 8 schema Questions**; **11 TOC anchors = 11 section IDs**; every JS-referenced element ID present exactly once.
- USD-primary confirmed (71 `$` figures; the only `£`/`GBP` are the conversion option + symbol). Zero stray `ct` karat notation.

## Notes
- Per the repo's `DEVELOPMENT_RULES.md`, the Playwright audit runs against the **deployed** URL — recommend running it post-merge/preview. Local headless rendering isn't available in this sandbox (no network egress to the gold API or browser binaries), but the client-side live feed reaches the API normally once served.

https://claude.ai/code/session_01K2jrUD1Xxyr1hi8KszpePK

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2jrUD1Xxyr1hi8KszpePK)_