### PR TITLE
Redesign: Gold in a SIPP UK — editorial layout + live tax-relief calculator

### DIFF
--- a/blog/gold-in-a-sipp-uk.html
+++ b/blog/gold-in-a-sipp-uk.html
@@ -29,7 +29,7 @@
   "headline": "Gold in a SIPP: How to Hold Gold in Your UK Pension",
   "description": "A complete UK guide to holding gold in a Self-Invested Personal Pension (SIPP) — eligible gold types, HMRC rules, approved depositories, contribution limits, and provider options.",
   "datePublished": "2026-05-03T08:00:00Z",
-  "dateModified": "2026-05-07T08:00:00Z",
+  "dateModified": "2026-06-16T08:00:00Z",
   "author": {
     "@type": "Organization",
     "name": "GoldPriceTools Editorial Team",
@@ -66,34 +66,50 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "Can I hold physical gold in my SIPP?",
+      "name": "Can I hold physical gold in a SIPP?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Directly holding physical gold bars or coins in a SIPP is not permitted under HMRC rules — physical gold is classified as a 'tangible moveable asset' and is an 'in-specie' contribution that fails the 'exclusively for the purpose of the scheme' test. However, you can hold gold through HMRC-approved routes: gold ETCs, mining company shares, or specialist gold SIPP providers like Talaria Capital."
+        "text": "Yes, but only investment-grade gold bars of at least 995 fineness (99.5% pure) in bullion-market-accepted weights, held through a specialist full SIPP with HMRC-approved vault storage. You can never take personal possession while the gold is inside the pension. Gold coins and jewellery do not qualify. For most investors the simplest route is a physically-backed gold ETC, which any share-dealing SIPP can hold."
       }
     },
     {
       "@type": "Question",
-      "name": "Are gold ETFs allowed in a SIPP?",
+      "name": "Are gold ETFs and ETCs allowed in a SIPP?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Physically-backed gold ETCs (such as SGLN, SGLD, PHAU) are permitted in most SIPPs that allow exchange-traded securities. They're treated as shares for SIPP purposes. You benefit from gold price exposure with full pension tax relief on contributions and no CGT within the wrapper."
+        "text": "Yes. Physically-backed gold ETCs such as iShares Physical Gold (SGLN/IGLN), Invesco Physical Gold (SGLD) and WisdomTree Physical Gold (PHAU) are treated as exchange-traded securities and are permitted in any SIPP that allows share dealing. You get full gold price exposure with pension tax relief on contributions and no Capital Gains Tax inside the wrapper."
       }
     },
     {
       "@type": "Question",
-      "name": "What is the tax benefit of gold in a SIPP?",
+      "name": "Can I hold Gold Sovereigns or Britannias in a SIPP?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Contributing to a SIPP with the intention of buying gold ETCs gives you: 20% basic rate tax relief on contributions (higher rate taxpayers can claim 40%), no CGT on gains within the pension, and no income tax on dividends. The main downside is pension tax rules apply on withdrawal (typically 25% tax-free lump sum, rest taxed as income)."
+        "text": "No. Even though Sovereigns and Britannias are Capital Gains Tax-exempt as UK legal tender when held personally, gold coins are classed as tangible moveable property for pension purposes and are not eligible for a SIPP. Only investment-grade gold bars qualify for physical holding. If you want coins, hold them outside your pension."
       }
     },
     {
       "@type": "Question",
-      "name": "Which SIPP providers allow gold ETFs?",
+      "name": "What is the tax benefit of holding gold in a SIPP?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Most major SIPP platforms that offer a full range of exchange-traded securities allow gold ETCs. These include Hargreaves Lansdown SIPP, AJ Bell Youinvest, Interactive Investor, and Vanguard SIPP. Check the platform's 'permitted investments' list — some low-cost SIPPs restrict to funds only."
+        "text": "Contributions receive tax relief at your marginal rate — 20% basic, 40% higher or 45% additional. A basic-rate taxpayer effectively buys £1,000 of gold for £800; a higher-rate taxpayer for £600. Gains inside the SIPP are free of Capital Gains Tax. On withdrawal (from age 57 from 2028) 25% is normally tax-free, with the rest taxed as income."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which SIPP providers allow gold?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Mainstream platforms such as Hargreaves Lansdown, AJ Bell, Interactive Investor, Fidelity and Vanguard allow gold ETCs through standard share dealing. For physical gold bars you need a specialist full SIPP that offers approved bullion storage (often via partners such as BullionVault or The Royal Mint), which carries higher administration fees of roughly £200–£500 a year."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much can I contribute to a SIPP each year?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The Annual Allowance for 2025–26 is £60,000, or 100% of your earned income if lower, across all your pensions. High earners may have a tapered allowance, and anyone who has flexibly accessed pension income is limited by the £10,000 Money Purchase Annual Allowance (MPAA)."
       }
     }
   ]
@@ -422,6 +438,239 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 
 </style>
 <style id="gpt-h1-fix">h1.article-title{font-family:var(--font-display);font-size:clamp(1.75rem,3.5vw,2.75rem);font-weight:700;line-height:1.15;margin:var(--space-2) 0 var(--space-5);color:var(--color-text)}</style>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,500&family=Inter:wght@400;500;600;700&display=swap">
