### PR TITLE
Phase 2 (cont.): extend E-E-A-T sources section to silver & calculato…

### DIFF
--- a/24-hour-gold-silver-prices.html
+++ b/24-hour-gold-silver-prices.html
@@ -589,6 +589,18 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <a href="https://www.reddit.com/submit?url=https://goldpricetools.com/24-hour-gold-silver-prices&title=24-Hour+Gold+and+Silver+Prices" target="_blank" rel="noopener" aria-label="Share on Reddit">Reddit</a>
 </div>
 </div>
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Gold demand &amp; supply data</strong> &mdash; <a href="https://www.gold.org/" target="_blank" rel="nofollow noopener">World Gold Council</a>.</li>
+    <li><strong>Silver market data</strong> &mdash; <a href="https://www.silverinstitute.org/" target="_blank" rel="nofollow noopener">The Silver Institute</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">

--- a/800-silver-price-per-gram.html
+++ b/800-silver-price-per-gram.html
@@ -1147,6 +1147,17 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border)}
   </a>
 </div>
 
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Silver market data</strong> &mdash; <a href="https://www.silverinstitute.org/" target="_blank" rel="nofollow noopener">The Silver Institute</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">

--- a/900-silver-price-per-gram.html
+++ b/900-silver-price-per-gram.html
@@ -1232,6 +1232,17 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border)}
     Calculate
   </a>
 </div>
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Silver market data</strong> &mdash; <a href="https://www.silverinstitute.org/" target="_blank" rel="nofollow noopener">The Silver Institute</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">

--- a/docs/adsense-remediation.md
+++ b/docs/adsense-remediation.md
@@ -83,9 +83,13 @@ the `gold-price-per-gram` hub):
 
 ## Phase 2 — STILL REMAINING before requesting review
 
-- [ ] **Extend the same "Sources, methodology & review" section** to the other
-      price/calculator pages (silver per-gram/kilo, gold-silver-ratio,
-      gold-bar-value, 24-hour-prices, scrap/coins calculators).
+- [x] **Extended the "Sources, methodology & review" section site-wide** to the
+      remaining 10 live-price/calculator tool pages (silver per-kilo, .800/.900
+      silver per-gram, silver-coins-calculator, us-silver-dollar-values,
+      gold-silver-ratio, 24-hour-gold-silver-prices, zakat calculator,
+      gold-bar-value, scrap-gold-calculator) — 17 tool pages total now covered,
+      with citations matched per metal (Silver Institute on silver pages, World
+      Gold Council on gold pages, both on mixed pages).
 - [ ] **Optionally deepen the karat pages** (already ~2.2k–3.9k words) with more
       page-specific analysis so they read less formulaically vs each other.
 - [ ] **Raise the content-to-chrome ratio.** The mega-menu renders twice in the

--- a/gold-bar-value.html
+++ b/gold-bar-value.html
@@ -1157,6 +1157,17 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
 
 </main>
 
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Gold demand &amp; supply data</strong> &mdash; <a href="https://www.gold.org/" target="_blank" rel="nofollow noopener">World Gold Council</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">

--- a/gold-silver-ratio.html
+++ b/gold-silver-ratio.html
@@ -1244,6 +1244,18 @@ details[open] .faq-answer-summary::after{content:"▼"}
   </div>
 </section>
 
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Gold demand &amp; supply data</strong> &mdash; <a href="https://www.gold.org/" target="_blank" rel="nofollow noopener">World Gold Council</a>.</li>
+    <li><strong>Silver market data</strong> &mdash; <a href="https://www.silverinstitute.org/" target="_blank" rel="nofollow noopener">The Silver Institute</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">

--- a/scrap-gold-calculator.html
+++ b/scrap-gold-calculator.html
@@ -1134,6 +1134,17 @@ function fireCalcEngaged() {
 
 </div>
 
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Gold demand &amp; supply data</strong> &mdash; <a href="https://www.gold.org/" target="_blank" rel="nofollow noopener">World Gold Council</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">

--- a/silver-coins-calculator.html
+++ b/silver-coins-calculator.html
@@ -868,6 +868,17 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </div>
 </section>
 
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Silver market data</strong> &mdash; <a href="https://www.silverinstitute.org/" target="_blank" rel="nofollow noopener">The Silver Institute</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">

--- a/silver-price-per-kilo.html
+++ b/silver-price-per-kilo.html
@@ -1147,6 +1147,17 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border)}
   </a>
 </div>
 
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Silver market data</strong> &mdash; <a href="https://www.silverinstitute.org/" target="_blank" rel="nofollow noopener">The Silver Institute</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">

--- a/us-silver-dollar-values.html
+++ b/us-silver-dollar-values.html
@@ -897,6 +897,17 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </div>
 </section>
 
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Silver market data</strong> &mdash; <a href="https://www.silverinstitute.org/" target="_blank" rel="nofollow noopener">The Silver Institute</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">

--- a/zakat-gold-silver-calculator.html
+++ b/zakat-gold-silver-calculator.html
@@ -1531,6 +1531,18 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </a>
 </div>
 
+<section class="gpt-sources" aria-labelledby="gpt-sources-title">
+  <h2 id="gpt-sources-title">Sources, methodology &amp; review</h2>
+  <p>This page is maintained by the <a href="/authors/goldpricetools-editorial-team/">GoldPriceTools Editorial Team</a> and was last reviewed on <time datetime="2026-06-17">17 June 2026</time>. Live prices auto-refresh every 60 seconds; the review date reflects our most recent human editorial check, not the price tick.</p>
+  <ul>
+    <li><strong>Live spot prices</strong> &mdash; <a href="https://www.gold-api.com/" target="_blank" rel="nofollow noopener">gold-api.com</a>, providing LBMA-referenced bid/ask quotes.</li>
+    <li><strong>Market structure &amp; benchmark fixes</strong> &mdash; <a href="https://www.lbma.org.uk/" target="_blank" rel="nofollow noopener">London Bullion Market Association (LBMA)</a>.</li>
+    <li><strong>Gold demand &amp; supply data</strong> &mdash; <a href="https://www.gold.org/" target="_blank" rel="nofollow noopener">World Gold Council</a>.</li>
+    <li><strong>Silver market data</strong> &mdash; <a href="https://www.silverinstitute.org/" target="_blank" rel="nofollow noopener">The Silver Institute</a>.</li>
+    <li><strong>Currency conversion</strong> &mdash; Frankfurter (European Central Bank reference rates).</li>
+  </ul>
+  <p>For our full sourcing, review cadence and corrections policy, see our <a href="/editorial-standards/">Editorial Standards &amp; Methodology</a>. Prices shown are indicative melt values for reference only and are not financial advice.</p>
+</section>
 <footer>
   <div class="footer-inner">
     <div class="footer-brand-col">


### PR DESCRIPTION
…r tool pages

Extends the "Sources, methodology & review" section from the gold price pages (merged in #421) to the remaining 10 live-price/calculator tool pages, so the full tool surface (17 pages) is consistent. Citations matched per metal:
- Silver pages  -> The Silver Institute
- Gold pages    -> World Gold Council
- Mixed pages   -> both

Pages: silver-price-per-kilo, 800/900-silver-price-per-gram, silver-coins-calculator, us-silver-dollar-values, gold-silver-ratio, 24-hour-gold-silver-prices, zakat-gold-silver-calculator, gold-bar-value, scrap-gold-calculator.

Verified: JSON-LD validates (217 blocks / 76 files); one section per page.


Claude-Session: https://claude.ai/code/session_013nEMTpxKGQFGsWWLu7PqRk