### PR TITLE
seo: de-overlap troy-ounce — link converter to the guide

### DIFF
--- a/how-many-grams-in-troy-ounce.html
+++ b/how-many-grams-in-troy-ounce.html
@@ -1171,6 +1171,11 @@ footer{background:var(--color-surface);border-top:1px solid var(--color-border);
   </div>
 
   <div class="related-guides-grid">
+    <a href="/guides/troy-ounce-guide" class="related-card">
+      <span class="related-card__tag">GUIDE</span>
+      <span class="related-card__title">Troy Ounce Guide</span>
+      <span class="related-card__desc">The complete guide to the troy ounce — its history, why precious metals are weighed in it, and how it compares across gold, silver and platinum.</span>
+    </a>
     <a href="/scrap-gold-calculator" class="related-card">
       <span class="related-card__tag">TOOL</span>
       <span class="related-card__title">Scrap Gold Calculator</span>


### PR DESCRIPTION
## Why
`guides/troy-ounce-guide` is **"Crawled – currently not indexed"** in GSC. It's a well-formed 4,215-word guide with breadcrumbs and a self-canonical — not thin or broken. The likely cause is **topical overlap** with the *indexed* `how-many-grams-in-troy-ounce` converter, which Google indexed instead.

The gap: the converter (indexed, ranking) had **no internal link to the guide**, so it passed no signal toward it.

## What
Adds a **"Troy Ounce Guide" card** as the first item in the converter page's existing `related-guides-grid` (reuses the `related-card` component — no new UI, on-brand). Descriptive anchor "Troy Ounce Guide".

This clarifies the hierarchy (converter = quick answer, guide = deep dive) and passes internal-link signal from the indexed page to help the guide earn indexing. The guide already links back to the converter, so it's now bidirectional.

## Note
Pair this with a manual **"Request indexing"** for `guides/troy-ounce-guide` in GSC's URL Inspection (can't be done via API) to nudge re-evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)