### PR TITLE
Redesign Royal Mint buying guide: editorial layout + live GBP/USD premium calculator

### DIFF
--- a/blog/how-to-buy-gold-royal-mint.html
+++ b/blog/how-to-buy-gold-royal-mint.html
@@ -17,7 +17,7 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
-<meta property="og:title" content="How to Buy Gold from the Royal Mint UK 2026 | GoldPriceTools">><meta property="og:description" content="Complete guide to buying gold from the Royal Mint — account setup, product range (Sovereigns, Britannias, DigiGold), premiums and vault storage.">>
+<meta property="og:title" content="How to Buy Gold from the Royal Mint UK 2026 | GoldPriceTools"><meta property="og:description" content="Complete guide to buying gold from the Royal Mint — account setup, product range (Sovereigns, Britannias, DigiGold), premiums and vault storage.">
 <meta property="og:type" content="article"><meta property="og:url" content="https://goldpricetools.com/blog/how-to-buy-gold-royal-mint">
 <meta property="og:site_name" content="GoldPriceTools">
 <meta property="og:image" content="https://assets.goldpricetools.com/og-image.jpg">
@@ -29,7 +29,7 @@
   "headline": "How to Buy Gold from the Royal Mint: A UK Step-by-Step Guide",
   "description": "A complete guide to buying gold from the Royal Mint — account setup, product range (Sovereigns, Britannias, bars, DigiGold), premiums, Vault storage, and how to compare with commercial dealers.",
   "datePublished": "2026-05-03T08:00:00Z",
-  "dateModified": "2026-05-07T08:00:00Z",
+  "dateModified": "2026-06-15T08:00:00Z",
   "author": {
     "@type": "Organization",
     "name": "GoldPriceTools Editorial Team",
@@ -64,38 +64,27 @@
   "@context": "https://schema.org",
   "@type": "FAQPage",
   "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "Is the Royal Mint a good place to buy gold?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. The Royal Mint is the UK's official coin manufacturer, founded in 886 AD, and is considered the most trusted source for investment gold coins in the UK. Prices are competitive with other major dealers, and coins purchased directly carry the full Royal Mint guarantee of authenticity and purity. They also offer a DigiGold service for fractional gold ownership."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What gold products does the Royal Mint sell?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The Royal Mint sells Britannia gold coins (1oz, 1/2oz, 1/4oz, 1/10oz), Sovereign gold coins (full, half, quarter), gold bars (1g to 1kg), and collectable commemorative coins. Britannias and Sovereigns are CGT-exempt for UK investors, making them particularly tax-efficient."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Are Royal Mint gold coins CGT free?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. Gold Britannias and gold Sovereigns are classified as 'coin of the realm' and legal tender, making any gains from their sale completely exempt from Capital Gains Tax for UK investors. This is a significant advantage over gold bars or foreign gold coins, which are subject to standard CGT rates (18% or 24%)."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How does Royal Mint DigiGold work?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "DigiGold lets you buy fractions of a gold bar from as little as £25, with your gold physically stored at the Royal Mint's vault in Llantrisant, Wales. You own actual allocated gold, not a financial instrument. You can convert to physical delivery (coins or bars) at any time. Storage fees apply (0.5% per year)."
-      }
-    }
+    {"@type":"Question","name":"Is the Royal Mint a good place to buy gold?","acceptedAnswer":{"@type":"Answer","text":"Yes. The Royal Mint is the UK's official coin manufacturer and is considered the most trusted source for investment gold coins in the UK. Prices are competitive with other major dealers, and coins purchased directly carry the full Royal Mint guarantee of authenticity and purity. It also offers a DigiGold service for fractional gold ownership from £25."}},
+    {"@type":"Question","name":"What gold products does the Royal Mint sell?","acceptedAnswer":{"@type":"Answer","text":"The Royal Mint sells Britannia gold coins (1oz, 1/2oz, 1/4oz, 1/10oz and smaller), Sovereign gold coins (quarter, half, full and double), gold bars from 1g to 1kg, and collectable commemorative coins. Britannias and Sovereigns are CGT-exempt for UK investors, making them particularly tax-efficient."}},
+    {"@type":"Question","name":"Are Royal Mint gold coins CGT free?","acceptedAnswer":{"@type":"Answer","text":"Yes. Gold Britannias and gold Sovereigns are classified as legal tender, making any gains from their sale completely exempt from Capital Gains Tax for UK investors. This is a significant advantage over gold bars or foreign gold coins, which are subject to standard CGT rates (18% or 24%)."}},
+    {"@type":"Question","name":"How does Royal Mint DigiGold work?","acceptedAnswer":{"@type":"Answer","text":"DigiGold lets you buy fractions of a gold bar from as little as £25, with your gold physically stored at the Royal Mint's vault in Llantrisant, Wales. You own actual allocated gold and can convert to physical delivery (coins or bars) at any time. Storage fees apply at 0.5% per year."}},
+    {"@type":"Question","name":"Is gold cheaper from the Royal Mint or a dealer?","acceptedAnswer":{"@type":"Answer","text":"It depends on the product. For 1oz coins the Royal Mint is competitive, but commercial dealers often beat it on large bars (100g and above) and sometimes on buyback spreads. Use a live gold spot price to check the premium over spot, then compare against a dealer before buying."}}
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Buy Gold from the Royal Mint",
+  "description": "A step-by-step guide to buying investment gold from the UK's Royal Mint — account setup, choosing products, checking premiums, and selecting delivery or vault storage.",
+  "totalTime": "PT15M",
+  "estimatedCost": {"@type":"MonetaryAmount","currency":"GBP","value":"25"},
+  "step": [
+    {"@type":"HowToStep","position":1,"name":"Create your account","text":"Register at royalmint.com with your name, UK address, email and date of birth, and complete identity verification (photo ID plus proof of address) where AML thresholds require it. Pay by debit card or bank transfer.","url":"https://goldpricetools.com/blog/how-to-buy-gold-royal-mint#steps"},
+    {"@type":"HowToStep","position":2,"name":"Choose your products","text":"Decide between CGT-exempt coins (Sovereigns and Britannias) and lower-premium bars. Coins suit most UK investors for tax efficiency and liquidity; bars are more cost-efficient at larger sizes.","url":"https://goldpricetools.com/blog/how-to-buy-gold-royal-mint#products"},
+    {"@type":"HowToStep","position":3,"name":"Check the premium against spot","text":"Every product is priced above the live gold spot price. Compare the Royal Mint's price against the live metal value to confirm the premium is fair before buying.","url":"https://goldpricetools.com/blog/how-to-buy-gold-royal-mint#calculator"},
+    {"@type":"HowToStep","position":4,"name":"Pick delivery or vault storage","text":"At checkout choose free insured home delivery (orders over £500) or allocated Royal Mint Vault storage at 0.5% per year. Vault holdings can be delivered physically at any time.","url":"https://goldpricetools.com/blog/how-to-buy-gold-royal-mint#storage"}
   ]
 }
 </script>
@@ -421,6 +410,242 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .article-card:hover .article-card-title{color:var(--color-primary)}
 
 </style>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,500&family=Inter:wght@400;500;600;700&display=swap">
