### PR TITLE
Redesign "How Much Is a Gold Ring Worth?" guide (premium editorial, USD primary, live tools)

### DIFF
--- a/guides/how-much-is-a-gold-ring-worth.html
+++ b/guides/how-much-is-a-gold-ring-worth.html
@@ -5,19 +5,19 @@
 <script>(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();</script>
 <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>How Much Is a Gold Ring Worth? Live Calculator &amp; Value Guide 2026 | GoldPriceTools</title>
+<title>How Much Is a Gold Ring Worth? Live USD Calculator &amp; 2026 Value Guide | GoldPriceTools</title>
 <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Find out exactly how much your gold ring is worth. Use our live calculator — enter weight and karat to get melt value in GBP, USD, EUR and 7 more currencies, updated every 60 seconds.">
+<meta name="description" content="Find out exactly what your gold ring is worth in USD. Use our live calculator — enter weight and karat for the melt value at the current gold spot price, refreshed every 60 seconds — plus where to sell for 85–95% of melt. GBP, EUR, INR and more shown as live conversions.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth">
-<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth">
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
-<meta property="og:title" content="How Much Is a Gold Ring Worth? Live Calculator &amp; Value Guide 2026">
-<meta property="og:description" content="Find out exactly how much your gold ring is worth. Use our live calculator — enter weight and karat to get melt value in GBP, USD, EUR and 7 more currencies, updated every 60 seconds.">
+<meta property="og:title" content="How Much Is a Gold Ring Worth? Live USD Calculator &amp; 2026 Value Guide">
+<meta property="og:description" content="Enter weight and karat to value any gold ring in USD at the live gold spot price — updated every 60 seconds. Melt value, realistic offer range, and where to sell for the most.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth">
 <meta property="og:site_name" content="GoldPriceTools">
@@ -27,9 +27,9 @@
 <meta property="og:image:alt" content="How Much Is a Gold Ring Worth — GoldPriceTools">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="https://assets.goldpricetools.com/og-image.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How Much Is a Gold Ring Worth? (2026 Guide)","description":"Find out exactly how much your gold ring is worth. Use our live calculator to get the melt value of any gold ring based on karat, weight and live spot price.","url":"https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth","datePublished":"2026-05-08","dateModified":"2026-06-13T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How Much Is a Gold Ring Worth? (2026 Guide)","description":"Find out exactly what your gold ring is worth in USD. Use our live calculator to get the melt value of any gold ring from its karat, weight and the live gold spot price, with realistic buyer offer ranges.","url":"https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth","datePublished":"2026-05-08","dateModified":"2026-06-13T06:00:00Z","author":{"@type":"Organization","name":"GoldPriceTools Editorial Team","url":"https://goldpricetools.com/authors/goldpricetools-editorial-team/"},"publisher":{"@type":"Organization","name":"GoldPriceTools","url":"https://goldpricetools.com","logo":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/logo.svg"}},"mainEntityOfPage":{"@type":"WebPage","@id":"https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth"},"image":{"@type":"ImageObject","url":"https://assets.goldpricetools.com/og-image.jpg"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://goldpricetools.com/guides/"},{"@type":"ListItem","position":3,"name":"How Much Is a Gold Ring Worth?","item":"https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How much is a 9ct gold ring worth?","acceptedAnswer":{"@type":"Answer","text":"A 9ct gold ring weighing 3 grams has a melt value of approximately £125 at current prices (May 2026). Most specialist buyers pay 85–95% of melt value, so expect an offer of around £106–£119. Heavier rings of 5–6 grams will fetch proportionally more. Use the live calculator above with your ring's actual weight for a precise figure."}},{"@type":"Question","name":"How much is an 18ct gold ring worth?","acceptedAnswer":{"@type":"Answer","text":"An 18ct gold ring weighing 4 grams has a melt value of around £335 at May 2026 prices. Specialist buyers paying 85–95% of melt would offer approximately £285–£318. 18ct is 75% pure gold, making it significantly more valuable per gram than 9ct (37.5% pure)."}},{"@type":"Question","name":"Does a diamond make a gold ring worth more?","acceptedAnswer":{"@type":"Answer","text":"It depends on the diamond's quality and size. Most scrap gold buyers ignore small accent diamonds (under 0.1ct) entirely and pay only for the gold weight. Larger, certified diamonds (0.5ct+) can add significant value, but only if sold through a jeweller or specialist diamond dealer rather than a scrap gold buyer. Have any ring with a substantial stone independently appraised before selling."}},{"@type":"Question","name":"How do I find the karat of my gold ring?","acceptedAnswer":{"@type":"Answer","text":"Look for a hallmark stamped inside the band. In the UK, common markings are 375 (9ct), 585 (14ct), 750 (18ct), 916 (22ct) and 999 (24ct). You may also see the karat written directly as 9K, 14K, 18K, etc. If there is no visible hallmark, a jeweller can test the metal with an acid test kit or an electronic gold tester."}},{"@type":"Question","name":"Is it better to sell a gold ring to a jeweller or a gold buyer?","acceptedAnswer":{"@type":"Answer","text":"For plain gold rings with no special gemstones or antique value, specialist online gold buyers and bullion dealers typically offer the best price — usually 85–95% of melt value. Local jewellers often offer 55–75% of melt value, and pawn shops 40–60%. For antique, designer, or signed pieces, an auction house or specialist dealer may offer more than melt value."}},{"@type":"Question","name":"How much does a gold wedding ring weigh?","acceptedAnswer":{"@type":"Answer","text":"A typical plain gold wedding band weighs between 3 and 6 grams. Wider bands, heavily engraved rings, and men's rings tend to be heavier (5–8g). Women's rings with thinner shanks are often 2–4g. The precise weight is the most important number for calculating melt value — use a digital kitchen scale accurate to 0.1g."}},{"@type":"Question","name":"What is the difference between melt value and resale value?","acceptedAnswer":{"@type":"Answer","text":"Melt value is the pure gold content of the ring valued at the current spot price — the baseline floor. Resale value is what a buyer will actually pay, which is almost always lower than melt for plain rings (the buyer needs a margin). However, for antique, designer, or rare pieces, resale value can exceed melt value if there is a collector market for the piece."}},{"@type":"Question","name":"How often does the gold ring value update?","acceptedAnswer":{"@type":"Answer","text":"The live calculator on this page updates every 60 seconds using the current gold spot price. Gold trades continuously during market hours (Sunday 22:00 to Friday 22:00 UK time). The LBMA publishes official benchmark fix prices at 10:30 AM and 3:00 PM London time on weekdays. Prices are less volatile at weekends when markets are closed."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How much is a 9K gold ring worth?","acceptedAnswer":{"@type":"Answer","text":"A 9K (375) gold ring weighing 3 grams holds about 1.13 g of pure gold — a melt value near $172 at a representative spot of about $4,750/oz. Specialist buyers paying 85–95% of melt would offer roughly $146–$163. Heavier 5–6 g rings are worth proportionally more. Use the live calculator above with your ring's actual weight for the exact USD figure right now."}},{"@type":"Question","name":"How much is an 18K gold ring worth?","acceptedAnswer":{"@type":"Answer","text":"An 18K (750) gold ring weighing 4 grams contains 3 g of pure gold — a melt value around $458 at a representative spot near $4,750/oz. A specialist offer of 85–95% would be about $389–$435. 18K is 75% pure gold, so it is worth roughly twice as much per gram as 9K (37.5% pure)."}},{"@type":"Question","name":"Does a diamond make a gold ring worth more?","acceptedAnswer":{"@type":"Answer","text":"For a scrap gold buyer, usually not — they pay for the gold weight only and ignore small melee diamonds under about 0.1 ct. A larger, certified diamond (0.5 ct and up) can add real value, but only when sold through a jeweller, auction house or specialist diamond dealer rather than a scrap buyer. Have any substantial stone independently appraised before a scrap sale."}},{"@type":"Question","name":"How do I find the karat of my gold ring?","acceptedAnswer":{"@type":"Answer","text":"Look for a hallmark stamped inside the band: 375 = 9K, 585 = 14K, 750 = 18K, 916 = 22K and 999 = 24K. You may also see the karat written directly as 9K, 14K, 18K, and so on. If there is no visible hallmark, a jeweller can test the metal with an acid test kit or an electronic gold tester in minutes."}},{"@type":"Question","name":"Is it better to sell a gold ring to a jeweller or a gold buyer?","acceptedAnswer":{"@type":"Answer","text":"For plain gold rings with no special gemstones or antique value, specialist online gold buyers and bullion dealers typically pay the most — about 85–95% of melt value. Local jewellers often pay 55–75% and pawn shops 40–60%. For antique, designer or signed pieces, an auction house or specialist dealer may offer more than melt value."}},{"@type":"Question","name":"How much does a gold wedding ring weigh?","acceptedAnswer":{"@type":"Answer","text":"A typical plain gold wedding band weighs between 3 and 6 grams. Wider bands, heavily engraved rings and men's rings tend to be heavier (5–8 g); women's rings with thinner shanks are often 2–4 g. Weight is the single biggest driver of melt value, so weigh the ring on a digital scale accurate to 0.1 g."}},{"@type":"Question","name":"What is the difference between melt value and resale value?","acceptedAnswer":{"@type":"Answer","text":"Melt value is the pure gold content of the ring valued at the live spot price — the baseline floor. Resale value is what a buyer will actually pay, which is almost always below melt for plain rings because the buyer needs a margin. For antique, designer or certified pieces, resale value can exceed melt if there is a collector market."}},{"@type":"Question","name":"How often does the gold ring value update?","acceptedAnswer":{"@type":"Answer","text":"The live calculator on this page refreshes every 60 seconds using the current USD gold spot price. Gold trades continuously from Sunday evening to Friday evening, and the LBMA sets official benchmark fixes at 10:30 AM and 3:00 PM London time on weekdays. Prices are less volatile at weekends when markets are closed."}}]}</script>
 <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});</script>
 <script async src="https://fundingchoicesmessages.google.com/i/pub-8849494330640880?ers=1" nonce=""></script>
 <script>(function(){function signalGooglefcPresent(){if(!window.frames['googlefcPresent']){if(document.body){const iframe=document.createElement('iframe');iframe.style='width:0;height:0;border:none;z-index:-1000;left:-1000px;top:-1000px;';iframe.style.display='none';iframe.name='googlefcPresent';document.body.appendChild(iframe);}else{setTimeout(signalGooglefcPresent,0);}}}signalGooglefcPresent();})();</script>
@@ -38,37 +38,32 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.gold-api.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,500;1,600&display=swap" rel="stylesheet">
 <style>
-.mega-panel__category-link{display:block;padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);border:1px solid var(--color-border);text-decoration:none;color:var(--color-text);transition:border-color var(--transition),background var(--transition)}
-.mega-panel__category-link:hover{border-color:var(--color-gold-bright);background:var(--color-surface-offset);color:var(--color-text)}
-.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
-.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
-.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
-:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-alt:#f4f3ef;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#7a7974;--color-text-faint:#bab9b4;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#d19900;--color-silver:#6b7280;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--transition:180ms cubic-bezier(0.16,1,0.3,1)}
-[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#d4d3d0;--color-text-muted:#7a7974;--color-text-faint:#4a4947;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#b07a00;--color-gold-bright:#e8af34;--color-silver:#9ca3af;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5)}
+/* ── DESIGN TOKENS ── kept compatible with site-wide variables ── */
+:root,[data-theme="light"]{--color-bg:#f7f6f2;--color-surface:#f9f8f5;--color-surface-2:#fbfbf9;--color-surface-offset:#f3f0ec;--color-surface-offset-2:#edeae5;--color-surface-alt:#f4f3ef;--color-surface-dynamic:#e6e4df;--color-divider:#dcd9d5;--color-border:#d4d1ca;--color-text:#28251d;--color-text-muted:#5c5b56;--color-text-faint:#8b8a85;--color-text-inverse:#f9f8f4;--color-primary:#01696f;--color-primary-hover:#0c4e54;--color-gold:#b07a00;--color-gold-bright:#c8830a;--color-silver:#6b7280;--color-rose:#b85850;--color-emerald:#0a8060;--shadow-sm:0 1px 2px oklch(0.2 0.01 80/0.06);--shadow-md:0 4px 12px oklch(0.2 0.01 80/0.08);--shadow-lg:0 12px 32px oklch(0.2 0.01 80/0.12);--shadow-glow:0 0 0 1px oklch(0.7 0.15 80/0.2),0 8px 24px oklch(0.7 0.15 80/0.12);--radius-sm:0.375rem;--radius-md:0.5rem;--radius-lg:0.75rem;--radius-xl:1rem;--radius-2xl:1.5rem;--radius-full:9999px;--space-1:0.25rem;--space-2:0.5rem;--space-3:0.75rem;--space-4:1rem;--space-5:1.25rem;--space-6:1.5rem;--space-8:2rem;--space-10:2.5rem;--space-12:3rem;--space-16:4rem;--text-xs:clamp(0.75rem,0.7rem + 0.25vw,0.875rem);--text-sm:clamp(0.875rem,0.8rem + 0.35vw,1rem);--text-base:clamp(1rem,0.95rem + 0.25vw,1.125rem);--text-lg:clamp(1.125rem,1rem + 0.75vw,1.5rem);--text-xl:clamp(1.5rem,1.2rem + 1.25vw,2.25rem);--text-2xl:clamp(2rem,1.2rem + 2.5vw,3.5rem);--text-3xl:clamp(2.5rem,1.6rem + 3.5vw,4.5rem);--font-body:'Inter','Helvetica Neue',sans-serif;--font-display:'IBM Plex Sans','Inter',sans-serif;--font-editorial:'Playfair Display','Georgia',serif;--transition:180ms cubic-bezier(0.16,1,0.3,1);--transition-slow:320ms cubic-bezier(0.16,1,0.3,1)}
+[data-theme="dark"]{--color-bg:#0f0e0c;--color-surface:#161513;--color-surface-2:#1b1a18;--color-surface-offset:#1d1c1a;--color-surface-offset-2:#222120;--color-surface-dynamic:#2a2927;--color-divider:#252422;--color-border:#333230;--color-text:#e8e6e1;--color-text-muted:#a3a09a;--color-text-faint:#6c6a65;--color-text-inverse:#1a1917;--color-primary:#4f98a3;--color-primary-hover:#6ab3be;--color-gold:#d19900;--color-gold-bright:#f0c14b;--color-silver:#c0c4cb;--color-rose:#e88a82;--color-emerald:#5fc59f;--shadow-sm:0 1px 2px oklch(0 0 0/0.3);--shadow-md:0 4px 12px oklch(0 0 0/0.4);--shadow-lg:0 12px 32px oklch(0 0 0/0.5);--shadow-glow:0 0 0 1px oklch(0.78 0.16 80/0.25),0 8px 32px oklch(0.78 0.16 80/0.15)}
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 a{color:var(--color-primary);text-decoration:none}
 a:hover{color:var(--color-primary-hover);text-decoration:underline}
 a:visited{color:var(--color-primary)}
-.article-card,.blog-preview-card,.related-card,.guide-card,.guide-card-link,.post-card,.byline-card{color:var(--color-text)}
-.article-card:hover,.blog-preview-card:hover,.related-card:hover,.guide-card:hover,.post-card:hover{color:var(--color-text)}
-.article-title,.article-card-title{font-weight:700;color:var(--color-text);margin-bottom:.3rem}
-.article-tag,.related-card__tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright)}
-.article-excerpt,.article-card-desc,.related-card__desc{color:var(--color-text-muted);font-size:var(--text-sm);line-height:1.55}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:var(--space-16)}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;scroll-behavior:smooth;scroll-padding-top:84px}
 body{min-height:100dvh;line-height:1.6;font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);background:var(--color-bg)}
 img,svg{display:block;max-width:100%;height:auto}
 button{cursor:pointer;background:none;border:none;font:inherit;color:inherit}
-h1,h2,h3,h4{text-wrap:balance;line-height:1.2}
+h1,h2,h3,h4{text-wrap:balance;line-height:1.15}
 p,li{text-wrap:pretty;max-width:72ch}
 a,button,[role="button"],input,select{transition:color var(--transition),background var(--transition),border-color var(--transition),box-shadow var(--transition)}
 :focus-visible{outline:2px solid var(--color-primary);outline-offset:3px;border-radius:var(--radius-sm)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}
-@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}}
-.site-nav{position:sticky;top:0;z-index:200;background:var(--color-surface);border-bottom:1px solid var(--color-border)}
-.nav-inner{max-width:1200px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important;scroll-behavior:auto!important}}
+/* ── NAV ── */
+.mega-panel__col--browse{display:flex;align-items:center;justify-content:center}
+.mega-panel__browse-all{display:block;padding:var(--space-3) var(--space-5);border:1px solid var(--color-gold);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-gold);text-decoration:none;transition:background var(--transition),color var(--transition)}
+.mega-panel__browse-all:hover{background:var(--color-gold);color:var(--color-bg)}
+.site-nav{position:sticky;top:0;z-index:200;background:color-mix(in oklch,var(--color-surface) 92%,transparent);backdrop-filter:saturate(180%) blur(14px);-webkit-backdrop-filter:saturate(180%) blur(14px);border-bottom:1px solid var(--color-border)}
+.nav-inner{max-width:1280px;margin:0 auto;padding:0 var(--space-4);display:flex;align-items:center;justify-content:space-between;height:56px;gap:var(--space-2)}
 .nav-logo{display:flex;align-items:center;gap:var(--space-2);font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright);text-decoration:none;flex-shrink:0}
 .mega-nav{display:flex;align-items:center;list-style:none;margin:0;padding:0;gap:2px;flex:1;justify-content:center}
 .mega-nav__item{position:relative}
@@ -88,7 +83,6 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .mega-panel a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:6px 10px;border-radius:var(--radius-md);transition:color .12s,background .12s;display:block}
 .mega-panel a:hover{color:var(--color-text);background:var(--color-surface-offset)}
 .mega-panel__view-all{margin-top:var(--space-2);font-weight:600!important;color:var(--color-primary)!important}
-.mega-panel__view-all:hover{color:var(--color-primary-hover)!important}
 .mega-panel__col+.mega-panel__col{border-left:1px solid var(--color-divider);padding-left:var(--space-4)}
 .nav-actions{display:flex;align-items:center;gap:var(--space-2);flex-shrink:0}
 .theme-toggle{display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:var(--radius-md);color:var(--color-text-muted);border:1px solid var(--color-border);background:none;cursor:pointer}
@@ -102,172 +96,306 @@ a,button,[role="button"],input,select{transition:color var(--transition),backgro
 .mobile-menu.open{display:block;transform:translateX(0)}
 .mobile-menu__inner{padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-1)}
 .mobile-section{border-radius:var(--radius-md);overflow:hidden}
-.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s}
+.mobile-section__toggle{width:100%;display:flex;align-items:center;justify-content:space-between;padding:12px 14px;font-size:var(--text-sm);font-weight:600;color:var(--color-text);background:none;border:none;cursor:pointer;border-radius:var(--radius-md);transition:background .12s;min-height:44px}
 .mobile-section__toggle:hover{background:var(--color-surface-offset)}
 .mobile-section__toggle svg{transition:transform .2s;flex-shrink:0}
 .mobile-section__toggle[aria-expanded="true"] svg{transform:rotate(180deg)}
 .mobile-section__toggle[aria-expanded="true"]{background:var(--color-surface-offset);border-radius:var(--radius-md) var(--radius-md) 0 0}
 .mobile-section__items{display:none;flex-direction:column;background:var(--color-surface-offset);border-radius:0 0 var(--radius-md) var(--radius-md);padding:4px 8px 8px}
 .mobile-section__items.open{display:flex}
-.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-sm);transition:color .12s,background .12s}
+.mobile-section__items a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-sm);transition:color .12s,background .12s;min-height:44px;display:flex;align-items:center}
 .mobile-section__items a:hover{color:var(--color-text);background:var(--color-surface-dynamic)}
 .mobile-view-all{font-weight:600!important;color:var(--color-primary)!important;margin-top:4px}
 .mobile-section--flat{display:flex;flex-direction:column;padding:8px 4px;border-top:1px solid var(--color-divider);margin-top:var(--space-2)}
