### PR TITLE
Redesign: Understanding Gold Karat Purities (editorial layout + live USD karat valuation)

### DIFF
--- a/blog/understanding-gold-karat-purities/index.html
+++ b/blog/understanding-gold-karat-purities/index.html
@@ -7,17 +7,17 @@
 </script>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Gold Karat Purities: 9K to 24K Explained | GoldPriceTools</title>
-<meta name="description" content="What does 9K, 10K, 14K, 18K, 22K or 24K gold mean? This guide explains every common gold karat, its hallmark, purity percentage, and melt value calculation.">
+<meta name="description" content="What do 9K, 10K, 14K, 18K, 22K &amp; 24K gold mean? Purity %, hallmarks, colours and live melt value per gram in USD for every karat — updated every 60 seconds.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://goldpricetools.com/blog/understanding-gold-karat-purities/">
-<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/blog/understanding-gold-karat-purities/">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/blog/understanding-gold-karat-purities/">
+<link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/blog/understanding-gold-karat-purities/">
 <link rel="alternate" hreflang="x-default" href="https://goldpricetools.com/blog/understanding-gold-karat-purities/">
 <link rel="manifest" href="/manifest.json">
 <link rel="icon" type="image/svg+xml" href="https://assets.goldpricetools.com/logo.svg">
 <meta name="theme-color" content="#0f0e0c">
 <meta property="og:title" content="Gold Karat Purities: 9K to 24K Explained | GoldPriceTools">
-<meta property="og:description" content="What does 9K, 10K, 14K, 18K, 22K or 24K gold mean? Every common gold karat, its hallmark, purity percentage, and melt value calculation.">
+<meta property="og:description" content="Every common gold karat explained — purity %, hallmark, typical colour, and live melt value per gram in USD. 9K, 10K, 14K, 18K, 22K and 24K.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://goldpricetools.com/blog/understanding-gold-karat-purities/">
 <meta property="og:site_name" content="GoldPriceTools">
@@ -29,10 +29,10 @@
   "@context": "https://schema.org",
   "@type": "BlogPosting",
   "headline": "Understanding Gold Karat Purities: 9K to 24K Explained",
-  "description": "What does 9K, 10K, 14K, 18K, 22K or 24K gold mean? Every common gold karat, its hallmark, purity percentage, and melt value calculation.",
+  "description": "Every common gold karat explained — purity percentage, hallmark fineness, typical colour, and how to calculate live melt value per gram in USD.",
   "url": "https://goldpricetools.com/blog/understanding-gold-karat-purities/",
   "datePublished": "2026-04-30T08:00:00Z",
-  "dateModified": "2026-05-02T06:00:00Z",
+  "dateModified": "2026-06-16T06:00:00Z",
   "author": {
     "@type": "Organization",
     "name": "GoldPriceTools Editorial Team",
@@ -57,10 +57,66 @@
     "width": 1200,
     "height": 630
   },
-  "wordCount": 1847
+  "wordCount": 2250
 }
 </script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://goldpricetools.com/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https://goldpricetools.com/blog/"},{"@type":"ListItem","position":3,"name":"Understanding Gold Karat Purities"}]}</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the purest gold karat?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "24 karat (24K) is the purest gold, at 99.9% pure, stamped 999 (or 999.9 for 'four nines fine'). Because pure gold is very soft it is used mainly for investment bullion bars and coins rather than everyday jewellery."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which gold karat is best for jewellery?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It depends on the balance you want between gold content and durability. 18K (75% gold) is the global standard for fine jewellery and luxury watches; 14K (58.33%) is the most popular everyday alloy in the United States; 22K (91.67%) is favoured for South Asian bridal gold; and 9K (37.5%) is the affordable, hard-wearing standard in the UK and Australia."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What does the 750, 585 or 375 stamp on gold mean?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Those numbers are the millesimal fineness — the parts of gold per 1,000. 750 = 18K (75%), 585 = 14K (58.33%), 375 = 9K (37.5%), 417 = 10K (41.67%), 916 = 22K (91.67%) and 999 = 24K (99.9%)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I calculate the melt value of gold?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Take the live 24K gold price per gram (the USD spot price per troy ounce divided by 31.1035), multiply it by the karat's purity factor (0.999 for 24K, 0.9167 for 22K, 0.75 for 18K, 0.5833 for 14K, 0.4167 for 10K, 0.375 for 9K), then multiply by the item's weight in grams. GoldPriceTools does this automatically in USD for every karat."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is higher karat gold always more valuable?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Per gram, yes — more gold means more intrinsic melt value, so 24K is worth more than 18K, which is worth more than 9K at the same weight. But higher karat gold is softer and less hard-wearing, and a finished piece's retail price also reflects design and making charges, not just metal content."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between karat and carat?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Karat (K) measures gold purity in parts out of 24, so 18K is 75% pure. Carat (ct) is a unit of weight for gemstones, where 1 carat = 0.2 grams. In British English 'carat' is also used for gold purity, meaning exactly the same as 'karat'; the spelling 'K' is the global standard for bullion and jewellery to avoid confusion with gemstone weight."
+      }
+    }
+  ]
+}
+</script>
 <script>
   window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}
   gtag('consent','default',{'ad_storage':'denied','analytics_storage':'denied','ad_user_data':'denied','ad_personalization':'denied','wait_for_update':500});
@@ -72,7 +128,9 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8849494330640880" crossorigin="anonymous"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=Inter:wght@300..700&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.gold-api.com">
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
 <style>
 
 /* ── Guides mega panel — category links ── */
@@ -389,7 +447,276 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 .article-card:hover .article-card-title{color:var(--color-primary)}
 
 </style>
