### PR TITLE
SEO: add content to thin hub pages + lengthen short titles (Ubersuggest)

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -7,7 +7,7 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Contact Us | GoldPriceTools</title>
+<title>Contact Us — GoldPriceTools Support &amp; Feedback</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
 <meta name="description" content="Contact GoldPriceTools with questions about our live gold and silver calculators, data sources, feedback or advertising enquiries. We respond within 48 hours.">
 <meta name="robots" content="index, follow">
@@ -567,6 +567,11 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   <div class="contact-card">
     <h2>About GoldPriceTools</h2>
     <p>GoldPriceTools is a free, independent precious metals calculator. We are not a gold dealer, broker, or financial adviser. Our data is sourced from live commodity markets and updated every 60 seconds. See our <a href="/about">About page</a> for more information.</p>
+  </div>
+  <div class="contact-card">
+    <h2>What we can help with</h2>
+    <p>We read every message and aim to respond within a few working days. We&rsquo;re especially glad to hear about <strong>data or calculation queries</strong> &mdash; if a figure looks wrong, tell us the page and we&rsquo;ll check it against our live market feed &mdash; as well as <strong>corrections or feedback</strong> on any guide, and <strong>partnership, advertising or press</strong> enquiries.</p>
+    <p>As an independent information service rather than a dealer, there are a few things we can&rsquo;t do: we don&rsquo;t buy, sell, value or appraise individual items, and we can&rsquo;t offer personalised investment, tax or financial advice. For those, use our free <a href="/scrap-gold-calculator">calculators</a> and <a href="/guides/">guides</a> to do your research, then speak to an accredited dealer or a regulated adviser. If you&rsquo;re weighing up where to sell, our <a href="/where-to-sell-gold-silver">where to sell gold &amp; silver</a> comparison is a good starting point.</p>
   </div>
 </main>
 

--- a/guides/buying-investing/index.html
+++ b/guides/buying-investing/index.html
@@ -525,6 +525,12 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
           <p class="article-card-desc">Top-rated custodians for holding physical gold in a self-directed IRA.</p>
         </a>
       </div>
+      <section class="category-overview" style="max-width:760px;margin:var(--space-12) auto 0">
+        <h2 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-5)">How to start buying and investing in gold</h2>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Gold has been a store of value for thousands of years, and for today’s investor it plays three roles at once: a hedge against inflation and currency weakness, a diversifier that often moves independently of stocks and bonds, and a tangible asset with no counterparty risk. The guides in this section cover every practical decision involved in building a gold position, from your very first purchase to structuring a long-term holding.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Your first choice is which form of gold to own. Physical bullion — coins and bars — gives you direct ownership and is VAT-free in the UK at investment grade, but carries a premium over the spot price and needs secure storage. Gold ETFs and funds offer instant liquidity with no storage to worry about, though you never hold the metal yourself. Retirement savers can hold physical gold inside a tax-advantaged wrapper through a <a href="/best-gold-ira-companies">Gold IRA</a> in the US or a SIPP in the UK. Our <a href="/guides/how-to-invest-in-gold">how to invest in gold</a> guide compares each route side by side.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:0">Once you’ve picked a format, the details decide how much you pay. Understanding <a href="/guides/gold-purity-guide">karat purity</a> and reading <a href="/guides/gold-hallmarks-explained">hallmarks</a> protects you from overpaying, while knowing the typical <a href="/gold-coins-vs-bars">premiums on coins versus bars</a> helps you buy efficiently. Whether you’re investing a few hundred pounds or building a five-figure allocation, these guides give you the grounding to buy with confidence and sidestep the costly mistakes most beginners make.</p>
+      </section>
     </div>
   </main>
   <footer>

--- a/guides/deep-dives/index.html
+++ b/guides/deep-dives/index.html
@@ -505,6 +505,12 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
           <p class="article-card-desc">What's the difference? How much gold is in each, and which holds value?</p>
         </a>
       </div>
+      <section class="category-overview" style="max-width:760px;margin:var(--space-12) auto 0">
+        <h2 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-5)">The technical fundamentals behind gold and silver</h2>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Precious metals come with their own vocabulary — karats, fineness, troy ounces, hallmarks — and understanding it is what separates a confident buyer from one who overpays. The deep-dive guides in this section unpack the technical details that determine exactly what your gold and silver are worth, so you can value any piece accurately and tell the difference between solid metal and a thin layer of plating.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Purity is where most value is won or lost. The <a href="/guides/what-is-14k-gold">karat system</a> tells you how much pure gold an item actually contains — 14K is 58.3% gold, 24K is 99.9% — and that ratio drives the melt value directly. Weight matters just as much: gold and silver are priced per <a href="/guides/troy-ounce-guide">troy ounce</a> (31.1035g), which is heavier than the everyday ounce, so getting the unit right is essential when you convert a spot price into the value of a specific item.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:0">These guides also clear up the costly confusions — most importantly the difference between <a href="/guides/difference-between-gold-filled-and-gold-plated">gold-filled and gold-plated</a> items, which can look identical but differ in value by a hundredfold. Whether you’re assessing an inherited piece, buying second-hand, or simply want to understand what the numbers stamped on your jewellery mean, the explainers here give you the technical grounding to judge real value for yourself.</p>
+      </section>
     </div>
   </main>
   <footer>

