### PR TITLE
feat(news): smart (Claude) article classifier for auto-routing

### DIFF
--- a/news-app/PUBLISHING.md
+++ b/news-app/PUBLISHING.md
@@ -88,13 +88,41 @@ You can also feed text directly instead of a file:
 `npm run news:suggest -- --title "Silver Surges" --text "…body…" --json`, or pipe
 the body on stdin.
 
+### Two classifiers: smart (Claude) and lexical
+
+`suggest`/`emit` route an article two ways, both constrained to the **same
+taxonomy**:
+
+- **Smart (Claude)** — reads the article and routes it by its **overall concept**
+  (handles paraphrase and novelty, not just keywords). Used **automatically when
+  `ANTHROPIC_API_KEY` is set** (in `.env.local`). The category is locked to the
+  four slugs and tags to the vocabulary via a JSON schema, so it **cannot return
+  an invalid category or tag**; it may also propose new tags (surfaced separately,
+  never auto-applied). This is the path to use for n8n.
+- **Lexical** — offline keyword matching. Zero-config fallback; runs when no key
+  is set, or when forced with `--lexical`.
+
+Flags: `--ai` (force Claude), `--lexical` (force offline), `--explain` (show the
+model's one-line reasoning), `--print-request` (dump the Claude request without
+sending — key redacted, handy for debugging).
+
+**Enabling the smart classifier:** add to `.env.local` (gitignored):
+```
+ANTHROPIC_API_KEY=sk-ant-...
+# optional — defaults to claude-opus-4-8; haiku is ~5x cheaper and plenty for classification:
+ANTHROPIC_MODEL=claude-haiku-4-5
+```
+Cost is a fraction of a cent per article (classification is one short call).
+
 ## n8n integration (later)
 
 The pieces are deliberately CLI- and JSON-shaped so an automated pipeline can use
-them headlessly:
+them headlessly. With `ANTHROPIC_API_KEY` set in the environment, steps 1–2 use
+the **smart (Claude) classifier** automatically:
 
 1. **Classify**: `node scripts/news-meta.mjs suggest --title "$T" --text "$BODY" --json`
-   → `{ "category": "...", "tags": [...] }`.
+   → `{ "engine": "claude:…", "category": "...", "tags": [...], "new_tags": [...], "reasoning": "..." }`.
+   (Add `--ai` to make a missing key a hard failure instead of a silent lexical fallback.)
 2. **Assemble**: `node scripts/news-meta.mjs emit --title "$T" --slug "$SLUG" --text "$BODY"`
    → front-matter block; prepend it to the body and write
    `news-app/src/content/news/$SLUG.md`.
@@ -104,6 +132,7 @@ them headlessly:
 5. **Publish**: `npm run build-news` then commit the markdown **and** the
    regenerated `/news/` output.
 
-The classifier is **advisory** — it suggests, the schema + linter enforce. n8n (or
-a reviewer) always sets the final `category`; that keeps a wrong guess from
-silently misfiling an article.
+The classifier **suggests**; the JSON schema + the build-time contract **enforce**.
+The category is constrained to the four valid slugs and tags to the vocabulary, so
+a wrong answer can't produce an invalid placement — but for full safety a reviewer
+(or an n8n approval step) can still confirm the `category` before publish.