-<style id="gpt-h1-fix">h1.article-title{font-family:var(--font-display);font-size:clamp(1.75rem,3.5vw,2.75rem);font-weight:700;line-height:1.15;margin:var(--space-2) 0 var(--space-5);color:var(--color-text)}</style>
+<style id="kg-redesign">
+/* ============================================================
+   Understanding Gold Karat Purities — editorial redesign
+   Namespaced .kg-*  ·  Mobile-first  ·  Uses site design tokens
+   (light + dark both work)  ·  USD primary currency
+   ============================================================ */
+:root{--font-serif:'Playfair Display',Georgia,'Times New Roman',serif}
+
+/* ---- Breadcrumb (not defined site-wide — scoped here) ---- */
+.breadcrumb-wrap{max-width:1180px;margin:0 auto;padding:var(--space-4) var(--space-4) 0}
+.breadcrumb{list-style:none;display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2);font-size:var(--text-xs);color:var(--color-text-muted)}
+.breadcrumb li{display:flex;align-items:center;gap:var(--space-2)}
+.breadcrumb li:not(:last-child)::after{content:'';width:5px;height:5px;border-right:1.5px solid var(--color-text-faint);border-bottom:1.5px solid var(--color-text-faint);transform:rotate(-45deg);margin-left:var(--space-1)}
+.breadcrumb a{color:var(--color-text-muted)}
+.breadcrumb a:hover{color:var(--color-gold-bright);text-decoration:none}
+.breadcrumb [aria-current="page"]{color:var(--color-text);font-weight:600}
+
+/* ---- Shell ---- */
+.kg-article{max-width:1180px;margin:0 auto;padding:0 var(--space-4) var(--space-16)}
+.kg-section{scroll-margin-top:96px}
+
+/* ---- Hero ---- */
+.kg-hero{position:relative;padding:var(--space-8) 0 var(--space-6);border-bottom:1px solid var(--color-divider);margin-bottom:var(--space-8)}
+.kg-eyebrow{display:inline-flex;align-items:center;gap:var(--space-2);font-family:var(--font-body);font-size:var(--text-xs);font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--color-gold-bright);margin-bottom:var(--space-5)}
+.kg-eyebrow::before{content:'';width:22px;height:1.5px;background:var(--color-gold-bright)}
+.kg-hero__title{font-family:var(--font-serif);font-weight:700;font-size:clamp(2rem,5vw + .4rem,3.6rem);line-height:1.05;letter-spacing:-.015em;color:var(--color-text);margin:0 0 var(--space-5);max-width:20ch;text-wrap:balance}
+.kg-hero__title em{font-style:italic;color:var(--color-gold-bright)}
+.kg-hero__dek{font-size:clamp(1.05rem,.6vw + .95rem,1.28rem);line-height:1.6;color:var(--color-text-muted);max-width:64ch;margin:0 0 var(--space-6)}
+.kg-byline{display:flex;flex-wrap:wrap;align-items:center;gap:var(--space-2) var(--space-3);font-size:var(--text-sm);color:var(--color-text-muted)}
+.kg-byline a{color:var(--color-text);font-weight:600}
+.kg-byline a:hover{color:var(--color-gold-bright);text-decoration:none}
+.kg-dot{width:3px;height:3px;border-radius:50%;background:var(--color-text-faint)}
+.kg-read{display:inline-flex;align-items:center;gap:6px}
+
+/* ---- Key facts strip ---- */
+.kg-keyfacts{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin-top:var(--space-8)}
+.kg-keyfact{display:flex;gap:var(--space-3);align-items:flex-start;padding:var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.kg-keyfact svg{flex-shrink:0;width:22px;height:22px;color:var(--color-gold-bright)}
+.kg-keyfact dt{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:2px}
+.kg-keyfact dd{font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0;line-height:1.2;font-variant-numeric:tabular-nums}
+
+/* ============================================================
+   LIVE KARAT VALUE MATRIX — the centrepiece
+   ============================================================ */
+.kg-matrix{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-md);margin-bottom:var(--space-8)}
+.kg-matrix__head{padding:var(--space-5);border-bottom:1px solid var(--color-divider);background:linear-gradient(180deg,color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface)),var(--color-surface));display:flex;flex-wrap:wrap;align-items:flex-end;justify-content:space-between;gap:var(--space-4)}
+.kg-matrix__eyebrow{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.kg-matrix__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:0 0 var(--space-1)}
+.kg-matrix__sub{font-size:var(--text-xs);color:var(--color-text-muted);margin:0}
+.kg-matrix__sub strong{color:var(--color-text);font-weight:700}
+
+/* Currency segmented control */
+.kg-curswitch{display:inline-flex;background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-full);padding:3px;gap:2px}
+.kg-curswitch__btn{min-height:36px;padding:6px var(--space-4);font-size:var(--text-xs);font-weight:700;color:var(--color-text-muted);border-radius:var(--radius-full);cursor:pointer;transition:color var(--transition),background var(--transition);letter-spacing:.04em}
+.kg-curswitch__btn:hover{color:var(--color-text)}
+.kg-curswitch__btn[aria-pressed="true"]{background:linear-gradient(135deg,var(--color-gold),var(--color-gold-bright));color:#1a1306}
+
+/* Live spot bar */
+.kg-spotbar{display:grid;grid-template-columns:1fr;gap:var(--space-3);padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--color-divider);background:var(--color-surface-offset)}
+.kg-spot{display:flex;align-items:baseline;justify-content:space-between;gap:var(--space-3)}
+.kg-spot__k{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.06em}
+.kg-spot__v{font-size:var(--text-base);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+
+/* Karat rows */
+.kg-rows{padding:var(--space-2) var(--space-2) var(--space-3)}
+.kg-krow{display:grid;grid-template-columns:64px 1fr auto;gap:var(--space-3);align-items:center;padding:var(--space-3);border-radius:var(--radius-lg);text-decoration:none;transition:background var(--transition)}
+.kg-krow:hover{background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface));text-decoration:none}
+.kg-krow__id{display:flex;flex-direction:column;gap:3px}
+.kg-krow__k{display:inline-flex;align-items:center;gap:6px;font-family:var(--font-display);font-size:var(--text-base);font-weight:800;color:var(--color-text);line-height:1}
+.kg-swatch{width:12px;height:12px;border-radius:50%;flex-shrink:0;box-shadow:inset 0 0 0 1px rgba(0,0,0,.18)}
+.kg-sw-24k{background:linear-gradient(135deg,#ffd24a,#e6a700)}
+.kg-sw-22k{background:linear-gradient(135deg,#ffcb3d,#e0a100)}
+.kg-sw-18k{background:linear-gradient(135deg,#f7c948,#d99a00)}
+.kg-sw-14k{background:linear-gradient(135deg,#f2d585,#d9b24a)}
+.kg-sw-10k{background:linear-gradient(135deg,#edd9a0,#d3bb78)}
+.kg-sw-9k{background:linear-gradient(135deg,#ead9aa,#cdba80)}
+.kg-sw-white{background:linear-gradient(135deg,#f4f5f7,#c9ced6)}
+.kg-sw-rose{background:linear-gradient(135deg,#f4c0a8,#dd9270)}
+.kg-krow__fine{font-size:11px;font-weight:600;color:var(--color-text-faint);font-variant-numeric:tabular-nums;letter-spacing:.04em}
+.kg-krow__meter{display:flex;flex-direction:column;gap:5px;min-width:0}
+.kg-meter{display:block;height:8px;border-radius:var(--radius-full);background:var(--color-surface-dynamic);overflow:hidden}
+.kg-meter__fill{display:block;height:100%;min-width:6px;border-radius:var(--radius-full);background:linear-gradient(90deg,var(--color-gold),var(--color-gold-bright))}
+.kg-krow__pct{font-size:var(--text-xs);color:var(--color-text-muted);font-variant-numeric:tabular-nums}
+.kg-krow__pct strong{color:var(--color-text);font-weight:700}
+.kg-krow__val{text-align:right;white-space:nowrap}
+.kg-krow__price{display:block;font-size:var(--text-base);font-weight:800;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+.kg-krow__unit{display:block;margin-top:1px;font-size:10px;color:var(--color-text-faint);text-transform:uppercase;letter-spacing:.06em}
+.kg-matrix__foot{padding:var(--space-3) var(--space-5) var(--space-4);border-top:1px solid var(--color-divider);font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.6}
+
+/* ---- Layout: prose + sticky TOC ---- */
+.kg-layout{display:grid;grid-template-columns:1fr;gap:var(--space-8)}
+.kg-toc{order:-1}
+.kg-toc details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden}
+.kg-toc summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-2);padding:var(--space-4);font-family:var(--font-display);font-size:var(--text-sm);font-weight:700;color:var(--color-text);cursor:pointer;list-style:none}
+.kg-toc summary::-webkit-details-marker{display:none}
+.kg-toc__chev{transition:transform var(--transition);color:var(--color-text-muted)}
+.kg-toc details[open] summary .kg-toc__chev{transform:rotate(180deg)}
+.kg-toc__list{list-style:none;padding:0 var(--space-3) var(--space-3);margin:0;display:flex;flex-direction:column;gap:2px}
+.kg-toc__list a{display:block;padding:var(--space-2) var(--space-3);border-radius:var(--radius-md);font-size:var(--text-sm);color:var(--color-text-muted);border-left:2px solid transparent}
+.kg-toc__list a:hover{color:var(--color-text);background:var(--color-surface-offset);text-decoration:none}
+.kg-toc__list a.is-active{color:var(--color-gold-bright);border-left-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 7%,transparent);font-weight:600}
+
+/* ---- Prose ---- */
+.kg-prose{font-size:var(--text-base);color:var(--color-text);line-height:1.75;min-width:0}
+.kg-prose>section+section{margin-top:var(--space-12)}
+.kg-prose h2{font-family:var(--font-serif);font-weight:700;font-size:clamp(1.5rem,2.2vw + .6rem,2.05rem);line-height:1.15;letter-spacing:-.01em;color:var(--color-text);margin:0 0 var(--space-4)}
+.kg-prose h3{font-family:var(--font-display);font-weight:700;font-size:var(--text-lg);color:var(--color-text);margin:var(--space-6) 0 var(--space-2)}
+.kg-prose p{margin:0 0 var(--space-4);max-width:68ch}
+.kg-prose a{color:var(--color-primary);font-weight:600;text-decoration:underline;text-decoration-color:color-mix(in oklch,var(--color-primary) 40%,transparent);text-underline-offset:2px}
+.kg-prose a:hover{color:var(--color-primary-hover)}
+.kg-prose strong{color:var(--color-text);font-weight:700}
+.kg-prose ul{list-style:none;margin:0 0 var(--space-4);padding:0;display:flex;flex-direction:column;gap:var(--space-3)}
+.kg-prose ul li{position:relative;padding-left:var(--space-6);max-width:66ch;color:var(--color-text-muted)}
+.kg-prose ul li strong{color:var(--color-text)}
+.kg-prose ul li::before{content:'';position:absolute;left:2px;top:.62em;width:7px;height:7px;border-radius:1px;background:var(--color-gold-bright);transform:rotate(45deg)}
+.kg-lead{font-size:clamp(1.1rem,.5vw + 1rem,1.26rem)!important;line-height:1.62;color:var(--color-text)!important;max-width:64ch!important}
+.kg-lead::first-letter{float:left;font-family:var(--font-serif);font-weight:700;font-size:3.4em;line-height:.78;padding:.05em .12em 0 0;color:var(--color-gold-bright)}
+
+/* section kicker numerals */
+.kg-kicker{display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3)}
+.kg-kicker__num{font-family:var(--font-display);font-size:var(--text-xs);font-weight:700;letter-spacing:.1em;color:var(--color-gold-bright);padding:3px 9px;border:1px solid color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));border-radius:var(--radius-full);text-transform:uppercase}
+.kg-kicker__rule{flex:1;height:1px;background:var(--color-divider)}
+
+/* ---- Per-karat spec strip ---- */
+.kg-spec{display:flex;flex-wrap:wrap;gap:var(--space-2);margin:0 0 var(--space-4)}
+.kg-chip{display:inline-flex;align-items:center;gap:6px;padding:6px var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-full);font-size:var(--text-xs);font-weight:600;color:var(--color-text-muted);font-variant-numeric:tabular-nums}
+.kg-chip strong{color:var(--color-text);font-weight:700}
+.kg-chip--price{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border));background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface))}
+.kg-chip--price strong{color:var(--color-gold-bright)}
+.kg-chip__dot{width:9px;height:9px;border-radius:50%;box-shadow:inset 0 0 0 1px rgba(0,0,0,.18)}
+.kg-chip__live{width:6px;height:6px;border-radius:50%;background:var(--color-up);animation:pulse 2s ease-in-out infinite}
+
+/* ---- Premium reference table ---- */
+.kg-tablewrap{overflow-x:auto;-webkit-overflow-scrolling:touch;border:1px solid var(--color-border);border-radius:var(--radius-lg);margin:var(--space-2) 0 var(--space-4)}
+.kg-table{width:100%;border-collapse:collapse;min-width:620px;font-variant-numeric:tabular-nums}
+.kg-table th,.kg-table td{padding:var(--space-3) var(--space-4);text-align:left;font-size:var(--text-sm);border-bottom:1px solid var(--color-divider)}
+.kg-table thead th{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:.05em;color:var(--color-text-muted);font-weight:700;background:var(--color-surface-offset);white-space:nowrap}
+.kg-table th:not(:first-child),.kg-table td:not(:first-child){text-align:left}
+.kg-table .kg-table__num{text-align:right;color:var(--color-gold-bright);font-weight:700}
+.kg-table tbody tr:last-child td{border-bottom:none}
+.kg-table tbody tr:hover td{background:color-mix(in oklch,var(--color-gold-bright) 4%,var(--color-surface))}
+.kg-table td:first-child{font-weight:800;color:var(--color-text);font-family:var(--font-display)}
+.kg-table .kg-kbadge{display:inline-flex;align-items:center;gap:7px}
+
+/* ---- Formula display ---- */
+.kg-formula{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:var(--space-2) var(--space-3);padding:var(--space-5);background:var(--color-surface);border:1px dashed color-mix(in oklch,var(--color-gold-bright) 40%,var(--color-border));border-radius:var(--radius-lg);margin:var(--space-2) 0 var(--space-4);text-align:center}
+.kg-formula__part{font-family:var(--font-display);font-size:var(--text-sm);font-weight:600;color:var(--color-text);line-height:1.3}
+.kg-formula__part small{display:block;font-size:11px;font-weight:500;color:var(--color-text-muted);margin-top:2px}
+.kg-formula__op{font-size:var(--text-lg);font-weight:700;color:var(--color-gold-bright)}
+
+/* ---- Live melt-value calculator ---- */
+.kg-calc{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-md);margin:var(--space-4) 0}
+.kg-calc__head{padding:var(--space-5) var(--space-5) var(--space-4);border-bottom:1px solid var(--color-divider);background:linear-gradient(180deg,color-mix(in oklch,var(--color-gold-bright) 7%,var(--color-surface)),var(--color-surface))}
+.kg-calc__eyebrow{display:flex;align-items:center;gap:var(--space-2);font-size:var(--text-xs);font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--color-gold-bright);margin-bottom:var(--space-2)}
+.kg-calc__title{font-family:var(--font-display);font-size:var(--text-lg);font-weight:700;color:var(--color-text);margin:0}
+.kg-calc__body{padding:var(--space-5)}
+.kg-calc__controls{display:grid;grid-template-columns:1fr;gap:var(--space-5);margin-bottom:var(--space-5)}
+.kg-field-label{display:block;font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);margin-bottom:var(--space-2)}
+.kg-money{display:flex;align-items:center;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface-offset);overflow:hidden}
+.kg-money:focus-within{border-color:var(--color-primary)}
+.kg-money input{flex:1;width:100%;padding:var(--space-3) var(--space-4);border:none;background:none;font-size:var(--text-lg);font-weight:700;color:var(--color-text);-moz-appearance:textfield;font-variant-numeric:tabular-nums}
+.kg-money input::-webkit-outer-spin-button,.kg-money input::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
+.kg-money__sym{padding:0 var(--space-3) 0 var(--space-4);font-size:var(--text-sm);font-weight:700;color:var(--color-text-muted);white-space:nowrap}
+.kg-karatpick{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-2)}
+.kg-karatpick__btn{display:flex;flex-direction:column;align-items:center;gap:2px;padding:var(--space-3) var(--space-2);background:var(--color-surface-offset);border:1px solid var(--color-border);border-radius:var(--radius-md);font-size:var(--text-sm);font-weight:700;color:var(--color-text);cursor:pointer;transition:border-color var(--transition),background var(--transition)}
+.kg-karatpick__btn small{font-size:11px;font-weight:600;color:var(--color-text-muted)}
+.kg-karatpick__btn:hover{border-color:var(--color-gold-bright)}
+.kg-karatpick__btn[aria-pressed="true"]{border-color:var(--color-gold-bright);background:color-mix(in oklch,var(--color-gold-bright) 12%,var(--color-surface))}
+.kg-karatpick__btn[aria-pressed="true"] small{color:var(--color-gold-bright)}
+.kg-result{border:1px solid color-mix(in oklch,var(--color-gold-bright) 22%,var(--color-border));background:color-mix(in oklch,var(--color-gold-bright) 6%,var(--color-surface-offset));border-radius:var(--radius-lg);padding:var(--space-5)}
+.kg-result__label{font-size:var(--text-xs);font-weight:600;text-transform:uppercase;letter-spacing:.07em;color:var(--color-text-muted);margin-bottom:var(--space-1)}
+.kg-result__big{font-size:clamp(1.9rem,5vw,2.6rem);font-weight:800;line-height:1;color:var(--color-gold-bright);font-variant-numeric:tabular-nums;letter-spacing:-.02em}
+.kg-result__sub{font-size:var(--text-sm);font-weight:600;color:var(--color-text-muted);margin-top:var(--space-2);font-variant-numeric:tabular-nums}
+.kg-result__divider{height:1px;background:var(--color-divider);margin:var(--space-4) 0}
+.kg-result__grid{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3)}
+.kg-stat{display:flex;flex-direction:column;gap:2px}
+.kg-stat__k{font-size:var(--text-xs);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:.05em}
+.kg-stat__v{font-size:var(--text-lg);font-weight:700;color:var(--color-text);font-variant-numeric:tabular-nums}
+.kg-calc__note{font-size:var(--text-xs);color:var(--color-text-muted);margin:var(--space-4) 0 0;line-height:1.6;max-width:none}
+
+/* ---- Hallmark stamp grid ---- */
+.kg-hallmarks{display:grid;grid-template-columns:repeat(2,1fr);gap:var(--space-3);margin:var(--space-2) 0 var(--space-4)}
+.kg-stamp{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3) var(--space-4);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg)}
+.kg-stamp__oval{display:flex;align-items:center;justify-content:center;width:58px;height:38px;flex-shrink:0;border:2px solid var(--color-gold-bright);border-radius:50%;font-family:var(--font-display);font-weight:800;font-size:var(--text-sm);color:var(--color-gold-bright);font-variant-numeric:tabular-nums;background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface))}
+.kg-stamp__txt{display:flex;flex-direction:column;gap:1px}
+.kg-stamp__k{font-size:var(--text-sm);font-weight:700;color:var(--color-text)}
+.kg-stamp__d{font-size:var(--text-xs);color:var(--color-text-muted)}
+
+/* ---- Gold colour spectrum ---- */
+.kg-colors{display:grid;grid-template-columns:repeat(3,1fr);gap:var(--space-3);margin:var(--space-2) 0 var(--space-4)}
+.kg-color{padding:var(--space-3);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-align:center}
+.kg-color__sw{height:56px;border-radius:var(--radius-md);margin-bottom:var(--space-3);box-shadow:inset 0 0 0 1px rgba(0,0,0,.12)}
+.kg-color__n{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:2px}
+.kg-color__d{font-size:var(--text-xs);color:var(--color-text-muted);line-height:1.5}
+
+/* ---- Callouts ---- */
+.kg-callout{display:grid;grid-template-columns:auto 1fr;gap:var(--space-4);padding:var(--space-5);border-radius:var(--radius-lg);margin:var(--space-4) 0}
+.kg-callout svg{width:26px;height:26px;flex-shrink:0}
+.kg-callout h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0 0 var(--space-2)}
+.kg-callout p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.65;margin:0;max-width:none}
+.kg-callout p+p{margin-top:var(--space-2)}
+.kg-callout--info{background:color-mix(in oklch,var(--color-primary) 7%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-primary) 28%,var(--color-border))}
+.kg-callout--info svg{color:var(--color-primary)}
+.kg-callout--gold{background:color-mix(in oklch,var(--color-gold-bright) 8%,var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border))}
+.kg-callout--gold svg{color:var(--color-gold-bright)}
+
+/* ---- Takeaways ---- */
+.kg-takeaways{padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-left:3px solid var(--color-gold-bright);border-radius:var(--radius-lg);margin:var(--space-4) 0}
+.kg-takeaways h3{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);margin:0 0 var(--space-3);display:flex;align-items:center;gap:var(--space-2)}
+.kg-takeaways h3 svg{width:20px;height:20px;color:var(--color-gold-bright)}
+
+/* ---- CTA ---- */
+.kg-cta{position:relative;overflow:hidden;text-align:center;padding:var(--space-10) var(--space-5);background:linear-gradient(135deg,color-mix(in oklch,var(--color-gold) 18%,var(--color-surface)),var(--color-surface));border:1px solid color-mix(in oklch,var(--color-gold-bright) 30%,var(--color-border));border-radius:var(--radius-xl);margin:var(--space-12) 0 0}
+.kg-cta h2{font-family:var(--font-serif);font-size:clamp(1.5rem,3vw,2rem);font-weight:700;color:var(--color-text);margin:0 0 var(--space-3)}
+.kg-cta p{font-size:var(--text-base);color:var(--color-text-muted);line-height:1.6;margin:0 auto var(--space-6);max-width:54ch}
+.kg-cta__btn{display:inline-flex;align-items:center;gap:var(--space-2);padding:var(--space-4) var(--space-8);background:var(--color-gold-bright);color:#1a1306!important;font-weight:700;font-size:var(--text-base);border-radius:var(--radius-full);text-decoration:none!important;box-shadow:var(--shadow-md);transition:transform var(--transition),box-shadow var(--transition)}
+.kg-cta__btn:hover{transform:translateY(-2px);box-shadow:var(--shadow-lg)}
+
+/* ---- FAQ accordion ---- */
+.kg-faq{display:flex;flex-direction:column;gap:var(--space-3);margin-top:var(--space-2)}
+.kg-faq details{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);overflow:hidden;transition:border-color var(--transition)}
+.kg-faq details[open]{border-color:color-mix(in oklch,var(--color-gold-bright) 35%,var(--color-border))}
+.kg-faq summary{display:flex;align-items:center;justify-content:space-between;gap:var(--space-4);padding:var(--space-4) var(--space-5);font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);cursor:pointer;list-style:none}
+.kg-faq summary::-webkit-details-marker{display:none}
+.kg-faq__icon{flex-shrink:0;width:20px;height:20px;color:var(--color-gold-bright);transition:transform var(--transition)}
+.kg-faq details[open] summary .kg-faq__icon{transform:rotate(45deg)}
+.kg-faq__a{padding:0 var(--space-5) var(--space-5);font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.7;max-width:72ch}
+.kg-faq__a .kg-hl{color:var(--color-gold-bright);font-weight:600}
+
+/* ---- Related ---- */
+.kg-related{margin-top:var(--space-12);padding-top:var(--space-8);border-top:1px solid var(--color-divider)}
+.kg-related>h2{font-family:var(--font-serif);font-size:clamp(1.4rem,2.5vw,1.9rem);font-weight:700;color:var(--color-text);margin:0 0 var(--space-6)}
+.kg-related-grid{display:grid;grid-template-columns:1fr;gap:var(--space-4)}
+.kg-rcard{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:border-color var(--transition),box-shadow var(--transition)}
+.kg-rcard:hover{border-color:var(--color-gold-bright);box-shadow:var(--shadow-md);text-decoration:none}
+.kg-rcard__tag{align-self:flex-start;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--color-gold-bright);padding:2px 8px;border-radius:var(--radius-full);background:color-mix(in oklch,var(--color-gold-bright) 12%,transparent)}
+.kg-rcard__title{font-family:var(--font-display);font-size:var(--text-base);font-weight:700;color:var(--color-text);line-height:1.3}
+.kg-rcard:hover .kg-rcard__title{color:var(--color-gold-bright)}
+.kg-rcard__desc{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.55}
+
+/* ---- Hero entrance only (one-time). Body content always visible. ---- */
+@media (prefers-reduced-motion:no-preference){
+  .kg-hero{animation:kg-introUp .7s cubic-bezier(.16,1,.3,1) both}
+  @keyframes kg-introUp{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:none}}
+  .kg-meter__fill{transition:width .9s cubic-bezier(.16,1,.3,1)}
+}
+
+/* ============================================================
+   Responsive — tablet & desktop
+   ============================================================ */
+@media(min-width:560px){
+  .kg-keyfacts{grid-template-columns:repeat(4,1fr)}
+  .kg-spotbar{grid-template-columns:repeat(3,1fr)}
+  .kg-spot{flex-direction:column;align-items:flex-start;gap:2px}
+  .kg-calc__controls{grid-template-columns:1fr 1fr}
+  .kg-hallmarks{grid-template-columns:repeat(3,1fr)}
+  .kg-related-grid{grid-template-columns:repeat(2,1fr)}
+  .kg-krow{grid-template-columns:84px 1fr auto}
+}
+@media(min-width:992px){
+  .kg-layout{grid-template-columns:minmax(0,1fr) 264px;align-items:start;gap:var(--space-10)}
+  .kg-toc{order:1;position:sticky;top:84px;align-self:start}
+  .kg-toc details{position:static}
+  .kg-toc summary{cursor:default}
+  .kg-toc__chev{display:none}
+  .kg-related-grid{grid-template-columns:repeat(3,1fr)}
+  .kg-hero__title{max-width:18ch}
+}
+</style>
+
 <link rel="stylesheet" href="/assets/site.css">
 <!-- Microsoft Clarity -->
 <script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