+<style id="sipp-redesign">
+/* ============================================================
+   Gold in a SIPP — editorial redesign (namespaced .sipp-*)
+   Mobile-first. Uses site design tokens so light/dark both work.
+   ============================================================ */
+:root{--font-serif:'Playfair Display',Georgia,'Times New Roman',serif}
+
+/* Breadcrumb (undefined site-wide — scoped here) */
+.breadcrumb-wrap{max-width:1180px;margin:0 auto;padding:var(--space-4) var(--space-4) 0}
+.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);font-size:var(--text-xs);color:var(--color-text-muted)}
+.breadcrumb li{display:flex;align-items:center;gap:var(--space-2)}
+.breadcrumb li:not(:last-child)::after{content:'';width:5px;height:5px;border-right:1.5px solid var(--color-text-faint);border-bottom:1.5px solid var(--color-text-faint);transform:rotate(-45deg);margin-left:var(--space-1)}
+.breadcrumb a{color:var(--color-text-muted)}
+.breadcrumb a:hover{color:var(--color-gold-bright);text-decoration:none}
+.breadcrumb [aria-current="page"]{color:var(--color-text);font-weight:600}
+
+/* ---- Shell ---- */
+.sipp-article{max-width:1180px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
+.sipp-prose,.sipp-section{scroll-margin-top:96px}
+
+/* ---- Hero ---- */
+.sipp-hero{position:relative;padding:var(--space-8) 0 var(--space-6);border-bottom:1px solid var(--color-divider);margin-bottom:var(--space-8)}
+.sipp-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);font-family:var(--font-body);font-size:var(--text-xs);font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--color-gold-bright);margin-bottom:var(--space-5)}
+.sipp-eyebrow::before{content:'';width:22px;height:1.5px;background:var(--color-gold-bright)}
+.sipp-hero__title{font-family:var(--font-serif);font-weight:700;font-size:clamp(2rem,5vw + .4rem,3.7rem);line-height:1.05;letter-spacing:-.015em;color:var(--color-text);margin:0 0 var(--space-5);max-width:20ch;text-wrap:balance}
+.sipp-hero__title em{font-style:italic;color:var(--color-gold-bright)}
+.sipp-hero__dek{font-size:clamp(1.05rem,.6vw + .95rem,1.3rem);line-height:1.6;color:var(--color-text-muted);max-width:62ch;margin:0 0 var(--space-6)}
+.sipp-byline{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted)}
+.sipp-byline a{color:var(--color-text);font-weight:600}
+.sipp-byline a:hover{color:var(--color-gold-bright);text-decoration:none}
+.sipp-byline .sipp-dot{width:3px;height:3px;border-radius:50%;background:var(--color-text-faint)}
+.sipp-byline .sipp-read{display:inline-flex;align-items:center;gap:6px}
+
+/* ---- Key facts strip ---- */
+.sipp-keyfacts{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin-top:var(--space-8)}
+.sipp-keyfact{display:flex;gap:var(--space-3);align-items:flex-start;padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.sipp-keyfact svg{flex-shrink:0;width:22px;height:22px;color:var(--color-gold-bright)}
+.sipp-keyfact dt{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:2px}
+.sipp-keyfact dd{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0;line-height:1.2;font-variant-numeric:tabular-nums}
+
+/* ---- Layout: content + sticky TOC ---- */
+.sipp-layout{display:grid;grid-template-columns:1fr;gap:var(--space-8)}
+.sipp-toc{order:-1}
+.sipp-toc details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden}
+.sipp-toc summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2);padding:var(--space-4);font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text);cursor:pointer;list-style:none}
+.sipp-toc summary::-webkit-details-marker{display:none}
+.sipp-toc summary .sipp-toc__chev{transition:transform var(--transition);color:var(--color-text-muted)}
+.sipp-toc details[open] summary .sipp-toc__chev{transform:rotate(180deg)}
+.sipp-toc__list{list-style:none;padding:0 var(--space-3) var(--space-3);margin:0;display:flex;flex-direction:column;gap:2px}
+.sipp-toc__list a{display:block;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);border-left:2px solid transparent}
+.sipp-toc__list a:hover{color:var(--color-text);background:var(--color-surface-offset);text-decoration:none}
+.sipp-toc__list a.is-active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 7%,transparent);font-weight:600}
+
+/* ---- Prose ---- */
+.sipp-prose{font-size:var(--text-base);color:var(--color-text);line-height:1.75}
+.sipp-prose>section+section{margin-top:var(--space-12)}
+.sipp-prose h2{font-family:var(--font-serif);font-weight:700;font-size:clamp(1.55rem,2.2vw + .6rem,2.1rem);line-height:1.15;letter-spacing:-.01em;color:var(--color-text);margin:0 0 var(--space-4)}
+.sipp-prose h3{font-family:var(--font-display);font-weight:700;font-size:var(--text-lg);color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
+.sipp-prose p{margin:0 0 var(--space-4);max-width:68ch}
+.sipp-prose a{color:var(--color-primary);font-weight:600;text-decoration:underline;text-decoration-color:color-mix(in oklch,var(--color-primary) 40%,transparent);text-underline-offset:2px}
+.sipp-prose a:hover{color:var(--color-primary-hover)}
+.sipp-prose strong{color:var(--color-text);font-weight:700}
+.sipp-prose ul{list-style:none;margin:0 0 var(--space-4);padding:0;display:flex;flex-direction:column;gap:var(--space-3)}
+.sipp-prose ul li{position:relative;padding-left:var(--space-6);max-width:66ch;color:var(--color-text-muted)}
+.sipp-prose ul li strong{color:var(--color-text)}
+.sipp-prose ul li::before{content:'';position:absolute;left:2px;top:.62em;width:7px;height:7px;border-radius:1px;background:var(--color-gold-bright);transform:rotate(45deg)}
+.sipp-lead{font-size:clamp(1.1rem,.5vw + 1rem,1.28rem)!important;line-height:1.62;color:var(--color-text)!important;max-width:64ch!important}
+.sipp-lead::first-letter{float:left;font-family:var(--font-serif);font-weight:700;font-size:3.4em;line-height:.78;padding:.05em .12em 0 0;color:var(--color-gold-bright)}
+
+/* section kicker numerals */
+.sipp-kicker{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3)}
+.sipp-kicker__num{font-family:var(--font-display);font-size:var(--text-xs);font-weight:700;letter-spacing:.1em;color:var(--color-gold-bright);padding:3px 9px;border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));border-radius:var(--radius-full);text-transform:uppercase}
+.sipp-kicker__rule{flex:1;height:1px;background:var(--color-divider)}
+
+/* ---- Feature grid ---- */
+.sipp-features{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-2)}
+.sipp-feature{padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);transition:border-color var(--transition)}
+.sipp-feature:hover{border-color:color-mix(in oklch,var(--color-gold-bright) 45%,var(--color-border))}
+.sipp-feature__icon{display:flex;align-items:center;justify-content:center;width:42px;height:42px;border-radius:var(--radius-md);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface-offset));color:var(--color-gold-bright);margin-bottom:var(--space-3)}
+.sipp-feature__icon svg{width:22px;height:22px}
+.sipp-feature h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0 0 var(--space-1)}
+.sipp-feature p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0;max-width:none}
+
+/* ---- Live tax-relief calculator ---- */
+.sipp-calc{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-md);margin:var(--space-6) 0 0}
+.sipp-calc__head{padding:var(--space-5) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);background:linear-gradient(180deg,color-mix(in oklch,var(--color-gold-bright) 7%,var(--color-surface)),var(--color-surface))}
+.sipp-calc__eyebrow{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.sipp-calc__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:0 0 var(--space-1)}
+.sipp-calc__sub{font-size:var(--text-xs);color:var(--color-text-muted);margin:0}
+.sipp-spotbar{display:grid;grid-template-columns:1fr;gap:var(--space-3);padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-divider);background:var(--color-surface-offset)}
+.sipp-spot{display:flex;align-items:baseline;justify-content:space-between;gap:var(--space-3)}
+.sipp-spot__k{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.sipp-spot__v{font-size:var(--text-base);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.sipp-usd{font-size:var(--text-xs);font-weight:500;color:var(--color-text-muted);margin-left:6px}
+.sipp-calc__body{padding:var(--space-5)}
+.sipp-calc__controls{display:grid;grid-template-columns:1fr;gap:var(--space-5);margin-bottom:var(--space-5)}
+.sipp-field-label{display:block;font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.sipp-money{display:flex;align-items:center;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface-offset);overflow:hidden}
+.sipp-money:focus-within{border-color:var(--color-primary)}
+.sipp-money__sym{padding:0 var(--space-2) 0 var(--space-4);font-size:var(--text-lg);font-weight:700;color:var(--color-text-muted)}
+.sipp-money input{flex:1;width:100%;padding:var(--space-3) var(--space-4) var(--space-3) var(--space-1);border:none;background:none;font-size:var(--text-lg);font-weight:700;color:var(--color-text);-moz-appearance:textfield;font-variant-numeric:tabular-nums}
+.sipp-money input::-webkit-outer-spin-button,.sipp-money input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
+.sipp-presets{display:flex;flex-wrap:wrap;gap:var(--space-2);margin-top:var(--space-2)}
+.sipp-preset{padding:6px var(--space-3);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);cursor:pointer;transition:border-color var(--transition),color var(--transition)}
+.sipp-preset:hover{border-color:var(--color-gold-bright);color:var(--color-text)}
+.sipp-bands{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-2)}
+.sipp-band{display:flex;flex-direction:column;align-items:center;gap:2px;padding:var(--space-3) var(--space-2);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-text);cursor:pointer;transition:border-color var(--transition),background var(--transition)}
+.sipp-band small{font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted)}
+.sipp-band:hover{border-color:var(--color-gold-bright)}
+.sipp-band[aria-pressed="true"]{border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface))}
+.sipp-band[aria-pressed="true"] small{color:var(--color-gold-bright)}
+.sipp-result{border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border-radius:var(--radius-lg);padding:var(--space-5)}
+.sipp-result__label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.sipp-result__big{font-size:clamp(1.9rem,5vw,2.6rem);font-weight:800;line-height:1;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.sipp-result__big .sipp-usd{display:block;font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);margin-top:var(--space-2);margin-left:0;letter-spacing:0}
+.sipp-result__grams{font-size:var(--text-sm);font-weight:600;color:var(--color-text);margin-top:var(--space-3)}
+.sipp-result__divider{height:1px;background:var(--color-divider);margin:var(--space-4) 0}
+.sipp-result__grid{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3)}
+.sipp-stat{display:flex;flex-direction:column;gap:2px}
+.sipp-stat__k{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.05em}
+.sipp-stat__v{font-size:var(--text-lg);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.sipp-stat__v.is-pos{color:#16a34a}
+[data-theme="dark"] .sipp-stat__v.is-pos{color:#4ade80}
+.sipp-discount{display:flex;align-items:center;gap:var(--space-2);margin-top:var(--space-4);padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);background:color-mix(in oklch,var(--color-gold-bright) 13%,transparent);font-size:var(--text-sm);color:var(--color-text);line-height:1.45}
+.sipp-discount svg{flex-shrink:0;width:18px;height:18px;color:var(--color-gold-bright)}
+.sipp-discount strong{color:var(--color-gold-bright);font-weight:800}
+.sipp-calc__note{font-size:var(--text-xs);color:var(--color-text-muted);margin:var(--space-4) 0 0;line-height:1.6;max-width:none}
+
+/* ---- Rules grid (permitted / not) ---- */
+.sipp-rules{display:grid;grid-template-columns:1fr;gap:var(--space-3);margin-top:var(--space-2)}
+.sipp-rule{display:grid;grid-template-columns:auto 1fr;gap:var(--space-3);padding:var(--space-4) var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.sipp-rule__icon{display:flex;align-items:center;justify-content:center;width:30px;height:30px;border-radius:50%;flex-shrink:0;margin-top:2px}
+.sipp-rule__icon svg{width:16px;height:16px}
+.sipp-rule.is-yes .sipp-rule__icon{background:color-mix(in oklch,#16a34a 16%,transparent);color:#16a34a}
+.sipp-rule.is-no .sipp-rule__icon{background:color-mix(in oklch,#dc2626 15%,transparent);color:#dc2626}
+[data-theme="dark"] .sipp-rule.is-yes .sipp-rule__icon{color:#4ade80}
+[data-theme="dark"] .sipp-rule.is-no .sipp-rule__icon{color:#f87171}
+.sipp-rule__h{display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;margin-bottom:2px}
+.sipp-rule__h h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0}
+.sipp-rule__badge{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;padding:2px 7px;border-radius:var(--radius-full)}
+.sipp-rule.is-yes .sipp-rule__badge{background:color-mix(in oklch,#16a34a 16%,transparent);color:#16a34a}
+.sipp-rule.is-no .sipp-rule__badge{background:var(--color-surface-dynamic);color:var(--color-text-muted)}
+[data-theme="dark"] .sipp-rule.is-yes .sipp-rule__badge{color:#4ade80}
+.sipp-rule p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0;max-width:none}
+
+/* ---- Split (two routes) ---- */
+.sipp-split{display:grid;grid-template-columns:1fr;gap:var(--space-4);margin-top:var(--space-2)}
+.sipp-splitcard{padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.sipp-splitcard__h{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-2)}
+.sipp-splitcard__h svg{width:24px;height:24px;color:var(--color-gold-bright);flex-shrink:0}
+.sipp-splitcard__h h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0}
+.sipp-splitcard__tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--color-gold-bright);margin-bottom:var(--space-3);display:block}
+.sipp-splitcard ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:var(--space-2)}
+.sipp-splitcard li{position:relative;padding-left:var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55;max-width:none}
+.sipp-splitcard li::before{content:'';position:absolute;left:2px;top:.55em;width:6px;height:6px;border-radius:50%;background:var(--color-gold-bright)}
+
+/* ---- Callout ---- */
+.sipp-callout{display:grid;grid-template-columns:auto 1fr;gap:var(--space-4);padding:var(--space-5);background:color-mix(in oklch,var(--color-primary) 7%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 28%,var(--color-border));border-radius:var(--radius-lg);margin-top:var(--space-2)}
+.sipp-callout svg{width:26px;height:26px;color:var(--color-primary);flex-shrink:0}
+.sipp-callout h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0 0 var(--space-2)}
+.sipp-callout p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+
+/* ---- Table ---- */
+.sipp-tablewrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px solid var(--color-border);border-radius:var(--radius-lg);margin-top:var(--space-2)}
+.sipp-table{width:100%;border-collapse:collapse;min-width:560px}
+.sipp-table th,.sipp-table td{padding:var(--space-3) var(--space-4);text-align:left;font-size:var(--text-sm);border-bottom:1px solid var(--color-divider)}
+.sipp-table thead th{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:.05em;color:var(--color-text-muted);font-weight:700;background:var(--color-surface-offset)}
+.sipp-table tbody tr:last-child td{border-bottom:none}
+.sipp-table td:first-child{font-weight:600;color:var(--color-text)}
+.sipp-table .sipp-yes{color:#16a34a;font-weight:700}
+.sipp-table .sipp-no{color:var(--color-text-faint);font-weight:600}
+[data-theme="dark"] .sipp-table .sipp-yes{color:#4ade80}
+
+/* ---- CTA ---- */
+.sipp-cta{position:relative;overflow:hidden;text-align:center;padding:var(--space-10) var(--space-5);background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold) 18%,var(--color-surface)),var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));border-radius:var(--radius-xl);margin:var(--space-12) 0 0}
+.sipp-cta h2{font-family:var(--font-serif);font-size:clamp(1.5rem,3vw,2rem);font-weight:700;color:var(--color-text);margin:0 0 var(--space-3)}
+.sipp-cta p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.6;margin:0 auto var(--space-6);max-width:52ch}
+.sipp-cta__btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-4) var(--space-8);background:var(--color-gold-bright);color:#1a1306!important;font-weight:700;font-size:var(--text-base);border-radius:var(--radius-full);text-decoration:none!important;box-shadow:var(--shadow-md);transition:transform var(--transition),box-shadow var(--transition)}
+.sipp-cta__btn:hover{transform:translateY(-2px);box-shadow:var(--shadow-lg)}
+
+/* ---- FAQ accordion ---- */
+.sipp-faq{display:flex;flex-direction:column;gap:var(--space-3);margin-top:var(--space-2)}
+.sipp-faq details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.sipp-faq details[open]{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border))}
+.sipp-faq summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);cursor:pointer;list-style:none}
+.sipp-faq summary::-webkit-details-marker{display:none}
+.sipp-faq summary .sipp-faq__icon{flex-shrink:0;width:20px;height:20px;color:var(--color-gold-bright);transition:transform var(--transition)}
+.sipp-faq details[open] summary .sipp-faq__icon{transform:rotate(45deg)}
+.sipp-faq__a{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;max-width:68ch}
+.sipp-faq__a .sipp-hl{color:var(--color-gold-bright);font-weight:600}
+
+/* ---- Related ---- */
+.sipp-related{margin-top:var(--space-12);padding-top:var(--space-8);border-top:1px solid var(--color-divider)}
+.sipp-related>h2{font-family:var(--font-serif);font-size:clamp(1.4rem,2.5vw,1.9rem);font-weight:700;color:var(--color-text);margin:0 0 var(--space-6)}
+.sipp-related-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+.sipp-rcard{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
+.sipp-rcard:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);text-decoration:none}
+.sipp-rcard__tag{align-self:flex-start;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);padding:2px 8px;border-radius:var(--radius-full);background:color-mix(in oklch,var(--color-gold-bright) 12%,transparent)}
+.sipp-rcard__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);line-height:1.3}
+.sipp-rcard:hover .sipp-rcard__title{color:var(--color-gold-bright)}
+.sipp-rcard__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55}
+
+/* ---- Hero entrance only (one-time). Body content is ALWAYS visible. ---- */
+@media (prefers-reduced-motion:no-preference){
+  .sipp-hero{animation:sipp-introUp .7s cubic-bezier(.16,1,.3,1) both}
+  @keyframes sipp-introUp{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:none}}
+}
+
+/* ============================================================
+   Responsive — tablet & desktop
+   ============================================================ */
+@media(min-width:560px){
+  .sipp-keyfacts{grid-template-columns:repeat(4,1fr)}
+  .sipp-features{grid-template-columns:repeat(2,1fr)}
+  .sipp-split{grid-template-columns:repeat(2,1fr)}
+  .sipp-spotbar{grid-template-columns:repeat(3,1fr)}
+  .sipp-spot{flex-direction:column;align-items:flex-start;gap:2px}
+  .sipp-calc__controls{grid-template-columns:1fr 1fr}
+  .sipp-related-grid{grid-template-columns:repeat(2,1fr)}
+}
+@media(min-width:992px){
+  .sipp-layout{grid-template-columns:minmax(0,1fr) 264px;align-items:start;gap:var(--space-10)}
+  .sipp-toc{order:1;position:sticky;top:84px;align-self:start}
+  .sipp-toc details{position:static}
+  .sipp-toc summary{cursor:default}
+  .sipp-toc summary .sipp-toc__chev{display:none}
+  .sipp-related-grid{grid-template-columns:repeat(3,1fr)}
+  .sipp-hero__title{max-width:18ch}
+}
+</style>
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
@@ -522,127 +771,336 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <ol class="breadcrumb" aria-label="Breadcrumb">
     <li><a href="/">Home</a></li>
     <li><a href="/blog/">Blog</a></li>