-.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:8px 10px;border-radius:var(--radius-md)}
+.mobile-section--flat a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;padding:10px;border-radius:var(--radius-md);min-height:44px;display:flex;align-items:center}
 .mobile-section--flat a:hover{background:var(--color-surface-offset);color:var(--color-text)}
 @media(max-width:900px){.mega-nav{display:none}.hamburger{display:flex}}
 @media(max-width:768px){.nav-logo span{display:none}}
 .ad-slot{min-height:0!important;margin:var(--space-2) 0}
 .ad-slot:not(:has(ins[data-ad-status])){border:none!important;background:none!important;padding:0!important;min-height:0!important;margin:0!important}
+.scroll-progress{position:fixed;top:56px;left:0;right:0;height:2px;background:transparent;z-index:198;pointer-events:none}
+.scroll-progress__fill{height:100%;width:0;background:linear-gradient(90deg,var(--color-gold-bright),var(--color-gold),var(--color-rose));transition:width 80ms linear;box-shadow:0 0 8px color-mix(in oklch,var(--color-gold-bright) 60%,transparent)}
+/* ── BREADCRUMB ── */
+.breadcrumb-wrap{max-width:1280px;margin:0 auto;padding:var(--space-3) var(--space-4)}
+.breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
+.breadcrumb li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
+.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
+.breadcrumb a:hover{color:var(--color-primary)}
+.breadcrumb li[aria-current="page"]{color:var(--color-text)}
+/* ── ARTICLE LAYOUT ── */
+.article-shell{max-width:1280px;margin:0 auto;padding:0 var(--space-4) var(--space-16);position:relative}
+@media(min-width:1024px){.article-shell{display:grid;grid-template-columns:240px minmax(0,1fr);gap:var(--space-10);align-items:flex-start;padding:0 var(--space-6) var(--space-16)}}
+/* ── HERO ── */
+.hero-wrap{margin:0 0 var(--space-6);grid-column:1/-1}
+.hero-tag{display:inline-flex;align-items:center;gap:8px;padding:5px 12px;background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright)}
+.hero-tag::before{content:"";display:block;width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright);box-shadow:0 0 8px var(--color-gold-bright)}
+.hero-title{font-family:var(--font-editorial);font-size:var(--text-3xl);font-weight:600;line-height:1.05;letter-spacing:-0.02em;color:var(--color-text);margin:var(--space-4) 0 var(--space-3);max-width:20ch}
+.hero-title em{font-style:italic;color:var(--color-gold-bright);font-weight:500}
+.hero-sub{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.6;max-width:64ch;margin-bottom:var(--space-5)}
+.hero-byline{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-3);font-size:var(--text-sm);color:var(--color-text-faint);margin-bottom:var(--space-6)}
+.hero-byline a{color:var(--color-text-muted);font-weight:500;text-decoration:none}
+.hero-byline a:hover{color:var(--color-primary)}
+.hero-byline-dot{width:3px;height:3px;border-radius:50%;background:var(--color-text-faint)}
+/* ── BENTO HERO GRID ── */
+.bento-hero{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-6)}
+@media(min-width:560px){.bento-hero{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:960px){.bento-hero{grid-template-columns:repeat(6,1fr);grid-auto-rows:minmax(132px,auto)}}
+.bento-cell{position:relative;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);overflow:hidden;transition:border-color var(--transition),transform var(--transition),box-shadow var(--transition)}
+.bento-cell:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));transform:translateY(-1px);box-shadow:var(--shadow-md)}
+.bento-cell__label{display:flex;align-items:center;gap:8px;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.bento-cell__value{font-family:var(--font-editorial);font-size:clamp(1.6rem,1rem + 2.2vw,2.25rem);font-weight:600;color:var(--color-text);line-height:1;font-variant-numeric:tabular-nums;letter-spacing:-0.02em}
+.bento-cell__value-em{color:var(--color-gold-bright)}
+.bento-cell__caption{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-2);line-height:1.5}
+@media(min-width:960px){.bento-a{grid-column:4/5}.bento-b{grid-column:5/6}.bento-c{grid-column:6/7}.bento-d{grid-column:4/7;grid-row:2}}
+.bento-d{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface))}
+.bento-d::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;border-radius:var(--radius-xl) var(--radius-xl) 0 0;background:linear-gradient(90deg,#f0c14b,#d19900,#b07a00)}
+.bento-d__formula{font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text);line-height:1.3}
+.bento-d__formula span{color:var(--color-gold-bright)}
+.bento-ring{flex-shrink:0;width:64px;height:64px;color:var(--color-gold-bright);opacity:.9}
+@media(max-width:520px){.bento-ring{width:52px;height:52px}}
+/* live spot price hero card */
+.bento-spot{grid-column:1/-1;background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface)),color-mix(in oklch,var(--color-rose) 6%,var(--color-surface)));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));display:flex;flex-direction:column;justify-content:space-between;min-height:160px}
+.bento-spot::after{content:"";position:absolute;top:-50%;right:-30%;width:70%;height:160%;background:radial-gradient(ellipse,color-mix(in oklch,var(--color-gold-bright) 16%,transparent),transparent 70%);pointer-events:none}
+.bento-spot>*{position:relative;z-index:1}
+@media(min-width:960px){.bento-spot{grid-column:1/4;grid-row:span 2;padding:var(--space-6)}}
+.bento-spot__head{display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-3)}
+.bento-spot__title{font-family:var(--font-display);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-muted)}
+.bento-spot__price{font-family:var(--font-editorial);font-size:clamp(2.25rem,1.4rem + 3.5vw,3.5rem);font-weight:600;color:var(--color-text);line-height:1;letter-spacing:-0.02em;font-variant-numeric:tabular-nums;margin:var(--space-4) 0 var(--space-2)}
+.bento-spot__delta{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-sm);font-weight:600;font-variant-numeric:tabular-nums}
+.bento-spot__delta--up{color:var(--color-emerald)}
+.bento-spot__delta--down{color:var(--color-rose)}
+.bento-spot__meta{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-3);display:flex;flex-wrap:wrap;gap:var(--space-3)}
+.live-pill{display:inline-flex;align-items:center;gap:6px;padding:4px 9px;background:color-mix(in oklch,var(--color-emerald) 12%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-emerald) 28%,var(--color-border));border-radius:var(--radius-full);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-emerald);white-space:nowrap}
+.live-pill__dot{width:6px;height:6px;border-radius:50%;background:var(--color-emerald);animation:livePulse 1.8s infinite}
+@keyframes livePulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.55;transform:scale(.85)}}
+.live-pill--idle{color:var(--color-text-muted);background:var(--color-surface-offset);border-color:var(--color-border)}
+.live-pill--idle .live-pill__dot{background:var(--color-text-faint);animation:none}
+.live-pill--error{color:var(--color-rose);background:color-mix(in oklch,var(--color-rose) 10%,var(--color-surface));border-color:color-mix(in oklch,var(--color-rose) 30%,var(--color-border))}
+.live-pill--error .live-pill__dot{background:var(--color-rose);animation:none}
+/* ── SIDEBAR TOC ── */
+.toc{display:none}
+@media(min-width:1024px){.toc{display:block;position:sticky;top:84px;align-self:flex-start;max-height:calc(100dvh - 100px);overflow-y:auto;padding:var(--space-4) var(--space-3) var(--space-4) 0;border-right:1px solid var(--color-divider);scrollbar-width:thin;scrollbar-color:var(--color-border) transparent}}
+.toc__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-text-faint);margin-bottom:var(--space-3);padding-left:var(--space-3)}
+.toc__list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:1px;counter-reset:toc}
+.toc__list a{display:block;padding:8px 12px;font-size:13px;font-weight:500;color:var(--color-text-muted);text-decoration:none;border-left:2px solid transparent;border-radius:0 var(--radius-sm) var(--radius-sm) 0;transition:color var(--transition),border-color var(--transition),background var(--transition);line-height:1.35}
+.toc__list a:hover{color:var(--color-text);background:var(--color-surface-offset);border-left-color:var(--color-border)}
+.toc__list a.is-active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));font-weight:600}
+.toc-fab{position:fixed;bottom:20px;right:20px;width:auto;height:52px;padding:0 var(--space-5);border-radius:var(--radius-full);background:var(--color-text);color:var(--color-bg);border:none;cursor:pointer;display:inline-flex;gap:8px;align-items:center;justify-content:center;font-size:var(--text-sm);font-weight:700;z-index:150;box-shadow:var(--shadow-lg);transition:transform var(--transition)}
+.toc-fab:hover{transform:translateY(-2px)}
+@media(min-width:1024px){.toc-fab{display:none}}
+.toc-sheet{position:fixed;inset:0;background:color-mix(in oklch,var(--color-bg) 80%,transparent);backdrop-filter:blur(8px);z-index:201;display:none;align-items:flex-end;justify-content:center}
+.toc-sheet.is-open{display:flex;animation:fadeIn .2s ease-out}
+@keyframes fadeIn{from{opacity:0}to{opacity:1}}
+.toc-sheet__panel{width:100%;max-width:560px;max-height:80dvh;background:var(--color-surface);border-radius:var(--radius-xl) var(--radius-xl) 0 0;padding:var(--space-5) var(--space-4) var(--space-6);overflow-y:auto;animation:slideUp .25s cubic-bezier(.16,1,.3,1)}
+@keyframes slideUp{from{transform:translateY(40px)}to{transform:translateY(0)}}
+.toc-sheet__head{display:flex;justify-content:space-between;align-items:center;margin-bottom:var(--space-4);padding-bottom:var(--space-3);border-bottom:1px solid var(--color-border)}
+.toc-sheet__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text)}
+.toc-sheet__close{width:40px;height:40px;border-radius:50%;background:var(--color-surface-offset);display:flex;align-items:center;justify-content:center}
+.toc-sheet__list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:2px}
+.toc-sheet__list a{padding:12px 14px;font-size:var(--text-sm);font-weight:500;color:var(--color-text-muted);text-decoration:none;border-radius:var(--radius-md);min-height:44px;display:flex;align-items:center}
+.toc-sheet__list a:hover{color:var(--color-text);background:var(--color-surface-offset)}
+/* ── PROSE ── */
+.prose-main{min-width:0;grid-column:2}
+@media(max-width:1023px){.prose-main{grid-column:1}}
+.prose{max-width:760px}
+.prose h2{font-family:var(--font-editorial);font-size:clamp(1.5rem,1.1rem + 1.5vw,2.25rem);font-weight:600;color:var(--color-text);margin:var(--space-12) 0 var(--space-3);line-height:1.15;letter-spacing:-0.015em;scroll-margin-top:90px}
+.prose h2 .h2-num{display:inline-block;font-family:var(--font-display);font-size:0.4em;font-weight:700;color:var(--color-gold-bright);vertical-align:super;margin-right:8px;letter-spacing:.06em}
+.prose h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-8) 0 var(--space-2)}
+.prose h3 .hmark{vertical-align:2px;margin-left:6px}
+.prose h4{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-5) 0 var(--space-2)}
+.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
+.prose p.prose-lede{font-family:var(--font-editorial);font-size:clamp(1.125rem,0.9rem + 1vw,1.375rem);font-weight:500;color:var(--color-text);line-height:1.5;letter-spacing:-0.01em;margin-bottom:var(--space-5)}
+.prose p.prose-lede::first-letter{font-family:var(--font-editorial);font-size:3em;float:left;line-height:0.85;padding:6px 12px 0 0;color:var(--color-gold-bright);font-weight:600}
+.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
+.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
+.prose strong{color:var(--color-text);font-weight:600}
+.prose a{color:var(--color-primary);text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:3px;text-decoration-color:color-mix(in oklch,var(--color-primary) 40%,transparent)}
+.prose a:hover{color:var(--color-primary-hover);text-decoration-color:currentColor}
+.hmark{display:inline-flex;align-items:center;padding:2px 8px;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:.04em;font-family:var(--font-display)}
+/* ── PROSE TABLE ── */
+.table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch;margin:var(--space-5) 0 var(--space-6);border:1px solid var(--color-border);border-radius:var(--radius-xl);background:var(--color-surface)}
+.table-scroll table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:0;min-width:520px}
+.table-scroll th{text-align:left;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-4) var(--space-4);border-bottom:2px solid var(--color-border);background:var(--color-surface-offset)}
+.table-scroll td{padding:var(--space-3) var(--space-4);border-bottom:1px solid var(--color-divider);color:var(--color-text-muted);vertical-align:middle;line-height:1.5}
+.table-scroll tr:last-child td{border-bottom:none}
+.table-scroll td:first-child,.table-scroll th:first-child{color:var(--color-text);font-weight:600}
+.table-scroll td .usd{color:var(--color-gold-bright);font-weight:700;font-variant-numeric:tabular-nums;font-family:var(--font-display)}
+/* ── EXEC / CALLOUTS / PULL-QUOTE / STEPS ── */
+.exec-summary{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.exec-summary p{font-size:var(--text-base);color:var(--color-text);line-height:1.7;margin-bottom:0;max-width:none}
+.exec-summary strong{color:var(--color-gold-bright)}
+.info-callout{background:color-mix(in oklch,var(--color-primary) 7%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 18%,var(--color-border));border-left:3px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.info-callout::before{content:"i";display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:50%;background:var(--color-primary);color:#fff;font-family:var(--font-editorial);font-style:italic;font-weight:700;font-size:13px;margin-right:8px;float:left}
+.info-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
+.info-callout p+p{margin-top:var(--space-3);clear:both}
+.info-callout strong{color:var(--color-text)}
+.warning-callout{background:color-mix(in oklch,var(--color-rose) 7%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-rose) 20%,var(--color-border));border-left:3px solid var(--color-rose);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
+.warning-callout::before{content:"!";display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;border-radius:50%;background:var(--color-rose);color:#fff;font-weight:700;font-size:13px;margin-right:8px;float:left}
+.warning-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
+.warning-callout p+p{margin-top:var(--space-3);clear:both}
+.warning-callout strong{color:var(--color-text)}
+.pull-quote{font-family:var(--font-editorial);font-size:clamp(1.25rem,1rem + 1.5vw,1.875rem);font-weight:500;color:var(--color-text);line-height:1.3;letter-spacing:-0.015em;border-left:3px solid var(--color-gold-bright);padding:var(--space-2) 0 var(--space-2) var(--space-5);margin:var(--space-8) 0;max-width:60ch;font-style:italic}
+.pull-quote::before{content:"\201C";font-size:1.5em;color:var(--color-gold-bright);line-height:1;margin-right:4px;display:inline-block;transform:translateY(8px);font-style:normal}
+.step-list{list-style:none;padding:0;margin:var(--space-6) 0;display:flex;flex-direction:column;gap:var(--space-3)}
+.step-block{display:flex;align-items:flex-start;gap:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-4) var(--space-5);transition:border-color var(--transition),box-shadow var(--transition)}
+.step-block:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));box-shadow:var(--shadow-sm)}
+.step-number{flex-shrink:0;width:38px;height:38px;border-radius:var(--radius-full);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));color:var(--color-gold-bright);font-weight:700;font-size:var(--text-base);display:flex;align-items:center;justify-content:center;font-family:var(--font-editorial);border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border))}
+.step-content{flex:1;min-width:0}
+.step-content strong{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:4px}
+.step-content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+/* ── PURITY VISUALIZER (signature) ── */
+.purity-viz{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);padding:var(--space-5);margin:var(--space-6) 0}
+@media(min-width:640px){.purity-viz{padding:var(--space-6)}}
+.purity-viz__head{display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-3);flex-wrap:wrap;margin-bottom:var(--space-5)}
+.purity-viz__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0}
+.purity-viz__caption{font-size:11px;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em;font-weight:600;margin-top:4px}
+.purity-list{display:flex;flex-direction:column;gap:var(--space-3)}
+.purity-row{display:grid;grid-template-columns:1fr;gap:6px}
+.purity-row__top{display:flex;align-items:baseline;justify-content:space-between;gap:var(--space-3)}
+.purity-row__name{font-size:var(--text-sm);font-weight:600;color:var(--color-text);display:flex;align-items:center;gap:8px;min-width:0}
+.purity-row__mark{font-family:var(--font-display);font-size:11px;font-weight:700;color:var(--color-text-faint);font-variant-numeric:tabular-nums}
+.purity-row__pct{font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;flex-shrink:0}
+.purity-track{height:12px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);overflow:hidden}
+.purity-fill{height:100%;width:0;border-radius:var(--radius-full);background:linear-gradient(90deg,color-mix(in oklch,var(--color-gold-bright) 55%,transparent),var(--color-gold-bright));transition:width 1000ms cubic-bezier(.16,1,.3,1)}
+.purity-viz.is-in .purity-fill{width:var(--w)}
+.purity-viz__foot{font-size:11px;color:var(--color-text-faint);margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-divider);line-height:1.5}
+/* ── VALUE LADDER (retail → scrap) ── */
+.ladder{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin:var(--space-5) 0 var(--space-6)}
+@media(min-width:560px){.ladder{grid-template-columns:repeat(2,1fr)}}
+.ladder-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);position:relative;overflow:hidden}
+.ladder-card::before{content:"";position:absolute;top:0;left:0;right:0;height:3px;background:var(--color-silver)}
+.ladder-card--floor::before{background:var(--color-gold-bright)}
+.ladder-card__tag{display:inline-flex;align-items:center;gap:6px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);margin-bottom:var(--space-2)}
+.ladder-card--floor .ladder-card__tag{color:var(--color-gold-bright)}
+.ladder-card__name{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:4px}
+.ladder-card__pct{font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:600;color:var(--color-text);font-variant-numeric:tabular-nums;margin-bottom:6px}
+.ladder-card--floor .ladder-card__pct{color:var(--color-gold-bright)}
+.ladder-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;margin:0;max-width:none}
+/* ── BUYER PAYOUT COMPARISON ── */
+.acc-compare{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-2xl);padding:var(--space-5);margin:var(--space-6) 0}
+@media(min-width:640px){.acc-compare{padding:var(--space-6)}}
+.acc-compare__head{display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-3);flex-wrap:wrap;margin-bottom:var(--space-4)}
+.acc-compare__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0}
+.acc-compare__caption{font-size:11px;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.08em;font-weight:600;margin-top:4px}
+.acc-tabs{display:inline-flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px;gap:2px}
+.acc-tab{padding:7px 14px;font-size:12px;font-weight:600;color:var(--color-text-muted);border:none;background:none;border-radius:var(--radius-full);cursor:pointer;min-height:36px;white-space:nowrap}
+.acc-tab:hover{color:var(--color-text)}
+.acc-tab.is-active{background:var(--color-gold-bright);color:#1a1410}
+.acc-list{display:flex;flex-direction:column;gap:var(--space-3)}
+.acc-row{display:grid;grid-template-columns:1fr;gap:6px}
+.acc-row__top{display:flex;align-items:baseline;justify-content:space-between;gap:var(--space-3)}
+.acc-row__name{font-size:var(--text-sm);font-weight:600;color:var(--color-text);display:flex;align-items:center;gap:8px;min-width:0}
+.acc-row__rank{font-family:var(--font-display);font-size:11px;font-weight:700;color:var(--color-text-faint);font-variant-numeric:tabular-nums;flex-shrink:0}
+.acc-row__score{font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;flex-shrink:0}
+.acc-row__tier{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;padding:2px 7px;border-radius:var(--radius-full)}
+.acc-track{height:10px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);overflow:hidden}
+.acc-fill{height:100%;width:0;border-radius:var(--radius-full);transition:width 1000ms cubic-bezier(.16,1,.3,1)}
+.acc-compare.is-in .acc-fill{width:var(--w)}
+.acc--high .acc-fill,.acc--high .acc-row__tier{background:var(--color-emerald)}
+.acc--high .acc-row__tier{color:#06281e}
+.acc--medium .acc-fill,.acc--medium .acc-row__tier{background:#e0a020}
+.acc--medium .acc-row__tier{color:#2a1c00}
+.acc--low .acc-fill,.acc--low .acc-row__tier{background:var(--color-rose)}
+.acc--low .acc-row__tier{color:#2c0d0a}
+.acc--pro .acc-fill,.acc--pro .acc-row__tier{background:var(--color-primary)}
+.acc--pro .acc-row__tier{color:#04211f}
+.acc-compare__foot{font-size:11px;color:var(--color-text-faint);margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-divider);line-height:1.5}
+/* ── FAQ ── */
+.faq-accordion{display:flex;flex-direction:column;gap:var(--space-2);margin:var(--space-4) 0}
+details.faq-item{border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;background:var(--color-surface);transition:border-color var(--transition)}
+details.faq-item:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border))}
+details.faq-item[open]{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border))}
+details.faq-item summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;gap:var(--space-3);transition:background .15s;min-height:56px}
+details.faq-item summary::-webkit-details-marker,details.faq-item summary::marker{display:none}
+details.faq-item summary:hover{background:var(--color-surface-offset)}
+.faq-chevron{flex-shrink:0;transition:transform .2s;color:var(--color-gold-bright);width:18px;height:18px}
+details.faq-item[open] .faq-chevron{transform:rotate(180deg)}
+details.faq-item[open]>summary{background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
+.faq-body{padding:var(--space-4) var(--space-5) var(--space-5);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
+.faq-body p{margin:0;max-width:none;font-size:var(--text-sm);line-height:1.7}
+.faq-body p+p{margin-top:var(--space-3)}
+.faq-body strong{color:var(--color-text);font-weight:600}
+/* ── LIVE CALCULATOR ── */
+.gf-calc{position:relative;background:linear-gradient(160deg,color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface)),var(--color-surface) 60%);border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));border-radius:var(--radius-2xl);padding:var(--space-5);margin:var(--space-6) 0;overflow:hidden;box-shadow:var(--shadow-glow)}
+@media(min-width:640px){.gf-calc{padding:var(--space-6)}}
+.gf-calc::after{content:"";position:absolute;top:-40%;right:-20%;width:60%;height:120%;background:radial-gradient(ellipse,color-mix(in oklch,var(--color-gold-bright) 14%,transparent),transparent 70%);pointer-events:none;z-index:0}
+.gf-calc>*{position:relative;z-index:1}
+.gf-calc__head{display:flex;justify-content:space-between;align-items:flex-start;gap:var(--space-3);margin-bottom:var(--space-5);flex-wrap:wrap}
+.gf-calc__title-block{flex:1;min-width:200px}
+.gf-calc__eyebrow{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:6px}
+.gf-calc__title{font-family:var(--font-editorial);font-size:clamp(1.25rem,1rem + 1vw,1.625rem);font-weight:600;color:var(--color-text);line-height:1.2;letter-spacing:-0.015em;margin:0}
+.gf-calc__sub{font-size:var(--text-sm);color:var(--color-text-muted);margin-top:6px;line-height:1.55;max-width:52ch}
+.gf-calc__grid{display:grid;grid-template-columns:1fr;gap:var(--space-5)}
+@media(min-width:768px){.gf-calc__grid{grid-template-columns:1fr 1fr;gap:var(--space-6)}}
+.gf-calc__controls{display:flex;flex-direction:column;gap:var(--space-4)}
+.gf-field{display:flex;flex-direction:column;gap:var(--space-2)}
+.gf-label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted)}
+.gf-unit-toggle{display:flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);overflow:hidden}
+.gf-unit-btn{flex:1;padding:10px var(--space-3);font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);border:none;background:none;cursor:pointer;text-align:center;min-height:44px}
+.gf-unit-btn.is-active{background:var(--color-gold-bright);color:#1a1410}
+.gf-input{width:100%;padding:12px var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:500;color:var(--color-text);outline:none;font-variant-numeric:tabular-nums;min-height:48px;transition:border-color var(--transition),box-shadow var(--transition)}
+.gf-input:focus{border-color:var(--color-gold-bright);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-gold-bright) 18%,transparent)}
+.gf-karat-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:6px}
+@media(min-width:380px){.gf-karat-grid{grid-template-columns:repeat(6,1fr)}}
+.gf-karat-btn{padding:10px 6px;font-size:var(--text-xs);font-weight:700;color:var(--color-text-muted);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface);cursor:pointer;text-align:center;min-height:44px;display:flex;align-items:center;justify-content:center;font-family:var(--font-display);letter-spacing:.04em}
+.gf-karat-btn:hover{border-color:var(--color-gold-bright);color:var(--color-gold-bright)}
+.gf-karat-btn.is-active{background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface-offset));border-color:var(--color-gold-bright);color:var(--color-gold-bright)}
+.gf-select{width:100%;padding:12px var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-family:var(--font-body);font-size:var(--text-sm);color:var(--color-text);outline:none;cursor:pointer;min-height:44px}
+.gf-select:focus{border-color:var(--color-gold-bright)}
+.gf-calc__result{background:color-mix(in oklch,var(--color-bg) 86%,transparent);backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);border:1px solid var(--color-border);border-radius:var(--radius-xl);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-4)}
+.gf-result-primary{background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 24%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);text-align:center}
+.gf-result-primary__label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:8px}
+.gf-result-primary__value{font-family:var(--font-editorial);font-size:clamp(1.875rem,1.2rem + 2.5vw,2.625rem);font-weight:600;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1;letter-spacing:-0.02em}
+.gf-result-primary__note{font-size:11px;color:var(--color-text-faint);margin-top:8px}
+.gf-result-offer{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-4);text-align:center}
+.gf-result-offer__label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-text-muted);margin-bottom:4px}
+.gf-result-offer__value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.gf-stats{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-2)}
+.gf-stat{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3);text-align:left}
+.gf-stat__label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);margin-bottom:4px}
+.gf-stat__value{font-size:var(--text-sm);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums;font-family:var(--font-display)}
+.gf-placeholder{display:flex;align-items:center;justify-content:center;flex:1;min-height:200px;color:var(--color-text-faint);font-size:var(--text-sm);text-align:center;padding:var(--space-6);background:var(--color-surface-offset);border:1px dashed var(--color-border);border-radius:var(--radius-lg)}
+.gf-spot-line{font-size:11px;color:var(--color-text-faint);text-align:center;padding-top:var(--space-3);border-top:1px solid var(--color-divider);font-variant-numeric:tabular-nums}
+.gf-spot-line strong{color:var(--color-text-muted);font-family:var(--font-display)}
+/* ── CTA / DISCLAIMER / RELATED / FOOTER ── */
+.cta-box{background:linear-gradient(135deg,color-mix(in oklch,var(--color-primary) 12%,var(--color-surface)),color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface)));border:1px solid color-mix(in oklch,var(--color-primary) 25%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-6);margin:var(--space-8) 0}
+.cta-box h3{font-family:var(--font-editorial);font-size:var(--text-lg);font-weight:600;color:var(--color-text);margin:0 0 var(--space-2)!important}
+.cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-4);max-width:none}
+.cta-btn{display:inline-flex;align-items:center;gap:8px;padding:12px var(--space-5);background:var(--color-primary);color:#fff!important;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none!important;transition:background var(--transition),transform var(--transition);min-height:44px}
+.cta-btn:hover,.cta-btn:visited{background:var(--color-primary-hover);color:#fff!important;text-decoration:none!important;transform:translateY(-1px)}
+.cta-btn svg{transition:transform var(--transition)}
+.cta-btn:hover svg{transform:translateX(3px)}
+.disclaimer-box{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
+.disclaimer-box strong{color:var(--color-text);font-weight:600}
+.related-section{max-width:1280px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
+@media(min-width:1024px){.related-section{padding:0 var(--space-6)}}
+.related-section__head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:var(--space-5);flex-wrap:wrap;gap:var(--space-3)}
+.related-section__head h2{font-family:var(--font-editorial);font-size:var(--text-xl);font-weight:600;color:var(--color-text);margin:0;letter-spacing:-0.015em}
+.related-section__head p{font-size:var(--text-sm);color:var(--color-text-muted);margin:0}
+.related-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:var(--space-4)}
+.related-card{display:flex;flex-direction:column;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition),transform var(--transition);min-height:160px}
+.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);color:var(--color-text);transform:translateY(-2px)}
+.related-card__tag{display:inline-flex;align-items:center;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.related-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);line-height:1.3;margin-bottom:var(--space-2)}
+.related-card:hover .related-card__title{color:var(--color-primary)}
+.related-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6;margin-top:auto}
 footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:var(--space-10) 0}