@@ -491,220 +818,405 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </ol>
 </div>
 
-<article class="article-wrap" itemscope itemtype="https://schema.org/BlogPosting">
-  <div class="article-tag">Education</div>
-  <h1 class="article-title" itemprop="headline">Understanding Gold Karat Purities: 9K to 24K Explained</h1>
-  <div class="article-byline">
-    By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a>
-    &middot; <time datetime="2026-06-16" itemprop="datePublished">30 April 2026</time>
-  </div>
+<main id="content">
+<article class="kg-article" itemscope itemtype="https://schema.org/BlogPosting">
+  <meta itemprop="datePublished" content="2026-04-30">
+  <meta itemprop="dateModified" content="2026-06-16">
 
-  <div class="prose">
-
-    <h2>What Does "Karat" Mean?</h2>
-    <p>A gold karat (abbreviated <strong>K</strong> or <strong>ct</strong>) measures how many parts out of 24 are pure gold. For example, 18K gold contains 18 parts gold and 6 parts other metals (alloy). The term descends from the ancient weight of a carob seed used in Middle Eastern bazaars as a counterweight for gold. Today it is a strictly defined purity scale used by every major jewellery market globally, though the specific standards and legal minimum karat varies by country.</p>
-
-    <h2>Gold Karat Reference Table</h2>
-    <table class="data-table" aria-label="Gold karat purity reference">
-      <thead>
-        <tr><th>Karat</th><th>Purity</th><th>Fineness Mark</th><th>Common Use</th><th>Typical Colour</th></tr>
-      </thead>
-      <tbody>
-        <tr><td><strong>24K</strong></td><td>99.9%</td><td>999</td><td>Bullion bars &amp; coins, investment gold</td><td>Deep yellow</td></tr>
-        <tr><td><strong>22K</strong></td><td>91.67%</td><td>916</td><td>South Asian bridal jewellery, coins (Sovereign, Krugerrand)</td><td>Rich yellow</td></tr>
-        <tr><td><strong>18K</strong></td><td>75.0%</td><td>750</td><td>Fine jewellery, luxury watches (Rolex, Patek)</td><td>Yellow, white, or rose</td></tr>
-        <tr><td><strong>14K</strong></td><td>58.33%</td><td>585</td><td>Engagement rings, US everyday jewellery</td><td>Pale yellow or white</td></tr>
-        <tr><td><strong>10K</strong></td><td>41.67%</td><td>417</td><td>Fashion jewellery, US minimum legal gold</td><td>Light yellow</td></tr>
-        <tr><td><strong>9K</strong></td><td>37.5%</td><td>375</td><td>UK &amp; Australian everyday jewellery</td><td>Light yellow</td></tr>
-      </tbody>
-    </table>
-
-    <h2>24 Karat Gold</h2>
-    <p>24K is the purest gold commercially available, stamped <strong>999</strong> (99.9% pure) or <strong>999.9</strong> (99.99% pure, "four nines fine"). It is the standard for investment bullion bars and most modern bullion coins, including the Gold Britannia (999.9 fine from 2013 onwards), Canadian Gold Maple Leaf (999.9 fine), and Chinese Gold Panda (999.9 fine). At this purity, gold is noticeably soft — it scratches easily and is unsuitable for wearable jewellery in most markets. The Royal Mint's LBMA Good Delivery gold bars are 999.5 minimum fineness. The difference between 999 and 999.9 is meaningful for high-frequency trading and LBMA vault settlement but negligible for most retail investors.</p>
-
-    <h2>22 Karat Gold (916)</h2>
-    <p>22K gold (fineness mark <strong>916</strong>) contains 91.67% gold alloyed with copper and/or silver. It is the standard for South Asian bridal jewellery (particularly in India, Pakistan, and the UAE), where 22K is considered the premium wearable gold. It is also the karat used for the British Gold Sovereign (which has been 22K since 1817), the South African Krugerrand, and the American Gold Eagle. The copper alloy makes 22K significantly harder and more scratch-resistant than 24K — ideal for coins that circulate or change hands frequently. Jewellers selling 22K pieces must hallmark them with the <strong>916</strong> fineness stamp under the UK Hallmarking Act 1973.</p>
-
-    <h2>18 Karat Gold (750)</h2>
-    <p>18K (stamped <strong>750</strong>) is the preferred karat for fine jewellery across Europe, the UK, Switzerland, and luxury watchmaking. It contains 75% gold, with the remaining 25% typically comprising palladium, silver, copper, or nickel in different ratios to achieve white gold, yellow gold, or rose gold. White 18K gold — alloyed with palladium — is rhodium-plated to achieve the bright white finish seen in most UK engagement rings. Rose 18K gold achieves its warm pink tone from a higher copper content. Major luxury watch brands (Rolex, Patek Philippe, Audemars Piguet) use 18K for all their gold cases. 18K strikes the balance between a meaningful gold content and the hardness required for fine jewellery that must resist daily wear.</p>
-
-    <h2>14 Karat Gold (585)</h2>
-    <p>14K (<strong>585</strong>) is the most popular gold alloy in the United States, used in the majority of American jewellery sold at retail. It contains 58.33% gold — more than half gold by mass, giving it meaningful intrinsic value — and offers excellent durability for everyday pieces. At lower UK gold prices (pre-2020), 14K was also common in UK fashion jewellery, but as gold prices have risen dramatically, UK jewellers now more commonly use 9K for affordable price points. 14K is recognisable by the <strong>585</strong> hallmark and is fully legal for sale as gold in both the US and UK.</p>
-
-    <h2>10 Karat Gold (417)</h2>
-    <p>10K (<strong>417</strong>) is the legal minimum to be sold as gold in the United States and Canada. At 41.67% gold, it contains less than half gold by mass. It is the most affordable gold alloy available at the budget end of the US market — used for class rings, fashion jewellery, and children's pieces. In the UK and EU, 10K is legal for sale as gold but is rarely seen, as 9K is the established UK standard for the same price tier. Because 10K has a lower gold content than 9K's 37.5%... wait — actually 41.67% is higher than 37.5%. 10K has more gold than 9K and is legal in both markets, but UK consumers are more familiar with the 9K standard. A 10K piece will be stamped <strong>417</strong> or sometimes <strong>41.7%</strong>.</p>
-
-    <h2>9 Karat Gold (375)</h2>
-    <p>9K (<strong>375</strong>) is the legal minimum to be sold as gold in the UK, Ireland, and Australia — but not in the US, where 10K is the minimum. At 37.5% gold, 9K pieces contain more than 60% other metals by mass. This does not mean they are inferior jewellery — the copper and silver alloys used in 9K gold make it the most durable commercially available gold for wearable jewellery. 9K is extremely common in UK high-street jewellery (chains, rings, earrings) because it is the most affordable entry point for genuine gold. From an investment perspective, however, 9K pieces carry a high making charge (the cost of craftsmanship) relative to their gold content, and the melt value of a 9K piece is often far below its retail price. For pure investment purposes, 9K jewellery is almost always a poor choice.</p>
-
-    <h2>How to Identify Gold Karat Markings (Hallmarks)</h2>
-    <p>In the UK, all gold jewellery and items of gold above certain weight thresholds must be independently assayed and hallmarked by one of the UK's four Assay Offices (London, Birmingham, Edinburgh, or Sheffield). The hallmark consists of several marks, but the most important for karat identification is the <strong>millesimal fineness</strong> — a number in an oval or shield:</p>
-    <ul>
-      <li><strong>375</strong> = 9K gold</li>
-      <li><strong>417</strong> = 10K gold (rarely seen in UK)</li>
-      <li><strong>585</strong> = 14K gold</li>
-      <li><strong>750</strong> = 18K gold</li>
-      <li><strong>916</strong> = 22K gold</li>
-      <li><strong>999 or 999.9</strong> = 24K gold (pure bullion)</li>
-    </ul>
-    <p>The assay office mark (anchor for Birmingham, leopard's head for London, castle for Edinburgh, rose for Sheffield) guarantees that the fineness was independently tested. Items bearing only a maker's mark without an assay office mark may not be genuinely hallmarked and should be treated with caution.</p>
-
-    <h2>How to Calculate Melt Value</h2>
-    <p>The melt value of any gold item is what the metal alone is worth at the current spot price, ignoring craftsmanship, hallmarking, or collector value. The formula:</p>
-    <ul>
-      <li>Find the live 24K spot price per gram: divide the USD spot price per troy ounce by 31.1035, then convert to GBP at the live exchange rate. Or simply use our <a href="/">GoldPriceTools calculator</a>, which displays the GBP price per gram for all karats live.</li>
-      <li>Multiply the 24K per-gram price by the karat's purity factor: 0.999 (24K), 0.9167 (22K), 0.75 (18K), 0.5833 (14K), 0.4167 (10K), 0.375 (9K).</li>
-      <li>Multiply by the item's weight in grams.</li>
-    </ul>
-    <p><strong>Worked example:</strong> A 9K gold ring weighing 4.2g, with gold at £95/g (24K): melt value = 4.2 × 0.375 × £95 = <strong>£149.63</strong>. This is what a scrap gold dealer would pay based on metal content alone — the actual buying price may be slightly lower (the dealer's margin) and the retail price of a new piece would be significantly higher (including design and making charges).</p>
-
-    <h2>White Gold vs Yellow Gold: Is the Karat Different?</h2>
-    <p>White gold is not a separate metal — it is yellow gold alloyed with white metals (typically palladium or nickel) to produce a white or silver-grey colour, then plated with rhodium to achieve the bright white finish. An 18K white gold ring has exactly the same gold content (75%) as an 18K yellow gold ring. The karat tells you only the proportion of gold; the alloy metals determine the colour. When comparing white gold to yellow gold for melt value purposes, use the same purity factor — the gold content is identical at the same karat.</p>
-
-    <h2>Gold Karat vs Gold Carat: Is There a Difference?</h2>
-    <p>In the UK, both spellings are used and mean the same thing when referring to gold purity. The word "carat" is the traditional British spelling (hence "ct" for carat weight in gemstones), while "karat" (abbreviated K) is the American spelling adopted as the global standard for bullion and jewellery trading. Confusingly, "carat" is also used as a unit of weight for gemstones (1 gemstone carat = 0.2 grams) — a completely different measurement. When you see "18ct gold" and "18K gold," they are exactly the same: 18 parts gold out of 24, 75% pure. The GoldPriceTools calculator uses "K" to avoid any ambiguity with gemstone carats.</p>
-    .cta-box{background:var(--color-surface);border:1px solid var(--color-border);border-radius:1rem;padding:2rem;margin:2.5rem 0;text-align:center}
-.cta-box h3{font-size:1.125rem;font-weight:700;color:var(--color-text);margin-bottom:.5rem}
-.cta-box p{font-size:.9rem;color:var(--color-text-muted);margin-bottom:1.25rem}
-.cta-btn{display:inline-block;padding:.75rem 1.75rem;background:var(--color-gold-bright);color:#0f0e0c;font-weight:700;font-size:.9375rem;border-radius:.5rem;text-decoration:none}
-footer{background:var(--color-surface);border-top:1px solid var(--color-border);padding:2rem 1rem;text-align:center;font-size:.8125rem;color:var(--color-text-faint)}
-footer a{color:var(--color-text-muted);text-decoration:none;margin:0 .5rem}
-#googlefc{position:fixed!important;inset:auto 0 0 0;z-index:99999!important}
-
-
-/* BLOG PREVIEW SECTION */
-.blog-preview-section{background:var(--color-surface-offset);border-top:1px solid var(--color-border);padding:var(--space-10) var(--space-4)}
-.blog-preview-inner{max-width:1200px;margin:0 auto}
-.blog-preview-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6)}
-.blog-preview-title{font-size:var(--text-xl);font-weight:700;color:var(--color-text)}
-.blog-preview-all{font-size:var(--text-sm);font-weight:600;color:var(--color-primary);text-decoration:none}
-.blog-preview-all:hover{color:var(--color-primary-hover)}
-.blog-preview-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-4)}
-@media(max-width:900px){.blog-preview-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:600px){.blog-preview-grid{grid-template-columns:1fr}}
-.blog-preview-card{display:flex;flex-direction:column;gap:var(--space-2);padding:var(--space-5);background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius-lg);text-decoration:none;transition:box-shadow .15s,border-color .15s}
-.blog-preview-card:hover{border-color:var(--color-primary);box-shadow:0 4px 16px oklch(0 0 0/.08)}
-.blog-preview-tag{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--color-primary);padding:2px 8px;background:oklch(from var(--color-primary) l c h / .1);border-radius:99px;align-self:flex-start}
-.blog-preview-card h3{font-size:var(--text-base);font-weight:600;color:var(--color-text);line-height:1.4;margin:0}
-.blog-preview-card p{font-size:var(--text-sm);color:var(--color-text-muted);line-height:1.6;margin:0}
-/* FOOTER */
-.footer-brand-col{max-width:260px}
-.footer-inner{max-width:1200px;margin:0 auto;padding:var(--space-10) var(--space-4) var(--space-6);display:grid;grid-template-columns:1fr repeat(4,auto);gap:var(--space-8);align-items:start}
-@media(max-width:900px){.footer-inner{grid-template-columns:1fr 1fr;}.footer-brand-col{grid-column:1/-1}}
-@media(max-width:600px){.footer-inner{grid-template-columns:1fr 1fr}}
-.footer-col h4{font-size:var(--text-sm);font-weight:700;color:var(--color-text);margin-bottom:var(--space-3)}
-.footer-col ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px}
-.footer-col a{font-size:var(--text-sm);color:var(--color-text-muted);text-decoration:none;transition:color .12s}
-.footer-col a:hover{color:var(--color-text)}
-.footer-bottom{max-width:1200px;margin:0 auto;padding:var(--space-4) var(--space-4);border-top:1px solid var(--color-border);display:flex;justify-content:space-between;flex-wrap:wrap;gap:var(--space-2)}
-.footer-bottom span{font-size:var(--text-xs);color:var(--color-text-faint)}
-
-</style>
-<!-- Microsoft Clarity -->
-<script>(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i+"?ref=bwt";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wpxnx7usjr");</script>
-</head>
-
-
-<div class="ticker-wrap" aria-label="Live precious metals prices">
-  <div class="ticker">
-    <span class="ticker-item"><span class="live-dot"></span><span class="ticker-label">LIVE</span></span>
-    <span class="ticker-item"><span class="ticker-label">Gold (XAU/oz)</span> <span class="ticker-value" id="t-xau">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">24K/g</span> <span class="ticker-value" id="t-24k">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">18K/g</span> <span class="ticker-value" id="t-18k">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">14K/g</span> <span class="ticker-value" id="t-14k">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">10K/g</span> <span class="ticker-value" id="t-10k">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">Silver (XAG/oz)</span> <span class="ticker-value" id="t-xag">—</span></span>
-    <span class="ticker-item"><span class="live-dot"></span><span class="ticker-label">LIVE</span></span>
-    <span class="ticker-item"><span class="ticker-label">Gold (XAU/oz)</span> <span class="ticker-value" id="t-xau2">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">24K/g</span> <span class="ticker-value" id="t-24k2">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">18K/g</span> <span class="ticker-value" id="t-18k2">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">14K/g</span> <span class="ticker-value" id="t-14k2">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">10K/g</span> <span class="ticker-value" id="t-10k2">—</span></span>
-    <span class="ticker-item"><span class="ticker-label">Silver (XAG/oz)</span> <span class="ticker-value" id="t-xag2">—</span></span>
-  </div>
-</div>
-
-<nav>
-  <div class="nav-inner">
-    <a href="/" class="nav-logo"><img src="https://assets.goldpricetools.com/logo.svg" width="24" height="24" alt="GoldPriceTools logo" loading="eager" onerror="this.style.display='none'"> GoldPriceTools</a>
-    <div style="display:flex;gap:.75rem;font-size:.875rem">
-      <a href="/" style="color:var(--color-text-muted);text-decoration:none">Gold Rates</a>
-      <a href="/" style="color:var(--color-text-muted);text-decoration:none">Calculator</a>
-      <a href="/guides/" style="color:var(--color-text-muted);text-decoration:none">Guides</a>
-      <a href="/blog/" style="color:var(--color-text-muted);text-decoration:none">Blog</a>
-      <a href="/about" style="color:var(--color-text-muted);text-decoration:none">About</a>
+  <!-- ===== HERO ===== -->
+  <header class="kg-hero">
+    <span class="kg-eyebrow">Education · Gold Purity</span>
+    <h1 class="kg-hero__title" itemprop="headline">Understanding Gold Karat Purities: <em>9K to 24K</em> Explained</h1>
+    <p class="kg-hero__dek">Every common gold karat decoded — what the number really means, the hallmark stamped on it, its typical colour, and exactly what the metal is worth per gram. With a live valuation for all six karats in US dollars, refreshed every 60 seconds.</p>
+    <div class="kg-byline">
+      <span>By <a href="/authors/goldpricetools-editorial-team/" itemprop="author">GoldPriceTools Editorial Team</a></span>
+      <span class="kg-dot" aria-hidden="true"></span>
+      <span>Published <time datetime="2026-04-30" itemprop="datePublished">30 April 2026</time></span>
+      <span class="kg-dot" aria-hidden="true"></span>
+      <span>Updated <time datetime="2026-06-16">16 June 2026</time></span>
+      <span class="kg-dot" aria-hidden="true"></span>
+      <span class="kg-read"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> 9 min read</span>
     </div>
-  </div>
-</nav>
 
-<div class="breadcrumb-wrap">
-  <ol class="breadcrumb" aria-label="Breadcrumb">
-    <li><a href="/">Home</a></li>
-    <li><a href="/blog/">Blog</a></li>
-    <li aria-current="page">Understanding Gold Karat Purities</li>
-  </ol>
-</div>
+    <dl class="kg-keyfacts">
+      <div class="kg-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2l2.4 7.4H22l-6 4.6 2.3 7.4-6.3-4.6L5.7 21l2.3-7.4-6-4.6h7.6z"/></svg>
+        <div><dt>Purity range</dt><dd>37.5% – 99.9%</dd></div>
+      </div>
+      <div class="kg-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h10"/></svg>
+        <div><dt>Fineness marks</dt><dd>375 – 999</dd></div>
+      </div>
+      <div class="kg-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+        <div><dt>Live 24K / gram</dt><dd id="kg-kf-spot" data-nosnippet>$—</dd></div>
+      </div>
+      <div class="kg-keyfact">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 12V8H6a2 2 0 0 1 0-4h12v4"/><path d="M4 6v12a2 2 0 0 0 2 2h14v-4"/><path d="M18 12a2 2 0 0 0 0 4h4v-4z"/></svg>
+        <div><dt>Karats covered</dt><dd>6 grades</dd></div>
+      </div>
+    </dl>
+  </header>
 
-<article class="article-wrap" itemscope itemtype="https://schema.org/BlogPosting">
-  <div class="article-tag">Education</div>
-  <h2 class="article-title" itemprop="headline">Understanding Gold Karat Purities: 9K to 24K Explained</h2>
-  <div class="article-byline">
-    By <a href="/about" itemprop="author">GoldPriceTools Editorial Team</a>
-    &middot; <time datetime="2026-06-16" itemprop="datePublished">30 April 2026</time>
-  </div>
-
-  <div class="prose">
-    <p>A gold karat (abbreviated <strong>K</strong> or <strong>ct</strong>) measures how many parts out of 24 are pure gold. 24 karat gold is 99.9% pure; 18 karat is 75% pure; 9 karat is 37.5% pure. Everything else &mdash; the remaining fraction &mdash; is alloy metal added to improve hardness, change colour, or reduce cost. The karat stamped on a piece of jewellery directly determines its <strong>melt value</strong>: what a refiner would pay if the gold were melted down.</p>
-
-    <h2>Gold Karat Reference Table</h2>
-    <table class="data-table" aria-label="Gold karat purity reference">
-      <thead>
-        <tr><th>Karat</th><th>Purity</th><th>Fineness Mark</th><th>Common Use</th></tr>
-      </thead>
-      <tbody>
-        <tr><td><strong>24K</strong></td><td>99.9%</td><td>999</td><td>Bullion bars &amp; coins, investment gold</td></tr>
-        <tr><td><strong>22K</strong></td><td>91.67%</td><td>916</td><td>South Asian bridal jewellery, coins</td></tr>
-        <tr><td><strong>18K</strong></td><td>75.0%</td><td>750</td><td>Fine jewellery, luxury watches</td></tr>
-        <tr><td><strong>14K</strong></td><td>58.33%</td><td>585</td><td>Engagement rings, US everyday jewellery</td></tr>
-        <tr><td><strong>10K</strong></td><td>41.67%</td><td>417</td><td>Fashion jewellery, US minimum legal gold</td></tr>
-        <tr><td><strong>9K</strong></td><td>37.5%</td><td>375</td><td>UK &amp; Australian everyday jewellery</td></tr>
-      </tbody>
-    </table>
-
-    <h2>24 Karat Gold</h2>
-    <p>24K is the purest form commercially available, stamped <strong>999</strong> or <strong>999.9</strong>. Because pure gold is very soft it scratches and bends easily, making it unsuitable for rings or bracelets worn daily. It is used almost exclusively for <a href="/">investment-grade bullion</a> coins and bars, and for electroplating.</p>
-
-    <h2>22 Karat Gold</h2>
-    <p>22K gold (fineness mark <strong>916</strong>) contains 91.67% gold. It is the standard for traditional Indian, Pakistani, and Middle Eastern bridal jewellery, which values high gold content over durability. Many sovereign coins &mdash; including the British Sovereign and South African Krugerrand &mdash; are struck in 22K.</p>
-
-    <h2>18 Karat Gold</h2>
-    <p>18K (stamped <strong>750</strong>) is the preferred karat for fine jewellery across Europe, the UK, and international luxury brands. At 75% purity it balances richness of colour with practical wearability. White gold and rose gold settings in high-end rings and watches are most commonly 18K.</p>
-
-    <h2>14 Karat Gold</h2>
-    <p>14K (<strong>585</strong>) is the most popular gold alloy in the United States, used in the majority of engagement rings and wedding bands. Its 58.33% purity makes it noticeably harder than 18K, more resistant to scratches, and less expensive per gram &mdash; while still carrying the hallmark &ldquo;real gold&rdquo; connotation. See our live <a href="/14k-gold-price-per-gram">14K gold price per gram calculator</a>.</p>
-
-    <h2>10 Karat Gold</h2>
-    <p>10K (<strong>417</strong>) is the legal minimum to be sold as gold in the United States and Canada. At 41.67% purity it is the most durable karat &mdash; useful for items that take heavy wear &mdash; but has a slightly paler colour and lower melt value. Our <a href="/10k-gold-price-per-gram">10K gold price calculator</a> shows its live worth.</p>
-
-    <h2>9 Karat Gold</h2>
-    <p>9K (<strong>375</strong>) is the legal minimum in the UK, Ireland, and Australia. It contains just 37.5% gold, making it the most affordable and most durable of the common karats. The lower gold content can cause tarnishing faster than higher karats, though rhodium plating on white-gold 9K pieces mitigates this.</p>
-
-    <h2>How to Calculate Melt Value</h2>
-    <p>The melt value formula is straightforward:</p>
-    <ul>
-      <li>Find the 24K spot price per gram (spot price per troy ounce &divide; 31.1035)</li>
-      <li>Multiply by the karat&rsquo;s purity factor (e.g. 0.5833 for 14K)</li>
-      <li>Multiply by the item&rsquo;s weight in grams</li>
-    </ul>
-    <p>Our <a href="/">live gold calculator</a> does this automatically for every karat, updated every 60 seconds from LBMA spot prices.</p>
-
-    <div class="cta-box">
-      <h3>Calculate Any Karat at Today&rsquo;s Live Price</h3>
-      <p>Use GoldPriceTools&rsquo; free calculator to find the melt value of 9K through 24K gold in GBP, USD, EUR and more.</p>
-      <a href="/" class="cta-btn">Open Calculator &rarr;</a>
+  <!-- ===== LIVE KARAT VALUE MATRIX ===== -->
+  <section id="matrix" class="kg-section" aria-labelledby="kg-matrix-title">
+    <div class="kg-matrix">
+      <div class="kg-matrix__head">
+        <div>
+          <div class="kg-matrix__eyebrow"><span class="live-dot" aria-hidden="true"></span> Live gold valuation</div>
+          <h2 class="kg-matrix__title" id="kg-matrix-title">What each karat is worth right now</h2>
+          <p class="kg-matrix__sub" id="kg-updated">Connecting to live market data…</p>
+        </div>
+        <div class="kg-curswitch" role="group" aria-label="Display currency">
+          <button type="button" class="kg-curswitch__btn" data-cur="USD" aria-pressed="true">USD $</button>
+          <button type="button" class="kg-curswitch__btn" data-cur="GBP" aria-pressed="false">GBP £</button>
+          <button type="button" class="kg-curswitch__btn" data-cur="EUR" aria-pressed="false">EUR €</button>
+        </div>
+      </div>
+      <div class="kg-spotbar">
+        <div class="kg-spot"><span class="kg-spot__k">Gold spot / oz</span><span class="kg-spot__v" id="kg-spot-oz" data-nosnippet>$—</span></div>
+        <div class="kg-spot"><span class="kg-spot__k">24K spot / gram</span><span class="kg-spot__v" id="kg-spot-g" data-nosnippet>$—</span></div>
+        <div class="kg-spot"><span class="kg-spot__k">Exchange rate</span><span class="kg-spot__v" id="kg-fx" data-nosnippet>$1 = —</span></div>
+      </div>
+      <div class="kg-rows">
+        <a class="kg-krow" href="/24k-gold-price-per-gram">
+          <span class="kg-krow__id"><span class="kg-krow__k"><span class="kg-swatch kg-sw-24k" aria-hidden="true"></span>24K</span><span class="kg-krow__fine">999</span></span>
+          <span class="kg-krow__meter"><span class="kg-meter"><span class="kg-meter__fill" style="width:99.9%"></span></span><span class="kg-krow__pct"><strong>99.9%</strong> pure gold</span></span>
+          <span class="kg-krow__val"><span class="kg-krow__price" id="kg-v-24k" data-nosnippet>$—</span><span class="kg-krow__unit">per gram</span></span>
+        </a>
+        <a class="kg-krow" href="/22k-gold-price-per-gram">
+          <span class="kg-krow__id"><span class="kg-krow__k"><span class="kg-swatch kg-sw-22k" aria-hidden="true"></span>22K</span><span class="kg-krow__fine">916</span></span>
+          <span class="kg-krow__meter"><span class="kg-meter"><span class="kg-meter__fill" style="width:91.67%"></span></span><span class="kg-krow__pct"><strong>91.67%</strong> pure gold</span></span>
+          <span class="kg-krow__val"><span class="kg-krow__price" id="kg-v-22k" data-nosnippet>$—</span><span class="kg-krow__unit">per gram</span></span>
+        </a>
+        <a class="kg-krow" href="/18k-gold-price-per-gram">
+          <span class="kg-krow__id"><span class="kg-krow__k"><span class="kg-swatch kg-sw-18k" aria-hidden="true"></span>18K</span><span class="kg-krow__fine">750</span></span>
+          <span class="kg-krow__meter"><span class="kg-meter"><span class="kg-meter__fill" style="width:75%"></span></span><span class="kg-krow__pct"><strong>75.0%</strong> pure gold</span></span>
+          <span class="kg-krow__val"><span class="kg-krow__price" id="kg-v-18k" data-nosnippet>$—</span><span class="kg-krow__unit">per gram</span></span>
+        </a>
+        <a class="kg-krow" href="/14k-gold-price-per-gram">
+          <span class="kg-krow__id"><span class="kg-krow__k"><span class="kg-swatch kg-sw-14k" aria-hidden="true"></span>14K</span><span class="kg-krow__fine">585</span></span>
+          <span class="kg-krow__meter"><span class="kg-meter"><span class="kg-meter__fill" style="width:58.33%"></span></span><span class="kg-krow__pct"><strong>58.33%</strong> pure gold</span></span>
+          <span class="kg-krow__val"><span class="kg-krow__price" id="kg-v-14k" data-nosnippet>$—</span><span class="kg-krow__unit">per gram</span></span>
+        </a>
+        <a class="kg-krow" href="/10k-gold-price-per-gram">
+          <span class="kg-krow__id"><span class="kg-krow__k"><span class="kg-swatch kg-sw-10k" aria-hidden="true"></span>10K</span><span class="kg-krow__fine">417</span></span>
+          <span class="kg-krow__meter"><span class="kg-meter"><span class="kg-meter__fill" style="width:41.67%"></span></span><span class="kg-krow__pct"><strong>41.67%</strong> pure gold</span></span>
+          <span class="kg-krow__val"><span class="kg-krow__price" id="kg-v-10k" data-nosnippet>$—</span><span class="kg-krow__unit">per gram</span></span>
+        </a>
+        <a class="kg-krow" href="/9k-gold-price-per-gram">
+          <span class="kg-krow__id"><span class="kg-krow__k"><span class="kg-swatch kg-sw-9k" aria-hidden="true"></span>9K</span><span class="kg-krow__fine">375</span></span>
+          <span class="kg-krow__meter"><span class="kg-meter"><span class="kg-meter__fill" style="width:37.5%"></span></span><span class="kg-krow__pct"><strong>37.5%</strong> pure gold</span></span>
+          <span class="kg-krow__val"><span class="kg-krow__price" id="kg-v-9k" data-nosnippet>$—</span><span class="kg-krow__unit">per gram</span></span>
+        </a>
+      </div>
+      <p class="kg-matrix__foot">Live gold spot from <strong>gold-api.com</strong> (LBMA-derived), converted with European Central Bank reference rates. Values are the pure-metal melt value per gram and exclude dealer margins, making charges and VAT. Updated every 60 seconds. Tap any row for that karat's full live price page.</p>
     </div>
-  </div>
+  </section>
+
+  <div class="kg-layout">
+    <!-- ===== TABLE OF CONTENTS ===== -->
+    <nav class="kg-toc" aria-label="On this page">
+      <details open>
+        <summary>On this page <svg class="kg-toc__chev" width="16" height="16" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M2 4l4 4 4-4"/></svg></summary>
+        <ul class="kg-toc__list">
+          <li><a href="#what">What "karat" means</a></li>
+          <li><a href="#matrix">Live karat values</a></li>
+          <li><a href="#reference">Karat reference table</a></li>
+          <li><a href="#karats">Every karat: 24K to 9K</a></li>
+          <li><a href="#hallmarks">Reading gold hallmarks</a></li>
+          <li><a href="#melt">Calculate melt value</a></li>
+          <li><a href="#colours">Colour vs karat</a></li>
+          <li><a href="#carat">Karat vs carat</a></li>
+          <li><a href="#faq">FAQs</a></li>
+        </ul>
+      </details>
+    </nav>
+
+    <!-- ===== ARTICLE BODY ===== -->
+    <div class="kg-prose" itemprop="articleBody">
+      <p class="kg-lead">A gold karat measures how much of a piece is actually gold — and that single number drives everything from its colour and durability to what a refiner will pay for it. Learn to read the karat and the hallmark beside it, and you can value any gold item the moment you pick it up.</p>
+
+      <section id="what" class="kg-section">
+        <div class="kg-kicker"><span class="kg-kicker__num">01</span><span class="kg-kicker__rule"></span></div>
+        <h2>What does "karat" mean?</h2>
+        <p>A gold karat (abbreviated <strong>K</strong>, or <strong>ct</strong> in British English) measures how many parts out of 24 are pure gold. So 18K gold contains 18 parts gold and 6 parts other metals — an <strong>alloy</strong> added to harden the metal, change its colour or lower its cost. 24K, with all 24 parts gold, is as pure as commercial gold gets.</p>
+        <p>The term descends from the carob seed once used in Middle Eastern bazaars as a tiny counterweight for gold. Today it is a strictly defined purity scale used by every major jewellery market on earth, even though the legal minimum karat that may be sold as "gold" varies from country to country.</p>
+        <div class="kg-callout kg-callout--info">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>
+          <div>
+            <h3>The one formula that matters</h3>
+            <p>Purity as a fraction = <strong>karat ÷ 24</strong>. So 18K = 18 ÷ 24 = 0.75 = 75% gold. That fraction is the "purity factor" you multiply by to find an item's gold content — and its melt value.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="reference" class="kg-section">
+        <div class="kg-kicker"><span class="kg-kicker__num">02</span><span class="kg-kicker__rule"></span></div>
+        <h2>Gold karat reference table</h2>
+        <p>The six karats below cover virtually all gold jewellery and bullion traded worldwide. The final column shows the <strong>live melt value per gram in USD</strong>, so you can compare grades at today's price at a glance.</p>
+        <div class="kg-tablewrap">
+          <table class="kg-table" aria-label="Gold karat purity reference with live USD price per gram">
+            <thead>
+              <tr><th scope="col">Karat</th><th scope="col">Purity</th><th scope="col">Fineness</th><th scope="col">Typical colour</th><th scope="col">Common use</th><th scope="col" class="kg-table__num">Live USD / g</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><span class="kg-kbadge"><span class="kg-swatch kg-sw-24k" aria-hidden="true"></span>24K</span></td><td>99.9%</td><td>999</td><td>Deep yellow</td><td>Bullion bars &amp; coins, investment gold</td><td class="kg-table__num" id="kg-t-24k" data-nosnippet>$—</td></tr>
+              <tr><td><span class="kg-kbadge"><span class="kg-swatch kg-sw-22k" aria-hidden="true"></span>22K</span></td><td>91.67%</td><td>916</td><td>Rich yellow</td><td>South Asian bridal jewellery, coins</td><td class="kg-table__num" id="kg-t-22k" data-nosnippet>$—</td></tr>
+              <tr><td><span class="kg-kbadge"><span class="kg-swatch kg-sw-18k" aria-hidden="true"></span>18K</span></td><td>75.0%</td><td>750</td><td>Yellow, white or rose</td><td>Fine jewellery, luxury watches</td><td class="kg-table__num" id="kg-t-18k" data-nosnippet>$—</td></tr>
+              <tr><td><span class="kg-kbadge"><span class="kg-swatch kg-sw-14k" aria-hidden="true"></span>14K</span></td><td>58.33%</td><td>585</td><td>Pale yellow or white</td><td>Engagement rings, US everyday jewellery</td><td class="kg-table__num" id="kg-t-14k" data-nosnippet>$—</td></tr>
+              <tr><td><span class="kg-kbadge"><span class="kg-swatch kg-sw-10k" aria-hidden="true"></span>10K</span></td><td>41.67%</td><td>417</td><td>Light yellow</td><td>Fashion jewellery, US minimum legal gold</td><td class="kg-table__num" id="kg-t-10k" data-nosnippet>$—</td></tr>
+              <tr><td><span class="kg-kbadge"><span class="kg-swatch kg-sw-9k" aria-hidden="true"></span>9K</span></td><td>37.5%</td><td>375</td><td>Light yellow</td><td>UK &amp; Australian everyday jewellery</td><td class="kg-table__num" id="kg-t-9k" data-nosnippet>$—</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>Higher karat means more gold, deeper colour and more intrinsic value — but softer, less hard-wearing metal. Lower karat trades some of that gold content for durability and a lower price.</p>
+      </section>
+
+      <section id="karats" class="kg-section">
+        <div class="kg-kicker"><span class="kg-kicker__num">03</span><span class="kg-kicker__rule"></span></div>
+        <h2>Every karat, from 24K to 9K</h2>
+        <p>Each grade has its own character, its own markets and its own reasons to exist. Here is what sets them apart — with the live per-gram value for each.</p>
+
+        <h3 id="k24">24 karat gold — 999</h3>
+        <div class="kg-spec">
+          <span class="kg-chip"><span class="kg-chip__dot kg-sw-24k" aria-hidden="true"></span>Deep yellow</span>
+          <span class="kg-chip"><strong>99.9%</strong> pure</span>
+          <span class="kg-chip">Fineness <strong>999</strong></span>
+          <span class="kg-chip kg-chip--price"><span class="kg-chip__live" aria-hidden="true"></span>Live <strong id="kg-chip-24k" data-nosnippet>$—</strong>/g</span>
+        </div>
+        <p>24K is the purest gold commercially available, stamped <strong>999</strong> (99.9% pure) or <strong>999.9</strong> ("four nines fine"). It is the standard for investment bullion bars and most modern bullion coins, including the Gold Britannia, Canadian Maple Leaf and Chinese Panda. At this purity gold is noticeably soft — it scratches and bends easily — so it is rarely used for jewellery worn daily. The difference between 999 and 999.9 matters for vault settlement but is negligible for retail investors.</p>
+
+        <h3 id="k22">22 karat gold — 916</h3>
+        <div class="kg-spec">
+          <span class="kg-chip"><span class="kg-chip__dot kg-sw-22k" aria-hidden="true"></span>Rich yellow</span>
+          <span class="kg-chip"><strong>91.67%</strong> pure</span>
+          <span class="kg-chip">Fineness <strong>916</strong></span>
+          <span class="kg-chip kg-chip--price"><span class="kg-chip__live" aria-hidden="true"></span>Live <strong id="kg-chip-22k" data-nosnippet>$—</strong>/g</span>
+        </div>
+        <p>22K gold contains 91.67% gold, alloyed with copper and/or silver. It is the standard for South Asian bridal jewellery — particularly in India, Pakistan and the UAE — where high gold content is prized. It is also the karat of the British Gold Sovereign (22K since 1817), the South African Krugerrand and the American Gold Eagle. The copper alloy makes 22K markedly harder and more scratch-resistant than 24K, which is why it suits coins that change hands frequently.</p>
+
+        <h3 id="k18">18 karat gold — 750</h3>
+        <div class="kg-spec">
+          <span class="kg-chip"><span class="kg-chip__dot kg-sw-18k" aria-hidden="true"></span>Yellow / white / rose</span>
+          <span class="kg-chip"><strong>75.0%</strong> pure</span>
+          <span class="kg-chip">Fineness <strong>750</strong></span>
+          <span class="kg-chip kg-chip--price"><span class="kg-chip__live" aria-hidden="true"></span>Live <strong id="kg-chip-18k" data-nosnippet>$—</strong>/g</span>
+        </div>
+        <p>18K (stamped <strong>750</strong>) is the preferred karat for fine jewellery across Europe, the UK, Switzerland and luxury watchmaking. Its remaining 25% is typically palladium, silver, copper or nickel, blended to produce white, yellow or rose gold. White 18K is alloyed with palladium and then rhodium-plated for a bright finish; rose 18K gets its warm tone from extra copper. Rolex, Patek Philippe and Audemars Piguet all use 18K for their gold cases — it balances meaningful gold content with the hardness fine jewellery needs.</p>
+
+        <h3 id="k14">14 karat gold — 585</h3>
+        <div class="kg-spec">
+          <span class="kg-chip"><span class="kg-chip__dot kg-sw-14k" aria-hidden="true"></span>Pale yellow / white</span>
+          <span class="kg-chip"><strong>58.33%</strong> pure</span>
+          <span class="kg-chip">Fineness <strong>585</strong></span>
+          <span class="kg-chip kg-chip--price"><span class="kg-chip__live" aria-hidden="true"></span>Live <strong id="kg-chip-14k" data-nosnippet>$—</strong>/g</span>
+        </div>
+        <p>14K (<strong>585</strong>) is the most popular gold alloy in the United States, used in the majority of American jewellery sold at retail. At 58.33% gold it is more than half gold by mass — giving it meaningful intrinsic value — while offering excellent durability for everyday wear. It is recognised by the <strong>585</strong> hallmark and is fully legal to sell as gold in both the US and UK.</p>
+
+        <h3 id="k10">10 karat gold — 417</h3>
+        <div class="kg-spec">
+          <span class="kg-chip"><span class="kg-chip__dot kg-sw-10k" aria-hidden="true"></span>Light yellow</span>
+          <span class="kg-chip"><strong>41.67%</strong> pure</span>
+          <span class="kg-chip">Fineness <strong>417</strong></span>
+          <span class="kg-chip kg-chip--price"><span class="kg-chip__live" aria-hidden="true"></span>Live <strong id="kg-chip-10k" data-nosnippet>$—</strong>/g</span>
+        </div>
+        <p>10K (<strong>417</strong>) is the legal minimum that may be sold as gold in the United States and Canada. At 41.67% gold it contains less than half gold by mass, and is the most affordable gold alloy at the budget end of the US market — used for class rings, fashion jewellery and children's pieces. Interestingly, 10K actually contains <strong>more</strong> gold than 9K (41.67% versus 37.5%); it is simply less common in the UK, where shoppers are more familiar with the 9K standard at the same price tier. A 10K piece is stamped <strong>417</strong>.</p>
+
+        <h3 id="k9">9 karat gold — 375</h3>
+        <div class="kg-spec">
+          <span class="kg-chip"><span class="kg-chip__dot kg-sw-9k" aria-hidden="true"></span>Light yellow</span>
+          <span class="kg-chip"><strong>37.5%</strong> pure</span>
+          <span class="kg-chip">Fineness <strong>375</strong></span>
+          <span class="kg-chip kg-chip--price"><span class="kg-chip__live" aria-hidden="true"></span>Live <strong id="kg-chip-9k" data-nosnippet>$—</strong>/g</span>
+        </div>
+        <p>9K (<strong>375</strong>) is the legal minimum that may be sold as gold in the UK, Ireland and Australia — though not in the US, where 10K is the floor. At 37.5% gold, a 9K piece is more than 60% other metals by mass, which actually makes it the most durable of the common karats and the most affordable entry point into genuine gold. From an investment angle, though, 9K jewellery carries a high making charge relative to its gold content, so its melt value sits well below its retail price — for pure investment, higher karats or bullion are the better choice.</p>
+
+        <div class="kg-callout kg-callout--gold">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 2l2.4 7.4H22l-6 4.6 2.3 7.4-6.3-4.6L5.7 21l2.3-7.4-6-4.6h7.6z"/></svg>
+          <div>
+            <h3>Quick rule of thumb</h3>
+            <p>Roughly speaking, 18K holds about <strong>twice</strong> the gold of 9K, and 24K holds about <strong>1.33×</strong> the gold of 18K. Two pieces of identical weight can therefore differ in melt value by more than 2.5× depending only on their karat.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="hallmarks" class="kg-section">
+        <div class="kg-kicker"><span class="kg-kicker__num">04</span><span class="kg-kicker__rule"></span></div>
+        <h2>How to read gold hallmarks</h2>
+        <p>The fastest way to identify a karat is the <strong>millesimal fineness</strong> — a three-digit number, usually inside an oval, showing the parts of gold per 1,000. These six marks cover every karat above:</p>
+        <div class="kg-hallmarks">
+          <div class="kg-stamp"><span class="kg-stamp__oval">375</span><span class="kg-stamp__txt"><span class="kg-stamp__k">9K gold</span><span class="kg-stamp__d">37.5% pure</span></span></div>
+          <div class="kg-stamp"><span class="kg-stamp__oval">417</span><span class="kg-stamp__txt"><span class="kg-stamp__k">10K gold</span><span class="kg-stamp__d">41.67% pure</span></span></div>
+          <div class="kg-stamp"><span class="kg-stamp__oval">585</span><span class="kg-stamp__txt"><span class="kg-stamp__k">14K gold</span><span class="kg-stamp__d">58.33% pure</span></span></div>
+          <div class="kg-stamp"><span class="kg-stamp__oval">750</span><span class="kg-stamp__txt"><span class="kg-stamp__k">18K gold</span><span class="kg-stamp__d">75.0% pure</span></span></div>
+          <div class="kg-stamp"><span class="kg-stamp__oval">916</span><span class="kg-stamp__txt"><span class="kg-stamp__k">22K gold</span><span class="kg-stamp__d">91.67% pure</span></span></div>
+          <div class="kg-stamp"><span class="kg-stamp__oval">999</span><span class="kg-stamp__txt"><span class="kg-stamp__k">24K gold</span><span class="kg-stamp__d">99.9% pure</span></span></div>
+        </div>
+        <p>In markets with formal assay systems — the UK is the classic example — gold above a small weight threshold must be independently tested and hallmarked. A full UK hallmark adds an <strong>assay office mark</strong> (an anchor for Birmingham, a leopard's head for London, a castle for Edinburgh, a rose for Sheffield) that guarantees the fineness was verified. In the US, items are typically stamped with the karat itself (for example <strong>14K</strong> or <strong>14KT</strong>) by the maker. A piece bearing only a maker's mark, with no fineness or assay mark, should be treated with caution and tested before you trust the stated karat.</p>
+      </section>
+
+      <section id="melt" class="kg-section">
+        <div class="kg-kicker"><span class="kg-kicker__num">05</span><span class="kg-kicker__rule"></span></div>
+        <h2>How to calculate melt value</h2>
+        <p>The <strong>melt value</strong> is what the metal alone is worth at the current spot price, ignoring craftsmanship, hallmarking or collector value. The calculation is three simple steps:</p>
+        <div class="kg-formula" aria-hidden="true">
+          <span class="kg-formula__part">24K price / g<small>spot ÷ 31.1035</small></span>
+          <span class="kg-formula__op">×</span>
+          <span class="kg-formula__part">purity factor<small>e.g. 0.375 for 9K</small></span>
+          <span class="kg-formula__op">×</span>
+          <span class="kg-formula__part">weight<small>in grams</small></span>
+          <span class="kg-formula__op">=</span>
+          <span class="kg-formula__part">melt value<small>in USD</small></span>
+        </div>
+        <ul>
+          <li>Find the live 24K spot price per gram: divide the USD spot price per troy ounce by <strong>31.1035</strong> (the grams in a troy ounce).</li>
+          <li>Multiply by the karat's purity factor: 0.999 (24K), 0.9167 (22K), 0.75 (18K), 0.5833 (14K), 0.4167 (10K) or 0.375 (9K).</li>
+          <li>Multiply by the item's weight in grams.</li>
+        </ul>
+        <p><strong>Worked example.</strong> Take a 9K gold ring weighing 4.2&nbsp;g. At the live 9K price of <span id="kg-ex-perg" data-nosnippet>$—</span>/g, its melt value is 4.2&nbsp;g × <span id="kg-ex-perg2" data-nosnippet>$—</span> = <strong><span id="kg-ex-result" data-nosnippet>$—</span></strong>. That is what a scrap dealer pays based on metal content alone — the actual offer is usually a little lower (the dealer's margin), and a brand-new piece costs significantly more once design and making charges are added.</p>
+
+        <!-- Live melt calculator -->
+        <div class="kg-calc" aria-labelledby="kg-calc-title">
+          <div class="kg-calc__head">
+            <div class="kg-calc__eyebrow"><span class="live-dot" aria-hidden="true"></span> Live melt calculator</div>
+            <h3 class="kg-calc__title" id="kg-calc-title">Value your own gold by karat</h3>
+          </div>
+          <div class="kg-calc__body">
+            <div class="kg-calc__controls">
+              <div class="kg-field">
+                <label class="kg-field-label" for="kg-mc-weight">Weight</label>
+                <div class="kg-money">
+                  <input type="number" id="kg-mc-weight" value="5" min="0" max="100000" step="0.1" inputmode="decimal" aria-label="Item weight in grams">
+                  <span class="kg-money__sym" aria-hidden="true">grams</span>
+                </div>
+              </div>
+              <div class="kg-field">
+                <span class="kg-field-label" id="kg-karat-label">Karat purity</span>
+                <div class="kg-karatpick" role="group" aria-labelledby="kg-karat-label">
+                  <button type="button" class="kg-karatpick__btn" data-k="24">24K <small>99.9%</small></button>
+                  <button type="button" class="kg-karatpick__btn" data-k="22">22K <small>91.7%</small></button>
+                  <button type="button" class="kg-karatpick__btn" data-k="18">18K <small>75%</small></button>
+                  <button type="button" class="kg-karatpick__btn" data-k="14" aria-pressed="true">14K <small>58.3%</small></button>
+                  <button type="button" class="kg-karatpick__btn" data-k="10">10K <small>41.7%</small></button>
+                  <button type="button" class="kg-karatpick__btn" data-k="9">9K <small>37.5%</small></button>
+                </div>
+              </div>
+            </div>
+            <div class="kg-result" aria-live="polite">
+              <div class="kg-result__label">Gold melt value</div>
+              <div class="kg-result__big" id="kg-mc-result" data-nosnippet>$—</div>
+              <div class="kg-result__sub" id="kg-mc-sub" data-nosnippet>Connecting to live spot price…</div>
+              <div class="kg-result__divider"></div>
+              <div class="kg-result__grid">
+                <div class="kg-stat"><span class="kg-stat__k">Price per gram</span><span class="kg-stat__v" id="kg-mc-perg" data-nosnippet>$—</span></div>
+                <div class="kg-stat"><span class="kg-stat__k">Pure gold content</span><span class="kg-stat__v" id="kg-mc-grams" data-nosnippet>— g</span></div>
+              </div>
+            </div>
+            <p class="kg-calc__note">Shown in US dollars by default — switch the currency at the top of the page to value in GBP or EUR. Live gold spot from gold-api.com, refreshed every 60 seconds. Melt value is the pure-metal content only; dealers pay a margin below this and retail prices add making charges. Indicative figures, not an offer to buy or sell.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="colours" class="kg-section">
+        <div class="kg-kicker"><span class="kg-kicker__num">06</span><span class="kg-kicker__rule"></span></div>
+        <h2>White, yellow &amp; rose: colour vs karat</h2>
+        <p>White gold is not a different metal — it is yellow gold alloyed with white metals (palladium or nickel) and usually rhodium-plated for a bright finish. An 18K white gold ring has exactly the same 75% gold content as an 18K yellow gold ring. <strong>The karat tells you the proportion of gold; the alloy decides the colour.</strong> When comparing colours for melt value, use the same purity factor — the gold content is identical at the same karat.</p>
+        <div class="kg-colors">
+          <div class="kg-color">
+            <div class="kg-color__sw kg-sw-18k" aria-hidden="true"></div>
+            <div class="kg-color__n">Yellow gold</div>
+            <div class="kg-color__d">Gold with copper &amp; silver, the classic warm tone.</div>
+          </div>
+          <div class="kg-color">
+            <div class="kg-color__sw kg-sw-white" aria-hidden="true"></div>
+            <div class="kg-color__n">White gold</div>
+            <div class="kg-color__d">Gold with palladium/nickel, rhodium-plated bright.</div>
+          </div>
+          <div class="kg-color">
+            <div class="kg-color__sw kg-sw-rose" aria-hidden="true"></div>
+            <div class="kg-color__n">Rose gold</div>
+            <div class="kg-color__d">Gold with a higher copper share for a pink hue.</div>
+          </div>
+        </div>
+      </section>
+
+      <section id="carat" class="kg-section">
+        <div class="kg-kicker"><span class="kg-kicker__num">07</span><span class="kg-kicker__rule"></span></div>
+        <h2>Gold karat vs gold carat: any difference?</h2>
+        <p>When it comes to gold purity, "karat" and "carat" mean the same thing. "Karat" (abbreviated K) is the American spelling adopted as the global standard for bullion and jewellery trading; "carat" is the traditional British spelling. So <strong>"18ct gold" and "18K gold" are identical</strong> — 18 parts gold out of 24, 75% pure.</p>
+        <p>The confusion comes from a second, unrelated meaning: "carat" is also a unit of weight for gemstones, where 1 carat = 0.2 grams. A "2-carat diamond" describes the stone's weight, not any gold purity. To keep things unambiguous, GoldPriceTools always uses <strong>K</strong> for gold purity.</p>
+
+        <div class="kg-takeaways">
+          <h3><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg> Key takeaways</h3>
+          <ul>
+            <li><strong>Karat ÷ 24 = purity.</strong> 24K is 99.9% gold; 9K is 37.5%.</li>
+            <li><strong>The hallmark gives it away</strong> — 999, 916, 750, 585, 417 and 375 map directly to 24K, 22K, 18K, 14K, 10K and 9K.</li>
+            <li><strong>Higher karat = more value but softer metal.</strong> Lower karat trades gold for durability and price.</li>
+            <li><strong>Colour ≠ karat.</strong> White, yellow and rose gold of the same karat hold identical gold content.</li>
+            <li><strong>Melt value = 24K price/g × purity factor × weight</strong> — use the live calculator above for an exact figure in USD.</li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- ===== CTA ===== -->
+      <section class="kg-cta">
+        <h2>Value any karat at today's live price</h2>
+        <p>Use the free GoldPriceTools scrap calculator to find the melt value of 9K to 24K gold in USD — plus GBP, EUR and more — updated every 60 seconds from live spot data.</p>
+        <a href="/scrap-gold-calculator" class="kg-cta__btn">Open the scrap gold calculator
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </a>
+      </section>
+
+      <!-- ===== FAQ ===== -->
+      <section id="faq" class="kg-section">
+        <div class="kg-kicker"><span class="kg-kicker__num">08</span><span class="kg-kicker__rule"></span></div>
+        <h2>Frequently asked questions</h2>
+        <div class="kg-faq">
+          <details>
+            <summary>What is the purest gold karat? <svg class="kg-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="kg-faq__a">24 karat (24K) is the purest gold, at <span class="kg-hl">99.9% pure</span>, stamped 999 — or 999.9 for "four nines fine". Because pure gold is very soft, it is used mainly for investment bullion bars and coins rather than jewellery worn every day.</div>
+          </details>
+          <details>
+            <summary>Which gold karat is best for jewellery? <svg class="kg-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="kg-faq__a">It depends on the balance you want between gold content and durability. <span class="kg-hl">18K</span> (75%) is the global standard for fine jewellery and luxury watches; <span class="kg-hl">14K</span> (58.33%) is the most popular everyday alloy in the US; <span class="kg-hl">22K</span> (91.67%) is favoured for South Asian bridal gold; and <span class="kg-hl">9K</span> (37.5%) is the affordable, hard-wearing UK and Australian standard.</div>
+          </details>
+          <details>
+            <summary>What does the 750, 585 or 375 stamp mean? <svg class="kg-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="kg-faq__a">Those numbers are the <span class="kg-hl">millesimal fineness</span> — the parts of gold per 1,000. 750 = 18K (75%), 585 = 14K (58.33%) and 375 = 9K (37.5%). The full set is 375, 417, 585, 750, 916 and 999 for 9K, 10K, 14K, 18K, 22K and 24K.</div>
+          </details>
+          <details>
+            <summary>How do I calculate the melt value of gold? <svg class="kg-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="kg-faq__a">Take the live 24K gold price per gram (the USD spot price per troy ounce ÷ 31.1035), multiply by the karat's purity factor (0.75 for 18K, 0.375 for 9K, and so on), then multiply by the item's weight in grams. The <span class="kg-hl">live calculator above</span> does this automatically in USD for any karat and weight.</div>
+          </details>
+          <details>
+            <summary>Is higher karat gold always more valuable? <svg class="kg-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="kg-faq__a">Per gram, yes — more gold means more intrinsic melt value, so 24K beats 18K, which beats 9K at the same weight. But higher karat gold is <span class="kg-hl">softer and less durable</span>, and a finished piece's retail price also reflects design and making charges, not just metal content.</div>
+          </details>
+          <details>
+            <summary>What is the difference between karat and carat? <svg class="kg-faq__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg></summary>
+            <div class="kg-faq__a">Karat (K) measures gold <span class="kg-hl">purity</span> in parts out of 24, so 18K is 75% pure. Carat (ct) is a unit of <span class="kg-hl">weight</span> for gemstones, where 1 carat = 0.2 grams. British English also uses "carat" for gold purity, meaning exactly the same as "karat".</div>
+          </details>
+        </div>
+      </section>
+    </div><!-- /.kg-prose -->
+  </div><!-- /.kg-layout -->
+
+  <!-- ===== RELATED ===== -->
+  <section class="kg-related">
+    <h2>Related reading</h2>
+    <div class="kg-related-grid">
+      <a href="/24k-gold-price-per-gram" class="kg-rcard"><span class="kg-rcard__tag">Live Price</span><span class="kg-rcard__title">24K Gold Price Per Gram</span><span class="kg-rcard__desc">Today's pure-gold spot value per gram in USD, GBP and more.</span></a>
+      <a href="/14k-gold-price-per-gram" class="kg-rcard"><span class="kg-rcard__tag">Live Price</span><span class="kg-rcard__title">14K Gold Price Per Gram</span><span class="kg-rcard__desc">The world's most popular ring alloy, valued live by weight.</span></a>
+      <a href="/scrap-gold-calculator" class="kg-rcard"><span class="kg-rcard__tag">Calculator</span><span class="kg-rcard__title">Scrap Gold Calculator</span><span class="kg-rcard__desc">Mix karats and weights to value a whole drawer of old gold.</span></a>
+      <a href="/how-many-grams-in-troy-ounce" class="kg-rcard"><span class="kg-rcard__tag">Reference</span><span class="kg-rcard__title">Grams in a Troy Ounce</span><span class="kg-rcard__desc">Why 31.1035 g is the number behind every per-gram price.</span></a>
+      <a href="/gold-bar-value" class="kg-rcard"><span class="kg-rcard__tag">Calculator</span><span class="kg-rcard__title">Gold Bar Value</span><span class="kg-rcard__desc">From 1 g to 1 kg — what investment bars are worth today.</span></a>
+      <a href="/where-to-sell-gold-silver" class="kg-rcard"><span class="kg-rcard__tag">Guide</span><span class="kg-rcard__title">Where to Sell Gold &amp; Silver</span><span class="kg-rcard__desc">Turn that melt value into the best real-world payout.</span></a>
+    </div>
+  </section>
+
 </article>
+</main>
 
 <footer>
   <div class="footer-inner">
@@ -812,5 +1324,179 @@ loadTicker();setInterval(loadTicker,60000);
   document.addEventListener('click',function(e){if(!e.target.closest('.mega-nav__item')){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t)t.setAttribute('aria-expanded','false');});}});
   document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.mega-panel.is-open').forEach(function(p){p.classList.remove('is-open');const t=p.previousElementSibling;if(t){t.setAttribute('aria-expanded','false');t.focus();}});if(mob&&mob.classList.contains('open')){mob.classList.remove('open');if(ham){ham.setAttribute('aria-expanded','false');ham.focus();}document.body.style.overflow='';}}});
 })();</script>