+<style id="rm-redesign">
+/* ============================================================
+   Royal Mint guide — editorial redesign (namespaced .rm-*)
+   Mobile-first. Uses site design tokens so light/dark both work.
+   ============================================================ */
+:root{--font-serif:'Playfair Display',Georgia,'Times New Roman',serif}
+
+/* Breadcrumb (was undefined site-wide — scoped here) */
+.breadcrumb-wrap{max-width:1180px;margin:0 auto;padding:var(--space-4) var(--space-4) 0}
+.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);font-size:var(--text-xs);color:var(--color-text-muted)}
+.breadcrumb li{display:flex;align-items:center;gap:var(--space-2)}
+.breadcrumb li:not(:last-child)::after{content:'';width:5px;height:5px;border-right:1.5px solid var(--color-text-faint);border-bottom:1.5px solid var(--color-text-faint);transform:rotate(-45deg);margin-left:var(--space-1)}
+.breadcrumb a{color:var(--color-text-muted)}
+.breadcrumb a:hover{color:var(--color-gold-bright);text-decoration:none}
+.breadcrumb [aria-current="page"]{color:var(--color-text);font-weight:600}
+
+/* ---- Shell ---- */
+.rm-article{max-width:1180px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
+.rm-prose,.rm-section{scroll-margin-top:96px}
+
+/* ---- Hero ---- */
+.rm-hero{position:relative;padding:var(--space-8) 0 var(--space-6);border-bottom:1px solid var(--color-divider);margin-bottom:var(--space-8)}
+.rm-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);font-family:var(--font-body);font-size:var(--text-xs);font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--color-gold-bright);margin-bottom:var(--space-5)}
+.rm-eyebrow::before{content:'';width:22px;height:1.5px;background:var(--color-gold-bright)}
+.rm-hero__title{font-family:var(--font-serif);font-weight:700;font-size:clamp(2.1rem,5.4vw + .4rem,4rem);line-height:1.04;letter-spacing:-.015em;color:var(--color-text);margin:0 0 var(--space-5);max-width:18ch;text-wrap:balance}
+.rm-hero__title em{font-style:italic;color:var(--color-gold-bright)}
+.rm-hero__dek{font-size:clamp(1.05rem,.6vw + .95rem,1.3rem);line-height:1.6;color:var(--color-text-muted);max-width:60ch;margin:0 0 var(--space-6)}
+.rm-byline{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted)}
+.rm-byline a{color:var(--color-text);font-weight:600}
+.rm-byline a:hover{color:var(--color-gold-bright);text-decoration:none}
+.rm-byline .rm-dot{width:3px;height:3px;border-radius:50%;background:var(--color-text-faint)}
+.rm-byline .rm-read{display:inline-flex;align-items:center;gap:6px}
+
+/* ---- Key facts strip ---- */
+.rm-keyfacts{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin-top:var(--space-8)}
+.rm-keyfact{display:flex;gap:var(--space-3);align-items:flex-start;padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.rm-keyfact svg{flex-shrink:0;width:22px;height:22px;color:var(--color-gold-bright)}
+.rm-keyfact dt{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:2px}
+.rm-keyfact dd{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0;line-height:1.2;font-variant-numeric:tabular-nums}
+
+/* ---- Layout: content + sticky TOC ---- */
+.rm-layout{display:grid;grid-template-columns:1fr;gap:var(--space-8)}
+.rm-toc{order:-1}
+.rm-toc details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden}
+.rm-toc summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2);padding:var(--space-4);font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text);cursor:pointer;list-style:none}
+.rm-toc summary::-webkit-details-marker{display:none}
+.rm-toc summary .rm-toc__chev{transition:transform var(--transition);color:var(--color-text-muted)}
+.rm-toc details[open] summary .rm-toc__chev{transform:rotate(180deg)}
+.rm-toc__list{list-style:none;padding:0 var(--space-3) var(--space-3);margin:0;display:flex;flex-direction:column;gap:2px}
+.rm-toc__list a{display:block;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);border-left:2px solid transparent}
+.rm-toc__list a:hover{color:var(--color-text);background:var(--color-surface-offset);text-decoration:none}
+.rm-toc__list a.is-active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 7%,transparent);font-weight:600}
+
+/* ---- Prose ---- */
+.rm-prose{font-size:var(--text-base);color:var(--color-text);line-height:1.75}
+.rm-prose>section+section{margin-top:var(--space-12)}
+.rm-prose h2{font-family:var(--font-serif);font-weight:700;font-size:clamp(1.55rem,2.2vw + .6rem,2.1rem);line-height:1.15;letter-spacing:-.01em;color:var(--color-text);margin:0 0 var(--space-4)}
+.rm-prose h3{font-family:var(--font-display);font-weight:700;font-size:var(--text-lg);color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
+.rm-prose p{margin:0 0 var(--space-4);max-width:68ch}
+.rm-prose a{color:var(--color-primary);font-weight:600;text-decoration:underline;text-decoration-color:color-mix(in oklch,var(--color-primary) 40%,transparent);text-underline-offset:2px}
+.rm-prose a:hover{color:var(--color-primary-hover)}
+.rm-prose strong{color:var(--color-text);font-weight:700}
+.rm-prose ul{list-style:none;margin:0 0 var(--space-4);padding:0;display:flex;flex-direction:column;gap:var(--space-3)}
+.rm-prose ul li{position:relative;padding-left:var(--space-6);max-width:66ch;color:var(--color-text-muted)}
+.rm-prose ul li strong{color:var(--color-text)}
+.rm-prose ul li::before{content:'';position:absolute;left:2px;top:.62em;width:7px;height:7px;border-radius:1px;background:var(--color-gold-bright);transform:rotate(45deg)}
+.rm-lead{font-size:clamp(1.1rem,.5vw + 1rem,1.28rem)!important;line-height:1.62;color:var(--color-text)!important;max-width:64ch!important}
+.rm-lead::first-letter{float:left;font-family:var(--font-serif);font-weight:700;font-size:3.4em;line-height:.78;padding:.05em .12em 0 0;color:var(--color-gold-bright)}
+
+/* eyebrow numerals for sections */
+.rm-kicker{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3)}
+.rm-kicker__num{font-family:var(--font-display);font-size:var(--text-xs);font-weight:700;letter-spacing:.1em;color:var(--color-gold-bright);padding:3px 9px;border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));border-radius:var(--radius-full);text-transform:uppercase}
+.rm-kicker__rule{flex:1;height:1px;background:var(--color-divider)}
+
+/* ---- Live premium calculator ---- */
+.rm-calc{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-md);margin:var(--space-8) 0}
+.rm-calc__head{padding:var(--space-5) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);background:linear-gradient(180deg,color-mix(in oklch,var(--color-gold-bright) 7%,var(--color-surface)),var(--color-surface))}
+.rm-calc__eyebrow{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.rm-calc__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:0 0 var(--space-1)}
+.rm-calc__sub{font-size:var(--text-xs);color:var(--color-text-muted);margin:0}
+.rm-spotbar{display:grid;grid-template-columns:1fr;gap:var(--space-3);padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-divider);background:var(--color-surface-offset)}
+.rm-spot{display:flex;align-items:baseline;justify-content:space-between;gap:var(--space-3)}
+.rm-spot__k{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.rm-spot__v{font-size:var(--text-base);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.rm-spot__v .rm-usd{font-size:var(--text-xs);font-weight:500;color:var(--color-text-muted);margin-left:6px}
+.rm-calc__body{padding:var(--space-5)}
+.rm-field-label{display:block;font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.rm-products{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-2);margin-bottom:var(--space-4)}
+.rm-prod{display:flex;flex-direction:column;gap:2px;padding:var(--space-3);text-align:left;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);cursor:pointer;transition:border-color var(--transition),background var(--transition)}
+.rm-prod:hover{border-color:var(--color-gold-bright)}
+.rm-prod[aria-pressed="true"]{border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 10%,var(--color-surface))}
+.rm-prod__name{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.rm-prod__meta{font-size:var(--text-xs);color:var(--color-text-muted)}
+.rm-calc__qtyrow{display:grid;grid-template-columns:1fr auto;gap:var(--space-3);align-items:end;margin-bottom:var(--space-4)}
+.rm-qty{display:flex;align-items:center;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface-offset);overflow:hidden;width:max-content}
+.rm-qty button{width:42px;height:42px;font-size:1.2rem;color:var(--color-text);display:flex;align-items:center;justify-content:center}
+.rm-qty button:hover{background:var(--color-surface-dynamic);color:var(--color-gold-bright)}
+.rm-qty input{width:54px;text-align:center;border:none;background:none;font-size:var(--text-base);font-weight:700;color:var(--color-text);-moz-appearance:textfield;font-variant-numeric:tabular-nums}
+.rm-qty input::-webkit-outer-spin-button,.rm-qty input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
+.rm-result{border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border-radius:var(--radius-lg);padding:var(--space-5)}
+.rm-result__label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.rm-result__melt{font-size:clamp(1.9rem,5vw,2.6rem);font-weight:800;line-height:1;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.rm-result__melt .rm-usd{display:block;font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);margin-top:var(--space-2);letter-spacing:0}
+.rm-result__divider{height:1px;background:var(--color-divider);margin:var(--space-4) 0}
+.rm-result__buy{display:flex;flex-wrap:wrap;align-items:baseline;justify-content:space-between;gap:var(--space-2)}
+.rm-result__buy .rm-k{font-size:var(--text-sm);color:var(--color-text-muted)}
+.rm-result__buy .rm-v{font-size:var(--text-lg);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.rm-result__note{font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3);line-height:1.55}
+.rm-badge-cgt{display:inline-flex;align-items:center;gap:5px;font-size:var(--text-xs);font-weight:700;padding:3px 9px;border-radius:var(--radius-full);margin-top:var(--space-3)}
+.rm-badge-cgt.is-exempt{color:#16a34a;background:color-mix(in oklch,#16a34a 14%,transparent)}
+.rm-badge-cgt.is-taxed{color:var(--color-text-muted);background:var(--color-surface-dynamic)}
+[data-theme="dark"] .rm-badge-cgt.is-exempt{color:#4ade80}
+.rm-live-pill{display:inline-flex;align-items:center;gap:6px;font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted)}
+
+/* ---- Feature grid (why buy) ---- */
+.rm-features{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-2)}
+.rm-feature{padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);transition:border-color var(--transition),transform var(--transition)}
+.rm-feature:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 45%,var(--color-border))}
+.rm-feature__icon{display:flex;align-items:center;justify-content:center;width:42px;height:42px;border-radius:var(--radius-md);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.rm-feature__icon svg{width:22px;height:22px}
+.rm-feature h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0 0 var(--space-1)}
+.rm-feature p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0;max-width:none}
+
+/* ---- Steps ---- */
+.rm-steps{display:flex;flex-direction:column;gap:var(--space-4);margin-top:var(--space-2);counter-reset:rmstep}
+.rm-step{position:relative;display:grid;grid-template-columns:auto 1fr;gap:var(--space-4);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.rm-step__num{counter-increment:rmstep;display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:50%;background:color-mix(in oklch,var(--color-gold-bright) 14%,var(--color-surface-offset));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));font-family:var(--font-display);font-size:var(--text-lg);font-weight:800;color:var(--color-gold-bright);font-variant-numeric:tabular-nums}
+.rm-step__num::before{content:counter(rmstep)}
+.rm-step h3{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:6px 0 var(--space-2)}
+.rm-step p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0 0 var(--space-2);max-width:62ch}
+.rm-step p:last-child{margin-bottom:0}
+
+/* ---- Product comparison cards + table ---- */
+.rm-products-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin-top:var(--space-2)}
+.rm-pcard{display:flex;flex-direction:column;padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);transition:border-color var(--transition)}
+.rm-pcard:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 45%,var(--color-border))}
+.rm-pcard__top{display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);margin-bottom:var(--space-2)}
+.rm-pcard h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0}
+.rm-pcard__tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;padding:3px 8px;border-radius:var(--radius-full);background:var(--color-surface-dynamic);color:var(--color-text-muted)}
+.rm-pcard__tag.is-exempt{background:color-mix(in oklch,#16a34a 16%,transparent);color:#16a34a}
+[data-theme="dark"] .rm-pcard__tag.is-exempt{color:#4ade80}
+.rm-pcard p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0 0 var(--space-3);max-width:none}
+.rm-pcard__specs{margin-top:auto;display:flex;flex-wrap:wrap;gap:var(--space-2);padding-top:var(--space-3);border-top:1px solid var(--color-divider)}
+.rm-spec{font-size:var(--text-xs);color:var(--color-text-muted)}
+.rm-spec b{color:var(--color-gold-bright);font-weight:700;font-variant-numeric:tabular-nums}
+.rm-tablewrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px solid var(--color-border);border-radius:var(--radius-lg);margin-top:var(--space-4)}
+.rm-table{width:100%;border-collapse:collapse;min-width:520px}
+.rm-table caption{text-align:left;font-size:var(--text-xs);color:var(--color-text-muted);padding:var(--space-3) var(--space-4) 0}
+.rm-table th,.rm-table td{padding:var(--space-3) var(--space-4);text-align:left;font-size:var(--text-sm);border-bottom:1px solid var(--color-divider)}
+.rm-table thead th{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:.05em;color:var(--color-text-muted);font-weight:700;background:var(--color-surface-offset)}
+.rm-table tbody tr:last-child td{border-bottom:none}
+.rm-table td:first-child{font-weight:600;color:var(--color-text)}
+.rm-table .rm-num{text-align:right;font-variant-numeric:tabular-nums;color:var(--color-gold-bright);font-weight:600}
+
+/* ---- Split compare (delivery vs vault) ---- */
+.rm-split{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin-top:var(--space-2)}
+.rm-splitcard{padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.rm-splitcard__h{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3)}
+.rm-splitcard__h svg{width:24px;height:24px;color:var(--color-gold-bright);flex-shrink:0}
+.rm-splitcard__h h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0}
+.rm-splitcard ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:var(--space-2)}
+.rm-splitcard li{position:relative;padding-left:var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;max-width:none}
+.rm-splitcard li::before{content:'';position:absolute;left:2px;top:.55em;width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright)}
+
+/* ---- Callout ---- */
+.rm-callout{display:grid;grid-template-columns:auto 1fr;gap:var(--space-4);padding:var(--space-5);background:color-mix(in oklch,var(--color-primary) 7%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 28%,var(--color-border));border-radius:var(--radius-lg);margin-top:var(--space-2)}
+.rm-callout svg{width:26px;height:26px;color:var(--color-primary);flex-shrink:0}
+.rm-callout h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0 0 var(--space-2)}
+.rm-callout p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+
+/* ---- CTA ---- */
+.rm-cta{position:relative;overflow:hidden;text-align:center;padding:var(--space-10) var(--space-5);background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold) 18%,var(--color-surface)),var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));border-radius:var(--radius-xl);margin:var(--space-12) 0 0}
+.rm-cta h2{font-family:var(--font-serif);font-size:clamp(1.5rem,3vw,2rem);font-weight:700;color:var(--color-text);margin:0 0 var(--space-3)}
+.rm-cta p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.6;margin:0 auto var(--space-6);max-width:52ch}
+.rm-cta__btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-4) var(--space-8);background:var(--color-gold-bright);color:#1a1306!important;font-weight:700;font-size:var(--text-base);border-radius:var(--radius-full);text-decoration:none!important;box-shadow:var(--shadow-md);transition:transform var(--transition),box-shadow var(--transition)}
+.rm-cta__btn:hover{transform:translateY(-2px);box-shadow:var(--shadow-lg)}
+
+/* ---- FAQ accordion ---- */
+.rm-faq{display:flex;flex-direction:column;gap:var(--space-3);margin-top:var(--space-2)}
+.rm-faq details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.rm-faq details[open]{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border))}
+.rm-faq summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);cursor:pointer;list-style:none}
+.rm-faq summary::-webkit-details-marker{display:none}
+.rm-faq summary .rm-faq__icon{flex-shrink:0;width:20px;height:20px;color:var(--color-gold-bright);transition:transform var(--transition)}
+.rm-faq details[open] summary .rm-faq__icon{transform:rotate(45deg)}
+.rm-faq__a{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;max-width:68ch}
+.rm-faq__a .rm-hl{color:var(--color-gold-bright);font-weight:600}
+
+/* ---- Related ---- */
+.rm-related{margin-top:var(--space-12);padding-top:var(--space-8);border-top:1px solid var(--color-divider)}
+.rm-related>h2{font-family:var(--font-serif);font-size:clamp(1.4rem,2.5vw,1.9rem);font-weight:700;color:var(--color-text);margin:0 0 var(--space-6)}
+.rm-related-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+.rm-rcard{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
+.rm-rcard:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);text-decoration:none}
+.rm-rcard__tag{align-self:flex-start;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);padding:2px 8px;border-radius:var(--radius-full);background:color-mix(in oklch,var(--color-gold-bright) 12%,transparent)}
+.rm-rcard__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);line-height:1.3}
+.rm-rcard:hover .rm-rcard__title{color:var(--color-gold-bright)}
+.rm-rcard__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55}
+
+/* ---- Hero entrance only (one-time). Body content is ALWAYS visible. ---- */
+@media (prefers-reduced-motion:no-preference){
+  .rm-hero{animation:rm-introUp .7s cubic-bezier(.16,1,.3,1) both}
+  @keyframes rm-introUp{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:none}}
+}
+
+/* ============================================================
+   Responsive — tablet & desktop
+   ============================================================ */
+@media(min-width:560px){
+  .rm-keyfacts{grid-template-columns:repeat(4,1fr)}
+  .rm-features{grid-template-columns:repeat(2,1fr)}
+  .rm-products-grid{grid-template-columns:repeat(2,1fr)}
+  .rm-split{grid-template-columns:repeat(2,1fr)}
+  .rm-spotbar{grid-template-columns:repeat(3,1fr)}
+  .rm-spot{flex-direction:column;align-items:flex-start;gap:2px}
+  .rm-products{grid-template-columns:repeat(3,1fr)}
+  .rm-related-grid{grid-template-columns:repeat(2,1fr)}
+}
+@media(min-width:992px){
+  .rm-layout{grid-template-columns:minmax(0,1fr) 264px;align-items:start;gap:var(--space-10)}
+  .rm-toc{order:1;position:sticky;top:84px;align-self:start}
+  .rm-toc details{position:static}
+  .rm-toc summary{cursor:default}
+  .rm-toc summary .rm-toc__chev{display:none}
+  .rm-features{grid-template-columns:repeat(2,1fr)}
+  .rm-related-grid{grid-template-columns:repeat(3,1fr)}
+  .rm-hero__title{max-width:16ch}
+}
+@media(min-width:1200px){
+  .rm-products-grid{grid-template-columns:repeat(2,1fr)}
+}
+
+</style>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
@@ -521,130 +746,331 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <ol class="breadcrumb" aria-label="Breadcrumb">
     <li><a href="/">Home</a></li>
     <li><a href="/blog/">Blog</a></li>
