### PR TITLE
Reframe gold-price-guide as a hub to resolve canonical override

### DIFF
--- a/docs/gsc-indexing-audit.md
+++ b/docs/gsc-indexing-audit.md
@@ -111,8 +111,40 @@ outside this repo).
 `/editorial-standards` (→ trailing-slash canonical) — all correct protocol/host/
 slash canonicalisation. No change needed.
 
-## Still needs the URLs (when you're ready)
-The two **Duplicate** rows and **Crawled - currently not indexed** (7) are the
-only outstanding reasons. Export those URLs from each GSC issue row (or provide
-`gsc_token.json` so the GSC API scripts in `scripts/` can pull them) to action
-them surgically.
+## Final three reasons resolved (2026-06-19)
+
+The remaining example URLs were exported from GSC and assessed:
+
+**Crawled - currently not indexed (7):** Six are non-page resources that are
+*supposed* to be crawled but not indexed as search results — `sitemap.xml`,
+`image-sitemap.xml`, `robots.txt`, and three `chart-data/*.json` data files
+(allowed in robots.txt because Googlebot fetches them to render the charts).
+This is normal and correct; no fix is possible or desirable. The seventh,
+`/guides/troy-ounce-guide.html`, has a correct self→clean canonical and is just
+slow to consolidate. **No change needed.**
+
+**Duplicate without user-selected canonical (1):**
+`/gold-silver-test-kit-reviews.html` — its canonical was finalised on 2026-06-11,
+*after* the 27 May crawl shown in GSC, so the report is stale. The page now has
+a correct self→clean canonical. **No change needed; clears on re-crawl.**
+
+**Duplicate, Google chose different canonical than user (1):**
+`/guides/gold-price-guide` — technically correct (proper H1, self-canonical, in
+sitemap, well-linked, ~9% verbatim overlap with the history page, so not a true
+duplicate). The cause was that this broad hub re-stated content owned by focused
+pages, so Google folded it into one of them. **Fixed by reframing it as a true
+hub:** the intro now positions it as an overview and links to the focused guides;
+the History section's deep prose + duplicate annual-average table were condensed
+to a summary + a "read the full guide" CTA (chart and ad slot kept); and a
+forecast-guide CTA was added. Live widgets, JSON-LD, and the `gp-intro-oz` /
+`histChart` hooks were all preserved. This differentiates the hub from its spokes
+so Google can index it on its own. If Google still overrides the canonical after
+re-crawl, the fallback is consolidation (301 into the strongest focused page).
+
+## Status
+All eight GSC "why pages aren't indexed" reasons have now been worked through.
+The redirect/404 and canonical issues are fixed in code; the remaining counts are
+either working-as-intended (redirects, alternates, intentional noindex), benign
+non-page resources, or stale reports that clear on the next crawl. Use **Validate
+Fix** on the *Not found (404)* and *Page with redirect* reports to prompt a
+re-crawl.

--- a/guides/gold-price-guide.html
+++ b/guides/gold-price-guide.html
@@ -866,7 +866,7 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
 <main class="gpg-main">
   <article class="gpg-article">
   <div class="prose">