--- a/guides/index.html
+++ b/guides/index.html
@@ -499,6 +499,12 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
           <p class="article-card-desc">Detailed technical guides on gold purity, weights, and the science of precious metals.</p>
         </a>
       </div>
+      <section class="category-overview" style="max-width:760px;margin:var(--space-12) auto 0">
+        <h2 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-5)">Your complete library of gold and silver guides</h2>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Buying, selling and valuing precious metals involves a lot of small decisions, and getting them right can mean the difference between a smart purchase and an expensive mistake. This library brings together everything we’ve written on gold and silver, organised into five clear categories so you can go straight to what you need — whether you’re making your first purchase or valuing an inheritance.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Start with <a href="/guides/buying-investing/">Buying &amp; Investing</a> if you’re looking to own gold, covering bullion, coins, ETFs and IRAs. <a href="/guides/selling-testing/">Selling &amp; Testing</a> shows you how to value your pieces, verify they’re genuine, and get the best price. <a href="/guides/market-prices/">Market &amp; Prices</a> explains how the spot price is set and what moves it, while <a href="/guides/silver-guides/">Silver Guides</a> focuses specifically on silver pricing and purity.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:0">For the technical foundations — karats, troy ounces, hallmarks and the details that decide real value — head to the <a href="/guides/deep-dives/">Deep Dives</a>. Every guide is written and reviewed by our editorial team and checked against live market data and primary industry sources, so you can rely on the numbers as well as the explanations.</p>
+      </section>
     </div>
   </main>
   <footer>

--- a/guides/market-prices/index.html
+++ b/guides/market-prices/index.html
@@ -510,6 +510,12 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
           <p class="article-card-desc">Live INR rates by karat &amp; tola, the 2026 import-duty impact, a landed-price calculator and how to invest.</p>
         </a>
       </div>
+      <section class="category-overview" style="max-width:760px;margin:var(--space-12) auto 0">
+        <h2 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-5)">How gold and silver prices are set</h2>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">The headline gold price you see quoted is the global spot price — the cost of one troy ounce of pure gold for immediate delivery, set continuously across the world’s markets and anchored twice a day by the LBMA price in London. Silver works the same way. The guides in this section explain how that price is formed, what moves it, and how to read it so the numbers on a chart actually mean something to you.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Prices never move in a vacuum. Interest rates, inflation, the strength of the US dollar, central-bank buying and geopolitical risk all pull on gold at once — our <a href="/guides/what-affects-gold-price">what affects the gold price</a> guide breaks down the forces that matter most. To put today’s level in context, the <a href="/guides/gold-price-history">price history</a> guide charts gold’s climb from $35 under Bretton Woods to its modern record highs, and our <a href="/guides/gold-price-prediction-2026">2026 forecast</a> rounds up where major banks expect it to go next.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:0">If you’re new to reading a live quote, start with <a href="/guides/how-to-read-gold-spot-price">how to read the gold spot price</a> — it explains the bid/ask spread, premiums over spot, and why the price your dealer quotes differs from the headline figure. Together these guides give you the market literacy to interpret any precious-metals price with confidence rather than guesswork.</p>
+      </section>
     </div>
   </main>
   <footer>

--- a/guides/selling-testing/index.html
+++ b/guides/selling-testing/index.html
@@ -530,6 +530,12 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
           <p class="article-card-desc">Hands-on reviews of acid test kits and electronic gold testers.</p>
         </a>
       </div>