--- a/news-app/src/lib/taxonomy.json
+++ b/news-app/src/lib/taxonomy.json
@@ -4,19 +4,23 @@
   "categories": {
     "market-updates": {
       "title": "Market Updates",
+      "desc": "Timely, news-style coverage of the precious-metals market: daily/weekly price moves, session recaps, weekly wraps, and roundups that span both gold and silver. The default home for general market news that isn't primarily about one metal or a deep analytical thesis.",
       "fallback": true,
       "match": ["weekly wrap", "week in review", "weekly roundup", "roundup", "session", "wrap", "today's market", "market moved", "this week", "daily"]
     },
     "gold": {
       "title": "Gold",
+      "desc": "Stories whose primary subject is gold — gold price action, gold demand, central-bank gold buying, bullion/coins, mints, and gold-specific drivers.",
       "match": ["gold", "bullion", "xau", "sovereign", "krugerrand", "gold price", "gold demand", "royal mint gold", "gold-backed"]
     },
     "silver": {
       "title": "Silver",
+      "desc": "Stories whose primary subject is silver — silver price action, industrial/solar demand, silver coins, and silver-specific drivers.",
       "match": ["silver", "xag", "britannia", "industrial demand", "industrial silver", "solar", "silver price", "silver coins", "junk silver"]
     },
     "analysis": {
       "title": "Analysis",
+      "desc": "Pieces whose primary PURPOSE is interpretation rather than news: forecasts, outlooks, valuations, the gold-silver ratio as a thesis, relative-value or 'X vs Y' comparisons, technical analysis, and 'why/whether' explainers. A price story that merely mentions a ratio or forecast is NOT analysis — only file here when analysis is the point of the article.",
       "type_overlay": true,
       "$comment": "Routing keywords only. Kept specific on purpose: generic words like 'ratio' appear in plain price stories too, so they are NOT here (the gold-silver-ratio TAG handles those). Every real analysis piece carries one of these stronger signals, usually in the title.",
       "match": ["analysis", "forecast", "outlook", "relative value", "relative-value", "valuation", "scenario", "technical analysis", "why", "whether", " vs ", "versus", "case for", "deep dive", "what it means"]

--- a/scripts/news-meta.mjs
+++ b/scripts/news-meta.mjs
@@ -13,10 +13,22 @@
  *   • later — n8n pipes title+body to `suggest --json` (or `emit`) to fill
  *            front-matter, writes the .md, then `check` gates the commit.
  *
+ * Two classifiers share the taxonomy:
+ *   • SMART (Claude) — reads the article and routes it by overall concept;
+ *     constrained to the taxonomy via a json_schema so it can't invent a bad
+ *     category/tag. Used automatically when ANTHROPIC_API_KEY is set (in
+ *     .env.local). This is the recommended path for n8n. Override the model with
+ *     ANTHROPIC_MODEL (default claude-opus-4-8; claude-haiku-4-5 is ~5x cheaper).
+ *   • LEXICAL — offline keyword matching; the zero-config fallback (and --lexical).
+ *
  * Actions:
  *   suggest  Print the suggested category + tags for an article.
  *   emit     Print a ready-to-paste front-matter block (suggested cat+tags).
  *   check    Lint articles against the contract (default: all; or one --file).
+ *
+ * Engine flags (suggest/emit): --ai (force Claude), --lexical (force offline),
+ *   --explain (show the model's reasoning), --print-request (dump the Claude
+ *   request without sending — key redacted).
  *
  * Input (suggest/emit):
  *   --file <path.md>           read title+body from a markdown file, OR
@@ -41,7 +53,19 @@ const CONTENT_DIR = path.join(ROOT, 'news-app', 'src', 'content', 'news');
 
 const TAX = JSON.parse(fs.readFileSync(TAXONOMY_PATH, 'utf8'));
 const CATEGORY_SLUGS = Object.keys(TAX.categories);
+const KNOWN_TAG_SLUGS = Object.keys(TAX.tags);
 const RULES = TAX.rules ?? {};
+
+// Load .env.local / .env (KEY=VALUE; same shape as scripts/fetch-news-image.js)
+// so ANTHROPIC_API_KEY / ANTHROPIC_MODEL are available for the smart classifier.
+for (const f of ['.env.local', '.env']) {
+  const p = path.join(ROOT, f);
+  if (!fs.existsSync(p)) continue;
+  for (const line of fs.readFileSync(p, 'utf8').split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+}
 
 // ── text helpers ──────────────────────────────────────────────────────────
 const norm = (s) => (s || '').toLowerCase().replace(/\s+/g, ' ');
@@ -115,6 +139,117 @@ export function suggestTags(title, body) {
   }
   scored.sort((a, b2) => b2[1] - a[1]);
   return scored.slice(0, RULES.tagMax ?? 5).map(([c]) => c);
+}
+
+// ── Smart classifier (Claude) ───────────────────────────────────────────────
+// The lexical functions above match words; this reads the article and routes it
+// by overall concept. It's the recommended path for n8n. Constrained to the same
+// taxonomy via a json_schema (category is one of the 4 enum slugs; tags must come
+// from the vocabulary), so a wrong free-text answer is impossible. Raw fetch to
+// the Messages API — matches scripts/fetch-news-image.js's zero-dependency style
+// and avoids touching the repo's tracked (scope-guard-protected) package-lock.
+const ANTHROPIC_VERSION = '2023-06-01';
+const DEFAULT_MODEL = 'claude-opus-4-8'; // override with ANTHROPIC_MODEL (e.g. claude-haiku-4-5 for cheaper)
+
+function buildClaudeRequest(title, body) {
+  const cats = Object.entries(TAX.categories)
+    .map(([slug, d]) => `- ${slug} — ${d.desc ?? d.title}`)
+    .join('\n');
+  const tags = Object.entries(TAX.tags)
+    .map(([slug, d]) => `${slug} (${d.label})`)
+    .join(', ');
+
+  const system =
+    'You are a precise news-desk editor for GoldPriceTools, a gold & silver price/news site. ' +
+    'Classify an article into the site taxonomy by its OVERALL CONCEPT and primary purpose — not by isolated keywords.\n\n' +
+    `Categories (choose EXACTLY ONE — the single best home):\n${cats}\n\n` +
+    `Tags: choose the ${RULES.tagMin ?? 2}-${RULES.tagMax ?? 5} most relevant from this controlled vocabulary, using the exact slug:\n${tags}\n\n` +
+    'Only if a clearly central topic has no matching tag, propose up to 2 new lowercase-hyphenated tags in new_tag_suggestions; otherwise return []. ' +
+    'Give a one-sentence reasoning for the category.';
+
+  const text = `${title ? `TITLE: ${title}\n\n` : ''}ARTICLE:\n${(body || '').slice(0, 8000)}`;
+
+  return {
+    url: 'https://api.anthropic.com/v1/messages',
+    headers: {
+      'content-type': 'application/json',
+      'anthropic-version': ANTHROPIC_VERSION,
+      'x-api-key': process.env.ANTHROPIC_API_KEY || '',
+    },
+    body: {
+      model: process.env.ANTHROPIC_MODEL || DEFAULT_MODEL,
+      max_tokens: 1024,
+      system,
+      messages: [{ role: 'user', content: text }],
+      output_config: {
+        format: {
+          type: 'json_schema',
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              category: { type: 'string', enum: CATEGORY_SLUGS },
+              tags: { type: 'array', items: { type: 'string', enum: KNOWN_TAG_SLUGS } },
+              new_tag_suggestions: { type: 'array', items: { type: 'string' } },
+              reasoning: { type: 'string' },
+            },
+            required: ['category', 'tags', 'new_tag_suggestions', 'reasoning'],
+          },
+        },
+      },
+    },
+  };
+}
+
+export async function classifyWithClaude(title, body) {
+  if (!process.env.ANTHROPIC_API_KEY) throw new Error('ANTHROPIC_API_KEY not set (add it to .env.local)');
+  const req = buildClaudeRequest(title, body);
+
+  let res;
+  for (let attempt = 1; ; attempt++) {
+    res = await fetch(req.url, { method: 'POST', headers: req.headers, body: JSON.stringify(req.body) });
+    if (res.ok) break;
+    if ([429, 500, 529].includes(res.status) && attempt < 3) {
+      await new Promise((r) => setTimeout(r, 800 * attempt));
+      continue;
+    }
+    throw new Error(`Anthropic API ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  }
+
+  const data = await res.json();
+  if (data.stop_reason === 'refusal') throw new Error('model declined to classify this article');
+  const block = (data.content || []).find((b) => b.type === 'text');
+  if (!block) throw new Error('no text content in response');
+  const out = JSON.parse(block.text);
+
+  // Defensively re-validate against the taxonomy (the schema already constrains it).
+  const category = CATEGORY_SLUGS.includes(out.category) ? out.category : classifyCategory(title, body);
+  const tags = [...new Set((out.tags || []).map(normalizeTag).filter(isKnownTag))].slice(0, RULES.tagMax ?? 5);
+  const newTags = [...new Set((out.new_tag_suggestions || []).map(slugify).filter((t) => t && !isKnownTag(t)))].slice(0, 2);
+
+  return { engine: `claude:${req.body.model}`, category, tags, newTags, reasoning: out.reasoning || '' };
+}
+
+// Resolve metadata via the chosen engine. 'auto' uses Claude when a key is
+// present and falls back to lexical on any failure; 'ai' forces Claude (and
+// errors if unavailable); 'lexical' forces the offline keyword classifier.
+async function resolveMeta(title, body, engine) {
+  if (engine !== 'lexical') {
+    const hasKey = !!process.env.ANTHROPIC_API_KEY;
+    if (engine === 'ai' && !hasKey) {
+      console.error('--ai requires ANTHROPIC_API_KEY (add it to .env.local). Or omit --ai to use the lexical fallback.');
+      process.exit(2);
+    }
+    if (hasKey) {
+      try {
+        return await classifyWithClaude(title, body);
+      } catch (e) {
+        if (engine === 'ai') { console.error(`Claude classify failed: ${e.message}`); process.exit(1); }
+        console.error(`! Claude unavailable (${e.message}); using lexical fallback.`);
+      }
+    }
+  }
+  return { engine: 'lexical', category: classifyCategory(title, body), tags: suggestTags(title, body), newTags: [], reasoning: '' };
 }
 
 // ── front-matter (minimal reader; articles use inline scalars + arrays) ──────
@@ -229,15 +364,33 @@ async function main() {
     console.error('Provide --file <path.md>, or --title "…" (with --text "…" or piped stdin).');
     process.exit(2);
   }
-  const category = classifyCategory(title, body);
-  const tags = suggestTags(title, body);
+
+  // Engine: --lexical forces offline keyword matching; --ai forces Claude;
+  // default ('auto') uses Claude when ANTHROPIC_API_KEY is set, else lexical.
+  const engine = arg('lexical') === true ? 'lexical' : (arg('ai') === true ? 'ai' : 'auto');
+
+  // Inspect the exact Claude request without sending it (key redacted).
+  if (arg('print-request') === true) {
+    const req = buildClaudeRequest(title, body);
+    req.headers['x-api-key'] = req.headers['x-api-key'] ? '***redacted***' : '(unset)';
+    console.log(JSON.stringify(req, null, 2));
+    return;
+  }
+
+  const meta = await resolveMeta(title, body, engine);
 
   if (action === 'suggest') {
     if (arg('json') === true) {
-      process.stdout.write(JSON.stringify({ category, tags }) + '\n');
+      process.stdout.write(JSON.stringify({
+        engine: meta.engine, category: meta.category, tags: meta.tags,
+        new_tags: meta.newTags, reasoning: meta.reasoning,
+      }) + '\n');
     } else {
-      console.log(`category: ${category}`);
-      console.log(`tags:     [${tags.map((t) => `"${t}"`).join(', ')}]`);
+      console.log(`engine:   ${meta.engine}`);
+      console.log(`category: ${meta.category}`);
+      console.log(`tags:     [${meta.tags.map((t) => `"${t}"`).join(', ')}]`);
+      if (meta.newTags.length) console.log(`new tags: ${meta.newTags.join(', ')}  (not in vocabulary — add to taxonomy.json if useful)`);
+      if (meta.reasoning && (arg('explain') === true || meta.engine.startsWith('claude'))) console.log(`why:      ${meta.reasoning}`);
     }
     return;
   }
@@ -249,8 +402,8 @@ async function main() {
       '---',
       `title: "${title || 'TODO title'}"`,
       'description: "TODO: 60-165 char summary for SEO + social"',
-      `category: "${category}"`,
-      `tags: [${tags.map((t) => `"${t}"`).join(', ')}]`,
+      `category: "${meta.category}"`,
+      `tags: [${meta.tags.map((t) => `"${t}"`).join(', ')}]`,
       `pubDate: ${date}`,
       `image: "/assets/news/${slug}.jpg"`,
       'imageAlt: "TODO descriptive alt text"',
@@ -262,6 +415,7 @@ async function main() {
       '---',
     ].join('\n');
     console.log(block);
+    if (meta.newTags.length) console.error(`# note: suggested new tags not in vocabulary: ${meta.newTags.join(', ')}`);
     return;
   }
 


### PR DESCRIPTION
## What
Answers "can the system *understand the concept* of an article and route it automatically?" — yes. Adds a **concept-level classifier (Claude)** alongside the existing lexical one. It reads the article and assigns `category` + `tags` by overall meaning (handles paraphrase and novel phrasing), which keyword matching can't do. Built for the **n8n** auto-publishing pipeline.

## How it stays correct
The model's output is constrained to the **same `taxonomy.json`** via a JSON schema:
- `category` → enum of the 4 valid slugs
- `tags` → enum of the 23-tag vocabulary

So it **cannot return an invalid category or tag** — the "no gold articles in silver posts" guarantee holds even with an LLM in the loop. It can also propose *new* tags, surfaced separately and never auto-applied.

## Engine selection
| Mode | Behavior |
|---|---|
| auto (default) | Claude when `ANTHROPIC_API_KEY` is set in `.env.local`; otherwise the lexical fallback |
| `--ai` | Force Claude (hard error if no key) |
| `--lexical` | Force offline keyword matching |

Extra flags: `--explain` (model's one-line reasoning), `--print-request` (dump the request without sending, key redacted). Model via `ANTHROPIC_MODEL` (default `claude-opus-4-8`; `claude-haiku-4-5` is ~5× cheaper and ample for classification — a fraction of a cent per article).

## Implementation notes / decisions
- **Raw `fetch` to the Messages API, not the SDK.** Two repo-specific reasons: (1) the existing external-API script `scripts/fetch-news-image.js` is deliberately zero-dependency raw HTTPS — I matched that idiom; (2) the root `package-lock.json` is tracked but the required **Scope guard** check forbids modifying it, so adding `@anthropic-ai/sdk` would break CI or commit an out-of-sync lockfile. Structured output works identically over HTTP. (If you'd rather take the SDK dependency, easy to switch.)
- Uses `output_config.format` (json_schema) — the canonical structured-output param.
- **Lexical classifier unchanged** — still 9/9 on the seed articles, still the zero-config fallback.
- No live-site impact (tooling only; `/news/` unchanged).

## Tested
Engine selection, `--lexical`, `--ai`-without-key (clean exit 2), the lint gate, and the constructed request (correct model, category/tag enums, prompt) all verified. The live API call itself wasn't exercised here — there's no `ANTHROPIC_API_KEY` in this environment yet; add one to `.env.local` to turn the smart path on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)