-    <li aria-current="page">Gold &amp; Silver Price Outlook</li>
+    <li aria-current="page">Gold in a SIPP</li>
   </ol>
 </div>
 
-<div class="breadcrumb-wrap"><ol class="breadcrumb" aria-label="Breadcrumb">
-<li><a href="/">Home</a></li><li><a href="/blog/">Blog</a></li><li aria-current="page">Gold in a SIPP: How to Hold Gold in Your UK Pension</li>
-</ol></div>
-<article class="article-wrap" itemscope itemtype="https://schema.org/BlogPosting">
-  <div class="article-tag">Pensions & Tax</div>
-  <h1 class="article-title" itemprop="headline">Gold in a SIPP: How to Hold Gold in Your UK Pension</h1>
-  <div class="article-byline">
-    By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a>
-    &middot; <time datetime="2026-06-16" itemprop="datePublished">2026-05-03</time>
-    &middot; <span style="font-size:0.8em;color:var(--color-text-faint)">Last updated: 3 May 2026</span>
-  </div>
-  <div class="prose">
-    <p>Holding gold inside a Self-Invested Personal Pension (SIPP) is one of the most tax-efficient ways to invest in precious metals as a UK resident. You get tax relief on contributions at your marginal rate (20%–45%), all gains within the wrapper are free from Capital Gains Tax, and the income produced by the underlying gold (zero, in most cases) is also sheltered. This guide explains exactly what types of gold qualify for SIPP holding, how to set it up, and the key rules HMRC imposes.</p>
+<main id="content">
+<article class="sipp-article" itemscope itemtype="https://schema.org/BlogPosting">
+  <meta itemprop="datePublished" content="2026-05-03">
+  <meta itemprop="dateModified" content="2026-06-16">
 