-    <li aria-current="page">Gold &amp; Silver Price Outlook</li>
+    <li aria-current="page">How to Buy Gold from the Royal Mint</li>
   </ol>
 </div>
 
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb">
-<li><a href="/">Home</a></li><li><a href="/blog/">Blog</a></li><li aria-current="page">How to Buy Gold from the Royal Mint: A UK Step-by-Step Guide</li>
-</ol></div>
-<article class="article-wrap" itemscope itemtype="https://schema.org/BlogPosting">
-  <div class="article-tag">Buying Guide</div>
-  <h1 class="article-title" itemprop="headline">How to Buy Gold from the Royal Mint: A UK Step-by-Step Guide</h1>
-  <div class="article-byline">
-    By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a>
-    &middot; <time datetime="2026-06-15" itemprop="datePublished">2026-05-03</time>
-    &middot; <span style="font-size:0.8em;color:var(--color-text-faint)">Last updated: 3 May 2026</span>
+<main id="content">
+<article class="rm-article" itemscope itemtype="https://schema.org/BlogPosting">
+  <meta itemprop="datePublished" content="2026-05-03">
+  <meta itemprop="dateModified" content="2026-06-15">
+
+  <!-- ===== HERO ===== -->
+  <header class="rm-hero">
+    <span class="rm-eyebrow">UK Buying Guide</span>
+    <h1 class="rm-hero__title" itemprop="headline">How to Buy Gold from the <em>Royal Mint</em></h1>
+    <p class="rm-hero__dek">A step-by-step guide to buying investment gold from Britain's official mint — account setup, the full product range, how premiums work, storage options, and when a commercial dealer is the smarter choice.</p>
+    <div class="rm-byline">
+      <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
+      <span class="rm-dot" aria-hidden="true"></span>
+      <span>Published <time datetime="2026-05-03">3 May 2026</time></span>
+      <span class="rm-dot" aria-hidden="true"></span>
+      <span>Updated <time datetime="2026-06-15">15 June 2026</time></span>
+      <span class="rm-dot" aria-hidden="true"></span>
+      <span class="rm-read"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> 9 min read</span>
+    </div>
+
+    <dl class="rm-keyfacts">
+      <div class="rm-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 21h18M5 21V9l7-5 7 5v12M9 21v-6h6v6"/></svg>
+        <div><dt>Established</dt><dd>1,100+ yrs</dd></div>
+      </div>
+      <div class="rm-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 3l8 4v5c0 5-3.4 7.8-8 9-4.6-1.2-8-4-8-9V7z"/><path d="M9 12l2 2 4-4"/></svg>
+        <div><dt>Ownership</dt><dd>HM Treasury</dd></div>
+      </div>
+      <div class="rm-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M19 5L5 19"/><circle cx="7.5" cy="7.5" r="2.5"/><circle cx="16.5" cy="16.5" r="2.5"/></svg>
+        <div><dt>Coins</dt><dd>CGT-exempt</dd></div>
+      </div>
+      <div class="rm-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v6c0 1.7 3.6 3 8 3s8-1.3 8-3V6M4 12v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6"/></svg>
+        <div><dt>Entry from</dt><dd>£25</dd></div>
+      </div>
+    </dl>
+  </header>
+
+  <div class="rm-layout">
+    <!-- ===== TABLE OF CONTENTS ===== -->
+    <nav class="rm-toc" aria-label="On this page">
+      <details open>
+        <summary>On this page <svg class="rm-toc__chev" width="16" height="16" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></summary>
+        <ul class="rm-toc__list">
+          <li><a href="#why">Why the Royal Mint</a></li>
+          <li><a href="#calculator">Live premium calculator</a></li>
+          <li><a href="#steps">How to buy: 4 steps</a></li>
+          <li><a href="#products">The product range</a></li>
+          <li><a href="#storage">Delivery vs vault storage</a></li>
+          <li><a href="#dealers">When a dealer wins</a></li>
+          <li><a href="#faq">FAQs</a></li>
+        </ul>
+      </details>
+    </nav>
+
+    <!-- ===== ARTICLE BODY ===== -->
+    <div class="rm-prose" itemprop="articleBody">
+      <p class="rm-lead">The Royal Mint is the official mint of the United Kingdom — government-owned and operating for more than 1,100 years. For UK gold investors it is the most trusted route to investment-grade gold coins, particularly Sovereigns and Britannias, which are exempt from Capital Gains Tax as UK legal tender. This guide covers account setup, the full product range, how premiums work, storage, and how the Mint compares with commercial dealers.</p>
+
+      <section id="why" class="rm-reveal">
+        <div class="rm-kicker"><span class="rm-kicker__num">01</span><span class="rm-kicker__rule"></span></div>
+        <h2>Why buy from the Royal Mint?</h2>
+        <p>Five reasons the Mint is the default starting point for most UK gold buyers — and why convenience and trust can outweigh chasing the lowest premium.</p>
+        <div class="rm-features">
+          <div class="rm-feature">
+            <div class="rm-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 21h18M5 21V9l7-5 7 5v12M9 21v-6h6v6"/></svg></div>
+            <h3>Government-owned</h3>
+            <p>100% owned by HM Treasury, so there is no issuer-default risk on the mint itself.</p>
+          </div>
+          <div class="rm-feature">
+            <div class="rm-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 3l8 4v5c0 5-3.4 7.8-8 9-4.6-1.2-8-4-8-9V7z"/><path d="M9 12l2 2 4-4"/></svg></div>
+            <h3>BNTA member</h3>
+            <p>Follows the British Numismatic Trade Association code of conduct and full AML compliance.</p>
+          </div>
+          <div class="rm-feature">
+            <div class="rm-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M19 5L5 19"/><circle cx="7.5" cy="7.5" r="2.5"/><circle cx="16.5" cy="16.5" r="2.5"/></svg></div>
+            <h3>CGT-exempt coins</h3>
+            <p>Sovereigns, Britannias and the Beasts series are UK legal tender — gains are free of Capital Gains Tax.</p>
+          </div>
+          <div class="rm-feature">
+            <div class="rm-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="12" cy="12" r="3"/><path d="M7 4v16M17 4v16"/></svg></div>
+            <h3>Vault storage</h3>
+            <p>Allocated, segregated, insured storage at Llantrisant, Wales — your specific metal, not a pooled holding.</p>
+          </div>
+          <div class="rm-feature">
+            <div class="rm-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2l9 5-9 5-9-5 9-5z"/><path d="M3 12l9 5 9-5M3 17l9 5 9-5"/></svg></div>
+            <h3>Wide product range</h3>
+            <p>From £25 fractional digital gold to full kilobars — an entry point at almost any budget.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== LIVE CALCULATOR ===== -->
+      <section id="calculator" class="rm-reveal">
+        <div class="rm-kicker"><span class="rm-kicker__num">02</span><span class="rm-kicker__rule"></span></div>
+        <h2>Check the live premium before you buy</h2>
+        <p>The Royal Mint prices every product as a percentage above the live gold spot price. Use the live spot below to see the underlying metal value of each product and the typical price you would pay once the Mint's premium is added. Prices in <strong>GBP (£)</strong> with the international USD spot shown for reference, refreshed every 60 seconds.</p>
+
+        <div class="rm-calc" aria-labelledby="rm-calc-title">
+          <div class="rm-calc__head">
+            <div class="rm-calc__eyebrow"><span class="live-dot" aria-hidden="true"></span> Live spot price</div>
+            <h3 class="rm-calc__title" id="rm-calc-title">Royal Mint premium calculator</h3>
+            <p class="rm-calc__sub" id="rm-updated">Connecting to live market data…</p>
+          </div>
+          <div class="rm-spotbar">
+            <div class="rm-spot"><span class="rm-spot__k">Gold spot / oz</span><span class="rm-spot__v" id="rm-spot-oz">£—<span class="rm-usd" id="rm-spot-oz-usd">$—</span></span></div>
+            <div class="rm-spot"><span class="rm-spot__k">Gold spot / gram</span><span class="rm-spot__v" id="rm-spot-g">£—</span></div>
+            <div class="rm-spot"><span class="rm-spot__k">Exchange rate</span><span class="rm-spot__v" id="rm-fx">£1 = $—</span></div>
+          </div>
+          <div class="rm-calc__body">
+            <span class="rm-field-label" id="rm-prod-label">Choose a product</span>
+            <div class="rm-products" role="group" aria-labelledby="rm-prod-label">
+              <button type="button" class="rm-prod" data-fineoz="1" data-plo="2" data-phi="4" data-cgt="1" aria-pressed="true"><span class="rm-prod__name">1 oz Britannia</span><span class="rm-prod__meta">999.9 · 1 troy oz</span></button>
+              <button type="button" class="rm-prod" data-fineoz="0.2354" data-plo="3" data-phi="5" data-cgt="1" aria-pressed="false"><span class="rm-prod__name">Full Sovereign</span><span class="rm-prod__meta">22 ct · 7.32 g fine</span></button>
+              <button type="button" class="rm-prod" data-fineoz="0.1177" data-plo="4" data-phi="7" data-cgt="1" aria-pressed="false"><span class="rm-prod__name">Half Sovereign</span><span class="rm-prod__meta">22 ct · 3.66 g fine</span></button>
+              <button type="button" class="rm-prod" data-fineoz="1" data-plo="1" data-phi="2" data-cgt="0" aria-pressed="false"><span class="rm-prod__name">1 oz gold bar</span><span class="rm-prod__meta">999.9 · LBMA</span></button>
+              <button type="button" class="rm-prod" data-fineoz="3.21507" data-plo="1" data-phi="1.5" data-cgt="0" aria-pressed="false"><span class="rm-prod__name">100 g gold bar</span><span class="rm-prod__meta">999.9 · LBMA</span></button>
+              <button type="button" class="rm-prod" data-fineoz="0.03215" data-plo="4" data-phi="6" data-cgt="0" aria-pressed="false"><span class="rm-prod__name">1 g gold bar</span><span class="rm-prod__meta">999.9 · assay card</span></button>
+            </div>
+
+            <div class="rm-calc__qtyrow">
+              <div>
+                <label class="rm-field-label" for="rm-qty">Quantity</label>
+                <div class="rm-qty">
+                  <button type="button" id="rm-minus" aria-label="Decrease quantity">&minus;</button>
+                  <input type="number" id="rm-qty" value="1" min="1" max="999" inputmode="numeric" aria-label="Quantity">
+                  <button type="button" id="rm-plus" aria-label="Increase quantity">+</button>
+                </div>
+              </div>
+              <span class="rm-live-pill"><span class="live-dot" aria-hidden="true"></span> Auto-updates</span>
+            </div>
+
+            <div class="rm-result" aria-live="polite">
+              <div class="rm-result__label">Metal (melt) value — <span id="rm-prod-name">1 oz Britannia</span> &times; <span id="rm-qty-echo">1</span></div>
+              <div class="rm-result__melt" id="rm-melt">£—<span class="rm-usd" id="rm-melt-usd">$— USD</span></div>
+              <div class="rm-result__divider"></div>
+              <div class="rm-result__buy">
+                <span class="rm-k">Typical Royal Mint price <span id="rm-prem-label">(incl. 2–4% premium)</span></span>
+                <span class="rm-v" id="rm-buy">£—</span>
+              </div>
+              <span class="rm-badge-cgt is-exempt" id="rm-cgt-badge"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> CGT-exempt for UK investors</span>
+              <p class="rm-result__note">Melt value is the live metal content only. The Royal Mint's actual selling price adds a premium (shown above as a typical range) to cover minting, distribution and dealer margin. Figures are indicative — always confirm the live price at checkout.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== STEPS ===== -->
+      <section id="steps" class="rm-reveal">
+        <div class="rm-kicker"><span class="rm-kicker__num">03</span><span class="rm-kicker__rule"></span></div>
+        <h2>How to buy, step by step</h2>
+        <p>Four steps take you from a new account to gold in your hands — or in the Mint's vault.</p>
+        <div class="rm-steps">
+          <div class="rm-step">
+            <div class="rm-step__num" aria-hidden="true"></div>
+            <div>
+              <h3>Create your account</h3>
+              <p>Register at <a href="https://www.royalmint.com" rel="noopener nofollow">royalmint.com</a> with your full name, UK address, email and date of birth. Above certain AML thresholds you must verify your identity — a photo ID (passport or driving licence) and a proof of address dated within three months. This is a legal requirement under the Money Laundering Regulations 2017 and applies to every UK bullion dealer.</p>
+              <p>Accepted payment methods are debit card and bank transfer (BACS). Credit cards are not accepted for bullion purchases.</p>
+            </div>
+          </div>
+          <div class="rm-step">
+            <div class="rm-step__num" aria-hidden="true"></div>
+            <div>
+              <h3>Choose your products</h3>
+              <p>Decide between CGT-exempt coins (Sovereigns and Britannias) and lower-premium bars. Coins suit most UK investors for their tax efficiency and liquidity; bars are more cost-efficient at larger sizes. See the <a href="#products">full product range below</a>.</p>
+            </div>
+          </div>
+          <div class="rm-step">
+            <div class="rm-step__num" aria-hidden="true"></div>
+            <div>
+              <h3>Check the premium against spot</h3>
+              <p>Every product is priced above the live spot price. Use the <a href="#calculator">live calculator above</a> to see the metal value, then compare the Mint's price to confirm the premium is fair before you commit.</p>
+            </div>
+          </div>
+          <div class="rm-step">
+            <div class="rm-step__num" aria-hidden="true"></div>
+            <div>
+              <h3>Pick delivery or vault storage</h3>
+              <p>At checkout, choose free insured home delivery (orders over £500) or allocated <a href="#storage">Royal Mint Vault storage</a> at 0.5% per year. You can switch a vault holding to physical delivery at any time.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== PRODUCT RANGE ===== -->
+      <section id="products" class="rm-reveal">
+        <div class="rm-kicker"><span class="rm-kicker__num">04</span><span class="rm-kicker__rule"></span></div>
+        <h2>The product range in detail</h2>
+        <p>The Royal Mint sells four main categories of investment gold. Coins are CGT-exempt; bars and digital gold are not, but carry lower premiums or smaller entry points.</p>
+        <div class="rm-products-grid">
+          <div class="rm-pcard">
+            <div class="rm-pcard__top"><h3>Gold Sovereigns</h3><span class="rm-pcard__tag is-exempt">CGT-exempt</span></div>
+            <p>Minted continuously since 1817 and the most iconic British gold coin. A full Sovereign contains <strong>0.2354 troy oz (7.32 g) of 22-carat (916.7 fine) gold</strong> with a £1 face value. Their smaller unit size and modest premiums make them ideal for building a holding incrementally.</p>
+            <div class="rm-pcard__specs"><span class="rm-spec">Sizes: <b>¼ · ½ · full · double</b></span><span class="rm-spec">Premium: <b>3–5%</b></span></div>
+          </div>
+          <div class="rm-pcard">
+            <div class="rm-pcard__top"><h3>Gold Britannias</h3><span class="rm-pcard__tag is-exempt">CGT-exempt</span></div>
+            <p>Struck in <strong>999.9 fine (24-carat) gold</strong> in six sizes from 1 oz down to 1/40 oz. The 2026 Britannia carries four security features — micro-text, a latent image, tincture lines and surface animation. The 1 oz Britannia is the most liquid and widely traded UK gold coin internationally.</p>
+            <div class="rm-pcard__specs"><span class="rm-spec">Sizes: <b>1/40 oz → 1 oz</b></span><span class="rm-spec">Premium: <b>2–4%</b></span></div>
+          </div>
+          <div class="rm-pcard">
+            <div class="rm-pcard__top"><h3>Gold bars</h3><span class="rm-pcard__tag">Subject to CGT</span></div>
+            <p>Available from 1 g to 1 kg in tamper-evident assay packaging, LBMA Good Delivery compliant. Bars are <strong>not CGT-exempt</strong> as they are not legal tender, but larger bars offer the lowest premium per ounce — ideal inside a SIPP or for investors comfortable with CGT.</p>
+            <div class="rm-pcard__specs"><span class="rm-spec">Sizes: <b>1 g → 1 kg</b></span><span class="rm-spec">Premium: <b>1–2%</b></span></div>
+          </div>
+          <div class="rm-pcard">
+            <div class="rm-pcard__top"><h3>DigiGold / Signature Gold</h3><span class="rm-pcard__tag">Subject to CGT</span></div>
+            <p>Buy fractional physical gold <strong>from £25</strong> as a digital entitlement to part of a Royal Mint Vault bar. No dealer spread — you trade at the Mint's published spot price plus a small platform fee. Ideal for regular monthly savings, and convertible to coins or bars at any time.</p>
+            <div class="rm-pcard__specs"><span class="rm-spec">From: <b>£25</b></span><span class="rm-spec">Storage: <b>0.5%/yr</b></span></div>
+          </div>
+        </div>
+
+        <div class="rm-tablewrap">
+          <table class="rm-table">
+            <caption>Royal Mint gold products at a glance</caption>
+            <thead><tr><th scope="col">Product</th><th scope="col">Purity</th><th scope="col">CGT status</th><th scope="col" class="rm-num">Typical premium</th></tr></thead>
+            <tbody>
+              <tr><td>1 oz Britannia</td><td>999.9 (24 ct)</td><td>Exempt</td><td class="rm-num">2–4%</td></tr>
+              <tr><td>Full Sovereign</td><td>916.7 (22 ct)</td><td>Exempt</td><td class="rm-num">3–5%</td></tr>
+              <tr><td>1 oz gold bar</td><td>999.9 (24 ct)</td><td>Taxable</td><td class="rm-num">1–2%</td></tr>
+              <tr><td>100 g gold bar</td><td>999.9 (24 ct)</td><td>Taxable</td><td class="rm-num">~1%</td></tr>
+              <tr><td>DigiGold</td><td>999.9 (24 ct)</td><td>Taxable</td><td class="rm-num">Platform fee</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- ===== STORAGE ===== -->
+      <section id="storage" class="rm-reveal">
+        <div class="rm-kicker"><span class="rm-kicker__num">05</span><span class="rm-kicker__rule"></span></div>
+        <h2>Delivery vs Royal Mint Vault storage</h2>
+        <p>At checkout you choose how to hold your gold. Both are secure — the right answer depends on how much you hold and whether you want the metal in hand.</p>
+        <div class="rm-split">
+          <div class="rm-splitcard">
+            <div class="rm-splitcard__h"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 7h11v8H3zM14 10h4l3 3v2h-7z"/><circle cx="7" cy="17" r="2"/><circle cx="17" cy="17" r="2"/></svg><h3>Home delivery</h3></div>
+            <ul>
+              <li><strong>Free insured delivery</strong> on orders over £500 (Royal Mail Special Delivery or tracked courier).</li>
+              <li>Coins arrive in tamper-evident packaging.</li>
+              <li>Once delivered, home insurance responsibility becomes yours.</li>
+              <li>Best for smaller holdings you want to keep in hand.</li>
+            </ul>
+          </div>
+          <div class="rm-splitcard">
+            <div class="rm-splitcard__h"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="12" cy="12" r="3"/><path d="M7 4v16M17 4v16"/></svg><h3>Royal Mint Vault</h3></div>
+            <ul>
+              <li><strong>0.5% per year</strong> (minimum £100/year) for allocated, segregated storage.</li>
+              <li>Your specific coins at Llantrisant — never a pooled holding.</li>
+              <li>Request physical delivery at any time.</li>
+              <li>Often cheaper than private vault insurance (0.4–0.7% p.a.) and removes home-burglary risk.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== DEALERS ===== -->
+      <section id="dealers" class="rm-reveal">
+        <div class="rm-kicker"><span class="rm-kicker__num">06</span><span class="rm-kicker__rule"></span></div>
+        <h2>When a commercial dealer wins</h2>
+        <div class="rm-callout">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 3v18M3 7l9-4 9 4M5 7v6a7 7 0 0 0 14 0V7"/><path d="M3 13h4M17 13h4"/></svg>
+          <div>
+            <h3>The Mint isn't always the cheapest</h3>
+            <p>Consider a commercial dealer when buying <strong>large bars</strong> (tighter premiums on 100 g+ sizes), when <strong>selling back</strong> (some dealers beat the Mint's buyback spread), or when seeking <strong>foreign coins</strong> such as Maple Leafs, Krugerrands or American Eagles. Reputable UK dealers include BullionByPost, Chards, Atkinsons, Gold.co.uk and Sharps Pixley. To compare live prices side by side, services like BullionCompare list the Mint alongside these dealers. Always verify BNTA or IBMA membership first — see our <a href="/blog/best-uk-gold-dealers-2026">best UK gold dealers guide</a>.</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== CTA ===== -->
+      <div class="rm-cta">
+        <h2>See today's live gold price in GBP</h2>
+        <p>Check live 24K, 22K and 18K gold prices per gram and per troy ounce in pounds — the fastest way to sense-check any Royal Mint premium before you buy.</p>
+        <a href="/18k-gold-price-in-gbp" class="rm-cta__btn">View live GBP gold prices <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </div>
+
+      <!-- ===== FAQ ===== -->
+      <section id="faq" class="rm-reveal">
+        <div class="rm-kicker"><span class="rm-kicker__num">07</span><span class="rm-kicker__rule"></span></div>
+        <h2>Frequently asked questions</h2>
+        <div class="rm-faq">
+          <details>
+            <summary>Is the Royal Mint a good place to buy gold? <svg class="rm-faq__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="rm-faq__a">Yes. The Royal Mint is the UK's official coin manufacturer and the most trusted source for investment gold coins in the UK. Prices are competitive with other major dealers, and coins purchased directly carry the full Royal Mint guarantee of authenticity and purity. It also offers a <span class="rm-hl">DigiGold</span> service for fractional gold ownership from £25.</div>
+          </details>
+          <details>
+            <summary>What gold products does the Royal Mint sell? <svg class="rm-faq__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="rm-faq__a">Britannia gold coins (1 oz, ½ oz, ¼ oz, 1/10 oz and smaller), Sovereign gold coins (quarter, half, full and double), gold bars from 1 g to 1 kg, and collectable commemorative coins. <span class="rm-hl">Britannias and Sovereigns are CGT-exempt</span> for UK investors, making them particularly tax-efficient.</div>
+          </details>
+          <details>
+            <summary>Are Royal Mint gold coins CGT free? <svg class="rm-faq__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="rm-faq__a">Yes. Gold Britannias and Sovereigns are classified as legal tender ("coin of the realm"), so any gains on their sale are <span class="rm-hl">completely exempt from Capital Gains Tax</span> for UK investors. This is a significant advantage over gold bars or foreign coins, which are subject to standard CGT rates (18% or 24%).</div>
+          </details>
+          <details>
+            <summary>How does Royal Mint DigiGold work? <svg class="rm-faq__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="rm-faq__a">DigiGold lets you buy fractions of a gold bar from as little as <span class="rm-hl">£25</span>, with the gold physically stored at the Royal Mint's vault in Llantrisant, Wales. You own actual allocated gold and can convert to physical delivery (coins or bars) at any time. Storage fees apply at 0.5% per year.</div>
+          </details>
+          <details>
+            <summary>Is gold cheaper from the Royal Mint or a dealer? <svg class="rm-faq__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="rm-faq__a">It depends on the product. For 1 oz coins the Mint is competitive, but commercial dealers often beat it on <span class="rm-hl">large bars (100 g+)</span> and sometimes on buyback. Use the live calculator above to check the premium over spot, then compare against a dealer before buying.</div>
+          </details>
+        </div>
+      </section>
+    </div>
   </div>
-  <div class="prose">
-    <p>The Royal Mint is the official mint of the United Kingdom, government-owned and operating for over 1,100 years. For UK gold investors, it is the most trusted route to investment-grade gold coins — particularly Sovereigns and Britannias, which are CGT-exempt as UK legal tender. This step-by-step guide covers account setup, the full product range, how premiums work, storage options, and how the Royal Mint compares to commercial dealers.</p>
 
-    <h2>Why Buy from the Royal Mint?</h2>
-    <ul>
-      <li><strong>Government-owned:</strong> 100% owned by HM Treasury. No issuer default risk on the mint itself.</li>
-      <li><strong>BNTA member:</strong> Adheres to the British Numismatic Trade Association code of conduct and Anti-Money Laundering compliance framework.</li>
-      <li><strong>CGT-exempt coins:</strong> All Royal Mint bullion coins — Sovereigns, Britannias, Queen's Beasts, Tudor Beasts — are UK legal tender and fully exempt from Capital Gains Tax for UK residents.</li>
-      <li><strong>Vault storage:</strong> Allocated, insured storage of your metal at the Royal Mint's facility in Llantrisant, Wales, from £25 upwards. Your holdings are segregated — not pooled.</li>
-      <li><strong>Wide product range:</strong> From £25 fractional digital gold to full kilobars, with an entry point at almost any budget.</li>
-    </ul>
-
-    <h2>Step 1: Create Your Account</h2>
-    <p>Visit <strong>royalmint.com</strong> and register with your full name, UK address, email, and date of birth. For purchases above certain AML thresholds, you will be prompted to complete identity verification: upload a photo ID (passport or driving licence) and a proof of address dated within three months (utility bill or bank statement). This is a legal requirement under the Money Laundering Regulations 2017 and applies to all UK bullion dealers, not just the Royal Mint. Payment methods accepted include debit card and bank transfer (BACS). Credit cards are not accepted for bullion purchases.</p>
-
-    <h2>Step 2: Understand the Product Range</h2>
-    <h3>Gold Sovereigns</h3>
-    <p>The Sovereign has been minted continuously since 1817 and is the most iconic British gold coin. Each full Sovereign contains <strong>0.2354 troy oz (7.32g) of 22-carat (916.7 fine) gold</strong> with a face value of £1. Available in four sizes: Quarter Sovereign (1.997g gold), Half Sovereign (3.66g), full Sovereign (7.32g), and Double Sovereign (14.64g). All Sovereigns are CGT-exempt. They are particularly popular for investors building holdings incrementally due to their smaller unit size and relatively modest premiums over spot.</p>
-
-    <h3>Gold Britannia Coins</h3>
-    <p>The Britannia is struck in <strong>999.9 fine (24-carat) gold</strong> in six sizes: 1 oz (£100 face), 1/2 oz (£50), 1/4 oz (£25), 1/10 oz (£10), 1/20 oz (£5), and 1/40 oz (£2.50). The 2026 Britannia features four security elements: micro-text, a latent image, tincture lines, and surface animation. All Britannias are CGT-exempt as UK legal tender. The 1 oz Britannia is the most liquid size and the most widely traded UK gold coin internationally.</p>
-
-    <h3>Gold Bars</h3>
-    <p>Royal Mint gold bars are available from 1g to 1 kg in tamper-evident assay packaging, LBMA Good Delivery compliant. Bars are <strong>not CGT-exempt</strong> (they are not legal tender), but larger bars offer lower premiums per ounce than coins. A 1 oz bar typically carries a 1–2% premium over spot, versus 2–4% for the equivalent 1 oz Britannia. For investors who are comfortable with CGT (or sheltering bars inside a SIPP), bars are the more cost-efficient choice at larger sizes.</p>
-
-    <h3>DigiGold (Signature Gold)</h3>
-    <p>Signature Gold lets you buy fractional physical gold from £25. You hold a digital entitlement to a fraction of a Royal Mint Vault bar. It is not CGT-exempt (it is a financial instrument), but it allows micro-investments with no dealer spread — you buy and sell at the Royal Mint's published spot price plus a small platform fee. Suitable for regular savings strategies (e.g., monthly standing orders).</p>
-
-    <h2>Step 3: Premiums and Pricing</h2>
-    <p>The Royal Mint prices bullion products as a percentage above the live gold spot price. Typical premiums as of May 2026:</p>
-    <ul>
-      <li>1 oz Gold Britannia (bullion): 2–4% over spot</li>
-      <li>Full Sovereign (bullion): 3–5% over spot (smaller gold content = higher unit premium)</li>
-      <li>1 oz gold bar: 1–2% over spot</li>
-      <li>100g gold bar: approximately 1% over spot</li>
-    </ul>
-    <p>To compare prices across dealers, use <strong>BullionCompare.co.uk</strong> for live side-by-side comparisons including BullionByPost, Chards, Gold.co.uk, and Sharps Pixley. The Royal Mint is not always the cheapest option — commercial dealers often offer tighter premiums on larger bars — but the convenience of a single trusted provider with integrated vault storage has real value for many investors.</p>
-
-    <h2>Step 4: Delivery vs Royal Mint Vault Storage</h2>
-    <p>At checkout you choose between home delivery and Vault storage. <strong>Free insured delivery</strong> (Royal Mail Special Delivery or tracked courier) is available on orders over £500. Coins arrive in tamper-evident packaging; once delivered, home insurance responsibility begins. <strong>Royal Mint Vault storage</strong> costs 0.5% per annum (minimum £100/year) and keeps your coins in an allocated, segregated account at Llantrisant — your specific coins, not a pooled holding. You can request physical delivery at any time. For investors with significant holdings, Vault storage is typically more cost-effective than private vault insurance (usually 0.4–0.7% p.a. without the same security infrastructure) and eliminates the risk of home burglary.</p>
-
-    <h2>When to Use a Commercial Dealer Instead</h2>
-    <p>The Royal Mint is not always the best choice. Consider commercial alternatives (all BNTA members) when buying large gold bars (commercial dealers typically offer tighter premiums on 100g+ sizes), when selling back (check buyback spreads — some dealers beat the Royal Mint), or when seeking foreign coins such as Canadian Maple Leafs, Krugerrands, or American Eagles. Reputable UK commercial dealers include BullionByPost, Chards, Atkinsons, Gold.co.uk, and Sharps Pixley. Always verify BNTA or IBMA membership before purchasing from any dealer.</p>
-    <div class="cta-box"><h3>Check Today's Gold Price in GBP</h3><p>See live 24K, 22K, 18K, and 9K gold prices per gram and per troy oz in GBP. Useful for comparing Royal Mint premiums against the current spot price before you buy.</p><a href="/" class="cta-btn">See Live Gold Prices &rarr;</a></div>
-  </div>
-  
-<!-- FAQ Section -->
-<section style="padding:2rem 0 0;">
-  <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
-  <div class="faq-container">
-    <div class="faq-card">
-      <h3 class="faq-q">Is the Royal Mint a good place to buy gold?</h3>
-      <p class="faq-answer">Yes. The Royal Mint is the UK's official coin manufacturer, founded in 886 AD, and is considered the most trusted source for investment gold coins in the UK. Prices are competitive with other major dealers, and coins purchased directly carry the full Royal Mint guarantee of authenticity and purity. They also offer a DigiGold service for fractional gold ownership.</p>
+  <!-- ===== RELATED ===== -->
+  <section class="rm-related">
+    <h2>Related articles &amp; tools</h2>
+    <div class="rm-related-grid">
+      <a href="/blog/uk-gold-cgt-guide" class="rm-rcard"><span class="rm-rcard__tag">Article</span><span class="rm-rcard__title">UK Gold CGT Guide</span><span class="rm-rcard__desc">Which Royal Mint products are CGT-exempt — the full guide to gold capital gains tax.</span></a>
+      <a href="/blog/best-uk-gold-dealers-2026" class="rm-rcard"><span class="rm-rcard__tag">Article</span><span class="rm-rcard__title">Best UK Gold Dealers 2026</span><span class="rm-rcard__desc">How the Royal Mint compares to other UK dealers on spread, range and service.</span></a>
+      <a href="/guides/how-to-invest-in-gold" class="rm-rcard"><span class="rm-rcard__tag">Guide</span><span class="rm-rcard__title">How to Invest in Gold (UK)</span><span class="rm-rcard__desc">Beyond the Royal Mint — every UK gold investment option compared.</span></a>
+      <a href="/18k-gold-price-in-gbp" class="rm-rcard"><span class="rm-rcard__tag">Live Price</span><span class="rm-rcard__title">Live Gold Price in GBP</span><span class="rm-rcard__desc">Today's gold spot price in pounds — use it to assess Royal Mint premiums.</span></a>
+      <a href="/scrap-gold-calculator" class="rm-rcard"><span class="rm-rcard__tag">Tool</span><span class="rm-rcard__title">Gold Value Calculator</span><span class="rm-rcard__desc">Calculate the melt value of any gold coin or item at today's live spot price.</span></a>
+      <a href="/guides/gold-price-history" class="rm-rcard"><span class="rm-rcard__tag">Guide</span><span class="rm-rcard__title">Gold Price History</span><span class="rm-rcard__desc">Check long-term gold performance before buying from any dealer.</span></a>
     </div>
-    <div class="faq-card">
-      <h3 class="faq-q">What gold products does the Royal Mint sell?</h3>
-      <p class="faq-answer">The Royal Mint sells Britannia gold coins (1oz, 1/2oz, 1/4oz, 1/10oz), Sovereign gold coins (full, half, quarter), gold bars (1g to 1kg), and collectable commemorative coins. Britannias and Sovereigns are CGT-exempt for UK investors, making them particularly tax-efficient.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-q">Are Royal Mint gold coins CGT free?</h3>
-      <p class="faq-answer">Yes. Gold Britannias and gold Sovereigns are classified as 'coin of the realm' and legal tender, making any gains from their sale completely exempt from Capital Gains Tax for UK investors. This is a significant advantage over gold bars or foreign gold coins, which are subject to standard CGT rates (18% or 24%).</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-q">How does Royal Mint DigiGold work?</h3>
-      <p class="faq-answer">DigiGold lets you buy fractions of a gold bar from as little as £25, with your gold physically stored at the Royal Mint's vault in Llantrisant, Wales. You own actual allocated gold, not a financial instrument. You can convert to physical delivery (coins or bars) at any time. Storage fees apply (0.5% per year).</p>
-    </div>
-  </div>
-</section>
-
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
-    <h2>Related Articles &amp; Guides</h2>
-    <div class="related-guides-grid">
-      <a href="/blog/uk-gold-cgt-guide" class="related-card">
-        <div class="related-card__tag">Article</div>
-        <div class="related-card__title">UK Gold CGT Guide</div>
-        <div class="related-card__desc">Which Royal Mint products are CGT-exempt? Full guide to gold capital gains tax.</div>
-      </a>
-      <a href="/blog/best-uk-gold-dealers-2026" class="related-card">
-        <div class="related-card__tag">Article</div>
-        <div class="related-card__title">Best UK Gold Dealers 2026</div>
-        <div class="related-card__desc">How the Royal Mint compares to other UK dealers — spread, range and service.</div>
-      </a>
-      <a href="/guides/how-to-invest-in-gold" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">How to Invest in Gold UK</div>
-        <div class="related-card__desc">Beyond the Royal Mint — all UK gold investment options compared.</div>
-      </a>
-      <a href="/guides/gold-price-history" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold Price History</div>
-        <div class="related-card__desc">Check long-term gold price performance before buying from any dealer.</div>
-      </a>
-      <a href="/24k-gold-price-per-gram" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">Live Gold Price Per Gram</div>
-        <div class="related-card__desc">Today's gold spot price — use this to assess Royal Mint premiums.</div>
-      </a>
-      <a href="/scrap-gold-calculator" class="related-card">
-        <div class="related-card__tag">Tool</div>
-        <div class="related-card__title">Gold Value Calculator</div>
-        <div class="related-card__desc">Calculate the melt value of any Royal Mint coin at today's spot price.</div>
-      </a>
-    </div>
-  </div>
-</section>
-
+  </section>
 </article>
+</main>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">
@@ -739,5 +1165,167 @@ async function loadTicker(){
   }catch(e){}
 }
 loadTicker();setInterval(loadTicker,60000);