+<script id="kg-engine-js">
+/* ───────── Live karat valuation engine — preserves site API contract ─────────
+   Sources:
+     • Gold spot: https://api.gold-api.com/price/XAU  (LBMA-derived USD/oz)
+     • FX rates:  https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR (ECB)
+   Constants match every karat page site-wide for cross-page consistency:
+     • G_PER_OZ   = 31.1035
+     • PURITY     = {24:0.999, 22:0.9167, 18:0.75, 14:0.5833, 10:0.4167, 9:0.375}
+   Refresh: 60s. USD is the primary currency; GBP/EUR are live conversions.
+*/
+(function(){
+  "use strict";
+  var G_PER_OZ = 31.1035;
+  var REFRESH_MS = 60000;
+  var GOLD_API = 'https://api.gold-api.com/price/XAU';
+  var FX_API = 'https://api.frankfurter.dev/v1/latest?from=USD&to=GBP,EUR';
+  var PURITY = {24:0.999, 22:0.9167, 18:0.75, 14:0.5833, 10:0.4167, 9:0.375};
+  var KARATS = [24,22,18,14,10,9];
+
+  var spotUSD = 0;                          // USD per troy ounce
+  var rates = {USD:1, GBP:0.79, EUR:0.92};  // per 1 USD (ECB fallbacks)
+  var activeCur = 'USD';
+  var selectedK = 14;
+  var hasData = false;
+  var lastUpdated = 0;
+
+  var $ = function(id){ return document.getElementById(id); };
+  var LOCALE = {USD:'en-US', GBP:'en-GB', EUR:'en-IE'};
+  var fmtCache = {};
+  function money(cur, v, dp){
+    var key = cur + (dp == null ? 2 : dp);
+    if(!fmtCache[key]){
+      fmtCache[key] = new Intl.NumberFormat(LOCALE[cur] || 'en-US', {
+        style:'currency', currency:cur,
+        minimumFractionDigits: dp == null ? 2 : dp,
+        maximumFractionDigits: dp == null ? 2 : dp
+      });
+    }
+    return fmtCache[key].format(v);
+  }
+  function set(id, txt){ var e = $(id); if(e){ e.textContent = txt; } }
+
+  // pure gold value per gram in the active currency
+  function pureGram(){ return (spotUSD / G_PER_OZ) * rates[activeCur]; }
+  function karatGram(k){ return pureGram() * PURITY[k]; }
+
+  function render(){
+    if(!spotUSD){ return; }
+    var cur = activeCur;
+
+    // ---- Spot bar ----
+    set('kg-spot-oz', money(cur, spotUSD * rates[cur]));
+    set('kg-spot-g', money(cur, karatGram(24)));
+    set('kg-kf-spot', money(cur, karatGram(24)));
+    var fxEl = $('kg-fx');
+    if(fxEl){
+      fxEl.textContent = '$1 = ' + money('GBP', rates.GBP) + ' · ' + money('EUR', rates.EUR);
+    }
+
+    // ---- Matrix rows, reference table, spec chips (same numbers everywhere) ----
+    KARATS.forEach(function(k){
+      var v = money(cur, karatGram(k));
+      set('kg-v-' + k + 'k', v);    // matrix
+      set('kg-t-' + k + 'k', v);    // reference table
+      set('kg-chip-' + k + 'k', v); // per-karat spec chip
+    });
+
+    // ---- Worked example: 9K ring, 4.2 g ----
+    var pg9 = karatGram(9);
+    set('kg-ex-perg', money(cur, pg9));
+    set('kg-ex-perg2', money(cur, pg9));
+    set('kg-ex-result', money(cur, pg9 * 4.2));
+
+    renderCalc();
+  }
+
+  function renderCalc(){
+    if(!spotUSD){ return; }
+    var cur = activeCur;
+    var wEl = $('kg-mc-weight');
+    var w = wEl ? parseFloat(wEl.value) : NaN;
+    if(isNaN(w) || w < 0){ w = 0; }
+    var pg = karatGram(selectedK);
+    set('kg-mc-result', money(cur, pg * w));
+    set('kg-mc-perg', money(cur, pg) + ' /g');
+    set('kg-mc-grams', (w * PURITY[selectedK]).toLocaleString(undefined, {maximumFractionDigits:2}) + ' g');
+    var sub = $('kg-mc-sub');
+    if(sub){
+      sub.textContent = w > 0
+        ? (w.toLocaleString(undefined,{maximumFractionDigits:2}) + ' g of ' + selectedK + 'K gold at today’s spot price')
+        : 'Enter a weight to see its melt value.';
+    }
+  }
+
+  function tickAgo(){
+    var el = $('kg-updated');
+    if(!el || !hasData){ return; }
+    var s = Math.round((Date.now() - lastUpdated) / 1000);
+    var ago = s < 5 ? 'just now' : (s < 60 ? s + 's ago' : Math.round(s/60) + 'm ago');
+    el.textContent = 'Live · updated ' + ago + ' · gold-api.com + ECB FX';
+  }
+
+  function fetchFx(){
+    return fetch(FX_API, {cache:'no-store'})
+      .then(function(r){ if(!r.ok){ throw new Error(); } return r.json(); })
+      .then(function(d){
+        if(d && d.rates){
+          if(d.rates.GBP){ rates.GBP = d.rates.GBP; }
+          if(d.rates.EUR){ rates.EUR = d.rates.EUR; }
+        }
+      })
+      .catch(function(){ /* keep ECB fallbacks */ });
+  }
+  function fetchSpot(){
+    return fetch(GOLD_API, {cache:'no-store'})
+      .then(function(r){ if(!r.ok){ throw new Error(); } return r.json(); })
+      .then(function(d){
+        if(d && typeof d.price === 'number'){
+          spotUSD = d.price; hasData = true; lastUpdated = Date.now();
+          render(); tickAgo();
+          if(typeof gtag === 'function'){ gtag('event','price_view',{metal:'gold',page:'karat-purities'}); }
+        }
+      })
+      .catch(function(){
+        var el = $('kg-updated');
+        if(el && !hasData){ el.textContent = 'Live price temporarily unavailable — retrying…'; }
+      });
+  }
+  function refresh(){ return Promise.all([fetchFx(), fetchSpot()]); }
+
+  // ---- Currency switch ----
+  document.querySelectorAll('.kg-curswitch__btn').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      activeCur = btn.getAttribute('data-cur') || 'USD';
+      document.querySelectorAll('.kg-curswitch__btn').forEach(function(b){
+        b.setAttribute('aria-pressed', b === btn ? 'true' : 'false');
+      });
+      render();
+    });
+  });
+  // ---- Karat picker (melt calculator) ----
+  document.querySelectorAll('.kg-karatpick__btn').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      selectedK = parseInt(btn.getAttribute('data-k'), 10) || 14;
+      document.querySelectorAll('.kg-karatpick__btn').forEach(function(b){
+        b.setAttribute('aria-pressed', b === btn ? 'true' : 'false');
+      });
+      renderCalc();
+    });
+  });
+  // ---- Weight input ----
+  if($('kg-mc-weight')){ $('kg-mc-weight').addEventListener('input', renderCalc); }
+
+  // ---- Kick off ----
+  refresh();
+  setInterval(refresh, REFRESH_MS);
+  setInterval(tickAgo, 1000);
+
+  // ---- TOC active-section highlight ----
+  var tocLinks = Array.prototype.slice.call(document.querySelectorAll('.kg-toc__list a'));
+  var sections = tocLinks.map(function(a){ return document.getElementById(a.getAttribute('href').slice(1)); }).filter(Boolean);
+  if('IntersectionObserver' in window && sections.length){
+    var spy = new IntersectionObserver(function(entries){
+      entries.forEach(function(e){
+        if(e.isIntersecting){
+          tocLinks.forEach(function(l){ l.classList.toggle('is-active', l.getAttribute('href') === '#' + e.target.id); });
+        }
+      });
+    }, {rootMargin:'-40% 0px -55% 0px', threshold:0});
+    sections.forEach(function(s){ spy.observe(s); });
+  }
+})();
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary

Full mobile-first redesign of **`/blog/understanding-gold-karat-purities/`**, built with the `ui-ux-pro-max` design intelligence and matching the newest site editorial pattern (the Gold-in-a-SIPP redesign).

### Why this was a rebuild, not a tweak
The existing file was **corrupted**: two complete page copies concatenated together, raw CSS leaking into the article body, an `<h2>` used as the article title, and a published editing artefact in the 10K section (*"…wait — actually 41.67% is higher…"*). It is now **one clean, valid document** (single `<html>/<head>/<body>/<footer>/<h1>`).

### What's new
- **Editorial layout** — Playfair Display / IBM Plex Sans / Inter: hero with eyebrow, deck, byline (published / updated / reading time), key-facts strip, sticky table of contents, drop-cap prose.
- **Live Karat Value Matrix** (centrepiece) — all six karats with **proportional purity meters**, colour swatches, fineness marks and **live per-gram prices**, each row linking to its karat page.
- **Live melt-value calculator** (weight × karat) + a **live-wired worked example**.
- **Visual hallmark stamp grid** (375 → 999), **gold-colour spectrum** (yellow / white / rose), **FAQ accordion** (+ `FAQPage` schema), related-reading grid, CTA.
- All 12 original topics preserved and the **10K vs 9K error corrected**.