-    <h2>Why Hold Gold in a SIPP?</h2>
-    <p>The tax advantages are compelling. A basic-rate taxpayer contributing £800 to a SIPP receives £200 government tax relief automatically — effectively buying £1,000 of gold for £800. A higher-rate taxpayer contributing £600 can claim a further £200 through Self Assessment, buying £1,000 of gold for just £600 after all relief. Inside the SIPP, all gains are free from CGT regardless of size. On withdrawal from age 57 (rising from 55 in 2028), 25% of the fund can typically be taken as a tax-free lump sum, with the remainder taxed as income at your marginal rate at the time of withdrawal — which for many retirees is lower than their working rate.</p>
-
-    <h2>What Gold Can You Hold in a SIPP?</h2>
-    <p>HMRC has strict rules on which gold assets qualify for SIPP holding. The key distinction is between <em>investment-grade</em> gold (permitted) and <em>tangible moveable property</em> (not permitted). In plain terms:</p>
-    <ul>
-      <li><strong>Physical gold bars: Permitted</strong> — but only bars of at least <strong>99.5% purity (995 fineness)</strong> produced by an LBMA-approved refiner. Standard retail bar sizes (100g, 250g, 500g, 1 kg, 12.4 kg Good Delivery) all qualify provided they meet the purity threshold. The bars must be stored in a HMRC-approved depository — you cannot take personal physical possession.</li>
-      <li><strong>Physical gold coins: Permitted (approved list only)</strong> — coins must appear on HMRC's list of approved investment coins. Eligible coins include Gold Britannias, Gold Sovereigns, Canadian Gold Maple Leafs, South African Krugerrands, and Austrian Gold Philharmonics. The coins must be stored at an approved depository — personal possession is not permitted inside the SIPP.</li>
-      <li><strong>Gold ETCs and ETFs: Permitted</strong> — exchange-listed gold ETCs (iShares IGLN, Invesco SGLD, WisdomTree PHAU) are standard securities and qualify for SIPP holding. This is the simplest route: buy through any SIPP provider that allows self-directed share dealing.</li>
-      <li><strong>Gold jewellery, collectibles, or personal jewellery: Not permitted</strong> — treated as tangible moveable property and excluded from SIPPs entirely.</li>
-    </ul>
-
-    <h2>Choosing the Right SIPP Provider for Gold</h2>
-    <p>Not all SIPP providers support physical gold holding. The two main routes:</p>
-    <ul>
-      <li><strong>For gold ETCs (easiest):</strong> Any SIPP provider that offers a general investment account — including Hargreaves Lansdown, AJ Bell Youinvest, Fidelity, Interactive Investor, and Vanguard (for their own gold fund) — will allow you to buy gold ETCs. This is by far the most common approach.</li>
-      <li><strong>For physical gold bars and coins:</strong> You need a <em>specialist full SIPP</em> from a provider that offers approved bullion storage. BullionVault integrates directly with SIPP wrappers through approved providers. The Royal Mint also works with specialist SIPP trustees. This typically involves higher administration fees (£200–£500 p.a. in trustee charges) compared to standard SIPP platforms.</li>
-    </ul>
-
-    <h2>Annual Allowance and Contribution Limits</h2>
-    <p>The annual pension contribution limit (the Annual Allowance) for 2025–26 is <strong>£60,000</strong> per year, or 100% of your earned income if lower. This is the total amount you (and your employer) can contribute across all pension schemes. The SIPP receives basic-rate tax relief automatically at source. Higher and additional-rate taxpayers must claim the additional relief through Self Assessment. Be aware of the <strong>Money Purchase Annual Allowance (MPAA)</strong>: if you have already flexibly accessed pension income, your annual allowance for defined contribution pensions drops to £10,000.</p>
-
-    <h2>HMRC-Approved Depositories for Physical Gold</h2>
-    <p>Physical gold held in a SIPP must be stored at an HMRC-approved depository — you cannot store it at home or in a private vault. The gold remains physically allocated to you (it is your specific bars or coins), but you have no right to personal possession while it is inside the pension wrapper. Approved depositories typically include LBMA-member vaults in London (such as the Royal Mint Vault, Brink's, Malca-Amit, and Via Mat). Storage costs for physical SIPP gold typically run 0.12–0.5% p.a. depending on the custodian and quantity, on top of the SIPP trustee administration fee.</p>
-
-    <h2>Withdrawing Gold from a SIPP</h2>
-    <p>When you come to take benefits from your SIPP, you cannot withdraw physical gold in kind — HMRC requires cash or assets that can be valued and taxed as income. This means the gold (or gold ETC) must be sold and the proceeds taken as pension income, which is taxed at your marginal rate (with 25% of the fund typically available as a tax-free lump sum). The CGT-free status of Gold Britannias and Sovereigns does not apply within a pension — all withdrawals are taxed as income regardless of the underlying asset. This is an important point to understand before committing physical CGT-exempt coins to a SIPP versus holding them personally.</p>
-
-    <h2>SIPP vs ISA vs Personal Holding: A Quick Comparison</h2>
-    <table class="data-table" aria-label="Gold tax wrapper comparison">
-      <thead><tr><th>Wrapper</th><th>Tax relief on in?</th><th>CGT on gains?</th><th>Physical gold?</th><th>Annual limit</th></tr></thead>
-      <tbody>
-        <tr><td>Personal holding (CGT-exempt coins)</td><td>No</td><td>Exempt (Britannias/Sovereigns)</td><td>Yes</td><td>Unlimited</td></tr>
-        <tr><td>Stocks &amp; Shares ISA (gold ETC)</td><td>No</td><td>Exempt</td><td>No</td><td>£20,000/year</td></tr>
-        <tr><td>SIPP (gold ETC or physical)</td><td>Yes (20–45%)</td><td>Exempt within wrapper</td><td>Yes (approved)</td><td>£60,000/year</td></tr>
-      </tbody>
-    </table>
-    <div class="cta-box"><h3>Track Live Gold Prices in GBP</h3><p>Use GoldPriceTools' free live calculator to value your gold holdings before deciding on your SIPP contribution.</p><a href="/" class="cta-btn">Open Calculator &rarr;</a></div>
-  </div>
-  
-<!-- FAQ Section -->
-<section style="padding:2rem 0 0;">
-  <h2 style="font-size:1.3rem;font-weight:700;color:var(--color-text);margin-bottom:1.2rem;">Frequently Asked Questions</h2>
-  <div class="faq-container">
-    <div class="faq-card">
-      <h3 class="faq-q">Can I hold physical gold in my SIPP?</h3>
-      <p class="faq-answer">Directly holding physical gold bars or coins in a SIPP is not permitted under HMRC rules — physical gold is classified as a 'tangible moveable asset' and is an 'in-specie' contribution that fails the 'exclusively for the purpose of the scheme' test. However, you can hold gold through HMRC-approved routes: gold ETCs, mining company shares, or specialist gold SIPP providers like Talaria Capital.</p>
+  <!-- ===== HERO ===== -->
+  <header class="sipp-hero">
+    <span class="sipp-eyebrow">UK Pensions &amp; Tax</span>
+    <h1 class="sipp-hero__title" itemprop="headline">Gold in a <em>SIPP</em>: How to Hold Gold in Your UK Pension</h1>
+    <p class="sipp-hero__dek">Holding gold inside a Self-Invested Personal Pension is one of the most tax-efficient ways for a UK resident to own the metal — tax relief going in, no Capital Gains Tax on the way up. Here's exactly what qualifies, how to set it up, and the HMRC rules that catch people out.</p>
+    <div class="sipp-byline">
+      <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
+      <span class="sipp-dot" aria-hidden="true"></span>
+      <span>Published <time datetime="2026-05-03">3 May 2026</time></span>
+      <span class="sipp-dot" aria-hidden="true"></span>
+      <span>Updated <time datetime="2026-06-16">16 June 2026</time></span>
+      <span class="sipp-dot" aria-hidden="true"></span>
+      <span class="sipp-read"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> 8 min read</span>
     </div>
-    <div class="faq-card">
-      <h3 class="faq-q">Are gold ETFs allowed in a SIPP?</h3>
-      <p class="faq-answer">Yes. Physically-backed gold ETCs (such as SGLN, SGLD, PHAU) are permitted in most SIPPs that allow exchange-traded securities. They're treated as shares for SIPP purposes. You benefit from gold price exposure with full pension tax relief on contributions and no CGT within the wrapper.</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-q">What is the tax benefit of gold in a SIPP?</h3>
-      <p class="faq-answer">Contributing to a SIPP with the intention of buying gold ETCs gives you: 20% basic rate tax relief on contributions (higher rate taxpayers can claim 40%), no CGT on gains within the pension, and no income tax on dividends. The main downside is pension tax rules apply on withdrawal (typically 25% tax-free lump sum, rest taxed as income).</p>
-    </div>
-    <div class="faq-card">
-      <h3 class="faq-q">Which SIPP providers allow gold ETFs?</h3>
-      <p class="faq-answer">Most major SIPP platforms that offer a full range of exchange-traded securities allow gold ETCs. These include Hargreaves Lansdown SIPP, AJ Bell Youinvest, Interactive Investor, and Vanguard SIPP. Check the platform's 'permitted investments' list — some low-cost SIPPs restrict to funds only.</p>
-    </div>
-  </div>
-</section>
 
-<!-- Related Guides Section -->
-<section class="related-guides" >
-  <div class="container" >
-    <h2>Related Articles &amp; Guides</h2>
-    <div class="related-guides-grid">
-      <a href="/blog/gold-etf-vs-physical-gold-uk" class="related-card">
-        <div class="related-card__tag">Article</div>
-        <div class="related-card__title">Gold ETF vs Physical Gold UK</div>
-        <div class="related-card__desc">Should you buy gold ETFs or physical bullion? A complete UK comparison.</div>
-      </a>
-      <a href="/blog/uk-gold-cgt-guide" class="related-card">
-        <div class="related-card__tag">Article</div>
-        <div class="related-card__title">UK Gold CGT Guide</div>
-        <div class="related-card__desc">How CGT applies to gold outside a pension — and why SIPPs can avoid it.</div>
-      </a>
-      <a href="/guides/how-to-invest-in-gold" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">How to Invest in Gold UK</div>
-        <div class="related-card__desc">All the ways to invest in gold in the UK — ETFs, coins, bars and pensions.</div>
-      </a>
-      <a href="/guides/gold-vs-silver-investment" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold vs Silver Investment</div>
-        <div class="related-card__desc">Is gold or silver the better pension hedge? Key differences compared.</div>
-      </a>
-      <a href="/guides/gold-price-history" class="related-card">
-        <div class="related-card__tag">Guide</div>
-        <div class="related-card__title">Gold Price History</div>
-        <div class="related-card__desc">Long-term gold returns context for pension investors.</div>
-      </a>
-      <a href="/24k-gold-price-per-gram" class="related-card">
-        <div class="related-card__tag">Live Price</div>
-        <div class="related-card__title">Live Gold Price Today</div>
-        <div class="related-card__desc">Today's gold spot price — the benchmark for any gold investment decision.</div>
-      </a>
+    <dl class="sipp-keyfacts">
+      <div class="sipp-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        <div><dt>Tax relief</dt><dd>Up to 45%</dd></div>
+      </div>
+      <div class="sipp-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
+        <div><dt>Annual allowance</dt><dd>£60,000</dd></div>
+      </div>
+      <div class="sipp-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 3l8 4v5c0 5-3.4 7.8-8 9-4.6-1.2-8-4-8-9V7z"/><path d="M9 12l2 2 4-4"/></svg>
+        <div><dt>CGT in wrapper</dt><dd>0%</dd></div>
+      </div>
+      <div class="sipp-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+        <div><dt>Tax-free at 57</dt><dd>25% lump sum</dd></div>
+      </div>
+    </dl>
+  </header>
+
+  <div class="sipp-layout">
+    <!-- ===== TABLE OF CONTENTS ===== -->
+    <nav class="sipp-toc" aria-label="On this page">
+      <details open>
+        <summary>On this page <svg class="sipp-toc__chev" width="16" height="16" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></summary>
+        <ul class="sipp-toc__list">
+          <li><a href="#why">Why hold gold in a SIPP</a></li>
+          <li><a href="#calculator">Tax-relief calculator</a></li>
+          <li><a href="#what">What gold qualifies</a></li>
+          <li><a href="#provider">Choosing a provider</a></li>
+          <li><a href="#limits">Allowances &amp; withdrawal</a></li>
+          <li><a href="#compare">SIPP vs ISA vs personal</a></li>
+          <li><a href="#risks">Risks to weigh</a></li>
+          <li><a href="#faq">FAQs</a></li>
+        </ul>
+      </details>
+    </nav>
+
+    <!-- ===== ARTICLE BODY ===== -->
+    <div class="sipp-prose" itemprop="articleBody">
+      <p class="sipp-lead">A SIPP lets you wrap gold in the most generous tax shelter the UK offers a private investor. The government tops up every contribution at your marginal rate, gains compound free of Capital Gains Tax, and a quarter of the pot comes out tax-free from age 57. The catch is HMRC's strict definition of <em>eligible</em> gold — get it wrong and a tax charge follows the asset into your pension.</p>
+
+      <section id="why" class="sipp-section">
+        <div class="sipp-kicker"><span class="sipp-kicker__num">01</span><span class="sipp-kicker__rule"></span></div>
+        <h2>Why hold gold in a SIPP?</h2>
+        <p>Compared with buying gold personally, the SIPP wrapper changes the maths in four meaningful ways:</p>
+        <div class="sipp-features">
+          <div class="sipp-feature">
+            <div class="sipp-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></div>
+            <h3>Tax relief on the way in</h3>
+            <p>Every £800 you pay in becomes £1,000 of gold for a basic-rate taxpayer. Higher and additional-rate taxpayers reclaim more still through Self Assessment — an instant 40–45% effective discount.</p>
+          </div>
+          <div class="sipp-feature">
+            <div class="sipp-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 3l8 4v5c0 5-3.4 7.8-8 9-4.6-1.2-8-4-8-9V7z"/><path d="M9 12l2 2 4-4"/></svg></div>
+            <h3>No Capital Gains Tax</h3>
+            <p>Gold sold at a profit inside a SIPP is free of CGT, however large the gain — valuable given gold's run and the shrinking annual CGT exemption outside a pension.</p>
+          </div>
+          <div class="sipp-feature">
+            <div class="sipp-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 3v18h18"/><path d="M7 13l3-3 3 3 5-5"/></svg></div>
+            <h3>A genuine diversifier</h3>
+            <p>Gold has historically held value when equities and bonds fall. A modest allocation can lower the volatility of an otherwise share-heavy pension.</p>
+          </div>
+          <div class="sipp-feature">
+            <div class="sipp-feature__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg></div>
+            <h3>25% tax-free at retirement</h3>
+            <p>From age 57 (from 2028) you can normally take a quarter of the fund as a tax-free lump sum, with the balance taxed as income — often at a lower rate than during your working life.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="calculator" class="sipp-section">
+        <div class="sipp-kicker"><span class="sipp-kicker__num">02</span><span class="sipp-kicker__rule"></span></div>
+        <h2>How far does your contribution go?</h2>
+        <p>Enter what you'd pay in from your own pocket and your tax band. The calculator grosses up your contribution with tax relief and converts it to investment-grade gold at the <strong>live spot price</strong> — shown in pounds with the international USD benchmark for reference.</p>
+
+        <div class="sipp-calc" aria-labelledby="sipp-calc-title">
+          <div class="sipp-calc__head">
+            <div class="sipp-calc__eyebrow"><span class="live-dot" aria-hidden="true"></span> Live gold spot</div>
+            <h3 class="sipp-calc__title" id="sipp-calc-title">SIPP gold &amp; tax-relief calculator</h3>
+            <p class="sipp-calc__sub" id="sipp-updated">Connecting to live market data…</p>
+          </div>
+          <div class="sipp-spotbar">
+            <div class="sipp-spot"><span class="sipp-spot__k">Gold spot / oz</span><span class="sipp-spot__v" id="sipp-spot-oz">£—<span class="sipp-usd" id="sipp-spot-oz-usd">$—</span></span></div>
+            <div class="sipp-spot"><span class="sipp-spot__k">Gold spot / gram</span><span class="sipp-spot__v" id="sipp-spot-g">£—</span></div>
+            <div class="sipp-spot"><span class="sipp-spot__k">Exchange rate</span><span class="sipp-spot__v" id="sipp-fx">£1 = $—</span></div>
+          </div>
+          <div class="sipp-calc__body">
+            <div class="sipp-calc__controls">
+              <div class="sipp-field">
+                <label class="sipp-field-label" for="sipp-contrib">Your contribution (from your bank)</label>
+                <div class="sipp-money">
+                  <span class="sipp-money__sym" aria-hidden="true">£</span>
+                  <input type="number" id="sipp-contrib" value="800" min="0" max="48000" step="50" inputmode="numeric" aria-label="Your contribution in pounds">
+                </div>
+                <div class="sipp-presets" role="group" aria-label="Quick contribution amounts">
+                  <button type="button" class="sipp-preset" data-amt="800">£800</button>
+                  <button type="button" class="sipp-preset" data-amt="2000">£2,000</button>
+                  <button type="button" class="sipp-preset" data-amt="8000">£8,000</button>
+                  <button type="button" class="sipp-preset" data-amt="48000">Max*</button>
+                </div>
+              </div>
+              <div class="sipp-field">
+                <span class="sipp-field-label" id="sipp-band-label">Your income tax band</span>
+                <div class="sipp-bands" role="group" aria-labelledby="sipp-band-label">
+                  <button type="button" class="sipp-band" data-rate="20" aria-pressed="true">Basic <small>20%</small></button>
+                  <button type="button" class="sipp-band" data-rate="40" aria-pressed="false">Higher <small>40%</small></button>
+                  <button type="button" class="sipp-band" data-rate="45" aria-pressed="false">Additional <small>45%</small></button>
+                </div>
+              </div>
+            </div>
+
+            <div class="sipp-result" aria-live="polite">
+              <div class="sipp-result__label">Gold in your SIPP after tax relief</div>
+              <div class="sipp-result__big" id="sipp-gross">£—<span class="sipp-usd" id="sipp-gross-usd">$— USD</span></div>
+              <div class="sipp-result__grams" id="sipp-grams">Connecting to live spot price…</div>
+              <div class="sipp-result__divider"></div>
+              <div class="sipp-result__grid">
+                <div class="sipp-stat"><span class="sipp-stat__k">Your real cost after relief</span><span class="sipp-stat__v" id="sipp-cost">£—</span></div>
+                <div class="sipp-stat"><span class="sipp-stat__k">Government tax top-up</span><span class="sipp-stat__v is-pos" id="sipp-relief">£—</span></div>
+              </div>
+              <div class="sipp-discount"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> <span>You're effectively buying gold at a <strong id="sipp-disc-pct">20%</strong> discount versus buying it personally.</span></div>
+            </div>
+            <p class="sipp-calc__note">Live gold spot from gold-api.com, converted to GBP using ECB reference rates. Basic-rate (20%) relief is added to your pension automatically; higher- and additional-rate relief is reclaimed via Self Assessment and shown here as a reduction in your real cost. Figures value gold at the pure spot price before any dealer, ETC or vault-storage costs, and assume you have sufficient UK relevant earnings. *£48,000 net grosses up to roughly the £60,000 annual allowance. Indicative only — not financial advice.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="what" class="sipp-section">
+        <div class="sipp-kicker"><span class="sipp-kicker__num">03</span><span class="sipp-kicker__rule"></span></div>
+        <h2>What gold can you actually hold?</h2>
+        <p>HMRC draws a hard line between <strong>investment-grade gold bullion</strong> and <strong>tangible moveable property</strong>. The first is welcome in a pension; the second triggers punitive tax charges. This is where most misconceptions live — including the popular belief that CGT-free Sovereigns belong in a SIPP. They don't.</p>
+        <div class="sipp-rules">
+          <div class="sipp-rule is-yes">
+            <span class="sipp-rule__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg></span>
+            <div>
+              <div class="sipp-rule__h"><h3>Investment-grade gold bars</h3><span class="sipp-rule__badge">Permitted</span></div>
+              <p>Bars of at least <strong>995 fineness (99.5% pure)</strong> from an LBMA-approved refiner, in weights accepted by the bullion market (1&nbsp;g up to 400&nbsp;oz Good Delivery). Must be held in an approved vault — no personal possession.</p>
+            </div>
+          </div>
+          <div class="sipp-rule is-yes">
+            <span class="sipp-rule__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg></span>
+            <div>
+              <div class="sipp-rule__h"><h3>Gold ETCs &amp; ETFs</h3><span class="sipp-rule__badge">Permitted · easiest</span></div>
+              <p>Physically-backed trackers — iShares (SGLN/IGLN), Invesco (SGLD), WisdomTree (PHAU) — count as ordinary securities. Buy them in any share-dealing SIPP. This is the route most investors should take.</p>
+            </div>
+          </div>
+          <div class="sipp-rule is-yes">
+            <span class="sipp-rule__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg></span>
+            <div>
+              <div class="sipp-rule__h"><h3>Gold mining shares &amp; funds</h3><span class="sipp-rule__badge">Permitted</span></div>
+              <p>Listed miners, royalty companies and gold-equity funds are standard securities. They add operational leverage to the gold price — and company-specific risk along with it.</p>
+            </div>
+          </div>
+          <div class="sipp-rule is-no">
+            <span class="sipp-rule__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg></span>
+            <div>
+              <div class="sipp-rule__h"><h3>Gold coins (Sovereigns, Britannias, Krugerrands)</h3><span class="sipp-rule__badge">Not eligible</span></div>
+              <p>Coins are tangible moveable property for pension purposes, so they cannot go in a SIPP — even the CGT-exempt British coins. Hold these personally instead, where their CGT exemption actually applies.</p>
+            </div>
+          </div>
+          <div class="sipp-rule is-no">
+            <span class="sipp-rule__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M18 6L6 18M6 6l12 12"/></svg></span>
+            <div>
+              <div class="sipp-rule__h"><h3>Jewellery &amp; collectibles</h3><span class="sipp-rule__badge">Not eligible</span></div>
+              <p>Gold jewellery, numismatic and collectible pieces are excluded from SIPPs entirely as tangible moveable property.</p>
+            </div>
+          </div>
+        </div>
+        <div class="sipp-callout">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 16v-4M12 8h.01"/></svg>
+          <div>
+            <h3>The common mistake</h3>
+            <p>Because Gold Sovereigns and Britannias are CGT-free as UK legal tender, people assume they're the obvious pension gold. The opposite is true: their tax advantage is wasted inside a SIPP (every withdrawal is taxed as income anyway), and they're not even eligible. Keep coins personal; use bars or an ETC inside the pension.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="provider" class="sipp-section">
+        <div class="sipp-kicker"><span class="sipp-kicker__num">04</span><span class="sipp-kicker__rule"></span></div>
+        <h2>Choosing the right SIPP provider</h2>
+        <p>Your route to gold dictates the provider you need — and the fees you'll pay.</p>
+        <div class="sipp-split">
+          <div class="sipp-splitcard">
+            <span class="sipp-splitcard__tag">Easiest · lowest cost</span>
+            <div class="sipp-splitcard__h">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
+              <h3>Gold ETC route</h3>
+            </div>
+            <ul>
+              <li>Any mainstream share-dealing SIPP — Hargreaves Lansdown, AJ Bell, Interactive Investor, Fidelity, Vanguard.</li>
+              <li>Buy a physically-backed gold ETC like any share; typical platform fees of 0.15–0.45% a year.</li>
+              <li>Instant dealing, tight spreads and full liquidity, with no separate storage contract.</li>
+            </ul>
+          </div>
+          <div class="sipp-splitcard">
+            <span class="sipp-splitcard__tag">Specialist · physical metal</span>
+            <div class="sipp-splitcard__h">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="8" width="18" height="11" rx="1.5"/><path d="M7 8V6a5 5 0 0 1 10 0v2"/></svg>
+              <h3>Physical bullion route</h3>
+            </div>
+            <ul>
+              <li>A full SIPP from a specialist trustee that permits allocated bullion — often via BullionVault or The Royal Mint.</li>
+              <li>You own specific, segregated bars in an approved vault; expect £200–£500 a year admin plus 0.12–0.5% storage.</li>
+              <li>Best for larger holdings where owning the metal directly matters more than minimising cost.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="limits" class="sipp-section">
+        <div class="sipp-kicker"><span class="sipp-kicker__num">05</span><span class="sipp-kicker__rule"></span></div>
+        <h2>Allowances, limits &amp; getting money out</h2>
+        <h3>How much you can put in</h3>
+        <p>The <strong>Annual Allowance for 2025–26 is £60,000</strong>, or 100% of your earned income if lower, across every pension you hold. Basic-rate relief is added at source; higher and additional-rate taxpayers claim the rest via Self Assessment. Two traps to watch:</p>
+        <ul>
+          <li><strong>Money Purchase Annual Allowance (MPAA):</strong> once you've flexibly accessed pension income, your allowance for defined-contribution pensions drops to <strong>£10,000</strong> a year.</li>
+          <li><strong>Tapered allowance:</strong> very high earners see the £60,000 taper down, potentially as low as £10,000.</li>
+        </ul>
+        <h3>How money comes out</h3>
+        <p>You can't withdraw gold in kind. To take benefits, the gold or ETC is sold and the proceeds drawn as pension income — normally <strong>25% tax-free</strong> from age 57 (from 2028), with the rest taxed at your marginal rate. Because everything is taxed as income on the way out, the personal CGT exemption on Sovereigns and Britannias gives you nothing inside a pension — another reason to hold coins outside it.</p>
+        <p>Physical gold must stay in an HMRC-approved depository — typically LBMA-member vaults such as the Royal Mint Vault, Brink's or Malca-Amit. The metal is allocated to you specifically, but you have no right to take possession while it's inside the wrapper.</p>
+      </section>
+
+      <section id="compare" class="sipp-section">
+        <div class="sipp-kicker"><span class="sipp-kicker__num">06</span><span class="sipp-kicker__rule"></span></div>
+        <h2>SIPP vs ISA vs personal holding</h2>
+        <p>Each wrapper trades flexibility against tax efficiency. For gold specifically:</p>
+        <div class="sipp-tablewrap">
+          <table class="sipp-table" aria-label="Gold tax wrapper comparison">
+            <thead><tr><th>Wrapper</th><th>Relief going in?</th><th>CGT on gains?</th><th>Physical gold?</th><th>Annual limit</th></tr></thead>
+            <tbody>
+              <tr><td>Personal (CGT-exempt coins)</td><td class="sipp-no">No</td><td class="sipp-yes">Exempt*</td><td class="sipp-yes">Yes</td><td>Unlimited</td></tr>
+              <tr><td>Stocks &amp; Shares ISA (gold ETC)</td><td class="sipp-no">No</td><td class="sipp-yes">Exempt</td><td class="sipp-no">No</td><td>£20,000</td></tr>
+              <tr><td>SIPP (gold ETC or bars)</td><td class="sipp-yes">Yes, 20–45%</td><td class="sipp-yes">Exempt</td><td class="sipp-yes">Bars only</td><td>£60,000</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p style="font-size:var(--text-xs);color:var(--color-text-muted);margin-top:var(--space-3)">*CGT exemption applies to UK legal-tender coins such as Gold Sovereigns and Britannias when held personally.</p>
+      </section>
+
+      <section id="risks" class="sipp-section">
+        <div class="sipp-kicker"><span class="sipp-kicker__num">07</span><span class="sipp-kicker__rule"></span></div>
+        <h2>Risks to weigh first</h2>
+        <div class="sipp-callout">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg>
+          <div>
+            <h3>Gold is a long-term hedge, not a guarantee</h3>
+            <p>Gold pays no income, so a pension weighted heavily towards it relies entirely on price appreciation. The price is volatile in the short term, physical storage adds an ongoing drag, and your money is locked away until at least age 57. Most advisers treat gold as a 5–15% diversifier within a broader pension, not the core holding.</p>
+          </div>
+        </div>
+      </section>
+
+      <div class="sipp-cta">
+        <h2>Track the live gold price in GBP</h2>
+        <p>See today's spot price in pounds before you decide how much to contribute — refreshed every 60 seconds.</p>
+        <a href="/18k-gold-price-in-gbp" class="sipp-cta__btn">View live GBP gold prices <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+      </div>
+
+      <section id="faq" class="sipp-section">
+        <div class="sipp-kicker"><span class="sipp-kicker__num">08</span><span class="sipp-kicker__rule"></span></div>
+        <h2>Frequently asked questions</h2>
+        <div class="sipp-faq">
+          <details>
+            <summary>Can I hold physical gold in a SIPP? <svg class="sipp-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="sipp-faq__a">Yes, but only <span class="sipp-hl">investment-grade gold bars</span> of at least 995 fineness (99.5% pure) in bullion-market-accepted weights, held through a specialist full SIPP with HMRC-approved vault storage. You can never take personal possession while the gold is inside the pension. Gold coins and jewellery do not qualify. For most investors the simplest route is a physically-backed gold ETC, which any share-dealing SIPP can hold.</div>
+          </details>
+          <details>
+            <summary>Are gold ETFs and ETCs allowed in a SIPP? <svg class="sipp-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="sipp-faq__a">Yes. Physically-backed gold ETCs such as iShares Physical Gold (SGLN/IGLN), Invesco Physical Gold (SGLD) and WisdomTree Physical Gold (PHAU) are treated as exchange-traded securities and are permitted in any SIPP that allows share dealing. You get full gold price exposure with pension tax relief on contributions and no Capital Gains Tax inside the wrapper.</div>
+          </details>
+          <details>
+            <summary>Can I hold Gold Sovereigns or Britannias in a SIPP? <svg class="sipp-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="sipp-faq__a">No. Even though Sovereigns and Britannias are Capital Gains Tax-exempt as UK legal tender when held personally, gold coins are classed as <span class="sipp-hl">tangible moveable property</span> for pension purposes and are not eligible for a SIPP. Only investment-grade gold bars qualify for physical holding. If you want coins, hold them outside your pension.</div>
+          </details>
+          <details>
+            <summary>What is the tax benefit of holding gold in a SIPP? <svg class="sipp-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="sipp-faq__a">Contributions receive tax relief at your marginal rate — 20% basic, 40% higher or 45% additional. A basic-rate taxpayer effectively buys £1,000 of gold for £800; a higher-rate taxpayer for £600. Gains inside the SIPP are free of Capital Gains Tax. On withdrawal (from age 57 from 2028) 25% is normally tax-free, with the rest taxed as income.</div>
+          </details>
+          <details>
+            <summary>Which SIPP providers allow gold? <svg class="sipp-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="sipp-faq__a">Mainstream platforms such as Hargreaves Lansdown, AJ Bell, Interactive Investor, Fidelity and Vanguard allow gold ETCs through standard share dealing. For physical gold bars you need a specialist full SIPP that offers approved bullion storage (often via partners such as BullionVault or The Royal Mint), which carries higher administration fees of roughly £200–£500 a year.</div>
+          </details>
+          <details>
+            <summary>How much can I contribute to a SIPP each year? <svg class="sipp-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="sipp-faq__a">The Annual Allowance for 2025–26 is £60,000, or 100% of your earned income if lower, across all your pensions. High earners may have a tapered allowance, and anyone who has flexibly accessed pension income is limited by the £10,000 Money Purchase Annual Allowance (MPAA).</div>
+          </details>
+        </div>
+      </section>
+    </div><!-- /.sipp-prose -->
+  </div><!-- /.sipp-layout -->
+
+  <!-- ===== RELATED ===== -->
+  <section class="sipp-related">
+    <h2>Related reading</h2>
+    <div class="sipp-related-grid">
+      <a href="/blog/gold-etf-vs-physical-gold-uk" class="sipp-rcard"><span class="sipp-rcard__tag">Article</span><span class="sipp-rcard__title">Gold ETF vs Physical Gold (UK)</span><span class="sipp-rcard__desc">ETC or bullion? The comparison that decides your SIPP route.</span></a>
+      <a href="/blog/uk-gold-cgt-guide" class="sipp-rcard"><span class="sipp-rcard__tag">Article</span><span class="sipp-rcard__title">UK Gold &amp; Capital Gains Tax</span><span class="sipp-rcard__desc">How CGT hits gold outside a pension — and why SIPPs sidestep it.</span></a>
+      <a href="/blog/best-uk-gold-dealers-2026" class="sipp-rcard"><span class="sipp-rcard__tag">Article</span><span class="sipp-rcard__title">Best UK Gold Dealers 2026</span><span class="sipp-rcard__desc">Where to buy bars and ETCs at the keenest premiums.</span></a>
+      <a href="/guides/how-to-invest-in-gold" class="sipp-rcard"><span class="sipp-rcard__tag">Guide</span><span class="sipp-rcard__title">How to Invest in Gold (UK)</span><span class="sipp-rcard__desc">Every route into gold — ETFs, coins, bars and pensions.</span></a>
+      <a href="/guides/gold-vs-silver-investment" class="sipp-rcard"><span class="sipp-rcard__tag">Guide</span><span class="sipp-rcard__title">Gold vs Silver Investment</span><span class="sipp-rcard__desc">Which metal makes the better long-term pension hedge?</span></a>
+      <a href="/18k-gold-price-in-gbp" class="sipp-rcard"><span class="sipp-rcard__tag">Live Price</span><span class="sipp-rcard__title">Live Gold Price in GBP</span><span class="sipp-rcard__desc">Today's spot price in pounds — the benchmark for any decision.</span></a>
     </div>
-  </div>
-</section>
+  </section>
 
 </article>
+</main>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">
@@ -750,4 +1208,146 @@ loadTicker();setInterval(loadTicker,60000);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
 })();</script>