+</script>
+<script id="nav-ui-js">(function(){
+  const themeBtn=document.querySelector('[data-theme-toggle]'),root=document.documentElement;
+  let theme=root.getAttribute('data-theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+  root.setAttribute('data-theme',theme);
+  if(themeBtn){themeBtn.addEventListener('click',()=>{theme=theme==='dark'?'light':'dark';root.setAttribute('data-theme',theme);themeBtn.setAttribute('aria-label','Switch to '+(theme==='dark'?'light':'dark')+' mode');themeBtn.innerHTML=theme==='dark'?'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>':'<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';});}
+  const ham=document.getElementById('hamburger'),mob=document.getElementById('mobileMenu');
+  if(ham&&mob){ham.addEventListener('click',function(){const o=mob.classList.toggle('open');ham.setAttribute('aria-expanded',o);document.body.style.overflow=o?'hidden':'';});document.addEventListener('click',function(e){if(mob.classList.contains('open')&&!mob.contains(e.target)&&!ham.contains(e.target)){mob.classList.remove('open');ham.setAttribute('aria-expanded','false');document.body.style.overflow='';}});}
+  document.querySelectorAll('.mobile-section__toggle').forEach(function(btn){btn.addEventListener('click',function(){const items=this.nextElementSibling;const o=items.classList.toggle('open');this.setAttribute('aria-expanded',o);});});
+  document.querySelectorAll('.mega-nav__trigger[aria-haspopup]').forEach(function(t){t.addEventListener('click',function(e){e.stopPropagation();const p=this.nextElementSibling;if(!p)return;const o=p.classList.toggle('is-open');this.setAttribute('aria-expanded',o);document.querySelectorAll('.mega-panel.is-open').forEach(function(x){if(x!==p){x.classList.remove('is-open');const t2=x.previousElementSibling;if(t2)t2.setAttribute('aria-expanded','false');}});});});
+  document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
+  document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
+})();</script>
+<script id="rm-calc-js">
+(function(){
+  "use strict";
+  var TROY = 31.1035;
+  var GOLD_API = 'https://api.gold-api.com/price/XAU';
+  var FX_API = 'https://api.frankfurter.dev/v1/latest?from=USD&to=GBP';
+  var spotUSD = 0;            // USD per troy oz
+  var gbpRate = 0.79;         // GBP per 1 USD (fallback)
+  var lastUpdated = 0;
+  var hasData = false;
+
+  var $ = function(id){ return document.getElementById(id); };
+
+  function fmt(sym, v){
+    var dp = v >= 1000 ? 0 : 2;
+    return sym + v.toLocaleString('en-GB', {minimumFractionDigits:dp, maximumFractionDigits:dp});
+  }
+
+  function activeProduct(){
+    return document.querySelector('.rm-prod[aria-pressed="true"]') || document.querySelector('.rm-prod');
+  }
+
+  function render(){
+    if(!spotUSD){ return; }
+    var gPerOzGBP = spotUSD * gbpRate;
+    var gPerGramGBP = (spotUSD / TROY) * gbpRate;
+
+    var ozEl = $('rm-spot-oz');
+    if(ozEl){ ozEl.innerHTML = fmt('£', gPerOzGBP) + '<span class="rm-usd">' + fmt('$', spotUSD) + '</span>'; }
+    if($('rm-spot-g')){ $('rm-spot-g').textContent = fmt('£', gPerGramGBP); }
+    if($('rm-fx')){ $('rm-fx').textContent = '£1 = ' + fmt('$', (1 / gbpRate)); }
+
+    var p = activeProduct();
+    if(!p){ return; }
+    var fineOz = parseFloat(p.getAttribute('data-fineoz')) || 0;
+    var plo = parseFloat(p.getAttribute('data-plo')) || 0;
+    var phi = parseFloat(p.getAttribute('data-phi')) || 0;
+    var cgt = p.getAttribute('data-cgt') === '1';
+    var name = p.querySelector('.rm-prod__name').textContent;
+    var qty = Math.max(1, parseInt($('rm-qty').value, 10) || 1);
+
+    var meltUSD = fineOz * spotUSD * qty;
+    var meltGBP = meltUSD * gbpRate;
+    var buyLow = meltGBP * (1 + plo / 100);
+    var buyHigh = meltGBP * (1 + phi / 100);
+
+    if($('rm-prod-name')){ $('rm-prod-name').textContent = name; }
+    if($('rm-qty-echo')){ $('rm-qty-echo').textContent = qty; }
+
+    var meltEl = $('rm-melt');
+    if(meltEl){ meltEl.innerHTML = fmt('£', meltGBP) + '<span class="rm-usd">' + fmt('$', meltUSD) + ' USD</span>'; }
+
+    if($('rm-buy')){
+      $('rm-buy').textContent = (plo === phi)
+        ? fmt('£', buyLow)
+        : fmt('£', buyLow) + ' – ' + fmt('£', buyHigh);
+    }
+    if($('rm-prem-label')){
+      var premTxt = (plo === phi) ? ('~' + plo + '%') : (plo + '–' + phi + '%');
+      $('rm-prem-label').textContent = '(incl. ' + premTxt + ' premium)';
+    }
+    var badge = $('rm-cgt-badge');
+    if(badge){
+      if(cgt){
+        badge.className = 'rm-badge-cgt is-exempt';
+        badge.innerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> CGT-exempt for UK investors';
+      } else {
+        badge.className = 'rm-badge-cgt is-taxed';
+        badge.innerHTML = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M12 8v5M12 16h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg> Subject to Capital Gains Tax';
+      }
+    }
+  }
+
+  function tickAgo(){
+    var el = $('rm-updated');
+    if(!el){ return; }
+    if(!hasData){ return; }
+    var s = Math.round((Date.now() - lastUpdated) / 1000);
+    var ago = s < 5 ? 'just now' : (s < 60 ? s + 's ago' : Math.round(s/60) + 'm ago');
+    el.textContent = 'Live · updated ' + ago + ' · source gold-api.com + ECB FX';
+  }
+
+  function fetchFx(){
+    return fetch(FX_API, {cache:'no-store'})
+      .then(function(r){ if(!r.ok){ throw new Error(); } return r.json(); })
+      .then(function(d){ if(d && d.rates && d.rates.GBP){ gbpRate = d.rates.GBP; } })
+      .catch(function(){ /* keep fallback */ });
+  }
+
+  function fetchSpot(){
+    return fetch(GOLD_API, {cache:'no-store'})
+      .then(function(r){ if(!r.ok){ throw new Error(); } return r.json(); })
+      .then(function(d){
+        if(d && typeof d.price === 'number'){
+          spotUSD = d.price;
+          hasData = true;
+          lastUpdated = Date.now();
+          render();
+          tickAgo();
+        }
+      })
+      .catch(function(){
+        var el = $('rm-updated');
+        if(el && !hasData){ el.textContent = 'Live price temporarily unavailable — retrying…'; }
+      });
+  }
+
+  function refresh(){ Promise.all([fetchFx(), fetchSpot()]); }
+
+  // ---- Product selection ----
+  document.querySelectorAll('.rm-prod').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      document.querySelectorAll('.rm-prod').forEach(function(b){ b.setAttribute('aria-pressed','false'); });
+      btn.setAttribute('aria-pressed','true');
+      render();
+    });
+  });
+
+  // ---- Quantity ----
+  var qtyInput = $('rm-qty');
+  function clampQty(){
+    var v = parseInt(qtyInput.value, 10);
+    if(isNaN(v) || v < 1){ v = 1; }
+    if(v > 999){ v = 999; }
+    qtyInput.value = v;
+  }
+  if($('rm-minus')){ $('rm-minus').addEventListener('click', function(){ qtyInput.value = Math.max(1,(parseInt(qtyInput.value,10)||1)-1); render(); }); }
+  if($('rm-plus')){ $('rm-plus').addEventListener('click', function(){ qtyInput.value = Math.min(999,(parseInt(qtyInput.value,10)||1)+1); render(); }); }
+  if(qtyInput){ qtyInput.addEventListener('input', function(){ clampQty(); render(); }); }
+
+  // ---- Kick off live data ----
+  refresh();
+  setInterval(refresh, 60000);
+  setInterval(tickAgo, 1000);
+
+  // ---- TOC active-section highlight ----
+  var tocLinks = Array.prototype.slice.call(document.querySelectorAll('.rm-toc__list a'));
+  var sections = tocLinks.map(function(a){ return document.getElementById(a.getAttribute('href').slice(1)); }).filter(Boolean);
+  if('IntersectionObserver' in window && sections.length){
+    var spy = new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(e.isIntersecting){
+          tocLinks.forEach(function(l){ l.classList.toggle('is-active', l.getAttribute('href') === '#' + e.target.id); });
+        }
+      });
+    }, {rootMargin:'-40% 0px -55% 0px', threshold:0});
+    sections.forEach(function(s){ spy.observe(s); });
+  }
+})();
 </script>
 </body></html>