### Currency
**USD $ is now the primary currency** (the page previously led with GBP: `£95/g`, `£149.63`). Karat purity is a global topic, so USD leads with a **USD / GBP / EUR toggle** for conversions.

### Data accuracy (verified)
- Header **ticker preserved exactly** (`24K × .9999`) so it matches every other page.
- Matrix / table / chips / calculator use the **canonical** `PURITY_KARATS = {24:.999, 22:.9167, 18:.75, 14:.5833, 10:.4167, 9:.375}`, `G_PER_OZ = 31.1035`, **gold-api.com `XAU`** + **Frankfurter (ECB) FX**, **60 s refresh** — identical to the dedicated karat pages.
- Verified with mocked spot ($3,300/oz): every value matches the formula and is internally consistent across all components; currency conversion (USD→GBP→EUR) correct.

### Checks
- Playwright audit: **no horizontal overflow** at 360 / 390 / 768 / 1440, **no stray text nodes**, nav/h1/footer/main visible, sticky nav + footer grid intact.
- **JSON-LD valid** (BlogPosting + BreadcrumbList + new FAQPage) across the whole site.
- Accessibility: 44px targets, focus states, `aria` labels, `prefers-reduced-motion` respected, descriptive alt text.

> Note: in the sandbox, external resources (Google Fonts, the logo CDN, gold-api, analytics) are network-blocked — they resolve normally in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01752hNnUt4aGrXRX48BQCn4

---
_Generated by [Claude Code](https://claude.ai/code/session_01752hNnUt4aGrXRX48BQCn4)_