+<script id="sipp-calc-js">
+(function(){
+  "use strict";
+  var TROY = 31.1035;
+  var GOLD_API = 'https://api.gold-api.com/price/XAU';
+  var FX_API = 'https://api.frankfurter.dev/v1/latest?from=USD&to=GBP';
+  var spotUSD = 0;        // USD per troy oz
+  var gbpRate = 0.79;     // GBP per 1 USD (ECB fallback)
+  var lastUpdated = 0;
+  var hasData = false;
+
+  var $ = function(id){ return document.getElementById(id); };
+
+  // Spot/FX values keep pennies under £1,000, whole units above.
+  function fmtSpot(sym, v){
+    var dp = v >= 1000 ? 0 : 2;
+    return sym + v.toLocaleString('en-GB', {minimumFractionDigits:dp, maximumFractionDigits:dp});
+  }
+  // Contribution amounts read cleanest as whole pounds/dollars.
+  function gbp(v){ return '£' + Math.round(v).toLocaleString('en-GB'); }
+  function usd(v){ return '$' + Math.round(v).toLocaleString('en-US'); }
+
+  function activeRate(){
+    var b = document.querySelector('.sipp-band[aria-pressed="true"]') || document.querySelector('.sipp-band');
+    return b ? (parseFloat(b.getAttribute('data-rate')) || 20) : 20;
+  }
+
+  function render(){
+    // ---- Live spot bar (independent of the contribution inputs) ----
+    if(spotUSD){
+      var ozGBP = spotUSD * gbpRate;
+      var gramGBP = (spotUSD / TROY) * gbpRate;
+      var ozEl = $('sipp-spot-oz');
+      if(ozEl){ ozEl.innerHTML = fmtSpot('£', ozGBP) + '<span class="sipp-usd">' + fmtSpot('$', spotUSD) + '</span>'; }
+      if($('sipp-spot-g')){ $('sipp-spot-g').textContent = fmtSpot('£', gramGBP); }
+      if($('sipp-fx')){ $('sipp-fx').textContent = '£1 = ' + fmtSpot('$', (1 / gbpRate)); }
+    }
+
+    // ---- Contribution + tax relief ----
+    var contribEl = $('sipp-contrib');
+    if(!contribEl){ return; }
+    var net = parseFloat(contribEl.value);
+    if(isNaN(net) || net < 0){ net = 0; }
+    var rate = activeRate();
+    var gross = net / 0.8;                 // 20% relief at source grosses up the pot
+    var extraRate = (rate - 20) / 100;     // higher/additional rate reclaimed via SA
+    var extraRelief = gross * extraRate;
+    var totalRelief = (gross - net) + extraRelief;
+    var realCost = net - extraRelief;
+
+    if($('sipp-gross')){
+      $('sipp-gross').innerHTML = gbp(gross) +
+        '<span class="sipp-usd" id="sipp-gross-usd">' + (spotUSD ? usd(gross / gbpRate) + ' USD' : '$—') + '</span>';
+    }
+    if($('sipp-cost')){ $('sipp-cost').textContent = gbp(realCost); }
+    if($('sipp-relief')){ $('sipp-relief').textContent = (totalRelief > 0 ? '+' : '') + gbp(totalRelief); }
+    if($('sipp-disc-pct')){ $('sipp-disc-pct').textContent = rate + '%'; }
+
+    var gramsEl = $('sipp-grams');
+    if(gramsEl){
+      if(spotUSD && gross > 0){
+        var gramGBP2 = (spotUSD / TROY) * gbpRate;
+        var grams = gross / gramGBP2;
+        var oz = grams / TROY;
+        gramsEl.textContent = "≈ " + grams.toLocaleString('en-GB', {maximumFractionDigits:1}) +
+          " g of investment-grade gold · " + oz.toLocaleString('en-GB', {maximumFractionDigits:2}) +
+          " oz at today's spot";
+      } else if(spotUSD){
+        gramsEl.textContent = "Enter a contribution to see the gold it buys.";
+      }
+    }
+  }
+
+  function tickAgo(){
+    var el = $('sipp-updated');
+    if(!el || !hasData){ return; }
+    var s = Math.round((Date.now() - lastUpdated) / 1000);
+    var ago = s < 5 ? 'just now' : (s < 60 ? s + 's ago' : Math.round(s/60) + 'm ago');
+    el.textContent = 'Live · updated ' + ago + ' · gold-api.com + ECB FX';
+  }
+
+  function fetchFx(){
+    return fetch(FX_API, {cache:'no-store'})
+      .then(function(r){ if(!r.ok){ throw new Error(); } return r.json(); })
+      .then(function(d){ if(d && d.rates && d.rates.GBP){ gbpRate = d.rates.GBP; } })
+      .catch(function(){ /* keep ECB fallback */ });
+  }
+  function fetchSpot(){
+    return fetch(GOLD_API, {cache:'no-store'})
+      .then(function(r){ if(!r.ok){ throw new Error(); } return r.json(); })
+      .then(function(d){
+        if(d && typeof d.price === 'number'){
+          spotUSD = d.price; hasData = true; lastUpdated = Date.now();
+          render(); tickAgo();
+        }
+      })
+      .catch(function(){
+        var el = $('sipp-updated');
+        if(el && !hasData){ el.textContent = 'Live price temporarily unavailable — retrying…'; }
+      });
+  }
+  function refresh(){ Promise.all([fetchFx(), fetchSpot()]); }
+
+  // ---- Tax band selection ----
+  document.querySelectorAll('.sipp-band').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      document.querySelectorAll('.sipp-band').forEach(function(b){ b.setAttribute('aria-pressed','false'); });
+      btn.setAttribute('aria-pressed','true');
+      render();
+    });
+  });
+  // ---- Quick-amount presets ----
+  document.querySelectorAll('.sipp-preset').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      var c = $('sipp-contrib');
+      if(c){ c.value = btn.getAttribute('data-amt'); render(); }
+    });
+  });
+  // ---- Contribution input ----
+  if($('sipp-contrib')){ $('sipp-contrib').addEventListener('input', render); }
+
+  // ---- Kick off (render immediately with fallback FX, then go live) ----
+  render();
+  refresh();
+  setInterval(refresh, 60000);
+  setInterval(tickAgo, 1000);
+
+  // ---- TOC active-section highlight ----
+  var tocLinks = Array.prototype.slice.call(document.querySelectorAll('.sipp-toc__list a'));
+  var sections = tocLinks.map(function(a){ return document.getElementById(a.getAttribute('href').slice(1)); }).filter(Boolean);
+  if('IntersectionObserver' in window && sections.length){
+    var spy = new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(e.isIntersecting){
+          tocLinks.forEach(function(l){ l.classList.toggle('is-active', l.getAttribute('href') === '#' + e.target.id); });
+        }
+      });
+    }, {rootMargin:'-40% 0px -55% 0px', threshold:0});
+    sections.forEach(function(s){ spy.observe(s); });
+  }
+})();
+</script>
 </body></html>