### PR DESCRIPTION
## Summary
Full **mobile-first redesign** of `/blog/how-to-buy-gold-royal-mint`, built with the `ui-ux-pro-max` design system (Exaggerated Minimalism / editorial). Uses **Playfair Display + Inter** on the site's existing token palette so it works in **light and dark mode** and scales cleanly from 360px to desktop. All new styles are namespaced `.rm-*` and reuse the site's CSS variables — no shared components touched.

## What's new
- **Editorial hero** — oversized serif headline, byline (published/updated/read-time), and a 4-up key-facts strip.
- **Sticky table of contents** — pinned sidebar on desktop, collapsible `<details>` on mobile, with active-section highlighting.
- **Live Royal Mint premium calculator** — the standout interactive piece:
  - **GBP-primary with USD shown for reference** (correct for this UK Royal-Mint topic; USD kept as the global benchmark).
  - Pulls **live spot** (`gold-api.com`) + **USD→GBP FX** (`frankfurter.dev` / ECB) and refreshes **every 60s** — the exact same APIs, `TROY` constant and methodology as the rest of the site, so numbers stay consistent.
  - Pick a product (Britannia, Sovereign, Half-Sovereign, 1oz/100g/1g bars) → live melt value, typical premium range, and CGT status. Verified accurate across multiple price/FX inputs.
