### PR TITLE
feat(news): auto-routing publishing contract (category, tags, featured)

### DIFF
--- a/news-app/PUBLISHING.md
+++ b/news-app/PUBLISHING.md
@@ -1,0 +1,109 @@
+# Publishing a news article
+
+This is the contract for getting an article onto `/news/` correctly — where it's
+filed, how it's tagged, and where it shows up. It's written so the **same rules**
+work whether a human (or Claude) writes the article today or an **n8n** workflow
+writes it later.
+
+## TL;DR
+
+```bash
+# 1. (optional) get the right category + tags for your draft
+npm run news:emit -- --title "Gold Holds $4,500 as the Fed Pauses" --slug gold-holds-4500 --file draft.md
+#    → prints a complete front-matter block; paste it atop your markdown
+
+# 2. save the file as news-app/src/content/news/<slug>.md
+# 3. add + optimize the hero image
+node scripts/fetch-news-image.js --query "gold bullion" --slug gold-holds-4500 --provider pexels
+npm run optimize-images
+
+# 4. validate, build, commit
+npm run build-news        # runs validate-news → astro build → sync → sitemaps
+```
+
+## The front-matter contract
+
+Every article is a markdown file in `news-app/src/content/news/<slug>.md`. The
+**filename is the URL slug** (`gold-holds-4500.md` → `/news/gold-holds-4500/`).
+The schema in [`src/content.config.ts`](src/content.config.ts) validates this at
+build time — a malformed article **fails the build** rather than shipping broken.
+
+| Field | Req? | Notes |
+|---|---|---|
+| `title` | ✅ | Headline. |
+| `description` | ✅ | 60–165 chars (SEO + social). |
+| `category` | ✅ | **Exactly one** of `market-updates` \| `gold` \| `silver` \| `analysis`. This is the single placement key (see below). |
+| `tags` | – | Array; freeform but auto-normalized onto canonical slugs. Aim for 2–5. |
+| `pubDate` | ✅ | ISO datetime. **Drives ordering everywhere** (newest first). |
+| `updatedDate` | – | ISO datetime; shown as "updated". |
+| `image` | ✅* | `/assets/news/<slug>.jpg` (self-hosted) **or** a full Unsplash hotlink URL. *Required for published (non-draft) articles. |
+| `imageAlt` | – | Describe the image. |
+| `imageCredit` / `imageCreditUrl` | – | Photographer attribution. |
+| `author` | – | Defaults to "GoldPriceTools Editorial Team". |
+| `featured` | – | `true` pins it to the homepage hero (see below). Default `false`. |
+| `draft` | – | `true` hides it from the whole site + sitemaps. |
+
+## How placement works (where it shows, where it doesn't)
+
+There are **two independent taxonomies**, both set in front-matter:
+
+1. **`category` — the primary, closed taxonomy.** One per article. It decides:
+   - which **homepage section** it can appear in — `gold`, `silver`, and
+     `analysis` each have a dedicated band; `market-updates` is the catch-all
+     (no own band, but feeds the recency blocks);
+   - which **category archive** lists it (`/news/category/<category>/`).
+   Because it's a validated enum, **a `silver` article can never render in the
+   gold section** — cross-contamination is structurally impossible.
+
+2. **`tags` — the secondary, open taxonomy.** Zero or more per article. Each
+   distinct tag auto-builds an archive at `/news/tag/<tag>/`. Tags are
+   **normalized** (lowercased, hyphenated, synonyms folded) so the taxonomy
+   never fragments — `Central Bank`, `central_bank`, and `central-banks` all
+   collapse to `central-banks`.
+
+Two more levers:
+- **`pubDate`** orders everything newest-first (it's also how you control most of
+  the homepage, which is recency-driven).
+- **`featured: true`** pins the homepage **hero**. Among featured articles the
+  newest wins; with none set, the newest article overall is used.
+
+## Auto-routing tools
+
+The taxonomy lives in **one file**:
+[`src/lib/taxonomy.json`](src/lib/taxonomy.json) — categories (with routing
+keywords), the curated tag vocabulary (labels, synonyms, keywords), and the
+contract rules. Edit it to teach the system new tags or routing keywords; both
+the build and the tools below read from it.
+
+`scripts/news-meta.mjs` (run from the repo root) turns an article's text into the
+right metadata:
+
+| Command | What it does |
+|---|---|
+| `npm run news:suggest -- --file draft.md` | Print the suggested `category` + `tags`. Add `--json` for machine output. |
+| `npm run news:emit -- --title "…" --slug foo --file draft.md` | Print a ready-to-paste front-matter block. |
+| `npm run validate-news` | Lint **all** articles against the contract (errors block; warnings advise). Runs automatically inside `npm run build-news`. |
+
+You can also feed text directly instead of a file:
+`npm run news:suggest -- --title "Silver Surges" --text "…body…" --json`, or pipe
+the body on stdin.
+
+## n8n integration (later)
+
+The pieces are deliberately CLI- and JSON-shaped so an automated pipeline can use
+them headlessly:
+
+1. **Classify**: `node scripts/news-meta.mjs suggest --title "$T" --text "$BODY" --json`
+   → `{ "category": "...", "tags": [...] }`.
+2. **Assemble**: `node scripts/news-meta.mjs emit --title "$T" --slug "$SLUG" --text "$BODY"`
+   → front-matter block; prepend it to the body and write
+   `news-app/src/content/news/$SLUG.md`.
+3. **Image**: `node scripts/fetch-news-image.js --query "…" --slug $SLUG --provider pexels`
+   then `npm run optimize-images`.
+4. **Gate**: `npm run validate-news` (non-zero exit = stop the pipeline).
+5. **Publish**: `npm run build-news` then commit the markdown **and** the
+   regenerated `/news/` output.
+
+The classifier is **advisory** — it suggests, the schema + linter enforce. n8n (or
+a reviewer) always sets the final `category`; that keeps a wrong guess from
+silently misfiling an article.

