### PR TITLE
feat(news): CI publish pipeline + automation contract for n8n

### DIFF
--- a/.github/workflows/publish-news.yml
+++ b/.github/workflows/publish-news.yml
@@ -1,0 +1,139 @@
+name: Publish News (automation)
+
+# The "build hands" for automated publishing. n8n (or any orchestrator) sends a
+# repository_dispatch with the article content; this workflow classifies it,
+# fetches + optimizes a hero image, runs the full news build, and opens a PR
+# (optionally auto-merging). See AUTOMATION.md for the contract + n8n wiring.
+#
+# Trigger from n8n (HTTP Request node → GitHub API):
+#   POST /repos/{owner}/{repo}/dispatches
+#   { "event_type": "publish-news", "client_payload": { ...see AUTOMATION.md } }
+#
+# Required repo secrets:  GH_PAT (PR-opening token that triggers checks),
+#   ANTHROPIC_API_KEY, PEXELS_API_KEY  (+ optional UNSPLASH_ACCESS_KEY)
+# Optional repo variable: ANTHROPIC_MODEL (default claude-sonnet-4-6)
+
+on:
+  repository_dispatch:
+    types: [publish-news]
+  workflow_dispatch:
+    inputs:
+      title: { description: 'Headline', required: true }
+      body: { description: 'Article body (markdown)', required: true }
+      slug: { description: 'URL slug (= filename)', required: true }
+      description: { description: 'SEO/social description (60-165 chars)', required: false }
+      image_query: { description: 'Stock-photo search query (defaults to title)', required: false }
+      image_provider: { description: 'pexels | unsplash', required: false, default: 'pexels' }
+      image_alt: { description: 'Image alt text', required: false }
+      pub_date: { description: 'ISO datetime (defaults to now)', required: false }
+      featured: { description: 'Pin to homepage hero', required: false, default: 'false' }
+      auto_merge: { description: 'Auto-merge the PR once checks pass', required: false, default: 'false' }
+
+concurrency:
+  group: publish-news-${{ github.event.client_payload.slug || github.event.inputs.slug }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Classify, build, and open PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: |
+          npm install --no-audit --no-fund
+          npm --prefix news-app install --no-audit --no-fund
+
+      - name: Classify + assemble the article
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
+          TITLE: ${{ github.event.client_payload.title || github.event.inputs.title }}
+          BODY: ${{ github.event.client_payload.body || github.event.inputs.body }}
+          SLUG: ${{ github.event.client_payload.slug || github.event.inputs.slug }}
+          DESCRIPTION: ${{ github.event.client_payload.description || github.event.inputs.description }}
+          PUBDATE: ${{ github.event.client_payload.pub_date || github.event.inputs.pub_date }}
+          IMAGE_ALT: ${{ github.event.client_payload.image_alt || github.event.inputs.image_alt }}
+          FEATURED: ${{ github.event.client_payload.featured || github.event.inputs.featured || 'false' }}
+        run: |
+          set -euo pipefail
+          : "${TITLE:?title is required}" "${BODY:?body is required}" "${SLUG:?slug is required}"
+          printf '%s' "$BODY" > /tmp/body.md
+
+          ARGS=(--title "$TITLE" --slug "$SLUG" --ai)
+          if [ -n "${DESCRIPTION:-}" ]; then ARGS+=(--description "$DESCRIPTION"); fi
+          if [ -n "${PUBDATE:-}" ]; then ARGS+=(--date "$PUBDATE"); fi
+          if [ -n "${IMAGE_ALT:-}" ]; then ARGS+=(--image-alt "$IMAGE_ALT"); fi
+          if [ "${FEATURED}" = "true" ]; then ARGS+=(--featured); fi
+
+          # --ai = the smart (Claude) classifier; fails loudly if misconfigured.
+          node scripts/news-meta.mjs emit "${ARGS[@]}" < /tmp/body.md > /tmp/frontmatter.txt
+          { cat /tmp/frontmatter.txt; echo; cat /tmp/body.md; } > "news-app/src/content/news/${SLUG}.md"
+          echo "SLUG=${SLUG}" >> "$GITHUB_ENV"
+          echo "TITLE=${TITLE}" >> "$GITHUB_ENV"
+          echo "--- assembled news-app/src/content/news/${SLUG}.md ---"
+          head -16 "news-app/src/content/news/${SLUG}.md"
+
+      - name: Fetch + optimize hero image
+        env:
+          PEXELS_API_KEY: ${{ secrets.PEXELS_API_KEY }}
+          UNSPLASH_ACCESS_KEY: ${{ secrets.UNSPLASH_ACCESS_KEY }}
+          IMAGE_QUERY: ${{ github.event.client_payload.image_query || github.event.inputs.image_query }}
+          IMAGE_PROVIDER: ${{ github.event.client_payload.image_provider || github.event.inputs.image_provider || 'pexels' }}
+        run: |
+          set -euo pipefail
+          QUERY="${IMAGE_QUERY:-$TITLE}"
+          node scripts/fetch-news-image.js --query "$QUERY" --slug "$SLUG" --provider "$IMAGE_PROVIDER"
+          npm run optimize-images
+
+      - name: Build news (validate → astro → sync → sitemaps)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
+        run: npm run build-news
+
+      - name: Commit + open PR
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          AUTO_MERGE: ${{ github.event.client_payload.auto_merge || github.event.inputs.auto_merge || 'false' }}
+        run: |
+          set -euo pipefail
+          BRANCH="news-bot/${SLUG}"
+          git config user.name "news-bot"
+          git config user.email "news-bot@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git"
+          git checkout -b "$BRANCH"
+
+          # Stage only the publish artifacts — never package-lock / node_modules
+          # (the Scope guard forbids the former; the latter is gitignored).
+          git add \
+            "news-app/src/content/news/${SLUG}.md" \
+            assets/news \
+            news/ \
+            sitemap.xml news-sitemap.xml image-sitemap.xml
+          git commit -m "feat(news): publish ${SLUG}"
+          git push -u origin "$BRANCH"
+
+          PR_URL=$(gh pr create --base main --head "$BRANCH" \
+            --title "feat(news): ${TITLE}" \
+            --body "Automated draft (slug \`${SLUG}\`) assembled by the publish-news pipeline. Required checks will run; review and merge to publish.")
+          echo "Opened: $PR_URL"
+
+          if [ "$AUTO_MERGE" = "true" ]; then
+            gh pr merge "$PR_URL" --squash --auto --delete-branch \
+              || echo "Auto-merge not enabled on this repo (needs branch protection) — leaving PR open for review."
+          fi

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -1,0 +1,112 @@
+# Automation contract — publishing into the n8n ecosystem
+
+This repo is a **site node** in a multi-site marketing system. The orchestration
+(n8n, self-hosted) never builds anything itself — it hands a finished article to
+this repo's CI, which classifies, builds, and ships it. This file is the contract
+between the two. It travels with the site template, so **every new site exposes
+the same interface** and slots into n8n with zero per-site glue.
+
+```
+ n8n (control plane)                 this repo's CI (build hands)         Cloudflare
+ ───────────────────                 ────────────────────────────        ──────────
+ draft title+body ──repository_dispatch──▶  classify (Claude, taxonomy-
+                     {publish-news}          constrained) → fetch+optimize
+                                             image → npm run build-news →
+                                             open PR ──(checks)──▶ merge ──▶ deploy ▶ live
+```
+
+## Trigger
+
+Fire a GitHub **`repository_dispatch`** (n8n: HTTP Request node):
+
+```
+POST https://api.github.com/repos/{owner}/{repo}/dispatches
+Authorization: Bearer <GH_PAT or GitHub App token>
+Accept: application/vnd.github+json
+
+{
+  "event_type": "publish-news",
+  "client_payload": {
+    "title":          "Gold Holds Above $4,500 as the Fed Signals a Pause",
+    "body":           "Full article body in **markdown**…",
+    "slug":           "gold-holds-4500-fed-pause",
+    "description":    "60–165 char SEO/social summary.",
+    "image_query":    "gold bullion bars",
+    "image_provider": "pexels",
+    "image_alt":      "Stacked gold bullion bars",
+    "pub_date":       "2026-06-26T09:00:00Z",
+    "featured":       false,
+    "auto_merge":     false
+  }
+}
+```
+
+### Payload fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `title` | ✅ | Headline. |
+| `body` | ✅ | Article body, markdown (no front-matter — CI generates it). |
+| `slug` | ✅ | URL slug = filename. Lowercase-hyphenated, unique. |
+| `description` | – | SEO/social meta (aim 60–165 chars). Falls back to a TODO placeholder. |
+| `image_query` | – | Stock-photo search; defaults to `title`. |
+| `image_provider` | – | `pexels` (self-hosted, default) or `unsplash` (hotlink). |
+| `image_alt` | – | Defaults to `title`. |
+| `pub_date` | – | ISO datetime; defaults to now. Drives ordering. |
+| `featured` | – | `true` pins the homepage hero. Default `false`. |
+| `auto_merge` | – | `true` auto-merges once checks pass; else the PR waits for review. |
+
+**`category` and `tags` are intentionally NOT in the payload** — CI derives them
+from the body with the Claude classifier, constrained to this site's
+`taxonomy.json`, so the orchestrator can't misfile an article and doesn't need to
+know the site's taxonomy.
+
+## What CI does (`.github/workflows/publish-news.yml`)
+
+1. **Classify + assemble** — `news-meta.mjs emit --ai` → category + tags (locked to
+   the taxonomy) + front-matter, prepended to the body → `news-app/src/content/news/<slug>.md`.
+2. **Image** — `fetch-news-image.js` (self-hosts a Pexels photo) → `optimize-images`.
+3. **Build** — `npm run build-news` (lint **gate** → Astro build → sync `/news/` → sitemaps).
+4. **Ship** — commit the article + built `/news/` + sitemaps to `news-bot/<slug>`,
+   open a PR (auto-merge optional).
+
+Required checks (Cloudflare Pages preview, Scope guard, Validate JSON-LD, and the
+`validate-news` lint inside the build) run on the PR. Merge → Cloudflare deploys.
+
+## Repo configuration (per site)
+
+**Secrets** (Settings → Secrets and variables → Actions):
+
+| Secret | Purpose |
+|---|---|
+| `GH_PAT` | Opens the PR **as a user**, so the required `pull_request` checks actually run (a PR opened by the default `GITHUB_TOKEN` does **not** trigger them). A GitHub App installation token works too and is the better choice at ecosystem scale. |
+| `ANTHROPIC_API_KEY` | The classifier. |
+| `PEXELS_API_KEY` | Self-hosted images. (`UNSPLASH_ACCESS_KEY` optional.) |
+
+**Variable** (optional): `ANTHROPIC_MODEL` — defaults to `claude-sonnet-4-6`
+(9/9 on the seed set; `claude-haiku-4-5` is ~3× cheaper if you accept the rare
+borderline call).
+
+## Testing without n8n
+
+Use the Actions tab → **Publish News (automation)** → *Run workflow* (the
+`workflow_dispatch` form takes the same fields), or fire the dispatch with `gh`:
+
+```bash
+gh api repos/:owner/:repo/dispatches -f event_type=publish-news \
+  -F 'client_payload[title]=Test headline' \
+  -F 'client_payload[slug]=test-headline' \
+  -F 'client_payload[body]=A short **markdown** body about gold prices.' \
+  -F 'client_payload[image_query]=gold bars'
+```
+
+## How this scales to many sites
+
+- Clone the template → a new site **inherits this contract unchanged**; only
+  `taxonomy.json`, branding, and the repo secrets differ.
+- n8n keeps **one** publishing workflow, parameterized by a site registry
+  (`{ site, repo, image_provider, autonomy: review|auto, … }`); "add a site" =
+  clone the repo + add a registry row.
+- Start each site in **review** mode (`auto_merge:false`); flip to `auto_merge:true`
+  per site once you trust it. The schema-constrained classifier + the
+  `validate-news` gate + the PR checks are the safety net at every stage.

--- a/scripts/news-meta.mjs
+++ b/scripts/news-meta.mjs
@@ -396,22 +396,26 @@ async function main() {
   }
 
   if (action === 'emit') {
-    const slug = typeof arg('slug') === 'string' ? arg('slug') : 'article-slug';
-    const date = typeof arg('date') === 'string' ? arg('date') : new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+    // Optional flags let an orchestrator (n8n) fill real values; otherwise the
+    // block carries TODO placeholders for hand-authoring.
+    const opt = (name, def) => (typeof arg(name) === 'string' ? arg(name) : def);
+    const yq = (s) => `"${String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    const bool = (name) => arg(name) === true || arg(name) === 'true';
+    const slug = opt('slug', 'article-slug');
     const block = [
       '---',
-      `title: "${title || 'TODO title'}"`,
-      'description: "TODO: 60-165 char summary for SEO + social"',
+      `title: ${yq(title || 'TODO title')}`,
+      `description: ${yq(opt('description', 'TODO: 60-165 char summary for SEO + social'))}`,
       `category: "${meta.category}"`,
       `tags: [${meta.tags.map((t) => `"${t}"`).join(', ')}]`,
-      `pubDate: ${date}`,
+      `pubDate: ${opt('date', new Date().toISOString().replace(/\.\d+Z$/, 'Z'))}`,
       `image: "/assets/news/${slug}.jpg"`,
-      'imageAlt: "TODO descriptive alt text"',
-      'imageCredit: "Photographer / Pexels"',
-      'imageCreditUrl: "https://www.pexels.com/@photographer"',
+      `imageAlt: ${yq(opt('image-alt', title || 'TODO descriptive alt text'))}`,
+      `imageCredit: ${yq(opt('image-credit', 'Photographer / Pexels'))}`,
+      `imageCreditUrl: ${yq(opt('image-credit-url', 'https://www.pexels.com/@photographer'))}`,
       'author: "GoldPriceTools Editorial Team"',
-      'featured: false',
-      'draft: false',
+      `featured: ${bool('featured')}`,
+      `draft: ${bool('draft')}`,
       '---',
     ].join('\n');
     console.log(block);


### PR DESCRIPTION
## What
The **per-repo "build hands"** that let a self-hosted n8n publish articles to this site without owning the Astro/build toolchain. This is the piece the multi-site architecture leans on, and it's part of the reusable template — every future site inherits the same interface and slots into n8n with no per-site glue.

No live-site impact (CI workflow + docs + a CLI flag extension; `/news/` unchanged).

## Pieces
- **`.github/workflows/publish-news.yml`** — on `repository_dispatch` `{publish-news}` (or manual `workflow_dispatch`):
  1. **classify + assemble** — `news-meta.mjs emit --ai` derives category + tags (locked to `taxonomy.json`) and writes the front-matter + body to `news-app/src/content/news/<slug>.md`
  2. **image** — `fetch-news-image.js` (self-hosts a Pexels photo) → `optimize-images`
  3. **build** — `npm run build-news` (the `validate-news` lint is the gate)
  4. **ship** — commit to `news-bot/<slug>` → open PR (optional `auto_merge`)
- **`scripts/news-meta.mjs`** — `emit` now takes `--description / --image-alt / --image-credit[-url] / --featured / --draft` (+ existing `--date`), with YAML-safe quoting, so CI fills real front-matter from the payload.
- **`AUTOMATION.md`** — the n8n↔repo contract: payload schema, required secrets/vars, a `gh` test command, and how it scales to many sites via a site registry.

## Design decisions baked in
- **`category`/`tags` are NOT in the payload** — CI derives them from the body, so the orchestrator can't misfile an article and doesn't need to know each site's taxonomy. The schema constraint + `validate-news` gate + PR checks are the safety net.
- **Uses `GH_PAT` (existing repo secret) to open the PR** — a PR opened by the default `GITHUB_TOKEN` does *not* trigger the required `pull_request` checks; a PAT (or a GitHub App token, better at scale) does.
- **Stages only publish artifacts** (article, `/news/`, sitemaps, image) — never `package-lock.json` (Scope-guard-protected) or `node_modules`.
- **`auto_merge` opt-in** — start each site in review mode, flip to hands-off per site once trusted.

## New repo config this needs (for the workflow to run)
Secrets: `ANTHROPIC_API_KEY`, `PEXELS_API_KEY` (`GH_PAT` already exists). Optional var `ANTHROPIC_MODEL` (default `claude-sonnet-4-6`). Until those are set, the workflow simply isn't exercised — merging this PR is inert.

## Tested
`emit` with the new flags (YAML escaping, featured, description, date) ✓; workflow parses as valid YAML (2 triggers, 7 steps) ✓; `validate-news` clean ✓. The workflow itself runs against live GitHub on dispatch — to be exercised once the secrets are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)