- **Numbered step flow**, **product comparison cards + table**, **delivery-vs-vault split**, **dealer callout**, gold **CTA**, and a `<details>` **FAQ accordion**.

## Fixes (pre-existing issues found during the redesign)
- The article body relied on **undefined CSS classes** (`.article-wrap`, `.prose`, `.cta-box`, `.faq-container`) and the H1 was inheriting a *card-title* size — it now renders as a proper hero.
- Removed a **duplicate/incorrect breadcrumb** (`"Gold & Silver Price Outlook"` left over from another article).
- Fixed a **`>>` typo in the OG meta tags** that was injecting stray `>` text nodes into the body.
- Added the **missing nav interaction script** so the **mobile hamburger**, theme toggle and mega-menus actually work (clean, correctly-wrapped single script).
- Added a **`<main>` landmark** and reconciled the published/updated dates.

## SEO
- Added **HowTo** structured data matching the step flow; synced **FAQPage** to the on-page Q&As. `node scripts/validate-jsonld.js` passes.

## Verification
- Repo **Playwright audit** (desktop 1440 + iPhone 14 Pro): ✅ no horizontal overflow, ✅ `main` visible, ✅ **0 stray text nodes**, ✅ nav/footer/grid intact.
- All **12 inline scripts** pass JS syntax checks.
- Calculator math confirmed dynamic (e.g. $4,627.50 @ 0.79 → £3,656; $5,200 @ 0.82 → £4,264).
- Visually reviewed in **light + dark**, **mobile + desktop**.

> Remaining audit "failures" are sandbox-blocked external resources (gold-api, frankfurter, Google Fonts, GA, logo CDN) that resolve normally in production; the calculator has FX/price fallbacks.

https://claude.ai/code/session_019YakPPbteThxRi8HuzvQYS

---
_Generated by [Claude Code](https://claude.ai/code/session_019YakPPbteThxRi8HuzvQYS)_