### PR TITLE
feat(seo): Google News sitemap scaffold + robots.txt

### DIFF
--- a/news-sitemap.xml
+++ b/news-sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  GOOGLE NEWS SITEMAP — GoldPriceTools
+  Public URL: https://goldpricetools.com/news-sitemap.xml
+  Declared in robots.txt; submit this URL in Google Search Console.
+
+  RULES (important):
+   - List ONLY articles published in the LAST 48 HOURS. Remove entries once
+     they are older than 48 hours.
+   - <news:name> MUST match your publication name in Google Publisher Center
+     (e.g. "Gold Price Tools News").
+   - <news:publication_date> is the article's publish time in ISO 8601.
+   - This file is currently EMPTY (no news articles published yet). Google
+     Search Console may report "0 URLs" / a warning until the first <url>
+     entry below is added — this is expected for the pre-registration scaffold.
+
+  Add one <url> block per fresh article inside <urlset>, e.g.:
+
+  <url>
+    <loc>https://goldpricetools.com/news/your-article-slug</loc>
+    <news:news>
+      <news:publication>
+        <news:name>Gold Price Tools News</news:name>
+        <news:language>en</news:language>
+      </news:publication>
+      <news:publication_date>2026-06-23T09:00:00Z</news:publication_date>
+      <news:title>Your article headline</news:title>
+    </news:news>
+  </url>
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+</urlset>

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,6 @@
 # robots.txt for GoldPriceTools
 # https://developers.google.com/search/docs/crawling-indexing/robots/intro
-# Last updated: 2026-05-16
+# Last updated: 2026-06-23
 
 # ─────────────────────────────────────────────────
 # LLM / AI Discovery Files
@@ -21,6 +21,7 @@ Disallow: /*?
 
 Sitemap: https://goldpricetools.com/sitemap.xml
 Sitemap: https://goldpricetools.com/image-sitemap.xml
+Sitemap: https://goldpricetools.com/news-sitemap.xml
 
 User-agent: Googlebot
 Allow: /


### PR DESCRIPTION
## Summary
Pre-registers a **Google News sitemap** so the URL exists ahead of publishing the first news article.

- Adds `news-sitemap.xml` at the site root — a valid, empty `urlset` with the `xmlns:news` namespace and inline documentation on the required per-article format.
- Declares it in `robots.txt` (alongside `sitemap.xml` + `image-sitemap.xml`).

**Public URL:** `https://goldpricetools.com/news-sitemap.xml` → submit this in Search Console.

## Notes
- ⚠️ The file is **intentionally empty** (no news articles published yet). GSC may report **"0 URLs"** or a warning until the first `<url>` entry is added — expected for a pre-registration scaffold.
- A Google News sitemap may only list articles from the **last 48 hours**; the inline comment documents the exact `<news:news>` block to add (publication name must match the Publisher Center publication).
- Generation will be wired up when the first article is live.

## Verification
- ✅ `news-sitemap.xml` parses as valid XML
- ✅ robots.txt lists all three sitemaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)