### PR DESCRIPTION
## Summary

Redesigns **`/blog/gold-in-a-sipp-uk`** from a plain prose article into a premium, **mobile-first** editorial page that matches the site's redesigned-blog system (Royal Mint / Silver Coins), scaling cleanly from 393px to desktop. Built with the `ui-ux-pro-max` design intelligence and namespaced under `.sipp-*` so it's fully self-contained.

## What changed

**Design (mobile-first → scales to any device)**
- Hero: serif display H1 with gold emphasis, key-fact stat strip (Tax relief up to 45% · AA £60,000 · CGT 0% · 25% tax-free), byline, and a sticky **scrollspy table of contents** (collapses to an accordion on mobile).
- New **live "SIPP gold & tax-relief calculator"**: enter a contribution + tax band → grossed-up pot, **grams/oz of investment-grade gold at the live spot price**, real cost after relief, and the effective discount. Quick-amount presets + segmented band selector.
- Permitted/not-permitted rule cards, two-route provider split (ETC vs physical bullion), restyled comparison table, risks callout, gold CTA, and a FAQ accordion.

**Live-data accuracy (consistent across the site)**
- Reuses the exact site mechanism: `gold-api.com` XAU spot (USD/oz, `TROY 31.1035`) converted to GBP via `frankfurter.dev` ECB rates (fallback `0.79`), refreshed every **60s** — identical to the rest of the site so prices match everywhere.
- **GBP £ primary with the USD $ benchmark shown for reference.** GBP is the appropriate primary currency here because the topic is a UK pension (tax relief, £60k Annual Allowance, MPAA are GBP figures where USD would confuse) — matching the Royal Mint redesign precedent. The site-wide live ticker remains in USD.
- Calculator math verified: £800 → £1,000 pot (20%, real cost £800); £800 → real cost £600 at 40%; £48,000 → £60,000 at 45% (aligns with the Annual Allowance).

