### PR TITLE
feat(seo): Bing-aligned titles + promote high-engagement pages

### DIFF
--- a/gold-silver-ratio.html
+++ b/gold-silver-ratio.html
@@ -7,9 +7,9 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold-Silver Ratio Calculator & Live Chart | GoldPriceTools</title>
+<title>Gold to Silver Ratio Calculator &amp; Live Chart</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Live Gold-Silver Ratio calculator and historical charts. See how many ounces of silver equal one ounce of gold right now.">
+<meta name="description" content="Live gold-to-silver ratio calculator and historical chart. See how many ounces of silver equal one ounce of gold right now, what the ratio signals for investors, and how today compares to the long-term average.">
 <meta name="robots" content="index, follow">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/gold-silver-ratio">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/gold-silver-ratio">

--- a/guides/gold-hallmarks-explained.html
+++ b/guides/gold-hallmarks-explained.html
@@ -5,7 +5,7 @@
 <script>(function(){var r=document.documentElement;var s=localStorage.getItem('gpt-theme');var t=s||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');r.setAttribute('data-theme',t);})();</script>
 <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold Hallmarks Explained: Symbols &amp; Meanings</title>
+<title>Gold Hallmarks: Identification Chart, Symbols &amp; Meanings</title>
 <meta name="google-adsense-account" content="ca-pub-8849494330640880">
 <meta name="description" content="Everything about gold hallmarks — UK, European, antique, foreign and rare marks explained. Identify symbols on rings, necklaces and pocket watches, and see each fineness mark's live melt value in USD.">
 <meta name="robots" content="index, follow">

--- a/guides/gold-price-prediction-2026.html
+++ b/guides/gold-price-prediction-2026.html
@@ -7,7 +7,7 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold Price Prediction 2026: Forecast &amp; Outlook</title>
+<title>Gold Price Forecast 2026 &amp; 2027: Analyst Predictions</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
 <meta name="description" content="Comprehensive gold price prediction for 2026 through 2050. Forecasts from Goldman Sachs, J.P. Morgan, UBS, Bank of America. Bull, base, and bear case scenarios with structural drivers and risks.">
 <meta name="robots" content="index, follow">

--- a/guides/gold-purity-guide.html
+++ b/guides/gold-purity-guide.html
@@ -7,7 +7,7 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Gold Purity Guide: 9K to 24K Explained (2026)</title>
+<title>Gold Purity Chart: 9K to 24K Explained (2026)</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
 <meta name="description" content="Complete gold purity guide 2026: what 9K, 10K, 14K, 18K, 22K and 24K mean, fineness stamps (375, 585, 750, 916, 999), hallmark reading, home & XRF testing, and live value per karat.">
 <meta name="robots" content="index, follow">

--- a/guides/what-affects-gold-price.html
+++ b/guides/what-affects-gold-price.html
@@ -7,7 +7,7 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>What Affects the Price of Gold? Complete Guide</title>
+<title>What Affects Gold Prices? Key Drivers Explained</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
 <meta name="description" content="What affects gold prices? Interest rates, central bank buying, the US dollar, geopolitics, ETFs and 8 more drivers — explained with real correlations, 2025–2026 data, and a quick-reference table.">
 <meta name="robots" content="index, follow">

--- a/index.html
+++ b/index.html
@@ -1173,7 +1173,9 @@ body{background-image:radial-gradient(120% 60% at 50% -8%,color-mix(in oklch,var
         <a href="/10k-gold-price-per-gram">10K Gold Price Per Gram <span>→</span></a>
         <a href="/gold-value-calculator">Gold Value Calculator <span>→</span></a>
         <a href="/scrap-gold-calculator">Scrap Gold Calculator <span>→</span></a>
+        <a href="/gold-silver-ratio">Gold / Silver Ratio <span>→</span></a>
                 <a href="/silver-price-per-kilo">Silver Price Per Kilo <span>→</span></a>
+        <a href="/silver-coins-calculator">Silver Coin Calculator <span>→</span></a>
         <a href="/900-silver-price-per-gram">.900 Silver Price <span>→</span></a>
         <a href="/800-silver-price-per-gram">.800 Silver Price <span>→</span></a>
         <a href="/how-many-grams-in-troy-ounce">Grams in a Troy Ounce <span>→</span></a>
@@ -1189,6 +1191,7 @@ body{background-image:radial-gradient(120% 60% at 50% -8%,color-mix(in oklch,var
         <a href="/guides/gold-vs-silver-investment">Gold vs Silver Investment <span>→</span></a>
         <a href="/guides/how-to-sell-gold-jewellery">Selling Gold Jewellery <span>→</span></a>
         <a href="/guides/gold-price-history">Gold Price History <span>→</span></a>
+        <a href="/guides/gold-bar-guide">Gold Bar Guide <span>→</span></a>
         <a href="/guides/how-to-store-gold-silver-at-home">Store Gold at Home <span>→</span></a>
 
       </div>

--- a/silver-coins-calculator.html
+++ b/silver-coins-calculator.html
@@ -7,9 +7,9 @@
 </script>
     <meta name="cf-no-email-obfuscation">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>US Silver Coin Melt Value Calculator | GoldPriceTools</title>
+<title>Silver Coin Calculator &mdash; US Junk Silver Melt Values</title>
   <meta name="google-adsense-account" content="ca-pub-8849494330640880">
-<meta name="description" content="Calculate US junk silver coin melt values (Dimes, Quarters, Half Dollars, Morgan & Peace Dollars) with live silver prices.">
+<meta name="description" content="Free silver coin calculator for US junk silver — Dimes, Quarters, Half Dollars, Morgan &amp; Peace Dollars — with live melt values updated from the current silver spot price.">
 <meta name="robots" content="index, follow">
 <link rel="alternate" hreflang="en-gb" href="https://goldpricetools.com/silver-coins-calculator">
 <link rel="alternate" hreflang="en-us" href="https://goldpricetools.com/silver-coins-calculator">


### PR DESCRIPTION
Acts on the GSC + GA4 + Bing cross-reference: **Google sends ~0 clicks; Bing is the real click engine (192 clicks, ranks pos 1–6)** and AI assistants/Yahoo/DuckDuckGo send real engaged users. So this optimizes for the channels that actually convert.

**Titles aligned to proven Bing-click queries:**
- `gold-hallmarks-explained` → "Gold Hallmarks: Identification Chart, Symbols & Meanings"
- `gold-purity-guide` → "Gold Purity Chart: 9K to 24K Explained (2026)"
- `gold-price-prediction-2026` → "Gold Price Forecast 2026 & 2027: Analyst Predictions"
- `what-affects-gold-price` → "What Affects Gold Prices? Key Drivers Explained"
- `gold-silver-ratio` → "Gold to Silver Ratio Calculator & Live Chart" (+ richer meta)
- `silver-coins-calculator` → "Silver Coin Calculator — US Junk Silver Melt Values" (+ richer meta)

**Promoted high-engagement pages** (gold/silver ratio — 1,450s avg dwell; silver coin calculator — 86% engaged; gold bar guide) into the homepage sidebar widgets, on top of their existing site-wide footer links.

JSON-LD validator passes across all 78 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)