--- a/news-app/src/content.config.ts
+++ b/news-app/src/content.config.ts
@@ -1,5 +1,23 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
+import taxonomy from './lib/taxonomy.json';
+
+// ── Tag normalization ───────────────────────────────────────────────────────
+// Tags are freeform, but we fold them onto a canonical form so the taxonomy
+// never fragments (e.g. "Central Bank", "central_bank", "central-banks" all
+// become "central-banks"). Synonyms come from the shared taxonomy.json — the
+// same file scripts/news-meta.mjs uses to suggest + lint. This runs at build
+// time, so a mistyped tag is fixed before it ships, whether the article was
+// written by hand or by n8n.
+const slugify = (s: string) =>
+  s.toLowerCase().trim().replace(/[\s_]+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-+/g, '-').replace(/^-|-$/g, '');
+
+const TAG_CANON: Record<string, string> = {};
+for (const [canon, def] of Object.entries(taxonomy.tags as Record<string, { synonyms?: string[] }>)) {
+  TAG_CANON[canon] = canon;
+  for (const syn of def.synonyms ?? []) TAG_CANON[slugify(syn)] = canon;
+}
+const normalizeTag = (t: string): string => TAG_CANON[slugify(t)] ?? slugify(t);
 
 // News articles. This schema is the validated, automation-friendly (n8n) surface:
 // write a markdown file with this front-matter, run the build, commit the output.
