### PR TITLE
a11y: homepage select label + remove prohibited ad-slot aria-label

### DIFF
--- a/index.html
+++ b/index.html
@@ -793,7 +793,7 @@ body{background-image:radial-gradient(120% 60% at 50% -8%,color-mix(in oklch,var
 </div>
 
 <!-- AD SLOT 1 — below hero, display responsive -->
-<div class="ad-slot" aria-label="Advertisement">
+<div class="ad-slot">
   <ins class="adsbygoogle"
        style="display:block"
        data-ad-client="ca-pub-8849494330640880"
@@ -975,7 +975,7 @@ body{background-image:radial-gradient(120% 60% at 50% -8%,color-mix(in oklch,var
     </div>
 
     <!-- AD SLOT 2 — Mid-content, responsive -->
-    <div class="ad-slot" aria-label="Advertisement" style="margin:var(--space-6) 0;padding:0">
+    <div class="ad-slot" style="margin:var(--space-6) 0;padding:0">
       <ins class="adsbygoogle"
            style="display:block; text-align:center;"
            data-ad-layout="in-article"
@@ -1127,7 +1127,7 @@ body{background-image:radial-gradient(120% 60% at 50% -8%,color-mix(in oklch,var
              oninput="sbConvert()" aria-label="Amount to convert">
       <select id="sb-conv-unit" class="form-select"
               style="flex:1;padding:.35rem .5rem;font-size:.875rem"
-              onchange="sbConvert()">
+              onchange="sbConvert()" aria-label="Weight unit">
         <option value="g">Gram (g)</option>
         <option value="ozt">Troy Oz</option>
         <option value="kg">Kilogram</option>
@@ -1193,7 +1193,7 @@ body{background-image:radial-gradient(120% 60% at 50% -8%,color-mix(in oklch,var
       </div>
     </div>
     <!-- AD SLOT 3 — Sidebar, responsive -->
-    <div class="ad-slot-sidebar" aria-label="Advertisement">
+    <div class="ad-slot-sidebar">
       <ins class="adsbygoogle"
            style="display:block"
            data-ad-format="fluid"
@@ -1205,7 +1205,7 @@ body{background-image:radial-gradient(120% 60% at 50% -8%,color-mix(in oklch,var
 </section>
 
 <!-- AD SLOT 4 — Above footer, multiplex -->
-<div class="ad-slot" aria-label="Advertisement">
+<div class="ad-slot">
   <ins class="adsbygoogle"
        style="display:block"
        data-ad-format="autorelaxed"

--- a/zakat-gold-silver-calculator.html
+++ b/zakat-gold-silver-calculator.html
@@ -1210,7 +1210,7 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </div>
 </section>
 <!-- AD SLOT 4 — Above footer, multiplex -->
-<div class="ad-slot" aria-label="Advertisement">
+<div class="ad-slot">
   <ins class="adsbygoogle"
        style="display:block"
        data-ad-format="autorelaxed"


### PR DESCRIPTION
## Why
Clears the final two homepage accessibility flags (the non-contrast ones) for a clean Lighthouse Accessibility 100.

## What
- **`select-name`** — the sidebar weight-converter `<select id="sb-conv-unit">` had no accessible name. Added `aria-label="Weight unit"` (matches its sibling `<input aria-label="Amount to convert">`).
- **`aria-prohibited-attr`** — ad-slot wrapper `<div>`s carried `aria-label="Advertisement"`, which axe prohibits on a `<div>` with no role. Removed it: the AdSense iframe carries its own labeling, and dropping it avoids introducing duplicate landmarks. (2 files: `index.html`, `zakat-gold-silver-calculator.html`.)

## Verification (Lighthouse, mobile, local)
- **Accessibility: 100** ✅ (was held by these two)
- Best Practices 96, SEO 100
- Remaining axe item `region` (`.ticker-wrap` not in a landmark) is a **best-practice** rule Lighthouse does **not** score — noted, not blocking 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)