**Content accuracy & SEO**
- Corrects an internal contradiction in the old copy: **investment-grade gold bars (≥995) are eligible** via a specialist SIPP; **gold coins are not** (tangible moveable property — even CGT-exempt Sovereigns/Britannias). ETCs and mining shares permitted.
- FAQ expanded to **6 Q&As, kept word-for-word in sync with the FAQPage JSON-LD**. `dateModified` bumped to 2026-06-16.
- Removed a leftover/incorrect **duplicate breadcrumb** ("Gold & Silver Price Outlook"), added semantic `<main>`, and loads Playfair Display.

## Verification
- ✅ `node scripts/validate-jsonld.js` passes (BlogPosting + BreadcrumbList + FAQPage).
- ✅ Playwright audit (per `DEVELOPMENT_RULES.md`): **no horizontal overflow** on iPhone 14 Pro (393px) or desktop (1440px); balanced `main`/`article` structure; all 8 TOC anchors resolve; no stray text nodes; no 4xx/5xx. (Console/network errors in the audit are external domains blocked by the offline sandbox — Google Fonts, analytics, gold/FX APIs, logo CDN — all degrade gracefully.)
- ✅ Reviewed rendered strips on desktop and mobile (hero, calculator, rule cards, table, FAQ, related).

⚠️ Educational/reference content, not financial advice (disclaimer retained in-page).

https://claude.ai/code/session_01KihmyRWYWAgUJ5Y7LoAvBm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KihmyRWYWAgUJ5Y7LoAvBm)_