### PR TITLE
Fix invisible CTA button text on silver coins article

### DIFF
--- a/blog/silver-coins-for-investors-uk.html
+++ b/blog/silver-coins-for-investors-uk.html
@@ -722,10 +722,10 @@ table.sci-table .sci-melt{font-variant-numeric:tabular-nums;font-weight:700;colo
 .sci-cta h3{font-family:var(--font-display);font-weight:800;font-size:clamp(1.2rem,1rem + 1vw,1.7rem);color:var(--color-text);margin:0 0 var(--space-2);line-height:1.2}
 .sci-cta p{font-size:var(--text-sm);color:var(--color-text-muted);max-width:54ch;margin:0 auto var(--space-5);line-height:1.65}
 .sci-ctabtns{display:flex;flex-wrap:wrap;gap:var(--space-3);justify-content:center}
-.sci-ctabtn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-3) var(--space-6);background:var(--color-primary);color:#fff;border-radius:var(--radius-full);font-weight:700;font-size:var(--text-sm);text-decoration:none;box-shadow:var(--shadow-md);transition:background .15s,transform .15s,box-shadow .15s;min-height:44px}
-.sci-ctabtn:hover{background:var(--color-primary-hover);color:#fff;transform:translateY(-2px);box-shadow:var(--shadow-lg);text-decoration:none}
-.sci-ctabtn--ghost{background:transparent;color:var(--color-primary);border:1px solid var(--color-primary)}
-.sci-ctabtn--ghost:hover{background:var(--color-primary);color:#fff}
+.sci-ctabtn,.sci-ctabtn:link,.sci-ctabtn:visited{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-3) var(--space-6);background:var(--color-primary);color:#fff!important;border-radius:var(--radius-full);font-weight:700;font-size:var(--text-sm);text-decoration:none!important;box-shadow:var(--shadow-md);transition:background .15s,transform .15s,box-shadow .15s;min-height:44px}
+.sci-ctabtn:hover,.sci-ctabtn:active{background:var(--color-primary-hover);color:#fff!important;transform:translateY(-2px);box-shadow:var(--shadow-lg);text-decoration:none!important}
+.sci-ctabtn--ghost,.sci-ctabtn--ghost:link,.sci-ctabtn--ghost:visited{background:transparent;color:var(--color-primary)!important;border:1px solid var(--color-primary);box-shadow:none}
+.sci-ctabtn--ghost:hover,.sci-ctabtn--ghost:active{background:var(--color-primary);color:#fff!important;border-color:var(--color-primary)}
 
 /* ── SOURCES + DISCLAIMER ───────────────────────────────── */
 .sci-sources{margin-top:var(--space-8);border-top:1px solid var(--color-border);padding-top:var(--space-5)}


### PR DESCRIPTION
## Summary

Follow-up to #412. The "Silver Coins Calculator" CTA pill at the end of `/blog/silver-coins-for-investors-uk` was rendering with invisible text — both the label and the arrow icon were the same teal as the button background, so the button looked like an empty pill.

**Root cause:** the global `a:visited{color:var(--color-primary)}` rule in the page's inline `<style>` block was overriding the white text on `.sci-ctabtn` after the link had been visited. Because the icon uses `stroke="currentColor"`, it disappeared along with the label.

**Fix:** declare explicit `:link`, `:visited`, `:hover`, `:active` states with `color:#fff !important` and `text-decoration:none !important` — the same hardening pattern that `.cta-btn` already uses in `/assets/site.css` to defeat the global cascade. The ghost variant (`Silver Price Per Kilo` button) gets the same treatment so its hover state also stays readable.

## Diff

4 lines changed in `blog/silver-coins-for-investors-uk.html`, no other files touched.

## Test plan

- [ ] Visit `/blog/silver-coins-for-investors-uk` in a fresh browser profile — CTA label and arrow icon visible in white on teal
- [ ] Click through to the calculator and come back — text remains visible after visited state
- [ ] Hover the primary button — background darkens to `--color-primary-hover`, text stays white
- [ ] Hover the ghost button — fills with primary, text flips to white
- [ ] Check both dark and light themes
- [ ] Confirm no other elements regressed (no other `.sci-*` anchor uses `color:#fff` so blast radius is minimal)

https://claude.ai/code/session_01EtgZsjzKhbVap3Mr1XJT8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtgZsjzKhbVap3Mr1XJT8R)_