-    <p>Gold has entered a historically unprecedented era. From roughly $2,624 per ounce at the start of 2025, the metal surged through <strong>53 new all-time highs</strong>, peaking at a record <strong>$5,589.38 per ounce on 28 January 2026</strong>. Gold currently trades at approximately <strong><span id="gp-intro-oz">&mdash;</span> per ounce</strong> &mdash; still far above its year-earlier level. This guide covers live global prices in every major currency (with the US dollar as the benchmark), the complete historical record, the eight key forces driving the price, institutional forecasts for 2026&ndash;2027, and the full range of investment options open to buyers worldwide.</p>
+    <p>Gold has entered a historically unprecedented era. From roughly $2,624 per ounce at the start of 2025, the metal surged through <strong>53 new all-time highs</strong>, peaking at a record <strong>$5,589.38 per ounce on 28 January 2026</strong>. Gold currently trades at approximately <strong><span id="gp-intro-oz">&mdash;</span> per ounce</strong> &mdash; still far above its year-earlier level. This guide is your complete overview &mdash; spanning live global prices, the historical record, the eight forces moving the market, institutional forecasts, and how to invest &mdash; and links through to our in-depth guides on <a href="/guides/gold-price-history">gold price history</a>, <a href="/guides/gold-price-prediction-2026">2026 forecasts</a>, and <a href="/guides/how-to-invest-in-gold">how to invest in gold</a> for the full detail on each.</p>
 
     <h2 id="live-prices"><span class="sec-eyebrow"><span class="sec-eyebrow__n">01</span> Live Market</span>Live Gold Prices Today</h2>
     <p>Gold is priced globally in <strong>US dollars per troy ounce</strong> &mdash; the world's reserve-currency benchmark &mdash; then converted into local currencies using live exchange rates. Use the explorer below to convert today's spot price into any currency, unit and karat. <span id="gp-last-updated" style="color:var(--color-text-muted)"></span></p>
@@ -1101,33 +1101,12 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
       </div>
     </div>
 
-    <h3>The Fixed Era: Before 1971</h3>
-    <p>For most of the 20th century, gold was not a free-market asset. Under the <strong>Bretton Woods monetary system</strong> established in 1944, the US dollar was anchored to gold at a fixed rate of $35 per ounce. This kept the gold price artificially stable but suppressed its true market value for decades.</p>
+    <p>Gold spent most of the 20th century pegged at <strong>$35 per ounce</strong> under the Bretton Woods system. The <strong>1971 Nixon Shock</strong> ended dollar&ndash;gold convertibility and set the price free: it spiked to <strong>$850 by January 1980</strong>, spent the 1980s&ndash;90s in a long bear market around $300&ndash;$500, then climbed to roughly <strong>$1,920 by September 2011</strong> through the dot-com bust and the 2008 financial crisis. The defining era has been <strong>2024&ndash;2026</strong>: structural central-bank demand drove a <strong>56% surge in 2025 alone</strong> &mdash; one of the strongest years on record &mdash; culminating in the record <strong>$5,589.38 peak of January 2026</strong>.</p>
 
-    <h3>The Nixon Shock: 1971&ndash;1980</h3>
-    <p>Gold's modern price history began on <strong>15 August 1971</strong>, when US President Richard Nixon ended the dollar's convertibility to gold. Freed from its peg, gold surged from below $40 per ounce to an astonishing <strong>$850 per ounce in January 1980</strong> &mdash; a gain of more than 2,000% in under a decade &mdash; driven by surging inflation, the 1973 OPEC oil embargo, and the Iranian Revolution.</p>
-
-    <h3>The Long Bear Market: 1980&ndash;2000</h3>
-    <p>The US Federal Reserve's aggressive interest-rate policy under Paul Volcker crushed inflation &mdash; and gold's bull market. Prices retreated from $850 and spent much of the next two decades in the $300&ndash;$500 range. Gold was widely written off as a monetary relic.</p>
-
-    <h3>The 2000s Renaissance: 2002&ndash;2011</h3>
-    <p>Gold's comeback began in 2002. A weakening dollar, rising geopolitical risk after the 9/11 attacks, and the catastrophic global financial crisis of 2008&ndash;2009 drove gold from below $300 in 2002 to a then-record of about <strong>$1,920 per ounce in September 2011</strong>.</p>
-
-    <h3>The Modern Bull Market: 2019&ndash;2026</h3>
-    <div class="table-scroll"><table>
-      <thead><tr><th>Year</th><th>Annual Average (USD)</th><th>Key Event</th></tr></thead>
-      <tbody>
-        <tr><td>2019</td><td>~$1,392</td><td>Trade-war fears, Fed rate cuts</td></tr>
-        <tr><td>2020</td><td>~$1,773</td><td>COVID-19 pandemic, record QE</td></tr>
-        <tr><td>2021</td><td>~$1,799</td><td>Inflation begins to emerge</td></tr>
-        <tr><td>2022</td><td>~$1,800</td><td>Russia-Ukraine war, rate hikes begin</td></tr>
-        <tr><td>2023</td><td>~$1,940</td><td>Banking stress, persistent inflation</td></tr>
-        <tr><td>2024</td><td>~$2,386</td><td>Central-bank super-cycle begins</td></tr>
-        <tr><td>2025</td><td>~$3,431</td><td>53 new all-time highs; record $555bn demand</td></tr>
-        <tr><td>2026 (to date)</td><td>~$4,742</td><td>Post-ATH of $5,589.38</td></tr>
-      </tbody>
-    </table></div>
-    <p>Gold rose <strong>56% in 2025 alone</strong> &mdash; one of the strongest annual performances in modern history. The 2025&ndash;2026 cycle has been driven not by speculative frenzy but by a structural reassessment: central banks, sovereign wealth funds, and institutional investors worldwide have concluded that gold is a necessary hedge against the twin threats of de-dollarisation and currency debasement.</p>
+    <div class="callout callout--gold">
+      <div class="callout__title">Go deeper on the full timeline</div>
+      <p>Every milestone from Bretton Woods to the 2026 record &mdash; with annual-average tables and the events behind each move &mdash; is covered in our dedicated <a href="/guides/gold-price-history">Gold Price History guide &rarr;</a></p>
+    </div>
 
     <!-- Ad Slot -->
     <ins class="adsbygoogle"