+      <section class="category-overview" style="max-width:760px;margin:var(--space-12) auto 0">
+        <h2 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-5)">Selling and testing your gold and silver</h2>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">When it’s time to sell gold or silver, the gap between a good offer and a poor one can be 20% or more of your item’s value — and knowing how to test authenticity first protects you from both scams and lowball offers. The guides in this section walk you through valuing your pieces, verifying they’re genuine, choosing where to sell, and timing the sale to get the most for your metal.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Start with value. Our guides on <a href="/guides/how-much-is-a-gold-ring-worth">how much a gold ring is worth</a> and <a href="/guides/how-to-sell-gold-jewellery">how to sell gold jewellery</a> show you how to calculate melt value and what dealers actually pay above or below it. Before you sell, confirm what you’re holding: the <a href="/guides/how-to-test-if-gold-is-real">how to test if gold is real</a> guide ranks ten at-home methods by accuracy, so you can separate solid gold from plated or filled pieces worth a fraction as much.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:0">Where and when you sell matters too. Our <a href="/where-to-sell-gold-silver">where to sell gold and silver</a> comparison weighs up dealers, pawnbrokers, refiners and online buyers, while the guide on the <a href="/guides/what-is-best-time-to-sell-scrap-gold">best time to sell scrap gold</a> helps you read the market rather than sell on impulse. Follow these and you’ll walk into any sale knowing exactly what your gold is worth and who will pay the fairest price for it.</p>
+      </section>
     </div>
   </main>
   <footer>

--- a/guides/silver-guides/index.html
+++ b/guides/silver-guides/index.html
@@ -505,6 +505,12 @@ article.article-wrap .article-title,h1.article-title{font-family:var(--font-disp
           <p class="article-card-desc">The melt values and collector prices of Morgan, Peace and Eisenhower dollars.</p>
         </a>
       </div>
+      <section class="category-overview" style="max-width:760px;margin:var(--space-12) auto 0">
+        <h2 style="font-family:var(--font-display);font-size:var(--text-xl);color:var(--color-text);margin-bottom:var(--space-5)">Understanding silver: prices, purity and value</h2>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Silver is both a precious metal and an industrial one, which makes it more volatile — and often more interesting — than gold. Whether you’re valuing inherited flatware, buying coins, or adding silver to a portfolio, the guides in this section explain how silver is priced, what the purity marks mean, and how to work out exactly what any silver item is worth.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:var(--space-4)">Pricing starts with the spot price, quoted per troy ounce in US dollars. Our <a href="/guides/silver-price-per-gram-explained">silver price per gram explained</a> guide shows how to convert that into the per-gram figure most people actually need, and the broader <a href="/guides/silver-price-guide">silver price guide</a> covers the LBMA benchmark, the gold-silver ratio, and what drives silver’s swings. Purity is the other half of the equation: <a href="/guides/what-is-925-sterling-silver">925 sterling silver</a> is 92.5% pure and the standard for jewellery and flatware, while coin silver and other grades carry different values.</p>
+        <p style="line-height:1.75;color:var(--color-text-muted);margin-bottom:0">Collectible silver has its own rules. The guide to <a href="/guides/us-silver-dollar-values">US silver dollar values</a> explains how Morgan and Peace dollars are priced on both melt value and numismatic premium — often very different numbers. Taken together, these guides give you everything you need to identify, value and trade silver with the same confidence as gold.</p>
+      </section>
     </div>
   </main>
   <footer>

--- a/terms.html
+++ b/terms.html
@@ -7,7 +7,7 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Terms of Use | GoldPriceTools</title>
+<title>Terms of Use &amp; Disclaimer | GoldPriceTools</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
 <meta name="description" content="Terms of use for GoldPriceTools.com: permitted use of our gold and silver price data, disclaimers, liability limits and how to contact us with queries.">
 <meta name="robots" content="index, follow">


### PR DESCRIPTION
## What & why
Addresses the **Ubersuggest** SEO issues.

### ✅ Low word count (7 pages — High impact) — fixed
The thin category hubs had only ~115 words of unique content (a heading + a card grid). Added a genuine **~250-word overview** to each, with contextual internal links to the focused guides:

| Page | Main-content words: before → after |
|---|---|
| `/guides/` | 115 → ~308 |
| `/guides/buying-investing/` | 118 → ~408 |
| `/guides/deep-dives/` | 115 → ~326 |
| `/guides/market-prices/` | 115 → ~354 |
| `/guides/selling-testing/` | 118 → ~436 |
| `/guides/silver-guides/` | 114 → ~308 |
| `/contact` | 195 → ~243 (added a useful "What we can help with" section) |

### ✅ Title too short (2 pages) — fixed
- `contact`: *Contact Us \| GoldPriceTools* (27) → **Contact Us — GoldPriceTools Support & Feedback** (46)
- `terms`: *Terms of Use \| GoldPriceTools* (29) → **Terms of Use & Disclaimer \| GoldPriceTools** (42)

### ℹ️ The other two need no code change
- **35 titles too long** — **stale crawl.** 0 titles currently exceed 60 chars (fixed in an earlier PR). A Ubersuggest re-crawl clears it.
- **1 page blocked** — that's `/data/`, an **intentionally `noindex`** developer data-feed page. Correct as-is; safe to *Ignore* in Ubersuggest.

## Verified
- No broken internal links; JSON-LD passes; the new hub overview renders cleanly (screenshot checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkpbBcse8HZwhTQcpXtdDs)_