-.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start}
+.footer-inner{width:100%;display:grid;grid-template-columns:minmax(0,1.4fr) repeat(5,minmax(0,1fr));gap:var(--space-5);padding:0 var(--space-8);align-items:start;max-width:1280px;margin:0 auto}
 @media(max-width:900px){.footer-inner{grid-template-columns:repeat(3,1fr)}}
 @media(max-width:600px){.footer-inner{grid-template-columns:repeat(2,1fr);gap:var(--space-4)}}
 .footer-brand-col{max-width:260px}
 .footer-brand{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin-top:var(--space-3);max-width:40ch}
 .footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
 .footer-col{min-width:0}
-.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
+.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:8px}
 .footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
 .footer-col a:hover{color:var(--color-text)}
-.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
+.footer-bottom{max-width:1280px;margin:0 auto;padding:var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
 .footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
-.breadcrumb-wrap{max-width:1200px;margin:0 auto;padding:var(--space-3) var(--space-4)}
-.breadcrumb{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-1);list-style:none;padding:0;margin:0;font-size:var(--text-sm);color:var(--color-text-muted)}
-.breadcrumb li+li::before{content:"/";margin:0 var(--space-1);color:var(--color-text-faint)}
-.breadcrumb a{color:var(--color-text-muted);text-decoration:none}
-.breadcrumb a:hover{color:var(--color-primary)}
-.breadcrumb li[aria-current="page"]{color:var(--color-text)}
-.article-wrap{max-width:1200px;margin:0 auto;padding:var(--space-6) var(--space-4) var(--space-16)}
-.article-tag{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-gold-bright);margin-bottom:var(--space-3)}
-article.article-wrap .article-title,h1.article-title{font-family:var(--font-display)!important;font-size:clamp(1.75rem,3.5vw,2.75rem)!important;font-weight:700!important;line-height:1.15!important;margin:var(--space-2) 0 var(--space-5)!important;color:var(--color-text)!important}
-.article-byline{font-size:var(--text-sm);color:var(--color-text-muted);display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);margin-bottom:var(--space-6);padding-bottom:var(--space-4);border-bottom:1px solid var(--color-border)}
-.article-byline a{color:var(--color-primary);text-decoration:none;font-weight:500}
-.article-byline a:hover{text-decoration:underline}
-.prose{max-width:860px}
-.prose h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin:var(--space-8) 0 var(--space-3);line-height:1.25}
-.prose h3{font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
-.prose h4{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:var(--space-5) 0 var(--space-2)}
-.prose p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75;margin-bottom:var(--space-4)}
-.prose ul,.prose ol{padding-left:var(--space-5);margin-bottom:var(--space-4)}
-.prose li{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-2)}
-.prose strong{color:var(--color-text);font-weight:700}
-.prose a{color:var(--color-primary);text-decoration:underline}
-.prose a:hover{color:var(--color-primary-hover)}
-.prose sup{font-size:.7em;vertical-align:super;color:var(--color-text-faint)}
-.prose table{width:100%;border-collapse:collapse;font-size:var(--text-sm);margin:var(--space-4) 0 var(--space-6)}
-.prose table th{text-align:left;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-faint);padding:var(--space-2) var(--space-3) var(--space-2) 0;border-bottom:2px solid var(--color-border)}
-.prose table td{padding:var(--space-3) var(--space-3) var(--space-3) 0;border-bottom:1px solid var(--color-border);color:var(--color-text-muted);vertical-align:middle}
-.prose table tr:last-child td{border-bottom:none}
-.prose table td:first-child,.prose table th:first-child{padding-left:0;color:var(--color-text)}
-.table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch;margin:var(--space-4) 0 var(--space-6)}
-.table-scroll table{margin:0;min-width:560px}
-.cta-box{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 18%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-8) 0}
-.cta-box h3{font-family:var(--font-display);font-size:var(--text-lg);color:var(--color-text);margin:0 0 var(--space-2)}
-.cta-box p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-4)}
-.cta-btn{display:inline-flex;align-items:center;gap:var(--space-1);padding:var(--space-2) var(--space-5);background:var(--color-primary);color:#fff!important;border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:600;text-decoration:none;transition:background .15s}
-.cta-btn:hover,.cta-btn:visited{background:var(--color-primary-hover);color:#fff!important;text-decoration:none}
-.disclaimer-box{background:var(--color-surface-alt,#f4f3ef);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:var(--space-8) 0}
-.disclaimer-box strong{color:var(--color-text);font-weight:700}
-.related-guides-section{max-width:860px;margin:0 auto var(--space-10);padding:0 var(--space-4)}
-.related-guides-section h2{font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-4)}
-.related-guides-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4)}
-.related-card{display:block;background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
-.related-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);color:var(--color-text)}
-.related-card__tag{display:block;font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
-.related-card__title{font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.4;margin-bottom:var(--space-2)}
-.related-card:hover .related-card__title{color:var(--color-primary)}
-.related-card__desc{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
-.exec-summary{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);padding:var(--space-6);margin:var(--space-6) 0}
-.exec-summary-intro{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.7;margin-bottom:var(--space-5)}
-.exec-summary-intro strong{color:var(--color-text)}
-.exec-summary-stats{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:var(--space-4)}
-.exec-stat{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3) var(--space-4)}
-.exec-stat-label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.exec-stat-value{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;margin-top:var(--space-1);line-height:1.2}
-.info-callout{background:color-mix(in oklch,var(--color-primary) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 20%,var(--color-border));border-left:3px solid var(--color-primary);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
-.info-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
-.info-callout p+p{margin-top:var(--space-3)}
-.info-callout strong{color:var(--color-text)}
-.info-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0}
-.info-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
-.warning-callout{background:color-mix(in oklch,#f59e0b 8%,var(--color-surface));border:1px solid color-mix(in oklch,#f59e0b 25%,var(--color-border));border-left:3px solid #f59e0b;border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin:var(--space-6) 0}
-.warning-callout p{margin:0;font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;max-width:none}
-.warning-callout p+p{margin-top:var(--space-3)}
-.warning-callout strong{color:var(--color-text)}
-.warning-callout ul{padding-left:var(--space-5);margin:var(--space-3) 0 0}
-.warning-callout li{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin-bottom:var(--space-2)}
-.faq-accordion{margin:var(--space-4) 0}
-details.faq-item{border:1px solid var(--color-border);border-radius:var(--radius-lg);margin-bottom:var(--space-2);overflow:hidden;background:var(--color-surface)}
-details.faq-item summary{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5);font-size:var(--text-base);font-weight:600;color:var(--color-text);cursor:pointer;list-style:none;gap:var(--space-3);transition:background .15s}
-details.faq-item summary::-webkit-details-marker{display:none}
-details.faq-item summary:hover{background:var(--color-surface-offset)}
-.faq-chevron{flex-shrink:0;transition:transform .2s;color:var(--color-text-muted)}
-details.faq-item[open] .faq-chevron{transform:rotate(180deg)}
-details.faq-item[open]>summary{background:var(--color-surface-offset);border-bottom:1px solid var(--color-border)}
-.faq-body{padding:var(--space-4) var(--space-5);font-size:var(--text-base);color:var(--color-text-muted);line-height:1.75}
-.faq-body p{margin:0;max-width:none}
-.faq-body p+p{margin-top:var(--space-3)}
-.faq-body strong{color:var(--color-text)}
-.step-list{list-style:none;padding:0;margin:var(--space-6) 0;display:flex;flex-direction:column;gap:var(--space-4)}
-.step-block{display:flex;align-items:flex-start;gap:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5)}
-.step-number{flex-shrink:0;width:36px;height:36px;border-radius:var(--radius-full);background:var(--color-primary);color:#fff;font-weight:700;font-size:var(--text-sm);display:flex;align-items:center;justify-content:center;font-family:var(--font-display)}
-.step-content{flex:1;min-width:0}
-.step-content strong{display:block;font-size:var(--text-base);font-weight:700;color:var(--color-text);margin-bottom:var(--space-2)}
-.step-content p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;margin:0;max-width:none}
-.hmark{display:inline-flex;align-items:center;padding:2px 8px;background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 25%,var(--color-border));border-radius:var(--radius-sm);font-size:var(--text-xs);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:.04em;font-family:var(--font-display)}
-/* Ring value calculator */
-.ring-calc{background:color-mix(in oklch,var(--color-gold-bright) 5%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-xl);padding:var(--space-6);margin:var(--space-8) 0}
-.ring-calc__header{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:var(--space-3);margin-bottom:var(--space-6)}
-.ring-calc__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text)}
-.ring-calc__live{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);padding:4px 10px;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full)}
-.live-dot{width:7px;height:7px;border-radius:50%;background:#22c55e;animation:livePulse 2s infinite}
-@keyframes livePulse{0%,100%{opacity:1}50%{opacity:.4}}
-.ring-calc__grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-6)}
-@media(max-width:640px){.ring-calc__grid{grid-template-columns:1fr}}
-.ring-calc__controls{display:flex;flex-direction:column;gap:var(--space-5)}
-.rc-field{display:flex;flex-direction:column;gap:var(--space-2)}
-.rc-label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted)}
-.unit-toggle{display:flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);overflow:hidden}
-.unit-btn{flex:1;padding:8px var(--space-3);font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);border:none;background:none;cursor:pointer;transition:background var(--transition),color var(--transition);text-align:center}
-.unit-btn.active{background:var(--color-primary);color:#fff}
-.rc-input{width:100%;padding:10px var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-family:var(--font-body);font-size:var(--text-base);color:var(--color-text);outline:none}
-.rc-input:focus{border-color:var(--color-primary);box-shadow:0 0 0 3px color-mix(in oklch,var(--color-primary) 15%,transparent)}
-.karat-grid{display:grid;grid-template-columns:repeat(6,1fr);gap:var(--space-1)}
-@media(max-width:400px){.karat-grid{grid-template-columns:repeat(3,1fr)}}
-.karat-btn{padding:8px 4px;font-size:var(--text-xs);font-weight:700;color:var(--color-text-muted);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface);cursor:pointer;text-align:center;transition:background var(--transition),border-color var(--transition),color var(--transition)}
-.karat-btn:hover{border-color:var(--color-gold-bright);color:var(--color-gold-bright)}
-.karat-btn.active{background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));border-color:var(--color-gold-bright);color:var(--color-gold-bright)}
-.rc-select{width:100%;padding:10px var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-md);font-family:var(--font-body);font-size:var(--text-sm);color:var(--color-text);outline:none;cursor:pointer}
-.rc-select:focus{border-color:var(--color-primary)}
-.ring-calc__results{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-4)}
-.rc-result-primary{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 20%,var(--color-border));border-radius:var(--radius-lg);padding:var(--space-5);text-align:center}
-.rc-result-primary__label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted);margin-bottom:var(--space-2)}
-.rc-melt-value{font-family:var(--font-display);font-size:var(--text-2xl);font-weight:700;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;line-height:1.1}
-.rc-melt-note{font-size:var(--text-xs);color:var(--color-text-faint);margin-top:var(--space-1)}
-.rc-offer-range{background:color-mix(in oklch,var(--color-primary) 8%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-primary) 18%,var(--color-border));border-radius:var(--radius-md);padding:var(--space-4);text-align:center}
-.rc-offer-label{font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
-.rc-offer-value{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-primary);font-variant-numeric:tabular-nums}
-.rc-stats{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3)}
-.rc-stat{background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);padding:var(--space-3)}
-.rc-stat__label{font-size:var(--text-xs);color:var(--color-text-muted);margin-bottom:4px}
-.rc-stat__value{font-size:var(--text-sm);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
-.rc-placeholder{display:flex;align-items:center;justify-content:center;flex:1;min-height:200px;color:var(--color-text-faint);font-size:var(--text-sm);text-align:center;padding:var(--space-6)}
-.rc-spot-line{font-size:var(--text-xs);color:var(--color-text-faint);text-align:center;padding-top:var(--space-3);border-top:1px solid var(--color-border)}
-/* Buyer comparison cards */
-.buyer-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:var(--space-4);margin:var(--space-6) 0}
-.buyer-card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);padding:var(--space-5);transition:border-color var(--transition),box-shadow var(--transition)}
-.buyer-card:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md)}
-.buyer-card__header{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-3);margin-bottom:var(--space-3)}
-.buyer-card__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);line-height:1.3}
-.payout-badge{display:inline-flex;align-items:center;padding:3px 10px;border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:700;white-space:nowrap;flex-shrink:0}
-.payout-badge--high{background:color-mix(in oklch,#22c55e 12%,var(--color-surface-offset));color:#16a34a;border:1px solid color-mix(in oklch,#22c55e 25%,var(--color-border))}
-[data-theme="dark"] .payout-badge--high{color:#4ade80}
-.payout-badge--mid{background:color-mix(in oklch,#f59e0b 12%,var(--color-surface-offset));color:#d97706;border:1px solid color-mix(in oklch,#f59e0b 25%,var(--color-border))}
-[data-theme="dark"] .payout-badge--mid{color:#fbbf24}
-.payout-badge--low{background:color-mix(in oklch,#ef4444 12%,var(--color-surface-offset));color:#dc2626;border:1px solid color-mix(in oklch,#ef4444 25%,var(--color-border))}
-[data-theme="dark"] .payout-badge--low{color:#f87171}
-.buyer-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+/* ── REVEAL ── */
+.reveal{opacity:0;transform:translateY(14px);transition:opacity 520ms cubic-bezier(0.16,1,0.3,1),transform 520ms cubic-bezier(0.16,1,0.3,1)}
+.reveal.is-in{opacity:1;transform:translateY(0)}
+@media(prefers-reduced-motion:reduce){.reveal{opacity:1;transform:none;transition:none}.purity-fill,.acc-fill{transition:none}}
 </style>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
@@ -322,8 +450,8 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     </ul>
     <div class="nav-actions">
       <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark/light mode">
-        <svg id="iconSun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-        <svg id="iconMoon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        <svg id="iconSun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        <svg id="iconMoon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
       </button>
       <button class="hamburger" id="hamburger" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
         <span></span><span></span><span></span>
@@ -331,6 +459,8 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
     </div>
   </div>
 </nav>
+
+<div class="scroll-progress" aria-hidden="true"><div class="scroll-progress__fill" id="scrollProgressFill"></div></div>
 
 <div id="mobileMenu" class="mobile-menu" aria-label="Mobile navigation">
   <div class="mobile-menu__inner">
@@ -364,460 +494,547 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
   </nav>
 </div>
 
-<article class="article-wrap">
-  <div class="article-tag">Guide &amp; Calculator</div>
-  <h1 class="article-title">How Much Is a Gold Ring Worth? (2026 Guide)</h1>
-  <div class="article-byline">
-    <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
-    <span>&middot;</span>
-    <time datetime="2026-06-13">8 May 2026</time>
-    <span>&middot;</span>
-    <span>20 min read</span>
-  </div>
-
-  <div class="prose">
-
-    <p>That gold ring sitting in a drawer has never been worth more. Gold hit an all-time high of $5,589 per troy ounce in early 2026, meaning even modest jewellery — a plain 9ct band, a broken engagement ring — carries real money. But "how much is it worth?" has no single answer. The figure depends on five things: the gold's karat purity, its weight in grams, the live spot price, who you sell to, and whether the ring has any value beyond its metal content.</p>
-    <p>This guide walks through all of it. Use the live calculator below for an instant answer, then read on to understand exactly what drives the number you see — so you are never caught out by a low offer.</p>
-
-    <div class="exec-summary">
-      <p class="exec-summary-intro">The calculator below updates every 60 seconds using the live gold spot price. For the article: all values shown use <strong>May 2026 spot prices</strong> as the baseline. Specialist buyers typically pay <strong>85–95% of melt value</strong> for plain gold rings; other buyers pay significantly less.</p>
-      <div class="exec-summary-stats">
-        <div class="exec-stat">
-          <div class="exec-stat-label">Typical ring weight</div>
-          <div class="exec-stat-value">3–6 g</div>
-        </div>
-        <div class="exec-stat">
-          <div class="exec-stat-label">9ct ring (4g) melt</div>
-          <div class="exec-stat-value">~£167</div>
-        </div>
-        <div class="exec-stat">
-          <div class="exec-stat-label">18ct ring (4g) melt</div>
-          <div class="exec-stat-value">~£335</div>
-        </div>
-        <div class="exec-stat">
-          <div class="exec-stat-label">Best payout rate</div>
-          <div class="exec-stat-value">85–95%</div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Live Ring Value Calculator -->
-    <div class="ring-calc" id="ringCalc">
-      <div class="ring-calc__header">
-        <div class="ring-calc__title">Gold Ring Value Calculator</div>
-        <div class="ring-calc__live" id="rcLiveStatus">
-          <span class="live-dot"></span>
-          <span id="rcStatusText">Connecting…</span>
-        </div>
-      </div>
-      <div class="ring-calc__grid">
-        <div class="ring-calc__controls">
-
-          <div class="rc-field">
-            <label class="rc-label" for="rcWeight">Ring Weight</label>
-            <div class="unit-toggle" role="group" aria-label="Weight unit">
-              <button class="unit-btn active" data-unit="g" id="btnGram">Grams (g)</button>
-              <button class="unit-btn" data-unit="oz" id="btnOz">Troy oz</button>
-            </div>
-            <input class="rc-input" type="number" id="rcWeight" placeholder="e.g. 4.2" min="0" step="0.1" aria-label="Ring weight" inputmode="decimal">
-          </div>
-
-          <div class="rc-field">
-            <div class="rc-label">Gold Karat</div>
-            <div class="karat-grid" role="group" aria-label="Gold karat">
-              <button class="karat-btn" data-karat="9K" data-purity="0.375">9K</button>
-              <button class="karat-btn" data-karat="10K" data-purity="0.4167">10K</button>
-              <button class="karat-btn active" data-karat="14K" data-purity="0.5833">14K</button>
-              <button class="karat-btn" data-karat="18K" data-purity="0.75">18K</button>
-              <button class="karat-btn" data-karat="22K" data-purity="0.9167">22K</button>
-              <button class="karat-btn" data-karat="24K" data-purity="0.999">24K</button>
-            </div>
-          </div>
-
-          <div class="rc-field">
-            <label class="rc-label" for="rcCurrency">Currency</label>
-            <select class="rc-select" id="rcCurrency" aria-label="Display currency">
-              <option value="GBP">GBP — British Pound (live)</option>
-              <option value="USD">USD — US Dollar</option>
-              <option value="EUR">EUR — Euro</option>
-              <option value="AUD">AUD — Australian Dollar</option>
-              <option value="CAD">CAD — Canadian Dollar</option>
-              <option value="INR">INR — Indian Rupee</option>
-              <option value="AED">AED — UAE Dirham</option>
-              <option value="CHF">CHF — Swiss Franc</option>
-              <option value="SGD">SGD — Singapore Dollar</option>
-              <option value="JPY">JPY — Japanese Yen</option>
-            </select>
-          </div>
-
-          <div class="rc-field">
-            <label class="rc-label" for="rcBuyer">Buyer Type</label>
-            <select class="rc-select" id="rcBuyer" aria-label="Buyer type">
-              <option value="specialist">Specialist Online Buyer (85–95%)</option>
-              <option value="dealer">In-person Gold Dealer (82–92%)</option>
-              <option value="jeweller">Local Jeweller (55–75%)</option>
-              <option value="pawn">Pawn Shop (40–60%)</option>
-            </select>
-          </div>
-
-        </div>
-
-        <div class="ring-calc__results" id="rcResults">
-          <div class="rc-placeholder" id="rcPlaceholder">
-            <span>Enter your ring weight above<br>to see the live value</span>
-          </div>
-          <div id="rcOutput" style="display:none;display:flex;flex-direction:column;gap:var(--space-4)">
-            <div class="rc-result-primary">
-              <div class="rc-result-primary__label">Melt Value (100% of spot)</div>
-              <div class="rc-melt-value" id="rcMeltValue">—</div>
-              <div class="rc-melt-note">Pure gold content × live spot price</div>
-            </div>
-            <div class="rc-offer-range">
-              <div class="rc-offer-label" id="rcOfferLabel">Expected Offer Range</div>
-              <div class="rc-offer-value" id="rcOfferValue">—</div>
-            </div>
-            <div class="rc-stats">
-              <div class="rc-stat">
-                <div class="rc-stat__label">Price per gram (pure)</div>
-                <div class="rc-stat__value" id="rcPricePerGram">—</div>
-              </div>
-              <div class="rc-stat">
-                <div class="rc-stat__label">Pure gold weight</div>
-                <div class="rc-stat__value" id="rcPureGold">—</div>
-              </div>
-            </div>
-            <div class="rc-spot-line" id="rcSpotLine">Spot price loading…</div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <h2 id="what-affects">What Determines a Gold Ring's Value?</h2>
-    <p>Every gold ring value calculation comes down to the same four-part formula: <strong>Weight × Purity × Spot price × Buyer payout rate</strong>. Each of these is variable, and each matters.</p>
-    <ul>
-      <li><strong>Weight</strong> — measured in grams or troy ounces. This is the single most powerful lever: a ring twice as heavy is worth twice as much, all else equal. Weigh your ring on a digital scale accurate to 0.1g.</li>
-      <li><strong>Karat purity</strong> — how much of the ring's weight is actually pure gold. A <span class="hmark">9ct</span> ring is 37.5% gold; an <span class="hmark">18ct</span> ring is 75% gold. The hallmark stamped inside the band tells you the karat.</li>
-      <li><strong>Spot price</strong> — the live global market price for gold, expressed in USD per troy ounce. This changes by the second during trading hours. The calculator above uses the live price updated every 60 seconds.</li>
-      <li><strong>Buyer payout rate</strong> — the percentage of melt value a buyer offers. Specialist online buyers offer 85–95%; pawn shops often offer 40–60%. Choosing the right buyer can nearly double your payout on the same piece of gold.</li>
-    </ul>
-
-    <div class="info-callout">
-      <p><strong>Melt value vs offer price.</strong> The "melt value" is what the gold is worth at 100% of spot — the theoretical ceiling. No buyer pays full melt value because they need a margin to cover refining, insurance, and profit. The calculator shows both the melt value and the realistic offer range for your chosen buyer type.</p>
-    </div>
-
-    <h2 id="karat-breakdown">Gold Ring Value by Karat</h2>
-    <p>Here is what each karat standard means, and what the gold in a typical ring weighing 4 grams is worth at May 2026 prices. The melt value figures are approximate — use the live calculator for the current number.</p>
-
-    <h3 id="9ct">9ct / 9K Gold Rings <span class="hmark">375</span></h3>
-    <p>Nine-carat is the most common gold standard for jewellery in the UK and Australia. It contains <strong>37.5% pure gold</strong> (375 parts per thousand — hence the hallmark). It is harder and more scratch-resistant than higher-karat gold, which is why it is popular for everyday rings and wedding bands.</p>
-    <p>A <strong>4-gram 9ct ring</strong> has approximately 1.5 grams of pure gold. At current prices, its melt value is approximately <strong>£125–£135</strong>. A good buyer will offer £106–£128. A lighter ring (2.5g) would be worth around £78–£85, while a heavier band (7g) could reach £220–£240.</p>
-
-    <h3 id="10ct">10ct / 10K Gold Rings <span class="hmark">417</span></h3>
-    <p>Ten-carat is the legal minimum for gold jewellery in the United States. It is rarely seen in the UK. It contains <strong>41.67% pure gold</strong> — slightly more than 9ct. A 4-gram 10ct ring has a melt value of approximately <strong>£145–£155</strong> at May 2026 prices.</p>
-
-    <h3 id="14ct">14ct / 14K Gold Rings <span class="hmark">585</span></h3>
-    <p>Fourteen-carat is the dominant standard for gold jewellery in the United States and much of Europe. It contains <strong>58.33% pure gold</strong>. It is a good balance of durability and gold content, which is why it is often used for engagement rings, eternity rings, and more intricate pieces.</p>
-    <p>A <strong>4-gram 14ct ring</strong> has approximately 2.33 grams of pure gold. Melt value is approximately <strong>£195–£210</strong>. A specialist buyer will typically offer £165–£200. For a slightly heavier 5-gram 14ct solitaire ring band, expect melt of around £245–£260.</p>
-
-    <h3 id="18ct">18ct / 18K Gold Rings <span class="hmark">750</span></h3>
-    <p>Eighteen-carat is the UK benchmark for fine jewellery and the standard used in high-street and independent jewellers. It contains <strong>75% pure gold</strong>, giving it a distinctly warmer colour and softer feel than 9ct or 14ct. It is the most common karat for engagement rings and high-value wedding bands.</p>
-    <p>A <strong>4-gram 18ct ring</strong> contains 3 grams of pure gold. Melt value is approximately <strong>£250–£270</strong>. A specialist buyer will offer approximately £213–£257. For a heavy 7-gram 18ct ring, melt value climbs to around £440–£475.</p>
-
-    <h3 id="22ct">22ct / 22K Gold Rings <span class="hmark">916</span></h3>
-    <p>Twenty-two-carat contains <strong>91.67% pure gold</strong>. It is the standard for traditional South Asian wedding jewellery — Indian, Pakistani, and Middle Eastern gold rings and bangles are often 22ct. The colour is a deep, rich yellow. It is relatively soft for everyday wear.</p>
-    <p>A <strong>4-gram 22ct ring</strong> has approximately 3.67 grams of pure gold — melt value is approximately <strong>£305–£330</strong>. Specialist buyers will offer approximately £259–£314.</p>
-
-    <h3 id="24ct">24ct / 24K Gold Rings <span class="hmark">999</span></h3>
-    <p>Pure gold. Twenty-four-carat jewellery is rare in Western markets — the metal is too soft for everyday rings and scratches easily. Most "24K" rings are ceremonial or collector pieces. A <strong>4-gram 24K ring</strong> has a melt value of approximately <strong>£334–£360</strong> at May 2026 prices.</p>
-
-    <h2 id="quick-reference">Quick Reference: Gold Ring Values by Weight &amp; Karat</h2>
-    <p>All figures are melt values in GBP, based on approximate May 2026 spot price of ~£111/g (24K). For live prices, use the calculator above.</p>
-
-    <div class="table-scroll">
-      <table>
-        <thead>
-          <tr>
-            <th>Weight</th>
-            <th><span class="hmark">9ct</span> GBP</th>
-            <th><span class="hmark">14ct</span> GBP</th>
-            <th><span class="hmark">18ct</span> GBP</th>
-            <th><span class="hmark">22ct</span> GBP</th>
-            <th><span class="hmark">24ct</span> GBP</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr><td>2g</td><td>£83</td><td>£130</td><td>£167</td><td>£204</td><td>£222</td></tr>
-          <tr><td>3g</td><td>£125</td><td>£195</td><td>£250</td><td>£305</td><td>£333</td></tr>
-          <tr><td>4g</td><td>£167</td><td>£260</td><td>£333</td><td>£407</td><td>£444</td></tr>
-          <tr><td>5g</td><td>£208</td><td>£325</td><td>£417</td><td>£509</td><td>£555</td></tr>
-          <tr><td>6g</td><td>£250</td><td>£390</td><td>£500</td><td>£611</td><td>£666</td></tr>
-          <tr><td>8g</td><td>£333</td><td>£520</td><td>£667</td><td>£815</td><td>£888</td></tr>
-          <tr><td>10g</td><td>£417</td><td>£650</td><td>£833</td><td>£1,019</td><td>£1,110</td></tr>
-        </tbody>
-      </table>
-    </div>
-
-    <p>For USD values, multiply GBP figures by approximately 1.27 (live rate varies — use the calculator with USD selected).</p>
-
-    <div class="table-scroll">
-      <table>
-        <thead>
-          <tr>
-            <th>Weight</th>
-            <th><span class="hmark">9ct</span> USD</th>
-            <th><span class="hmark">14ct</span> USD</th>
-            <th><span class="hmark">18ct</span> USD</th>
-            <th><span class="hmark">22ct</span> USD</th>
-            <th><span class="hmark">24ct</span> USD</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr><td>2g</td><td>$105</td><td>$165</td><td>$212</td><td>$259</td><td>$282</td></tr>
-          <tr><td>3g</td><td>$159</td><td>$248</td><td>$318</td><td>$388</td><td>$423</td></tr>
-          <tr><td>4g</td><td>$212</td><td>$330</td><td>$423</td><td>$517</td><td>$564</td></tr>
-          <tr><td>5g</td><td>$264</td><td>$413</td><td>$529</td><td>$646</td><td>$705</td></tr>
-          <tr><td>6g</td><td>$317</td><td>$495</td><td>$635</td><td>$776</td><td>$846</td></tr>
-          <tr><td>8g</td><td>$423</td><td>$660</td><td>$847</td><td>$1,034</td><td>$1,128</td></tr>
-          <tr><td>10g</td><td>$529</td><td>$825</td><td>$1,058</td><td>$1,293</td><td>$1,410</td></tr>
-        </tbody>
-      </table>
-    </div>
-
-    <h2 id="hallmarks">How to Find Your Ring's Karat Hallmark</h2>
-    <p>Before you can calculate a value, you need to know the karat. The hallmark is almost always stamped inside the band — look with a jeweller's loupe or a magnifying glass in good light.</p>
-
-    <ul>
-      <li><span class="hmark">375</span> = 9ct (UK/Australia common)</li>
-      <li><span class="hmark">417</span> or <span class="hmark">10K</span> = 10ct (US common)</li>
-      <li><span class="hmark">585</span> or <span class="hmark">14K</span> = 14ct (US/Europe common)</li>
-      <li><span class="hmark">750</span> or <span class="hmark">18K</span> = 18ct (UK fine jewellery)</li>
-      <li><span class="hmark">916</span> or <span class="hmark">22K</span> = 22ct (South Asian jewellery)</li>
-      <li><span class="hmark">999</span> or <span class="hmark">24K</span> = 24ct pure gold</li>
-    </ul>
-
-    <p>If there is no hallmark, or the stamp is worn off, a jeweller can test the metal with an acid test kit or an electronic gold tester in minutes. Do not assume — the difference between 9ct and 18ct on a 5-gram ring is over £200.</p>
-
-    <div class="warning-callout">
-      <p><strong>Gold-plated, gold-filled, and gold-vermeil rings have no meaningful scrap value.</strong> A gold-plated ring has a base metal core with a thin gold layer — usually less than 0.5 microns thick. The gold content is negligible. Gold-filled rings are better (typically 5% gold by weight) but still worth far less than solid gold. If a hallmark says <span class="hmark">GF</span>, <span class="hmark">GP</span>, or <span class="hmark">GE</span>, the ring is not solid gold.</p>
-    </div>
-
-    <h2 id="diamond-rings">Diamond Rings: When the Stone Changes Everything</h2>
-    <p>If your ring has a diamond, the calculation changes — but not always in the direction you might hope.</p>
-    <p>For a <strong>scrap gold buyer</strong>, diamonds are largely irrelevant. They pay for the gold weight only. Melee diamonds (tiny accent stones, under 0.1ct each) are effectively ignored — they cannot be recovered economically. Even a larger centre stone will typically be listed as "1 diamond included" in the offer with no meaningful premium added.</p>
-    <p>For a <strong>jewellery reseller or auction house</strong>, diamonds can dramatically increase a ring's value — but only if the stone is high quality, properly certificated, and in good condition. The factors are:</p>
-    <ul>
-      <li><strong>Certificate</strong> — a GIA, AGS, or IGI grading report is essential for secondary market value. Without one, a buyer cannot verify grade, so they will discount heavily.</li>
-      <li><strong>Size</strong> — diamonds above 0.5ct start to carry meaningful premiums. Below 0.3ct, resale value is negligible relative to the gold.</li>
-      <li><strong>Condition</strong> — chipped or heavily scratched diamonds recover only fraction of their original value.</li>
-      <li><strong>Cut quality</strong> — round brilliant cuts have the most liquid resale market. Fancy cuts (pear, marquise, heart) are harder to sell.</li>
-    </ul>
-
-    <div class="info-callout">
-      <p><strong>Practical advice:</strong> If your ring has a diamond larger than 0.5ct with a grading certificate, get it appraised by a specialist diamond dealer before committing to a scrap sale. The gold is worth what it is worth. The diamond might be worth considerably more through the right channel — or considerably less than you paid at retail.</p>
-    </div>
-
-    <h2 id="wedding-rings">Wedding Rings, Engagement Rings, and Sentimental Pieces</h2>
-    <p>The metal market does not pay a premium for sentimental value — and this can be jarring when you realise a ring you paid £2,000 for is worth £250 as scrap. Understanding why the gap exists helps you decide what to do about it.</p>
-    <p>Most rings are sold at retail with significant markups: the jeweller's margin, the setting labour, the brand premium, and the occasion premium (engagement rings, in particular, carry a "bridal tax"). The gold in a £2,000 engagement ring might represent only £150–£400 of the purchase price. When you sell, you are selling the raw material — not the occasion it represented.</p>
-    <p>This does not mean you should always accept melt value. If a ring has:</p>
-    <ul>
-      <li>A signed maker's mark (Tiffany, Cartier, Bulgari, Boodle &amp; Dunthorne)</li>
-      <li>A significant certified diamond or coloured gemstone</li>
-      <li>Antique or Victorian-era hallmarks and craftsmanship</li>
-      <li>An unusual design with collector appeal</li>
-    </ul>
-    <p>…then an auction house, antique jewellery dealer, or specialist reseller may offer considerably more than scrap value. A free auction estimate costs nothing and could mean the difference between £300 and £800 for the same piece.</p>
-
-    <h2 id="retail-vs-resale">Retail vs Resale vs Scrap: The Three Values of a Gold Ring</h2>
-    <p>Every gold ring effectively has three different values depending on the context:</p>
-
-    <div class="table-scroll">
-      <table>
-        <thead>
-          <tr>
-            <th>Value Type</th>
-            <th>What It Means</th>
-            <th>Typical % of Retail</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr><td><strong>Retail (RRP)</strong></td><td>What a jeweller charges new. Includes brand margin, labour, retail overhead.</td><td>100% (reference)</td></tr>
-          <tr><td><strong>Insurance / replacement value</strong></td><td>What your insurer would pay to replace. Usually at or above retail.</td><td>100–120%</td></tr>
-          <tr><td><strong>Pre-owned resale</strong></td><td>What a second-hand buyer pays. Depends heavily on brand and condition.</td><td>20–60%</td></tr>
-          <tr><td><strong>Auction estimate</strong></td><td>What a piece might achieve at auction. Varies widely by piece.</td><td>15–80%</td></tr>
-          <tr><td><strong>Scrap / melt value</strong></td><td>Pure gold content at spot price. The floor price for any gold ring.</td><td>5–35%</td></tr>
-        </tbody>
-      </table>
-    </div>
-
-    <p>For plain rings with no gemstones or collector appeal, scrap is usually the most practical exit. For anything with potential secondary market value, explore resale options before settling for melt.</p>
-
-    <h2 id="where-to-sell">Where to Sell a Gold Ring — and What Each Buyer Pays</h2>
-
-    <div class="buyer-grid">
-      <div class="buyer-card">
-        <div class="buyer-card__header">
-          <div class="buyer-card__title">Specialist Online Gold Buyers</div>
-          <span class="payout-badge payout-badge--high">85–95%</span>
-        </div>
-        <p>The best option for plain gold rings with no gemstone premium. They offer insured postal packs, quote within 24–48 hours, and pay by bank transfer. Look for buyers who publish their payout rates and buy-back policies clearly.</p>
-      </div>
-      <div class="buyer-card">
-        <div class="buyer-card__header">
-          <div class="buyer-card__title">Bullion Dealers &amp; Refiners</div>
-          <span class="payout-badge payout-badge--high">82–93%</span>
-        </div>
-        <p>Bullion dealers with direct refinery access offer competitive rates close to specialist buyers. Best for higher-weight or purer gold (18ct+). Many operate walk-in services as well as postal.</p>
-      </div>
-      <div class="buyer-card">
-        <div class="buyer-card__header">
-          <div class="buyer-card__title">Local Jewellers</div>
-          <span class="payout-badge payout-badge--mid">55–75%</span>
-        </div>
-        <p>Convenient but typically the second-lowest payer for scrap gold. A good jeweller will test and weigh accurately, but their margin is higher because they are not a high-volume refiner. Best used if speed and local trust matter more than maximum price.</p>
-      </div>
-      <div class="buyer-card">
-        <div class="buyer-card__header">
-          <div class="buyer-card__title">Pawn Shops</div>
-          <span class="payout-badge payout-badge--low">40–60%</span>
-        </div>
-        <p>Typically the lowest payer for gold jewellery. Pawn shops carry high overheads and need significant margins. They may make a quick offer, but walk away knowing what you are leaving on the table compared to a specialist buyer.</p>
-      </div>
-    </div>
-
-    <div class="info-callout">
-      <p><strong>Always get multiple quotes.</strong> There is no single regulated price for scrap gold offers. A ring worth £300 in melt value might attract offers from £120 to £285 depending on the buyer. The calculator above gives you the melt value baseline — any offer significantly below 80% of that figure warrants a second opinion.</p>
-    </div>
-
-    <h2 id="step-by-step">Step-by-Step: How to Get the Best Price for Your Gold Ring</h2>
-
-    <ol class="step-list">
-      <li class="step-block">
-        <div class="step-number" aria-hidden="true">1</div>
-        <div class="step-content">
-          <strong>Weigh it accurately</strong>
-          <p>Use a digital kitchen scale or jeweller's scale accurate to 0.1g. Weigh the ring alone — no packaging, no extra items. Write down the gram weight. This is the most important number you need.</p>
-        </div>
-      </li>
-      <li class="step-block">
-        <div class="step-number" aria-hidden="true">2</div>
-        <div class="step-content">
-          <strong>Identify the karat</strong>
-          <p>Look inside the band for a hallmark stamp: <span class="hmark">375</span>, <span class="hmark">585</span>, <span class="hmark">750</span>, <span class="hmark">916</span>, etc. If you cannot find one or are unsure, a jeweller can test it for free or a small fee. Do not guess.</p>
-        </div>
-      </li>
-      <li class="step-block">
-        <div class="step-number" aria-hidden="true">3</div>
-        <div class="step-content">
-          <strong>Calculate the melt value</strong>
-          <p>Use the live calculator above with your weight and karat. This gives you the melt value — the ceiling any buyer should approach. Note the figure in your chosen currency.</p>
-        </div>
-      </li>
-      <li class="step-block">
-        <div class="step-number" aria-hidden="true">4</div>
-        <div class="step-content">
-          <strong>Assess whether there is any value beyond the metal</strong>
-          <p>Does the ring have a maker's mark? A significant diamond with a certificate? Antique hallmarks? If yes, get an auction house estimate before committing to a scrap sale. If it is a plain, modern, unmarked ring — scrap is almost certainly the best route.</p>
-        </div>
-      </li>
-      <li class="step-block">
-        <div class="step-number" aria-hidden="true">5</div>
-        <div class="step-content">
-          <strong>Get at least two quotes</strong>
-          <p>Request a quote from at least one specialist online buyer and one local option. Compare offers as a percentage of melt value. Any quote below 80% of melt from a reputable buyer warrants challenge or a third quote.</p>
-        </div>
-      </li>
-      <li class="step-block">
-        <div class="step-number" aria-hidden="true">6</div>
-        <div class="step-content">
-          <strong>Accept, negotiate, or decline</strong>
-          <p>Reputable buyers will hold an offer for several days and return items free of charge if you decline. There is no pressure to sell immediately — especially at current high prices where the market favours sellers.</p>
-        </div>
-      </li>
+<div class="article-shell">
+  <aside class="toc" aria-label="Article sections">
+    <div class="toc__label">In this guide</div>
+    <ol class="toc__list" id="tocList">
+      <li><a href="#calculator">Live Ring Calculator</a></li>
+      <li><a href="#value-factors">What Sets the Value</a></li>
+      <li><a href="#by-karat">Value by Karat</a></li>
+      <li><a href="#reference">Quick Reference (USD)</a></li>
+      <li><a href="#hallmarks">Find the Hallmark</a></li>
+      <li><a href="#diamonds">Diamond Rings</a></li>
+      <li><a href="#sentimental">Sentimental Pieces</a></li>
+      <li><a href="#where-to-sell">Where to Sell</a></li>
+      <li><a href="#steps">Get the Best Price</a></li>
+      <li><a href="#faq">FAQ</a></li>
     </ol>
+  </aside>
 
-    <div class="cta-box">
-      <h3>Check the Live Gold Price Per Gram</h3>
-      <p>See today's live gold price per gram for every karat — 9K through 24K — updated every 60 seconds from the global spot market.</p>
-      <a href="/" class="cta-btn">View Live Gold Rates &rarr;</a>
+  <main class="prose-main">
+    <header class="hero-wrap">
+      <span class="hero-tag">Live Tool &middot; 2026 Value Guide</span>
+      <h1 class="hero-title">How Much Is a <em>Gold Ring</em> Worth?</h1>
+      <p class="hero-sub">That ring in the drawer has never been worth more. Enter its weight and karat below to value it instantly in US dollars at the live gold spot price &mdash; then learn exactly what drives the number so you are never caught out by a low offer.</p>
+      <div class="hero-byline">
+        <span>By <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a></span>
+        <span class="hero-byline-dot"></span>
+        <time datetime="2026-06-13">Updated 13 June 2026</time>
+        <span class="hero-byline-dot"></span>
+        <span>14 min read</span>
+      </div>
+
+      <div class="bento-hero">
+        <div class="bento-cell bento-spot reveal">
+          <div class="bento-spot__head">
+            <div class="bento-spot__title">Live Gold Spot &middot; USD / troy oz</div>
+            <span class="live-pill live-pill--idle" id="heroLive">
+              <span class="live-pill__dot"></span>
+              <span id="heroLiveText">Connecting</span>
+            </span>
+          </div>
+          <div class="bento-spot__price" id="heroSpotPrice">$&mdash;,&mdash;&mdash;&mdash;</div>
+          <div>
+            <span class="bento-spot__delta bento-spot__delta--up" id="heroSpotDelta" hidden>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 19V5M5 12l7-7 7 7"/></svg>
+              <span id="heroSpotDeltaText">&mdash;</span>
+            </span>
+          </div>
+          <div class="bento-spot__meta">
+            <span>Per gram (24K) <strong id="heroSpotPerGram" style="color:var(--color-text)">$&mdash;</strong></span>
+            <span>Updated <span id="heroSpotUpdated">just now</span></span>
+          </div>
+        </div>
+        <div class="bento-cell bento-a reveal">
+          <div class="bento-cell__label">2026 record high</div>
+          <div class="bento-cell__value"><span class="bento-cell__value-em">$5,589</span></div>
+          <div class="bento-cell__caption">Per troy oz, January 2026</div>
+        </div>
+        <div class="bento-cell bento-b reveal">
+          <div class="bento-cell__label">Typical ring</div>
+          <div class="bento-cell__value">3&ndash;6 g</div>
+          <div class="bento-cell__caption">Plain wedding band weight</div>
+        </div>
+        <div class="bento-cell bento-c reveal">
+          <div class="bento-cell__label">Top payout</div>
+          <div class="bento-cell__value">85&ndash;95%</div>
+          <div class="bento-cell__caption">Specialist buyer, % of melt</div>
+        </div>
+        <div class="bento-cell bento-d reveal">
+          <div>
+            <div class="bento-cell__label">The value formula</div>
+            <div class="bento-d__formula">Weight <span>&times;</span> Purity <span>&times;</span> Spot <span>&times;</span> Payout</div>
+            <div class="bento-cell__caption">Four levers decide what your ring is worth.</div>
+          </div>
+          <svg class="bento-ring" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="32" cy="45" r="13"/>
+            <path d="M22 16h20l5 9-15 13-15-13z"/>
+            <path d="M22 16l5 9h10l5-9"/>
+            <path d="M17 25h30"/>
+          </svg>
+        </div>
+      </div>
+    </header>
+
+    <div class="prose">
+
+      <p class="prose-lede reveal">There is a gold ring sitting in a drawer somewhere that you have been meaning to deal with for years. A plain band, a broken engagement ring, earrings from a relationship that ended. In 2026, with gold near record highs, even modest pieces carry real money &mdash; but "how much is it worth?" has no single answer.</p>
+
+      <p class="reveal">The figure depends on five things: the gold's <strong>karat purity</strong>, its <strong>weight in grams</strong>, the <strong>live spot price</strong>, <strong>who you sell to</strong>, and whether the ring has any value <strong>beyond its metal content</strong>. This guide walks through all of it. Start with the live calculator for an instant USD figure, then read on so the number you get is one you actually understand.</p>
+
+      <div class="exec-summary reveal">
+        <p>The calculator below refreshes every 60 seconds from the live USD gold spot price. Article figures use a <strong>representative spot near $4,750/oz</strong> as a baseline and are illustrative &mdash; the live tool is always the source of truth. Specialist buyers typically pay <strong>85&ndash;95% of melt value</strong> for plain gold rings; pawn shops pay far less.</p>
+      </div>
+
+      <!-- ───────── LIVE RING VALUE CALCULATOR ───────── -->
+      <h2 id="calculator" class="reveal"><span class="h2-num">01</span>Live Gold Ring Value Calculator</h2>
+      <p class="reveal">Enter your ring's weight and tap its karat. The tool multiplies weight by the gold purity, applies the live USD spot price, and shows the melt value plus a realistic offer for your chosen buyer. USD is the primary currency; switch the dropdown to see live conversions.</p>
+
+      <div class="gf-calc reveal" id="ringCalc">
+        <div class="gf-calc__head">
+          <div class="gf-calc__title-block">
+            <div class="gf-calc__eyebrow">Live Tool &middot; Updates every 60 seconds</div>
+            <h3 class="gf-calc__title" style="display:block">Gold Ring Value Calculator</h3>
+            <p class="gf-calc__sub">Melt value = weight &times; purity &times; live spot price. Offers are a share of melt that depends on the buyer.</p>
+          </div>
+          <span class="live-pill live-pill--idle" id="rcLive">
+            <span class="live-pill__dot"></span>
+            <span id="rcLiveText">Connecting</span>
+          </span>
+        </div>
+
+        <div class="gf-calc__grid">
+          <div class="gf-calc__controls">
+            <div class="gf-field">
+              <label class="gf-label" for="rcWeight">Ring weight</label>
+              <div class="gf-unit-toggle" role="group" aria-label="Weight unit">
+                <button type="button" class="gf-unit-btn is-active" data-unit="g">Grams (g)</button>
+                <button type="button" class="gf-unit-btn" data-unit="oz">Troy oz</button>
+              </div>
+              <input class="gf-input" type="number" id="rcWeight" placeholder="e.g. 4.2" min="0" step="0.1" inputmode="decimal" aria-label="Ring weight">
+            </div>
+
+            <div class="gf-field">
+              <span class="gf-label">Karat (purity)</span>
+              <div class="gf-karat-grid" role="group" aria-label="Gold karat">
+                <button type="button" class="gf-karat-btn" data-karat="9K" data-purity="0.375">9K</button>
+                <button type="button" class="gf-karat-btn" data-karat="10K" data-purity="0.4167">10K</button>
+                <button type="button" class="gf-karat-btn is-active" data-karat="14K" data-purity="0.5833">14K</button>
+                <button type="button" class="gf-karat-btn" data-karat="18K" data-purity="0.75">18K</button>
+                <button type="button" class="gf-karat-btn" data-karat="22K" data-purity="0.9167">22K</button>
+                <button type="button" class="gf-karat-btn" data-karat="24K" data-purity="0.999">24K</button>
+              </div>
+            </div>
+
+            <div class="gf-field">
+              <label class="gf-label" for="rcCurrency">Display currency</label>
+              <select class="gf-select" id="rcCurrency">
+                <option value="USD" selected>USD &middot; US Dollar (primary)</option>
+                <option value="EUR">EUR &middot; Euro</option>
+                <option value="GBP">GBP &middot; British Pound</option>
+                <option value="CAD">CAD &middot; Canadian Dollar</option>
+                <option value="AUD">AUD &middot; Australian Dollar</option>
+                <option value="INR">INR &middot; Indian Rupee</option>
+                <option value="AED">AED &middot; UAE Dirham</option>
+                <option value="JPY">JPY &middot; Japanese Yen</option>
+              </select>
+            </div>
+
+            <div class="gf-field">
+              <label class="gf-label" for="rcBuyer">Who you sell to</label>
+              <select class="gf-select" id="rcBuyer">
+                <option value="specialist" selected>Specialist Online Buyer (85&ndash;95%)</option>
+                <option value="dealer">Bullion Dealer / Refiner (80&ndash;92%)</option>
+                <option value="jeweller">Local Jeweller (55&ndash;75%)</option>
+                <option value="pawn">Pawn Shop (40&ndash;60%)</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="gf-calc__result">
+            <div id="rcPlaceholder" class="gf-placeholder">Enter your ring weight to see its live melt value and a realistic offer range.</div>
+            <div id="rcOutput" style="display:none;flex-direction:column;gap:var(--space-4)">
+              <div class="gf-result-primary">
+                <div class="gf-result-primary__label">Melt value (100% of spot)</div>
+                <div class="gf-result-primary__value" id="rcMeltValue">$0.00</div>
+                <div class="gf-result-primary__note">Pure-gold content &times; live spot price</div>
+              </div>
+              <div class="gf-result-offer">
+                <div class="gf-result-offer__label" id="rcOfferLabel">Specialist offer range</div>
+                <div class="gf-result-offer__value" id="rcOfferValue">$0 &ndash; $0</div>
+              </div>
+              <div class="gf-stats">
+                <div class="gf-stat">
+                  <div class="gf-stat__label">Pure gold content</div>
+                  <div class="gf-stat__value" id="rcPureGrams">&mdash; g</div>
+                </div>
+                <div class="gf-stat">
+                  <div class="gf-stat__label">Price / gram (this karat)</div>
+                  <div class="gf-stat__value" id="rcPricePerGram">$&mdash;</div>
+                </div>
+              </div>
+              <div class="gf-spot-line">Live spot <strong id="rcSpotLine">$&mdash; / oz</strong> &middot; updated <span id="rcUpdated">&mdash;</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="info-callout reveal">
+        <p><strong>Melt value vs offer price.</strong> Melt value is what the gold is worth at 100% of spot &mdash; the theoretical ceiling. No buyer pays full melt; they need a margin for refining, insurance and profit. The calculator shows both the melt value and the realistic offer band for the buyer you pick, so you walk in knowing the floor and the fair price.</p>
+      </div>
+
+      <!-- ───────── WHAT SETS THE VALUE ───────── -->
+      <h2 id="value-factors" class="reveal"><span class="h2-num">02</span>What Determines a Gold Ring's Value</h2>
+      <p class="reveal">Every gold ring valuation comes down to one formula: <strong>Weight &times; Purity &times; Spot price &times; Buyer payout rate</strong>. Each lever is variable, and each one matters.</p>
+      <ul class="reveal">
+        <li><strong>Weight</strong> &mdash; measured in grams or troy ounces, this is the most powerful lever. A ring twice as heavy is worth twice as much, all else equal. Weigh it on a digital scale accurate to 0.1 g.</li>
+        <li><strong>Karat purity</strong> &mdash; how much of the ring's weight is actually gold. A <span class="hmark">9K</span> ring is 37.5% gold; an <span class="hmark">18K</span> ring is 75% gold. The hallmark stamped inside the band tells you which.</li>
+        <li><strong>Spot price</strong> &mdash; the live global market price for gold, quoted in <strong>USD per troy ounce</strong>. It moves by the second during trading hours; the calculator pulls it fresh every 60 seconds.</li>
+        <li><strong>Buyer payout rate</strong> &mdash; the share of melt value an offer represents. Specialists pay 85&ndash;95%; pawn shops 40&ndash;60%. Choosing the right buyer can almost double your payout on the very same piece.</li>
+      </ul>
+
+      <p class="reveal">Purity is the lever people underestimate most, because two rings of identical weight can be worth wildly different amounts. Here is how the gold content of each karat standard stacks up &mdash; the bars show the percentage of pure gold in the metal:</p>
+
+      <div class="purity-viz reveal" id="purityViz" role="img" aria-label="Pure gold content by karat: 9K is 37.5%, 10K 41.7%, 14K 58.3%, 18K 75%, 22K 91.7%, 24K 99.9% pure gold.">
+        <div class="purity-viz__head">
+          <div>
+            <h3 class="purity-viz__title" style="display:block">Pure Gold Content by Karat</h3>
+            <div class="purity-viz__caption">Share of the metal that is gold</div>
+          </div>
+        </div>
+        <div class="purity-list">
+          <div class="purity-row" style="--w:37.5%">
+            <div class="purity-row__top"><span class="purity-row__name">9K <span class="purity-row__mark">&middot;375</span></span><span class="purity-row__pct">37.5%</span></div>
+            <div class="purity-track"><div class="purity-fill"></div></div>
+          </div>
+          <div class="purity-row" style="--w:41.7%">
+            <div class="purity-row__top"><span class="purity-row__name">10K <span class="purity-row__mark">&middot;417</span></span><span class="purity-row__pct">41.7%</span></div>
+            <div class="purity-track"><div class="purity-fill"></div></div>
+          </div>
+          <div class="purity-row" style="--w:58.3%">
+            <div class="purity-row__top"><span class="purity-row__name">14K <span class="purity-row__mark">&middot;585</span></span><span class="purity-row__pct">58.3%</span></div>
+            <div class="purity-track"><div class="purity-fill"></div></div>
+          </div>
+          <div class="purity-row" style="--w:75%">
+            <div class="purity-row__top"><span class="purity-row__name">18K <span class="purity-row__mark">&middot;750</span></span><span class="purity-row__pct">75.0%</span></div>
+            <div class="purity-track"><div class="purity-fill"></div></div>
+          </div>
+          <div class="purity-row" style="--w:91.7%">
+            <div class="purity-row__top"><span class="purity-row__name">22K <span class="purity-row__mark">&middot;916</span></span><span class="purity-row__pct">91.7%</span></div>
+            <div class="purity-track"><div class="purity-fill"></div></div>
+          </div>
+          <div class="purity-row" style="--w:99.9%">
+            <div class="purity-row__top"><span class="purity-row__name">24K <span class="purity-row__mark">&middot;999</span></span><span class="purity-row__pct">99.9%</span></div>
+            <div class="purity-track"><div class="purity-fill"></div></div>
+          </div>
+        </div>
+        <div class="purity-viz__foot">An 18K ring holds twice the gold of a 9K ring of the same weight &mdash; so it is worth roughly twice as much in melt value.</div>
+      </div>
+
+      <!-- ───────── VALUE BY KARAT ───────── -->
+      <h2 id="by-karat" class="reveal"><span class="h2-num">03</span>Gold Ring Value by Karat</h2>
+      <p class="reveal">Here is what each karat standard means and what the gold in a typical <strong>4-gram ring</strong> is worth at a representative spot near <strong>$4,750/oz</strong> (about <strong>$152.70 per gram of pure 24K gold</strong>). Figures are illustrative &mdash; use the live calculator for the exact number now.</p>
+
+      <h3 class="reveal">9K / 9ct Gold Rings <span class="hmark">375</span></h3>
+      <p class="reveal">Nine-karat is the most common gold standard for jewellery in the UK and Australia. It is <strong>37.5% pure gold</strong> (375 parts per thousand &mdash; hence the hallmark), harder and more scratch-resistant than higher karats, which is why it suits everyday bands. A 4 g 9K ring holds 1.5 g of pure gold &mdash; a melt value around <strong>$229</strong> (about <strong>$57 per gram</strong> of item). A specialist buyer paying 85&ndash;95% would offer roughly <strong>$195&ndash;$218</strong>.</p>
+
+      <h3 class="reveal">10K / 10ct Gold Rings <span class="hmark">417</span></h3>
+      <p class="reveal">Ten-karat is the legal minimum for "gold" jewellery in the United States and rarely appears in the UK. At <strong>41.7% pure gold</strong>, a 4 g 10K ring has a melt value near <strong>$255</strong> (about <strong>$64 per gram</strong>).</p>
+
+      <h3 class="reveal">14K / 14ct Gold Rings <span class="hmark">585</span></h3>
+      <p class="reveal">Fourteen-karat is the dominant standard for gold jewellery in the United States and much of Europe. At <strong>58.3% pure gold</strong> it balances durability and gold content, so it is common for engagement, eternity and detailed pieces. A 4 g 14K ring holds about 2.33 g of pure gold &mdash; a melt value near <strong>$356</strong> (about <strong>$89 per gram</strong>); a specialist would offer roughly <strong>$303&ndash;$338</strong>. A heavier 5 g band lands near <strong>$445</strong>.</p>
+
+      <h3 class="reveal">18K / 18ct Gold Rings <span class="hmark">750</span></h3>
+      <p class="reveal">Eighteen-karat is the benchmark for fine jewellery and the standard in high-street and independent jewellers. At <strong>75% pure gold</strong> it has a warmer colour and softer feel, and it is the most common karat for higher-value engagement and wedding rings. A 4 g 18K ring contains 3 g of pure gold &mdash; a melt value near <strong>$458</strong> (about <strong>$115 per gram</strong>); a specialist would offer roughly <strong>$389&ndash;$435</strong>. A heavy 7 g 18K ring climbs to around <strong>$802</strong>.</p>
+
+      <h3 class="reveal">22K / 22ct Gold Rings <span class="hmark">916</span></h3>
+      <p class="reveal">Twenty-two-karat is <strong>91.7% pure gold</strong> and the standard for traditional South Asian and Middle Eastern wedding jewellery &mdash; deep yellow, rich, and relatively soft for daily wear. A 4 g 22K ring holds about 3.67 g of pure gold &mdash; a melt value near <strong>$560</strong> (about <strong>$140 per gram</strong>); a specialist would offer roughly <strong>$476&ndash;$532</strong>.</p>
+
+      <h3 class="reveal">24K / 24ct Gold Rings <span class="hmark">999</span></h3>
+      <p class="reveal">Pure gold. Twenty-four-karat jewellery is rare in Western markets &mdash; too soft for everyday rings and easily scratched &mdash; so most 24K rings are ceremonial or collector pieces. A 4 g 24K ring has a melt value near <strong>$610</strong> (about <strong>$153 per gram</strong>).</p>
+
+      <!-- ───────── QUICK REFERENCE (USD) ───────── -->
+      <h2 id="reference" class="reveal"><span class="h2-num">04</span>Quick Reference: Ring Value by Weight &amp; Karat</h2>
+      <p class="reveal">Melt values in <strong>USD</strong>, at a representative spot near $4,750/oz (about $152.70/g for pure 24K gold). These are illustrative &mdash; the live calculator above shows the exact current figure, and converts to GBP, EUR, INR and more.</p>
+
+      <div class="table-scroll reveal">
+        <table>
+          <thead>
+            <tr>
+              <th>Weight</th>
+              <th><span class="hmark">9K</span></th>
+              <th><span class="hmark">14K</span></th>
+              <th><span class="hmark">18K</span></th>
+              <th><span class="hmark">22K</span></th>
+              <th><span class="hmark">24K</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>2 g</td><td><span class="usd">$115</span></td><td><span class="usd">$178</span></td><td><span class="usd">$229</span></td><td><span class="usd">$280</span></td><td><span class="usd">$305</span></td></tr>
+            <tr><td>3 g</td><td><span class="usd">$172</span></td><td><span class="usd">$267</span></td><td><span class="usd">$344</span></td><td><span class="usd">$420</span></td><td><span class="usd">$458</span></td></tr>
+            <tr><td>4 g</td><td><span class="usd">$229</span></td><td><span class="usd">$356</span></td><td><span class="usd">$458</span></td><td><span class="usd">$560</span></td><td><span class="usd">$610</span></td></tr>
+            <tr><td>5 g</td><td><span class="usd">$286</span></td><td><span class="usd">$445</span></td><td><span class="usd">$573</span></td><td><span class="usd">$700</span></td><td><span class="usd">$763</span></td></tr>
+            <tr><td>6 g</td><td><span class="usd">$344</span></td><td><span class="usd">$534</span></td><td><span class="usd">$687</span></td><td><span class="usd">$840</span></td><td><span class="usd">$915</span></td></tr>
+            <tr><td>8 g</td><td><span class="usd">$458</span></td><td><span class="usd">$713</span></td><td><span class="usd">$916</span></td><td><span class="usd">$1,120</span></td><td><span class="usd">$1,221</span></td></tr>
+            <tr><td>10 g</td><td><span class="usd">$573</span></td><td><span class="usd">$891</span></td><td><span class="usd">$1,145</span></td><td><span class="usd">$1,400</span></td><td><span class="usd">$1,526</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="reveal">These are melt values &mdash; what the gold itself is worth before any buyer margin. Most reputable specialists pay <strong>85&ndash;95%</strong> of these figures for plain rings; the calculator applies your chosen buyer's rate automatically.</p>
+
+      <div class="cta-box reveal">
+        <h3>Check the live gold price per gram</h3>
+        <p>See today's live gold price per gram for every karat &mdash; 9K through 24K &mdash; updated every 60 seconds from the global spot market, all in USD.</p>
+        <a href="/gold-price-per-gram" class="cta-btn">View Live Gold Rates <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </div>
+
+      <!-- ───────── HALLMARKS ───────── -->
+      <h2 id="hallmarks" class="reveal"><span class="h2-num">05</span>How to Find Your Ring's Karat Hallmark</h2>
+      <p class="reveal">Before you can value a ring, you need its karat. The hallmark is almost always stamped inside the band &mdash; look with a jeweller's loupe or a magnifying glass in good light.</p>
+      <ul class="reveal">
+        <li><span class="hmark">375</span> = 9K (UK / Australia common)</li>
+        <li><span class="hmark">417</span> or <span class="hmark">10K</span> = 10K (US common)</li>
+        <li><span class="hmark">585</span> or <span class="hmark">14K</span> = 14K (US / Europe common)</li>
+        <li><span class="hmark">750</span> or <span class="hmark">18K</span> = 18K (fine jewellery)</li>
+        <li><span class="hmark">916</span> or <span class="hmark">22K</span> = 22K (South Asian jewellery)</li>
+        <li><span class="hmark">999</span> or <span class="hmark">24K</span> = 24K pure gold</li>
+      </ul>
+      <p class="reveal">No hallmark, or a worn stamp? A jeweller can test the metal with an acid test kit or an electronic tester in minutes. Do not guess &mdash; the difference between 9K and 18K on a 5-gram ring is well over <strong>$280</strong>.</p>
+
+      <div class="warning-callout reveal">
+        <p><strong>Gold-plated, gold-filled and vermeil rings have almost no scrap value.</strong> A gold-plated ring is base metal with a microns-thin gold layer &mdash; negligible gold content. Gold-filled is better (around 5% gold by weight) but still worth a fraction of solid gold. If a stamp reads <span class="hmark">GF</span>, <span class="hmark">GP</span>, <span class="hmark">GEP</span> or <span class="hmark">1/20</span>, the ring is not solid gold and the calculator's solid-gold figures do not apply.</p>
+      </div>
+
+      <!-- ───────── DIAMONDS ───────── -->
+      <h2 id="diamonds" class="reveal"><span class="h2-num">06</span>Diamond Rings: When the Stone Changes Everything</h2>
+      <p class="reveal">If your ring has a diamond, the calculation changes &mdash; but not always in the direction you might hope.</p>
+      <p class="reveal">For a <strong>scrap gold buyer</strong>, diamonds are largely irrelevant. They pay for the gold weight only. Melee diamonds (tiny accent stones under about 0.1 ct each) are effectively ignored because they cannot be recovered economically. Even a larger centre stone is often listed as "1 diamond included" with no meaningful premium.</p>
+      <p class="reveal">For a <strong>jewellery reseller or auction house</strong>, diamonds can dramatically increase a ring's value &mdash; but only if the stone is high quality, properly certified and in good condition. The factors are:</p>
+      <ul class="reveal">
+        <li><strong>Certificate</strong> &mdash; a GIA, AGS or IGI grading report is essential for secondary-market value. Without one, a buyer cannot verify grade and will discount heavily.</li>
+        <li><strong>Size</strong> &mdash; diamonds above 0.5 ct start to carry meaningful premiums. Below 0.3 ct, resale value is negligible relative to the gold.</li>
+        <li><strong>Condition</strong> &mdash; chipped or heavily scratched stones recover only a fraction of their value.</li>
+        <li><strong>Cut</strong> &mdash; round brilliants have the most liquid resale market; fancy cuts (pear, marquise, heart) are harder to sell.</li>
+      </ul>
+      <div class="info-callout reveal">
+        <p><strong>Practical advice:</strong> if your ring has a diamond larger than 0.5 ct with a grading certificate, get it appraised by a specialist diamond dealer before committing to a scrap sale. The gold is worth what it is worth; the diamond might be worth considerably more through the right channel &mdash; or considerably less than you paid at retail.</p>
+      </div>
+
+      <!-- ───────── SENTIMENTAL / 3 VALUES ───────── -->
+      <h2 id="sentimental" class="reveal"><span class="h2-num">07</span>Wedding Rings &amp; Sentimental Pieces</h2>
+      <p class="reveal">The metal market does not pay a premium for sentiment &mdash; which can sting when you learn a ring you paid $2,000 for is worth $250 as scrap. Understanding the gap helps you decide what to do about it.</p>
+      <p class="reveal">Most rings are sold at retail with significant markups: the jeweller's margin, setting labour, brand premium, and the "occasion premium" that engagement rings carry. The gold in a $2,000 engagement ring might represent only $150&ndash;$450 of the purchase price. When you sell, you are selling raw material &mdash; not the occasion it represented.</p>
+
+      <p class="reveal">That does not mean you should always accept melt value. Every gold ring really has several values depending on the channel:</p>
+
+      <div class="ladder reveal">
+        <div class="ladder-card">
+          <div class="ladder-card__tag">Reference</div>
+          <div class="ladder-card__name">Retail (RRP)</div>
+          <div class="ladder-card__pct">100%</div>
+          <p>What a jeweller charges new &mdash; brand margin, labour and overhead included.</p>
+        </div>
+        <div class="ladder-card">
+          <div class="ladder-card__tag">Insurance</div>
+          <div class="ladder-card__name">Replacement value</div>
+          <div class="ladder-card__pct">100&ndash;120%</div>
+          <p>What your insurer would pay to replace it &mdash; usually at or above retail.</p>
+        </div>
+        <div class="ladder-card">
+          <div class="ladder-card__tag">Pre-owned</div>
+          <div class="ladder-card__name">Resale value</div>
+          <div class="ladder-card__pct">20&ndash;60%</div>
+          <p>What a second-hand buyer pays &mdash; driven heavily by brand and condition.</p>
+        </div>
+        <div class="ladder-card ladder-card--floor">
+          <div class="ladder-card__tag">The floor</div>
+          <div class="ladder-card__name">Scrap / melt value</div>
+          <div class="ladder-card__pct">5&ndash;35%</div>
+          <p>Pure gold content at spot. The price floor for any gold ring &mdash; what the calculator shows.</p>
+        </div>
+      </div>
+
+      <p class="reveal">If a ring has a signed maker's mark (Tiffany, Cartier, Bulgari), a significant certified stone, antique hallmarks, or genuine collector appeal, an auction house or antique dealer may offer well above scrap. A free auction estimate costs nothing and could be the difference between $300 and $800 for the same piece.</p>
+
+      <!-- ───────── WHERE TO SELL ───────── -->
+      <h2 id="where-to-sell" class="reveal"><span class="h2-num">08</span>Where to Sell a Gold Ring &mdash; and What Each Buyer Pays</h2>
+      <p class="reveal">There is no single regulated price for a scrap gold offer. The same ring with a $458 melt value might draw offers from $185 to $435 depending on who you ask. Here is the typical payout ladder, as a share of melt value:</p>
+
+      <div class="acc-compare reveal" id="payoutCompare">
+        <div class="acc-compare__head">
+          <div>
+            <h3 class="acc-compare__title" style="display:block">Typical Payout by Buyer Type</h3>
+            <div class="acc-compare__caption">% of melt value offered &middot; plain gold ring</div>
+          </div>
+          <div class="acc-tabs" role="group" aria-label="Filter buyers">
+            <button class="acc-tab is-active" data-filter="all" aria-pressed="true">All</button>
+            <button class="acc-tab" data-filter="online" aria-pressed="false">Online</button>
+            <button class="acc-tab" data-filter="inperson" aria-pressed="false">In-person</button>
+          </div>
+        </div>
+        <div class="acc-list">
+          <div class="acc-row acc--high" data-tier="online" style="--w:90%">
+            <div class="acc-row__top">
+              <span class="acc-row__name"><span class="acc-row__rank">01</span> Specialist Online Buyer <span class="acc-row__tier">Best</span></span>
+              <span class="acc-row__score">85&ndash;95%</span>
+            </div>
+            <div class="acc-track"><div class="acc-fill"></div></div>
+          </div>
+          <div class="acc-row acc--pro" data-tier="online" style="--w:86%">
+            <div class="acc-row__top">
+              <span class="acc-row__name"><span class="acc-row__rank">02</span> Bullion Dealer / Refiner <span class="acc-row__tier">Strong</span></span>
+              <span class="acc-row__score">80&ndash;92%</span>
+            </div>
+            <div class="acc-track"><div class="acc-fill"></div></div>
+          </div>
+          <div class="acc-row acc--medium" data-tier="inperson" style="--w:65%">
+            <div class="acc-row__top">
+              <span class="acc-row__name"><span class="acc-row__rank">03</span> Local Jeweller <span class="acc-row__tier">Fair</span></span>
+              <span class="acc-row__score">55&ndash;75%</span>
+            </div>
+            <div class="acc-track"><div class="acc-fill"></div></div>
+          </div>
+          <div class="acc-row acc--low" data-tier="inperson" style="--w:50%">
+            <div class="acc-row__top">
+              <span class="acc-row__name"><span class="acc-row__rank">04</span> Pawn Shop <span class="acc-row__tier">Lowest</span></span>
+              <span class="acc-row__score">40&ndash;60%</span>
+            </div>
+            <div class="acc-track"><div class="acc-fill"></div></div>
+          </div>
+        </div>
+        <div class="acc-compare__foot">Bars show the midpoint of each range. Specialist online buyers offer insured postal packs, quote in 24&ndash;48 hours and pay by bank transfer &mdash; usually the best price for plain gold rings.</div>
+      </div>
+
+      <div class="info-callout reveal">
+        <p><strong>Always get at least two quotes.</strong> Request one from a specialist online buyer and one local option, then compare each as a percentage of the melt value the calculator gives you. Any offer below 80% of melt from a buyer claiming to be a specialist warrants a second opinion. At today's prices the market favours sellers &mdash; you are not under pressure to accept the first number.</p>
+      </div>
+
+      <!-- ───────── STEPS ───────── -->
+      <h2 id="steps" class="reveal"><span class="h2-num">09</span>Step by Step: Get the Best Price for Your Ring</h2>
+      <ol class="step-list">
+        <li class="step-block reveal">
+          <div class="step-number" aria-hidden="true">1</div>
+          <div class="step-content">
+            <strong>Weigh it accurately</strong>
+            <p>Use a digital scale accurate to 0.1 g. Weigh the ring alone &mdash; no packaging, no other items. The gram weight is the single most important number you need.</p>
+          </div>
+        </li>
+        <li class="step-block reveal">
+          <div class="step-number" aria-hidden="true">2</div>
+          <div class="step-content">
+            <strong>Identify the karat</strong>
+            <p>Find the hallmark inside the band: <span class="hmark">375</span>, <span class="hmark">585</span>, <span class="hmark">750</span>, <span class="hmark">916</span>, and so on. If you cannot find one, a jeweller can test it for free or a small fee. Do not assume.</p>
+          </div>
+        </li>
+        <li class="step-block reveal">
+          <div class="step-number" aria-hidden="true">3</div>
+          <div class="step-content">
+            <strong>Calculate the melt value in USD</strong>
+            <p>Enter weight and karat in the live calculator above. That gives you the melt value &mdash; the ceiling any buyer should approach &mdash; in USD, with conversions a tap away.</p>
+          </div>
+        </li>
+        <li class="step-block reveal">
+          <div class="step-number" aria-hidden="true">4</div>
+          <div class="step-content">
+            <strong>Check for value beyond the metal</strong>
+            <p>A maker's mark? A certified diamond over 0.5 ct? Antique hallmarks? If yes, get an auction estimate before a scrap sale. If it is a plain, modern, unmarked band, scrap is almost certainly the best route.</p>
+          </div>
+        </li>
+        <li class="step-block reveal">
+          <div class="step-number" aria-hidden="true">5</div>
+          <div class="step-content">
+            <strong>Get at least two quotes</strong>
+            <p>Compare a specialist online buyer against one local option, both as a percentage of melt. Any quote below 80% of melt from a reputable buyer warrants a challenge or a third quote.</p>
+          </div>
+        </li>
+        <li class="step-block reveal">
+          <div class="step-number" aria-hidden="true">6</div>
+          <div class="step-content">
+            <strong>Accept, negotiate, or walk away</strong>
+            <p>Reputable buyers hold an offer for several days and return items free if you decline. There is no pressure to sell instantly &mdash; especially at current high prices, where the market favours sellers.</p>
+          </div>
+        </li>
+      </ol>
+
+      <!-- ───────── FAQ ───────── -->
+      <h2 id="faq" class="reveal"><span class="h2-num">10</span>Frequently Asked Questions</h2>
+      <div class="faq-accordion reveal">
+
+        <details class="faq-item">
+          <summary>How much is a 9K gold ring worth?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>A <strong>9K (375) gold ring weighing 3 grams</strong> holds about 1.13 g of pure gold &mdash; a melt value near <strong>$172</strong> at a representative spot around $4,750/oz. Specialist buyers paying 85&ndash;95% would offer roughly <strong>$146&ndash;$163</strong>. Heavier 5&ndash;6 g rings are worth proportionally more. Use the live calculator above with your ring's actual weight for the exact USD figure right now.</p></div>
+        </details>
+
+        <details class="faq-item">
+          <summary>How much is an 18K gold ring worth?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>An <strong>18K (750) gold ring weighing 4 grams</strong> contains 3 g of pure gold &mdash; a melt value around <strong>$458</strong> at a representative spot near $4,750/oz. A specialist offer of 85&ndash;95% would be about <strong>$389&ndash;$435</strong>. 18K is 75% pure gold, so it is worth roughly twice as much per gram as 9K (37.5% pure).</p></div>
+        </details>
+
+        <details class="faq-item">
+          <summary>Does a diamond make a gold ring worth more?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>For a scrap gold buyer, usually not &mdash; they pay for the gold weight only and ignore small melee diamonds under about 0.1 ct. A larger, certified diamond (0.5 ct and up) can add real value, but only when sold through a jeweller, auction house or specialist diamond dealer rather than a scrap buyer. Have any substantial stone independently appraised before a scrap sale.</p></div>
+        </details>
+
+        <details class="faq-item">
+          <summary>How do I find the karat of my gold ring?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>Look for a hallmark stamped inside the band: <span class="hmark">375</span> = 9K, <span class="hmark">585</span> = 14K, <span class="hmark">750</span> = 18K, <span class="hmark">916</span> = 22K and <span class="hmark">999</span> = 24K. You may also see the karat written directly as 9K, 14K, 18K, and so on. If there is no visible hallmark, a jeweller can test the metal with an acid test kit or an electronic gold tester in minutes.</p></div>
+        </details>
+
+        <details class="faq-item">
+          <summary>Is it better to sell a gold ring to a jeweller or a gold buyer?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>For plain gold rings with no special gemstones or antique value, specialist online gold buyers and bullion dealers typically pay the most &mdash; about <strong>85&ndash;95% of melt value</strong>. Local jewellers often pay 55&ndash;75% and pawn shops 40&ndash;60%. For antique, designer or signed pieces, an auction house or specialist dealer may offer more than melt value.</p></div>
+        </details>
+
+        <details class="faq-item">
+          <summary>How much does a gold wedding ring weigh?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>A typical plain gold wedding band weighs between <strong>3 and 6 grams</strong>. Wider bands, heavily engraved rings and men's rings tend to be heavier (5&ndash;8 g); women's rings with thinner shanks are often 2&ndash;4 g. Weight is the single biggest driver of melt value, so weigh the ring on a digital scale accurate to 0.1 g.</p></div>
+        </details>
+
+        <details class="faq-item">
+          <summary>What is the difference between melt value and resale value?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>Melt value is the pure gold content of the ring valued at the live spot price &mdash; the baseline floor. Resale value is what a buyer will actually pay, which is almost always below melt for plain rings because the buyer needs a margin. For antique, designer or certified pieces, resale value can exceed melt if there is a collector market.</p></div>
+        </details>
+
+        <details class="faq-item">
+          <summary>How often does the gold ring value update?<svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></summary>
+          <div class="faq-body"><p>The live calculator on this page refreshes every <strong>60 seconds</strong> using the current USD gold spot price. Gold trades continuously from Sunday evening to Friday evening, and the LBMA sets official benchmark fixes at 10:30 AM and 3:00 PM London time on weekdays. Prices are less volatile at weekends when markets are closed.</p></div>
+        </details>
+
+      </div>
+
+      <div class="disclaimer-box reveal">
+        <strong>Disclaimer:</strong> All values in this guide and the live calculator are melt values &mdash; the pure gold content at the current USD spot price &mdash; shown with USD as the primary currency and other currencies as live conversions. Illustrative figures use a representative spot near $4,750/oz and change continuously; the live tool is the source of truth. No buyer pays 100% of melt; realistic offers from reputable specialists are 85&ndash;95% of the figures shown. This page is for informational purposes only and is not financial advice. Live spot prices are sourced from gold-api.com and refresh every 60 seconds.
+      </div>
+
     </div>
+  </main>
+</div>
 
-    <h2 id="faq">Frequently Asked Questions</h2>
-
-    <div class="faq-accordion">
-
-      <div class="faq-item">
-        <h3>How much is a 9ct gold ring worth?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>A <strong>9ct gold ring weighing 3 grams</strong> has a melt value of approximately £125 at current prices (May 2026). Most specialist buyers pay 85–95% of melt value, so expect an offer of around <strong>£106–£119</strong>. Heavier rings of 5–6 grams will fetch proportionally more. Use the live calculator above with your ring's actual weight for a precise figure.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>How much is an 18ct gold ring worth?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>An <strong>18ct gold ring weighing 4 grams</strong> has a melt value of around £333 at May 2026 prices. Specialist buyers paying 85–95% of melt would offer approximately <strong>£283–£316</strong>. 18ct is 75% pure gold, making it significantly more valuable per gram than 9ct (37.5% pure).</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>Does a diamond make a gold ring worth more?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>It depends on the diamond's quality and size. Most scrap gold buyers ignore small accent diamonds (under 0.1ct) entirely and pay only for the gold weight. Larger, certificated diamonds (0.5ct+) can add significant value, but only if sold through a jeweller or specialist diamond dealer rather than a scrap gold buyer. Have any ring with a substantial stone independently appraised before selling.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>How do I find the karat of my gold ring?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Look for a hallmark stamped inside the band. In the UK, common markings are <span class="hmark">375</span> (9ct), <span class="hmark">585</span> (14ct), <span class="hmark">750</span> (18ct), <span class="hmark">916</span> (22ct) and <span class="hmark">999</span> (24ct). You may also see the karat written directly as 9K, 14K, 18K, etc. If there is no visible hallmark, a jeweller can test the metal with an acid test kit or an electronic gold tester.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>Is it better to sell a gold ring to a jeweller or a gold buyer?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>For plain gold rings with no special gemstones or antique value, specialist online gold buyers and bullion dealers typically offer the best price — usually <strong>85–95% of melt value</strong>. Local jewellers often offer 55–75% of melt value, and pawn shops 40–60%. For antique, designer, or signed pieces, an auction house or specialist dealer may offer more than melt value.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>How much does a gold wedding ring weigh?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>A typical plain gold wedding band weighs between <strong>3 and 6 grams</strong>. Wider bands, heavily engraved rings, and men's rings tend to be heavier (5–8g). Women's rings with thinner shanks are often 2–4g. The precise weight is the most important number for calculating melt value — use a digital kitchen scale accurate to 0.1g.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>What is the difference between melt value and resale value?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>Melt value is the pure gold content of the ring valued at the current spot price — the baseline floor. Resale value is what a buyer will actually pay, which is almost always lower than melt for plain rings (the buyer needs a margin). However, for antique, designer, or rare pieces, resale value can exceed melt value if there is a collector market for the piece.</p></div>
-      </div>
-
-      <div class="faq-item">
-        <h3>How often does the gold ring value update?<svg class="faq-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></h3>
-        <div class="faq-body"><p>The live calculator on this page updates every <strong>60 seconds</strong> using the current gold spot price. Gold trades continuously during market hours (Sunday 22:00 to Friday 22:00 UK time). The LBMA publishes official benchmark fix prices at 10:30 AM and 3:00 PM London time on weekdays. Prices are less volatile at weekends when markets are closed.</p></div>
-      </div>
-
-    </div>
-
-    <div class="disclaimer-box">
-      <strong>Disclaimer:</strong> All values shown in this guide and the live calculator are melt values — the pure gold content at the current spot price. Actual buyer offers will vary. No buyer pays 100% of melt value; realistic offers from reputable specialist buyers are 85–95% of the figures shown. The calculator is for informational purposes only and does not constitute financial advice. Gold prices are live and volatile.
-    </div>
-
+<section class="related-section" aria-label="Related guides and tools">
+  <div class="related-section__head">
+    <h2>Related Guides &amp; Tools</h2>
+    <p>Keep going &mdash; value, test and sell with confidence.</p>
   </div>
-</article>
-
-<section class="related-guides-section" aria-label="Related guides">
-  <h2>Related Guides &amp; Tools</h2>
-  <div class="related-guides-grid">
+  <div class="related-grid">
     <a href="/scrap-gold-calculator" class="related-card">
       <span class="related-card__tag">Tool</span>
       <div class="related-card__title">Scrap Gold Calculator</div>
-      <div class="related-card__desc">Calculate the live melt value of any gold item — chains, coins, bars, and jewellery — by weight and karat.</div>
+      <div class="related-card__desc">Value any gold item &mdash; chains, coins, bars and jewellery &mdash; by weight and karat in USD, live.</div>
     </a>
     <a href="/guides/gold-hallmarks-explained" class="related-card">
       <span class="related-card__tag">Guide</span>
       <div class="related-card__title">Gold Hallmarks Explained</div>
-      <div class="related-card__desc">UK, European, antique and foreign hallmarks decoded — symbols, date letters, assay office marks explained.</div>
+      <div class="related-card__desc">UK, European, antique and foreign hallmarks decoded &mdash; fineness numbers, date letters and assay marks.</div>
     </a>
     <a href="/guides/how-to-test-if-gold-is-real" class="related-card">
       <span class="related-card__tag">Guide</span>
       <div class="related-card__title">How to Test if Gold Is Real</div>
-      <div class="related-card__desc">10 methods ranked by accuracy — from the magnet test to acid testing and electronic testers.</div>
+      <div class="related-card__desc">10 methods ranked by accuracy &mdash; from the magnet test to acid testing and electronic testers.</div>
     </a>
     <a href="/guides/what-is-best-time-to-sell-scrap-gold" class="related-card">
       <span class="related-card__tag">Guide</span>
       <div class="related-card__title">Best Time to Sell Scrap Gold</div>
-      <div class="related-card__desc">Market timing, seasonal patterns, and how to get the highest price for your scrap gold in 2026.</div>
+      <div class="related-card__desc">Market timing, seasonal patterns and how to get the highest USD price for your gold in 2026.</div>
     </a>
   </div>
 </section>
@@ -829,15 +1046,15 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
         <img src="https://assets.goldpricetools.com/logo.svg" width="28" height="28" alt="GoldPriceTools logo" loading="lazy" onerror="this.style.display='none'">
         <span style="font-weight:700;font-size:var(--text-sm);color:var(--color-gold-bright)">GoldPriceTools</span>
       </a>
-      <p class="footer-brand">Live gold and silver prices. Real-time 9K–24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Updated every 60 seconds.</p>
+      <p class="footer-brand">Live gold and silver prices in USD. Real-time 9K&ndash;24K gold per gram, scrap gold calculator, silver per troy oz and kilo. Updated every 60 seconds.</p>
     </div>
     <div class="footer-col">
       <h4>Gold Prices</h4>
       <ul>
-        <li></li>
-        <li></li>
+        <li><a href="/14k-gold-price-per-gram">14K Gold Per Gram</a></li>
+        <li><a href="/18k-gold-price-per-gram">18K Gold Per Gram</a></li>
+        <li><a href="/24k-gold-price-per-gram">24K Gold Per Gram</a></li>
         <li><a href="/gold-silver-ratio">Gold / Silver Ratio</a></li>
-        
       </ul>
     </div>
     <div class="footer-col">
@@ -882,13 +1099,40 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
   </div>
   <div class="footer-bottom">
     <span>&copy; 2026 GoldPriceTools. All rights reserved.</span>
-    <span>Prices sourced via LBMA. Not financial advice.</span>
+    <span>Prices sourced via LBMA &middot; gold-api.com. Not financial advice.</span>
   </div>
 </footer>
 
+<button class="toc-fab" id="tocFab" aria-haspopup="dialog" aria-expanded="false" aria-controls="tocSheet">
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 6h16M4 12h16M4 18h10"/></svg>
+  Contents
+</button>
+<div class="toc-sheet" id="tocSheet" role="dialog" aria-modal="true" aria-label="Article contents">
+  <div class="toc-sheet__panel">
+    <div class="toc-sheet__head">
+      <span class="toc-sheet__title">In this guide</span>
+      <button class="toc-sheet__close" id="tocSheetClose" aria-label="Close contents">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <ul class="toc-sheet__list">
+      <li><a href="#calculator">Live Ring Calculator</a></li>
+      <li><a href="#value-factors">What Sets the Value</a></li>
+      <li><a href="#by-karat">Value by Karat</a></li>
+      <li><a href="#reference">Quick Reference (USD)</a></li>
+      <li><a href="#hallmarks">Find the Hallmark</a></li>
+      <li><a href="#diamonds">Diamond Rings</a></li>
+      <li><a href="#sentimental">Sentimental Pieces</a></li>
+      <li><a href="#where-to-sell">Where to Sell</a></li>
+      <li><a href="#steps">Get the Best Price</a></li>
+      <li><a href="#faq">FAQ</a></li>
+    </ul>
+  </div>
+</div>
+
 <script>
+/* Theme + nav + mobile menu (site standard) */
 (function(){
-  /* Theme + nav */
   var toggle=document.getElementById('themeToggle');
   var sun=document.getElementById('iconSun');
   var moon=document.getElementById('iconMoon');
@@ -922,169 +1166,319 @@ details.faq-item[open]>summary{background:var(--color-surface-offset);border-bot
 </script>
 
 <script>
-/* Fetch live gold spot price and GBP/USD rate — same pattern as scrap-gold-calculator */
-window._spot=null;
-window._gbpusd=0.79;
+/* Scroll progress, reveal-on-scroll, TOC active state, mobile TOC sheet, payout filter */
 (function(){
-  async function fetchFx(){
-    try{var r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});if(!r.ok)throw new Error();var d=await r.json();window._gbpusd=d.GBPUSD||0.79;}catch(e){window._gbpusd=0.79;}
+  var fill=document.getElementById('scrollProgressFill');
+  function updateProgress(){
+    var h=document.documentElement;
+    var max=h.scrollHeight-h.clientHeight;
+    var pct=max>0?(h.scrollTop/max)*100:0;
+    if(fill)fill.style.width=pct+'%';
   }
-  async function fetchSpot(){
-    try{var r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});if(!r.ok)throw new Error();var d=await r.json();window._spot=d.price;window.dispatchEvent(new Event('goldprice_updated'));}catch(e){console.warn('Gold price API unavailable',e);}
+  window.addEventListener('scroll',updateProgress,{passive:true});
+  window.addEventListener('resize',updateProgress);
+  updateProgress();
+
+  var reduced=matchMedia('(prefers-reduced-motion:reduce)').matches;
+  if(reduced){
+    document.querySelectorAll('.reveal').forEach(function(el){el.classList.add('is-in');});
+    document.querySelectorAll('.purity-viz,.acc-compare').forEach(function(el){el.classList.add('is-in');});
+  } else if('IntersectionObserver' in window){
+    var io=new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(e.isIntersecting){e.target.classList.add('is-in');io.unobserve(e.target);}
+      });
+    },{rootMargin:'0px 0px -8% 0px',threshold:0.12});
+    document.querySelectorAll('.reveal').forEach(function(el){io.observe(el);});
+    var io2=new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(e.isIntersecting){e.target.classList.add('is-in');io2.unobserve(e.target);}
+      });
+    },{rootMargin:'0px 0px -12% 0px',threshold:0.2});
+    document.querySelectorAll('.purity-viz,.acc-compare').forEach(function(el){io2.observe(el);});
+  } else {
+    document.querySelectorAll('.reveal,.purity-viz,.acc-compare').forEach(function(el){el.classList.add('is-in');});
   }
-  Promise.all([fetchFx(),fetchSpot()]);
-  setInterval(fetchSpot,60000);
+
+  var tocLinks=document.querySelectorAll('#tocList a');
+  var headings=Array.prototype.map.call(tocLinks,function(a){
+    var id=a.getAttribute('href').slice(1);
+    return {a:a,el:document.getElementById(id)};
+  }).filter(function(o){return o.el;});
+  function syncToc(){
+    var y=window.scrollY+120;
+    var current=null;
+    headings.forEach(function(o){
+      if(o.el.offsetTop<=y)current=o.a;
+    });
+    tocLinks.forEach(function(a){a.classList.remove('is-active');});
+    if(current)current.classList.add('is-active');
+  }
+  window.addEventListener('scroll',syncToc,{passive:true});
+  syncToc();
+
+  var fab=document.getElementById('tocFab');
+  var sheet=document.getElementById('tocSheet');
+  var closeBtn=document.getElementById('tocSheetClose');
+  function openSheet(){sheet.classList.add('is-open');fab.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';}
+  function closeSheet(){sheet.classList.remove('is-open');fab.setAttribute('aria-expanded','false');document.body.style.overflow='';}
+  if(fab)fab.addEventListener('click',openSheet);
+  if(closeBtn)closeBtn.addEventListener('click',closeSheet);
+  if(sheet)sheet.addEventListener('click',function(e){if(e.target===sheet)closeSheet();});
+  document.querySelectorAll('.toc-sheet__list a').forEach(function(a){a.addEventListener('click',closeSheet);});
+
+  /* Payout comparison filter tabs */
+  document.querySelectorAll('.acc-tab').forEach(function(tab){
+    tab.addEventListener('click',function(){
+      document.querySelectorAll('.acc-tab').forEach(function(t){t.classList.remove('is-active');t.setAttribute('aria-pressed','false');});
+      this.classList.add('is-active');this.setAttribute('aria-pressed','true');
+      var f=this.dataset.filter;
+      document.querySelectorAll('#payoutCompare .acc-row').forEach(function(r){
+        r.style.display=(f==='all'||r.dataset.tier===f)?'':'none';
+      });
+    });
+  });
 })();
 </script>
 
 <script>
+/* ── LIVE PRICE FEED ──
+   Endpoint: api.gold-api.com/price/XAU (USD per troy oz, no API key)
+   FX:       api.goldpricetoolsworker.io/fx (USD basis)
+   Refresh:  60 seconds  ·  Primary currency: USD $
+*/
+window._spot=null;
+window._spotPrev=null;
+window._spotTs=null;
+window._fx={USD:1};
 (function(){
-  /* Ring calculator */
+  var FALLBACK_FX={USD:1,EUR:0.92,GBP:0.79,CAD:1.38,AUD:1.55,INR:83.5,AED:3.673,JPY:153.8};
+  Object.keys(FALLBACK_FX).forEach(function(k){window._fx[k]=FALLBACK_FX[k];});
+
+  async function fetchFx(){
+    try{
+      var r=await fetch('https://api.goldpricetoolsworker.io/fx',{cache:'no-store'});
+      if(!r.ok)throw new Error('fx '+r.status);
+      var d=await r.json();
+      if(d&&typeof d==='object'){
+        if(d.GBPUSD)window._fx.GBP=d.GBPUSD;
+        if(d.EURUSD)window._fx.EUR=d.EURUSD;
+        if(d.USDEUR)window._fx.EUR=d.USDEUR;
+        if(d.USDGBP)window._fx.GBP=d.USDGBP;
+        ['EUR','GBP','CAD','AUD','INR','AED','JPY'].forEach(function(k){
+          if(d[k])window._fx[k]=d[k];
+        });
+      }
+    }catch(e){/* keep fallback */}
+  }
+
+  async function fetchSpot(){
+    try{
+      var r=await fetch('https://api.gold-api.com/price/XAU',{cache:'no-store'});
+      if(!r.ok)throw new Error('spot '+r.status);
+      var d=await r.json();
+      if(d&&typeof d.price==='number'){
+        window._spotPrev=window._spot;
+        window._spot=d.price;
+        if(typeof d.prev_close_price==='number')window._spotPrev=d.prev_close_price;
+        window._spotTs=Date.now();
+        window.dispatchEvent(new Event('goldprice_updated'));
+      } else {
+        window.dispatchEvent(new Event('goldprice_error'));
+      }
+    }catch(e){
+      window.dispatchEvent(new Event('goldprice_error'));
+    }
+  }
+
+  fetchFx();
+  fetchSpot();
+  setInterval(fetchSpot,60000);
+  setInterval(fetchFx,15*60*1000);
+})();
+</script>
+
+<script>
+/* ── HERO live spot card binding ── */
+(function(){
   var TROY=31.1035;
-  var PURITY={'9K':0.375,'10K':0.4167,'14K':0.5833,'18K':0.75,'22K':0.9167,'24K':0.999};
-  var CURRENCIES={
-    'GBP':{sym:'£',live:true},
-    'USD':{sym:'$',rate:1.0},
-    'EUR':{sym:'€',rate:0.922},
-    'AUD':{sym:'A$',rate:1.545},
-    'CAD':{sym:'C$',rate:1.384},
-    'INR':{sym:'₹',rate:83.50},
-    'AED':{sym:'د.إ',rate:3.673},
-    'CHF':{sym:'Fr',rate:0.898},
-    'SGD':{sym:'S$',rate:1.342},
-    'JPY':{sym:'¥',rate:153.8}
+  var priceEl=document.getElementById('heroSpotPrice');
+  var deltaEl=document.getElementById('heroSpotDelta');
+  var deltaText=document.getElementById('heroSpotDeltaText');
+  var gramEl=document.getElementById('heroSpotPerGram');
+  var updatedEl=document.getElementById('heroSpotUpdated');
+  var liveBadge=document.getElementById('heroLive');
+  var liveText=document.getElementById('heroLiveText');
+
+  function fmtUSD(v,d){return '$'+v.toLocaleString('en-US',{minimumFractionDigits:d!=null?d:2,maximumFractionDigits:d!=null?d:2});}
+  function fmtRel(ts){
+    if(!ts)return 'just now';
+    var s=Math.floor((Date.now()-ts)/1000);
+    if(s<5)return 'just now';
+    if(s<60)return s+'s ago';
+    if(s<3600)return Math.floor(s/60)+'m ago';
+    return Math.floor(s/3600)+'h ago';
+  }
+  function render(){
+    if(!window._spot)return;
+    priceEl.textContent=fmtUSD(window._spot,2);
+    var gram=window._spot/TROY;
+    gramEl.textContent=fmtUSD(gram,2);
+    if(window._spotPrev&&window._spotPrev!==window._spot){
+      var diff=window._spot-window._spotPrev;
+      var pct=(diff/window._spotPrev)*100;
+      deltaEl.hidden=false;
+      deltaEl.classList.remove('bento-spot__delta--up','bento-spot__delta--down');
+      deltaEl.classList.add(diff>=0?'bento-spot__delta--up':'bento-spot__delta--down');
+      var arrow=deltaEl.querySelector('svg');
+      if(arrow)arrow.style.transform=diff>=0?'rotate(0deg)':'rotate(180deg)';
+      var sign=diff>=0?'+':'';
+      deltaText.textContent=sign+fmtUSD(Math.abs(diff),2)+' ('+sign+pct.toFixed(2)+'%) vs prev close';
+    }
+    updatedEl.textContent=fmtRel(window._spotTs);
+    liveBadge.classList.remove('live-pill--idle','live-pill--error');
+    liveText.textContent='Live';
+  }
+  function errored(){
+    liveBadge.classList.add('live-pill--error');
+    liveBadge.classList.remove('live-pill--idle');
+    liveText.textContent='Reconnecting';
+  }
+  window.addEventListener('goldprice_updated',render);
+  window.addEventListener('goldprice_error',errored);
+  setInterval(function(){if(window._spotTs)updatedEl.textContent=fmtRel(window._spotTs);},5000);
+})();
+</script>
+
+<script>
+/* ── GOLD RING VALUE CALCULATOR ── USD primary ── melt math matches scrap-gold-calculator.html ── */
+(function(){
+  var TROY=31.1035;
+  var CURR={
+    USD:{sym:'$',locale:'en-US',decimals:2},
+    EUR:{sym:'€',locale:'en-GB',decimals:2},
+    GBP:{sym:'£',locale:'en-GB',decimals:2},
+    CAD:{sym:'C$',locale:'en-CA',decimals:2},
+    AUD:{sym:'A$',locale:'en-AU',decimals:2},
+    INR:{sym:'₹',locale:'en-IN',decimals:0},
+    AED:{sym:'د.إ ',locale:'en-AE',decimals:2},
+    JPY:{sym:'¥',locale:'ja-JP',decimals:0}
   };
   var BUYERS={
-    'specialist':{label:'Specialist Online Buyer',min:0.85,max:0.95},
-    'dealer':{label:'In-person Gold Dealer',min:0.82,max:0.92},
-    'jeweller':{label:'Local Jeweller',min:0.55,max:0.75},
-    'pawn':{label:'Pawn Shop',min:0.40,max:0.60}
+    specialist:{label:'Specialist',min:0.85,max:0.95},
+    dealer:{label:'Bullion dealer',min:0.80,max:0.92},
+    jeweller:{label:'Local jeweller',min:0.55,max:0.75},
+    pawn:{label:'Pawn shop',min:0.40,max:0.60}
   };
-
   var unit='g';
+  var purity=0.5833;
   var karat='14K';
-  var purity=PURITY['14K'];
-  var weightInput=document.getElementById('rcWeight');
+
+  var weightEl=document.getElementById('rcWeight');
   var currSel=document.getElementById('rcCurrency');
   var buyerSel=document.getElementById('rcBuyer');
-  var rcOutput=document.getElementById('rcOutput');
-  var rcPlaceholder=document.getElementById('rcPlaceholder');
-  var rcMelt=document.getElementById('rcMeltValue');
-  var rcOffer=document.getElementById('rcOfferValue');
-  var rcOfferLabel=document.getElementById('rcOfferLabel');
-  var rcPPG=document.getElementById('rcPricePerGram');
-  var rcPure=document.getElementById('rcPureGold');
-  var rcSpot=document.getElementById('rcSpotLine');
-  var rcStatus=document.getElementById('rcStatusText');
+  var placeholder=document.getElementById('rcPlaceholder');
+  var output=document.getElementById('rcOutput');
+  var meltEl=document.getElementById('rcMeltValue');
+  var offerEl=document.getElementById('rcOfferValue');
+  var offerLabelEl=document.getElementById('rcOfferLabel');
+  var pureGramsEl=document.getElementById('rcPureGrams');
+  var pricePerGramEl=document.getElementById('rcPricePerGram');
+  var spotLineEl=document.getElementById('rcSpotLine');
+  var updatedEl=document.getElementById('rcUpdated');
+  var liveBadge=document.getElementById('rcLive');
+  var liveText=document.getElementById('rcLiveText');
 
-  /* Unit toggle */
-  document.querySelectorAll('.unit-btn').forEach(function(btn){
-    btn.addEventListener('click',function(){
-      document.querySelectorAll('.unit-btn').forEach(function(b){b.classList.remove('active');});
-      this.classList.add('active');
+  document.querySelectorAll('#ringCalc .gf-unit-btn').forEach(function(b){
+    b.addEventListener('click',function(){
+      document.querySelectorAll('#ringCalc .gf-unit-btn').forEach(function(x){x.classList.remove('is-active');});
+      this.classList.add('is-active');
       unit=this.dataset.unit;
       calc();
     });
   });
-
-  /* Karat buttons */
-  document.querySelectorAll('.karat-btn').forEach(function(btn){
-    btn.addEventListener('click',function(){
-      document.querySelectorAll('.karat-btn').forEach(function(b){b.classList.remove('active');});
-      this.classList.add('active');
-      karat=this.dataset.karat;
+  document.querySelectorAll('#ringCalc .gf-karat-btn').forEach(function(b){
+    b.addEventListener('click',function(){
+      document.querySelectorAll('#ringCalc .gf-karat-btn').forEach(function(x){x.classList.remove('is-active');});
+      this.classList.add('is-active');
       purity=parseFloat(this.dataset.purity);
+      karat=this.dataset.karat;
       calc();
     });
   });
+  if(currSel)currSel.addEventListener('change',calc);
+  if(buyerSel)buyerSel.addEventListener('change',calc);
+  if(weightEl)weightEl.addEventListener('input',calc);
 
-  currSel.addEventListener('change',calc);
-  buyerSel.addEventListener('change',calc);
-  weightInput.addEventListener('input',calc);
-
-  function fmt(sym,val,decimals){
-    if(val>=1000){
-      return sym+val.toLocaleString('en-GB',{minimumFractionDigits:0,maximumFractionDigits:0});
-    }
-    return sym+val.toFixed(decimals!=null?decimals:2);
+  function fmt(c,v){
+    var info=CURR[c]||CURR.USD;
+    var n=Math.max(0,v).toLocaleString(info.locale,{minimumFractionDigits:info.decimals,maximumFractionDigits:info.decimals});
+    return info.sym+n;
+  }
+  function fmtRel(ts){
+    if(!ts)return '—';
+    var s=Math.floor((Date.now()-ts)/1000);
+    if(s<5)return 'just now';
+    if(s<60)return s+'s ago';
+    if(s<3600)return Math.floor(s/60)+'m ago';
+    return Math.floor(s/3600)+'h ago';
   }
 
   function calc(){
-    if(!window._spot||!window._gbpusd)return;
-    var rawWeight=parseFloat(weightInput.value);
-    if(isNaN(rawWeight)||rawWeight<=0){
-      rcOutput.style.display='none';
-      rcPlaceholder.style.display='flex';
+    if(!window._spot){
+      placeholder.style.display='flex';
+      placeholder.textContent='Waiting for the live spot price…';
+      output.style.display='none';
       return;
     }
-    var weightG=unit==='oz'?rawWeight*TROY:rawWeight;
-    var usd24=window._spot/TROY;
-    var gbp24=usd24*window._gbpusd;
-
-    var curr=currSel.value;
-    var cInfo=CURRENCIES[curr];
-    var pricePerGram24;
-    if(cInfo.live){
-      pricePerGram24=gbp24;
-    } else {
-      pricePerGram24=usd24*cInfo.rate;
+    var raw=parseFloat(weightEl.value);
+    if(!isFinite(raw)||raw<=0){
+      placeholder.style.display='flex';
+      placeholder.textContent='Enter your ring weight to see its live melt value and a realistic offer range.';
+      output.style.display='none';
+      return;
     }
+    placeholder.style.display='none';
+    output.style.display='flex';
 
-    var pureGrams=weightG*purity;
-    var melt=pureGrams*pricePerGram24;
-    var buyer=BUYERS[buyerSel.value];
-    var offerMin=melt*buyer.min;
-    var offerMax=melt*buyer.max;
-    var sym=cInfo.sym;
+    var weightG=unit==='oz'?raw*TROY:raw;
+    var fineGoldG=weightG*purity;
 
-    rcMelt.textContent=fmt(sym,melt);
-    rcOffer.textContent=fmt(sym,offerMin)+' – '+fmt(sym,offerMax);
-    rcOfferLabel.textContent=buyer.label+' Offer Range';
-    rcPPG.textContent=fmt(sym,pricePerGram24)+'/g';
-    rcPure.textContent=pureGrams.toFixed(3)+'g';
+    var spotUsdPerGram=window._spot/TROY;
+    var meltUsd=fineGoldG*spotUsdPerGram;
 
-    var spotDisp=cInfo.live
-      ? '£'+window._spot.toFixed(0)+'/oz spot'
-      : '$'+window._spot.toFixed(0)+'/oz spot';
-    rcSpot.textContent='Live spot: '+spotDisp+' · '+karat+' ('+Math.round(purity*100)+'% pure) · Updated every 60s'+(cInfo.live?'':', '+curr+' rate approx.');
+    var c=currSel.value;
+    var fxRate=(window._fx&&window._fx[c])?window._fx[c]:1;
+    var meltLocal=meltUsd*fxRate;
+    var pricePerGramLocal=spotUsdPerGram*purity*fxRate;
 
-    rcOutput.style.display='flex';
-    rcPlaceholder.style.display='none';
+    var buyer=BUYERS[buyerSel.value]||BUYERS.specialist;
+    var offerLow=meltLocal*buyer.min;
+    var offerHigh=meltLocal*buyer.max;
+
+    meltEl.textContent=fmt(c,meltLocal);
+    offerEl.textContent=fmt(c,offerLow)+' – '+fmt(c,offerHigh);
+    offerLabelEl.textContent=buyer.label+' offer ('+Math.round(buyer.min*100)+'–'+Math.round(buyer.max*100)+'% of melt)';
+    pureGramsEl.textContent=fineGoldG.toFixed(3)+' g';
+    pricePerGramEl.textContent=fmt(c,pricePerGramLocal);
+    spotLineEl.textContent='$'+window._spot.toFixed(2)+' / oz · '+karat;
+    updatedEl.textContent=fmtRel(window._spotTs);
+
+    liveBadge.classList.remove('live-pill--idle','live-pill--error');
+    liveText.textContent='Live';
   }
 
-  var _cdInterval=null;
-  var _cdSecs=60;
-
-  function updateCountdown(){
-    var m=Math.floor(_cdSecs/60);
-    var s=_cdSecs%60;
-    rcStatus.textContent='Live · '+String(m).padStart(2,'0')+':'+String(s).padStart(2,'0');
-  }
-
-  function startCountdown(){
-    if(_cdInterval)clearInterval(_cdInterval);
-    _cdSecs=60;
-    updateCountdown();
-    _cdInterval=setInterval(function(){
-      if(_cdSecs>0)_cdSecs--;
-      updateCountdown();
-    },1000);
-  }
-
-  function onPriceReady(){
-    startCountdown();
+  window.addEventListener('goldprice_updated',function(){
+    liveBadge.classList.remove('live-pill--idle','live-pill--error');
+    liveText.textContent='Live';
     calc();
-  }
-
-  function tryConnect(){
-    if(window._spot&&window._gbpusd){
-      onPriceReady();
-    } else {
-      setTimeout(tryConnect,600);
-    }
-  }
-  tryConnect();
-  window.addEventListener('goldprice_updated',onPriceReady);
+  });
+  window.addEventListener('goldprice_error',function(){
+    liveBadge.classList.remove('live-pill--idle');
+    liveBadge.classList.add('live-pill--error');
+    liveText.textContent='Reconnecting';
+  });
+  setInterval(function(){if(window._spotTs&&output.style.display==='flex')updatedEl.textContent=fmtRel(window._spotTs);},5000);
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary

Full redesign of **`/guides/how-much-is-a-gold-ring-worth`** on the site's premium editorial scaffold — mobile-first, fully responsive, and flipped from **GBP-primary → USD $ primary** throughout. Built with the `ui-ux-pro-max` design intelligence (luxury black + gold, Liquid Glass accents, Playfair Display editorial type — the skill's recommended pairing for jewellery).

## What changed

**Live tools & data accuracy (matches the rest of the site)**
- Live USD gold-spot card + a rebuilt **Gold Ring Value Calculator**: weight (g / troy oz), 6-karat selector, 8-currency conversion (USD default), and a **buyer-type** selector (specialist 85–95%, dealer 80–92%, jeweller 55–75%, pawn 40–60%).
- Melt math is **byte-identical to the canonical `scrap-gold-calculator.html`**: same endpoints (`api.gold-api.com/price/XAU` USD/oz + `api.goldpricetoolsworker.io/fx` USD-basis), `TROY=31.1035`, identical purity fractions, 60-second refresh, graceful fallback FX. Values stay consistent across the site.
- USD $ is primary everywhere — calculator, tables, narrative, FAQ and JSON-LD. Other currencies appear only as live conversions. Static figures are clearly **illustrative at a representative ~$4,750/oz** (consistent with the sister "Best Time to Sell" guide); the live tool is the source of truth.

**Design & UX**
- Bento-grid hero, signature animated **"Pure Gold Content by Karat"** visualizer, buyer **payout comparison** with Online/In-person filter tabs, a retail→scrap **value ladder**, hallmark finder, diamond & sentimental-piece sections, and a 6-step best-price walkthrough.
- Sidebar TOC + mobile FAB/sheet, scroll-progress bar, scroll-reveal, **reduced-motion fallbacks**, 44px touch targets, visible focus states, dark/light themes, WCAG AA contrast tokens.
- Liquid-glass nav, frosted calculator result panel, gold aurora glow.

**SEO & correctness**
- Canonical / OG / hreflang preserved; Article + Breadcrumb + FAQ JSON-LD rewritten USD-first, with FAQ schema **synced 1:1 to the visible accordion** (validator passes — 225 blocks valid).
- Fixes the prior footer's empty *Gold Prices* list items.

## Validation performed
- ✅ JSON-LD + rich-results validator passes
- ✅ HTML well-formed, CSS braces balanced (372/372), no duplicate IDs, all `getElementById`/`querySelector` targets resolve
- ✅ FAQ visible (8) == JSON-LD Questions (8); all 10 TOC anchors map to H2 ids; all internal links resolve to real files
- ✅ Static table & FAQ figures recomputed against the calculator's own formula (exact match)
- ✅ No emoji icons (SVG only), labels on all inputs, viewport + `lang` present

> ⚠️ The Playwright visual audit (per `DEVELOPMENT_RULES.md`) downloads browsers / hits the live URL, which the build sandbox blocks. **Recommend running `python3 tools/playwright_audit.py https://goldpricetools.com/guides/how-much-is-a-gold-ring-worth` after deploy** to confirm live render, console cleanliness, and the 400px screenshot strips.

https://claude.ai/code/session_01KE2ephCgdjdiCHsk6zMx9g

---
_Generated by [Claude Code](https://claude.ai/code/session_01KE2ephCgdjdiCHsk6zMx9g)_