@@ -8,8 +26,12 @@ const news = defineCollection({
   schema: z.object({
     title: z.string(),
     description: z.string(),
+    // The ONE placement key: it decides which homepage section + category
+    // archive an article appears in. A silver article can never render in the
+    // gold section. Keep these four in sync with taxonomy.json + lib/categories.ts.
     category: z.enum(['market-updates', 'gold', 'silver', 'analysis']),
-    tags: z.array(z.string()).default([]),
+    // Freeform, but normalized + deduped onto canonical slugs (see above).
+    tags: z.array(z.string()).default([]).transform((arr) => [...new Set(arr.map(normalizeTag).filter(Boolean))]),
     pubDate: z.coerce.date(),
     updatedDate: z.coerce.date().optional(),
     // image: a root-relative self-hosted path ("/assets/news/foo.jpg", Pexels)
@@ -19,6 +41,10 @@ const news = defineCollection({
     imageCredit: z.string().optional(),
     imageCreditUrl: z.string().optional(),
     author: z.string().default('GoldPriceTools Editorial Team'),
+    // Pin to the homepage hero. Among featured articles the newest wins the
+    // hero slot; with none set, the newest article overall is used (= old
+    // behavior, so this is a no-op until you opt in).
+    featured: z.boolean().default(false),
     draft: z.boolean().default(false),
   }),
 });

--- a/news-app/src/lib/taxonomy.json
+++ b/news-app/src/lib/taxonomy.json
@@ -1,0 +1,59 @@
+{
+  "$comment": "Single source of truth for news routing. Consumed by content.config.ts (tag normalization + the build-time contract) and by scripts/news-meta.mjs (the classifier/linter that suggests category+tags and validates articles). Keep category keys in sync with content.config.ts's category enum and lib/categories.ts. Edit this file to teach the system new tags or routing keywords.",
+
+  "categories": {
+    "market-updates": {
+      "title": "Market Updates",
+      "fallback": true,
+      "match": ["weekly wrap", "week in review", "weekly roundup", "roundup", "session", "wrap", "today's market", "market moved", "this week", "daily"]
+    },
+    "gold": {
+      "title": "Gold",
+      "match": ["gold", "bullion", "xau", "sovereign", "krugerrand", "gold price", "gold demand", "royal mint gold", "gold-backed"]
+    },
+    "silver": {
+      "title": "Silver",
+      "match": ["silver", "xag", "britannia", "industrial demand", "industrial silver", "solar", "silver price", "silver coins", "junk silver"]
+    },
+    "analysis": {
+      "title": "Analysis",
+      "type_overlay": true,
+      "$comment": "Routing keywords only. Kept specific on purpose: generic words like 'ratio' appear in plain price stories too, so they are NOT here (the gold-silver-ratio TAG handles those). Every real analysis piece carries one of these stronger signals, usually in the title.",
+      "match": ["analysis", "forecast", "outlook", "relative value", "relative-value", "valuation", "scenario", "technical analysis", "why", "whether", " vs ", "versus", "case for", "deep dive", "what it means"]
+    }
+  },
+
+  "tags": {
+    "spot-price":        { "label": "Spot Price",        "synonyms": ["price", "spot", "spot-prices"], "keywords": ["spot price", "per ounce", "an ounce", "$/oz", "price action", "closed at", "rose to", "fell to", "rallied", "eased"] },
+    "central-banks":     { "label": "Central Banks",     "synonyms": ["central-bank", "central bank", "cbs"], "keywords": ["central bank", "central-bank", "official sector", "official-sector", "pboc", "reserve bank", "monetary authority", "reserves buying"] },
+    "demand":            { "label": "Demand",            "synonyms": ["buying"], "keywords": ["demand", "appetite", "inflows", "buying interest", "physical demand"] },
+    "reserves":          { "label": "Reserves",          "synonyms": [], "keywords": ["reserves", "reserve holdings", "foreign reserves", "diversify reserves"] },
+    "fed":               { "label": "Federal Reserve",   "synonyms": ["federal-reserve", "fomc", "powell"], "keywords": ["fed", "federal reserve", "fomc", "powell", "rate decision", "rate cut", "rate hike", "pause", "higher for longer"] },
+    "real-yields":       { "label": "Real Yields",       "synonyms": ["real-yield", "yields", "real yield"], "keywords": ["real yield", "real yields", "treasury yield", "10-year", "tips yield"] },
+    "inflation":         { "label": "Inflation",         "synonyms": ["cpi"], "keywords": ["inflation", "cpi", "price pressures", "cost of living"] },
+    "dollar":            { "label": "US Dollar",         "synonyms": ["usd", "dxy", "greenback"], "keywords": ["dollar", "usd", "dxy", "greenback", "softer dollar", "stronger dollar"] },
+    "gold-silver-ratio": { "label": "Gold-Silver Ratio", "synonyms": ["gsr", "ratio", "gold to silver"], "keywords": ["gold-silver ratio", "gold to silver", "gold-to-silver", "the ratio"] },
+    "analysis":          { "label": "Analysis",          "synonyms": ["forecast", "outlook"], "keywords": ["analysis", "forecast", "outlook", "scenario", "valuation", "deep dive"] },
+    "platinum":          { "label": "Platinum",          "synonyms": ["pgm", "xpt"], "keywords": ["platinum", "pgm", "xpt", "platinum group"] },
+    "relative-value":    { "label": "Relative Value",    "synonyms": ["relative value"], "keywords": ["relative value", "relative-value", "cross-asset", "versus", " vs "] },
+    "coins":             { "label": "Coins",             "synonyms": ["coin", "bullion coins"], "keywords": ["coin", "coins", "britannia", "sovereign", "krugerrand", "eagle", "maple", "numismatic"] },
+    "bars":              { "label": "Bars",              "synonyms": ["bullion bars", "ingot"], "keywords": ["bar", "bars", "ingot", "minted bar", "cast bar"] },
+    "uk":                { "label": "UK",                "synonyms": ["britain", "united kingdom", "u.k."], "keywords": ["uk", "britain", "british", "royal mint", "hmrc", "sterling", "london"] },
+    "vat":               { "label": "VAT & Tax",         "synonyms": ["tax", "cgt"], "keywords": ["vat", "tax-free", "capital gains", "cgt", "tax efficient"] },
+    "beginners":         { "label": "Beginners",         "synonyms": ["beginner", "starter", "guide"], "keywords": ["beginner", "getting started", "how to start", "first-time", "for beginners", "starter"] },
+    "industrial-demand": { "label": "Industrial Demand", "synonyms": ["industrial"], "keywords": ["industrial demand", "industrial use", "manufacturing", "industrial offtake"] },
+    "solar":             { "label": "Solar",             "synonyms": ["photovoltaic", "pv"], "keywords": ["solar", "photovoltaic", "solar panels", "pv demand"] },
+    "royal-mint":        { "label": "Royal Mint",        "synonyms": ["the royal mint"], "keywords": ["royal mint"] },
+    "weekly-wrap":       { "label": "Weekly Wrap",       "synonyms": ["weekly roundup", "week in review", "weekly wrap-up"], "keywords": ["weekly wrap", "this week", "week in review", "roundup", "wrap-up"] },
+    "miners":            { "label": "Miners",            "synonyms": ["mining stocks", "gold miners", "mining"], "keywords": ["miner", "miners", "mining", "gdx", "producers", "mine supply"] },
+    "equities":          { "label": "Equities",          "synonyms": ["stocks", "shares", "equity"], "keywords": ["equities", "stocks", "shares", "equity market"] }
+  },
+
+  "rules": {
+    "tagMin": 2,
+    "tagMax": 5,
+    "descriptionMin": 60,
+    "descriptionMax": 165,
+    "requireImageWhenPublished": true
+  }
+}

--- a/news-app/src/pages/index.astro
+++ b/news-app/src/pages/index.astro
@@ -19,7 +19,9 @@ const all = (await getCollection('news'))
   .filter((a) => !a.data.draft)
   .sort((a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime());
 
-const featured = all[0];
+// Hero: the newest article flagged `featured: true`, else the newest overall.
+// (`all` is sorted newest-first, so .find returns the most recent featured.)
+const featured = all.find((a) => a.data.featured) ?? all[0];
 const secondary = all[1];
 const fresh = all.slice(1, 6);
 const popular = all.slice(4, 9);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "fetch-charts": "python3 scripts/fetch-chart-data.py",
     "minify": "node scripts/minify-assets.js",
     "optimize-images": "node scripts/optimize-news-images.js",
-    "build-news": "npm --prefix news-app run build && node scripts/sync-news.js && node scripts/build-news-sitemap.js && node scripts/generate-sitemap.js"
+    "news:suggest": "node scripts/news-meta.mjs suggest",
+    "news:emit": "node scripts/news-meta.mjs emit",
+    "validate-news": "node scripts/news-meta.mjs check",
+    "build-news": "npm run validate-news && npm --prefix news-app run build && node scripts/sync-news.js && node scripts/build-news-sitemap.js && node scripts/generate-sitemap.js"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/news-meta.mjs
+++ b/scripts/news-meta.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * news-meta.mjs — route + tag + lint news articles from one taxonomy.
+ *
+ * The taxonomy (categories, curated tags, rules) lives in
+ * news-app/src/lib/taxonomy.json — the single source of truth shared with the
+ * Astro build (content.config.ts normalizes tags from the same file). Edit that
+ * JSON to teach the system new tags or routing keywords; never hard-code them here.
+ *
+ * Designed for two publishing modes:
+ *   • now  — Claude/you paste an article; run `suggest`/`emit` to get correct
+ *            category + tags, then `check` to lint before committing.
+ *   • later — n8n pipes title+body to `suggest --json` (or `emit`) to fill
+ *            front-matter, writes the .md, then `check` gates the commit.
+ *
+ * Actions:
+ *   suggest  Print the suggested category + tags for an article.
+ *   emit     Print a ready-to-paste front-matter block (suggested cat+tags).
+ *   check    Lint articles against the contract (default: all; or one --file).
+ *
+ * Input (suggest/emit):
+ *   --file <path.md>           read title+body from a markdown file, OR
+ *   --title "..." [--text "…"] pass content directly (text may also be piped
+ *                              on stdin). --slug/--date seed the emit template.
+ *   --json                     machine output for suggest (n8n).
+ *
+ * Examples:
+ *   node scripts/news-meta.mjs suggest --file news-app/src/content/news/foo.md
+ *   echo "<body>" | node scripts/news-meta.mjs suggest --title "Silver Surges" --json
+ *   node scripts/news-meta.mjs emit --title "Gold Holds $4,500" --slug gold-holds-4500
+ *   node scripts/news-meta.mjs check        # lint every article (CI/build gate)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+const TAXONOMY_PATH = path.join(ROOT, 'news-app', 'src', 'lib', 'taxonomy.json');
+const CONTENT_DIR = path.join(ROOT, 'news-app', 'src', 'content', 'news');
+
+const TAX = JSON.parse(fs.readFileSync(TAXONOMY_PATH, 'utf8'));
+const CATEGORY_SLUGS = Object.keys(TAX.categories);
+const RULES = TAX.rules ?? {};
+
+// ── text helpers ──────────────────────────────────────────────────────────
+const norm = (s) => (s || '').toLowerCase().replace(/\s+/g, ' ');
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Count word-ish occurrences (lookarounds keep "uk" out of "ukraine").
+function count(hay, needle) {
+  const n = norm(needle).trim();
+  if (!n) return 0;
+  const m = hay.match(new RegExp(`(?<![a-z0-9])${esc(n)}(?![a-z0-9])`, 'g'));
+  return m ? m.length : 0;
+}
+// Title matches weigh 3x body matches.
+const scoreIn = (title, body, keys) =>
+  keys.reduce((s, k) => s + 3 * count(title, k) + count(body, k), 0);
+const scoreInTitle = (title, keys) => keys.reduce((s, k) => s + count(title, k), 0);
+
+// ── tag normalization (mirrors content.config.ts) ───────────────────────────
+export const slugify = (s) =>
+  norm(s).trim().replace(/[\s_]+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-+/g, '-').replace(/^-|-$/g, '');
+
+const SYNONYM_TO_CANON = (() => {
+  const map = {};
+  for (const [canon, def] of Object.entries(TAX.tags)) {
+    map[canon] = canon;
+    for (const syn of def.synonyms ?? []) map[slugify(syn)] = canon;
+  }
+  return map;
+})();
+
+export const normalizeTag = (t) => {
+  const k = slugify(t);
+  return SYNONYM_TO_CANON[k] ?? k;
+};
+const isKnownTag = (canon) => Object.prototype.hasOwnProperty.call(TAX.tags, canon);
+
+// ── classifier ──────────────────────────────────────────────────────────────
+// Priority mirrors how the existing articles are filed:
+//   1. a market/weekly signal in the TITLE  -> market-updates (catch-all)
+//   2. an analysis signal (ratio/forecast/"why"/"vs"…) -> analysis (type overlay)
+//   3. otherwise the dominant metal (gold vs silver) by keyword score
+//   4. nothing matched -> market-updates (fallback)
+export function classifyCategory(title, body) {
+  const t = norm(title);
+  const b = norm(body);
+  const C = TAX.categories;
+
+  if (scoreInTitle(t, C['market-updates'].match) > 0) return 'market-updates';
+
+  // A title signal is decisive; a body-only signal must be strong (>=4) so a
+  // passing mention of "forecast"/"outlook" in a price story doesn't reroute it.
+  const analysisInTitle = scoreInTitle(t, C.analysis.match);
+  const analysisScore = scoreIn(t, b, C.analysis.match);
+  if (analysisInTitle > 0 || analysisScore >= 4) return 'analysis';
+
+  const g = scoreIn(t, b, C.gold.match);
+  const s = scoreIn(t, b, C.silver.match);
+  if (g === 0 && s === 0) return 'market-updates';
+  if (g === s) return scoreInTitle(t, C.gold.match) >= scoreInTitle(t, C.silver.match) ? 'gold' : 'silver';
+  return g > s ? 'gold' : 'silver';
+}
+
+export function suggestTags(title, body) {
+  const t = norm(title);
+  const b = norm(body);
+  const scored = [];
+  for (const [canon, def] of Object.entries(TAX.tags)) {
+    const keys = [canon.replace(/-/g, ' '), def.label, ...(def.synonyms ?? []), ...(def.keywords ?? [])];
+    const sc = scoreIn(t, b, keys);
+    if (sc > 0) scored.push([canon, sc]);
+  }
+  scored.sort((a, b2) => b2[1] - a[1]);
+  return scored.slice(0, RULES.tagMax ?? 5).map(([c]) => c);
+}
+
+// ── front-matter (minimal reader; articles use inline scalars + arrays) ──────
+function splitFrontMatter(raw) {
+  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  return m ? { fm: m[1], body: m[2] } : { fm: '', body: raw };
+}
+function fmScalar(fm, key) {
+  const m = fm.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
+  if (!m) return undefined;
+  return m[1].trim().replace(/^["']|["']$/g, '');
+}
+function fmTags(fm) {
+  const m = fm.match(/^tags:\s*\[(.*)\]\s*$/m);
+  if (!m) return [];
+  return m[1].split(',').map((s) => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
+}
+
+function readArticle(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const { fm, body } = splitFrontMatter(raw);
+  const title = fmScalar(fm, 'title') || (body.match(/^#\s+(.+)$/m)?.[1] ?? '');
+  return {
+    file,
+    title,
+    body,
+    category: fmScalar(fm, 'category'),
+    description: fmScalar(fm, 'description') || '',
+    image: fmScalar(fm, 'image'),
+    draft: fmScalar(fm, 'draft') === 'true',
+    tags: fmTags(fm),
+  };
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--')
+    ? process.argv[i + 1]
+    : (process.argv.includes(`--${name}`) ? true : def);
+}
+async function readStdin() {
+  if (process.stdin.isTTY) return '';
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function getInput() {
+  const file = arg('file');
+  if (typeof file === 'string') {
+    const a = readArticle(path.resolve(file));
+    return { title: a.title, body: a.body };
+  }
+  const title = typeof arg('title') === 'string' ? arg('title') : '';
+  let text = typeof arg('text') === 'string' ? arg('text') : '';
+  if (!text) text = await readStdin();
+  return { title, body: text };
+}
+
+function lintArticle(a) {
+  const errors = [];
+  const warns = [];
+  if (!a.title) errors.push('missing title');
+  if (!a.description) errors.push('missing description');
+  if (!a.category) errors.push('missing category');
+  else if (!CATEGORY_SLUGS.includes(a.category)) errors.push(`invalid category "${a.category}" (use: ${CATEGORY_SLUGS.join(', ')})`);
+  if (!a.draft && RULES.requireImageWhenPublished && !a.image) errors.push('published article has no image');
+
+  const dlen = a.description.length;
+  if (dlen && (dlen < (RULES.descriptionMin ?? 0) || dlen > (RULES.descriptionMax ?? 1e9)))
+    warns.push(`description is ${dlen} chars (aim ${RULES.descriptionMin}-${RULES.descriptionMax})`);
+  if (a.tags.length < (RULES.tagMin ?? 0)) warns.push(`only ${a.tags.length} tag(s) (aim >= ${RULES.tagMin})`);
+  if (a.tags.length > (RULES.tagMax ?? 99)) warns.push(`${a.tags.length} tags (aim <= ${RULES.tagMax})`);
+  for (const t of a.tags) {
+    const c = normalizeTag(t);
+    if (c !== t) warns.push(`tag "${t}" normalizes to "${c}"`);
+    else if (!isKnownTag(c)) warns.push(`tag "${t}" not in vocabulary (fine, but check for a synonym)`);
+  }
+  if (a.category && CATEGORY_SLUGS.includes(a.category)) {
+    const guess = classifyCategory(a.title, a.body);
+    if (guess !== a.category) warns.push(`category "${a.category}" but classifier suggests "${guess}" — confirm placement`);
+  }
+  return { errors, warns };
+}
+
+async function main() {
+  const action = process.argv[2] && !process.argv[2].startsWith('--') ? process.argv[2] : 'suggest';
+
+  if (action === 'check') {
+    const file = arg('file');
+    const files = typeof file === 'string'
+      ? [path.resolve(file)]
+      : fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith('.md')).map((f) => path.join(CONTENT_DIR, f));
+    let hardErrors = 0;
+    let warnCount = 0;
+    for (const f of files) {
+      const a = readArticle(f);
+      const { errors, warns } = lintArticle(a);
+      if (errors.length || warns.length) {
+        console.log(`\n${path.basename(f)}`);
+        for (const e of errors) { console.log(`  ✗ ${e}`); hardErrors++; }
+        for (const w of warns) { console.log(`  ⚠ ${w}`); warnCount++; }
+      }
+    }
+    console.log(`\nchecked ${files.length} article(s): ${hardErrors} error(s), ${warnCount} warning(s)`);
+    process.exit(hardErrors > 0 ? 1 : 0);
+  }
+
+  const { title, body } = await getInput();
+  if (!title && !body) {
+    console.error('Provide --file <path.md>, or --title "…" (with --text "…" or piped stdin).');
+    process.exit(2);
+  }
+  const category = classifyCategory(title, body);
+  const tags = suggestTags(title, body);
+
+  if (action === 'suggest') {
+    if (arg('json') === true) {
+      process.stdout.write(JSON.stringify({ category, tags }) + '\n');
+    } else {
+      console.log(`category: ${category}`);
+      console.log(`tags:     [${tags.map((t) => `"${t}"`).join(', ')}]`);
+    }
+    return;
+  }
+
+  if (action === 'emit') {
+    const slug = typeof arg('slug') === 'string' ? arg('slug') : 'article-slug';
+    const date = typeof arg('date') === 'string' ? arg('date') : new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+    const block = [
+      '---',
+      `title: "${title || 'TODO title'}"`,
+      'description: "TODO: 60-165 char summary for SEO + social"',
+      `category: "${category}"`,
+      `tags: [${tags.map((t) => `"${t}"`).join(', ')}]`,
+      `pubDate: ${date}`,
+      `image: "/assets/news/${slug}.jpg"`,
+      'imageAlt: "TODO descriptive alt text"',
+      'imageCredit: "Photographer / Pexels"',
+      'imageCreditUrl: "https://www.pexels.com/@photographer"',
+      'author: "GoldPriceTools Editorial Team"',
+      'featured: false',
+      'draft: false',
+      '---',
+    ].join('\n');
+    console.log(block);
+    return;
+  }
+
+  console.error(`Unknown action "${action}". Use: suggest | emit | check`);
+  process.exit(2);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## What
Makes an article's **placement deterministic and automatable** — where it's filed, how it's tagged, and where it shows up — so the *same rules* work whether I write a post today or **n8n** writes one later.

No live-site change: the schema/featured additions are no-ops on the current 9 articles, so the generated `/news/` output is byte-identical. This PR is pure tooling + contract.

## Pieces
- **`news-app/src/lib/taxonomy.json`** — single source of truth: the 4 categories (with routing keywords), a curated **tag vocabulary** (labels / synonyms / keywords), and contract rules. Both the build and the tools read from it; edit it to teach the system new tags.
- **`scripts/news-meta.mjs`** — turns article text into the right metadata:
  - `suggest` → `category` + `tags` (`--json` for n8n)
  - `emit` → a ready-to-paste front-matter block
  - `check` → lints every article against the contract (errors block, warnings advise)
  - The classifier **reproduces the category of all 9 existing seed articles** (verified).
- **`content.config.ts`** — normalizes + dedupes `tags` onto canonical slugs at build time (so `Central Bank` / `central_bank` / `central-banks` never fragment) and adds a **`featured`** flag.
- **`index.astro`** — homepage hero = newest `featured: true`, else newest overall (safe fallback).
- **`package.json`** — `news:suggest`, `news:emit`, `validate-news` (wired as a **gate** into `build-news`).
- **`PUBLISHING.md`** — the contract for both manual and n8n publishing.

## Why this answers "no gold articles in silver posts"
`category` is a **validated enum** and the *single* placement key. Homepage sections and archives filter strictly on it, so a `silver` article can never render in the gold section — it's structurally impossible, now documented and enforced.

## How it's used
```bash
npm run news:emit -- --title "Gold Holds $4,500" --slug gold-holds-4500 --file draft.md
# → paste the front-matter block, save as news-app/src/content/news/gold-holds-4500.md
npm run build-news   # validate-news gate → astro build → sync → sitemaps
```
n8n calls the same commands headlessly (`suggest --json` to classify, `emit` to assemble, `validate-news` to gate). The classifier is **advisory** — it suggests, the schema + linter enforce — so a wrong guess can't silently misfile an article.

## Notes / decisions
- Tag vocabulary is **advisory, not closed**: unknown tags are allowed (freeform is a feature) but normalized and flagged, so the taxonomy stays clean without blocking new topics.
- `category` stays author-set + validated (not silently auto-derived) — safest against misclassification.
- Routing keywords are kept specific on purpose (e.g. generic `ratio` is a *tag*, not a category signal) so a silver price story that mentions the gold-silver ratio isn't rerouted to Analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)