@@ -1259,6 +1238,11 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
         <div class="v" id="ilGoldOz" data-skl>$&mdash;</div>
         <div class="k"><span id="ilGoldGram" data-skl>$&mdash; / g</span> &middot; <span id="ilGoldFx" data-skl>&pound;&mdash; &middot; &euro;&mdash;</span></div>
       </div>
+    </div>
+
+    <div class="callout callout--teal">
+      <div class="callout__title">See every institutional forecast</div>
+      <p>Bull, base and bear cases from J.P. Morgan, Goldman Sachs, UBS and more &mdash; with price targets running through 2050 &mdash; are laid out in our <a href="/guides/gold-price-prediction-2026">Gold Price Prediction 2026 guide &rarr;</a></p>
     </div>
 
     <h2 id="gold-mining"><span class="sec-eyebrow"><span class="sec-eyebrow__n">06</span> Supply</span>Global Gold Mining: Who Produces the World's Gold?</h2>


### PR DESCRIPTION
GSC reported /guides/gold-price-guide under "Duplicate, Google chose different canonical than user" — the page is technically correct (self-canonical, in sitemap, well-linked, only ~9% verbatim overlap with the history page), but as a broad guide it re-stated content owned by focused pages, so Google folded it into one of them.

Reframe it as a true hub so it reads as an overview that routes, not a competitor:
- Intro now positions the page as a complete overview and links to the focused guides (history, 2026 forecasts, how to invest).
- History section: condensed the deep prose + the duplicate annual-average table into a summary + a "read the full history guide" CTA. Kept the annual-average chart and the in-article ad slot.
- Added a forecast-guide CTA closing the Forecasts section.

Preserved all live widgets and hooks (gp-intro-oz, histChart/histLive, the price explorer and inline-live trackers), JSON-LD, and ad slots. Page stays substantial (~8.4k words). JSON-LD validation passes; rendered desktop to confirm no breakage.

Also documents the other two remaining reasons in docs/gsc-indexing-audit.md: "Crawled - currently not indexed" is 6 benign non-page resources + 1 stale .html, and "Duplicate without user-selected canonical" is a stale 27 May crawl of a page that already has a correct canonical. Neither needs a code change.


Claude-Session: https://claude.ai/code/session_01WkpbBcse8HZwhTQcpXtdDs